### PR TITLE
perf: L9/L10 cache-build skip-ahead at nice length

### DIFF
--- a/Zip/Native/DeflateParse.lean
+++ b/Zip/Native/DeflateParse.lean
@@ -37,6 +37,30 @@ def optNiceLen : Nat := 258
     ratio from candidate *choice* than raw depth buys. Pure ratio/speed knob. -/
 def optChainDepth : Nat := 256
 
+/-- Skip-ahead threshold for `buildCache` (#2740, libdeflate's
+    `nice_len` skip): once the deepest candidate recorded at a position
+    reaches this length, the match interior — the next `bestLen - 1`
+    positions — is only hash-inserted into the chains, never searched or
+    cached. A long repeated region then costs one chain walk instead of one
+    per byte (the match finder is ~70% of the L9/L10 cost). The DP still sees
+    the long match at its start position, so it can take it and jump the
+    interior; interior positions with no cached candidate fall back to a
+    literal or a shorter step. Pure ratio/speed knob — the emitter re-verifies
+    every match, so this is ratio-risk only.
+
+    Level 10 (exact DP). Swept on the Silesia geomean: `64` sits at the knee —
+    ~2.5× on xml, ~1.8× on nci for +0.3% geomean ratio; dropping to 48 falls off
+    a cliff (nci +5.3%) as length-48–64 matches start being skipped. -/
+def optNiceSkip : Nat := 64
+
+/-- `optNiceSkip` for the L9-fast tier (`computeChoicesFast`). Separate from
+    the level-10 value so each tier's speed/ratio balance can be swept
+    independently. The L9 matcher is shallower (`fastChainDepth = 64`, single
+    round), so skipping saves less and costs proportionally more ratio; `128`
+    keeps the Silesia geomean under budget (~+0.45%) while still buying ~1.5× on
+    xml. Pure ratio/speed knob. -/
+def fastNiceSkip : Nat := 128
+
 /-- DP region size in bytes. The cost/cache arrays live per region (memory
     cap); cost continuity across the region end is approximated by a baseline
     tail estimate, and matches may extend past the region end, so the region
@@ -72,9 +96,9 @@ arrays or pairs (boxing). -/
     distance), given that the DP also evaluates truncated lengths. -/
 def chainWalkAll (data : ByteArray) (prev : Array Nat) (pos maxLen : Nat)
     (hpm : pos + maxLen ≤ data.size) (cand fuel bestLen k slotBase : Nat)
-    (lens dists : Array Nat) : Array Nat × Array Nat :=
-  if fuel = 0 then (lens, dists)
-  else if optCacheSlots ≤ k then (lens, dists)
+    (lens dists : Array Nat) : Array Nat × Array Nat × Nat :=
+  if fuel = 0 then (lens, dists, bestLen)
+  else if optCacheSlots ≤ k then (lens, dists, bestLen)
   else if hc : cand < pos ∧ pos - cand ≤ 32768 then
     have hcand : cand + maxLen ≤ data.size := by omega
     -- Prefilter (#2622): mirror of `chainWalkAllFast` — skip the compare when the
@@ -93,13 +117,13 @@ def chainWalkAll (data : ByteArray) (prev : Array Nat) (pos maxLen : Nat)
     if 3 ≤ ml ∧ bestLen < ml then
       let lens := lens.set! (slotBase + k) ml
       let dists := dists.set! (slotBase + k) (pos - cand)
-      if min optNiceLen maxLen ≤ ml then (lens, dists)
+      if min optNiceLen maxLen ≤ ml then (lens, dists, ml)
       else chainWalkAll data prev pos maxLen hpm prev[cand &&& 0x7FFF]! (fuel - 1) ml (k + 1)
         slotBase lens dists
     else
       chainWalkAll data prev pos maxLen hpm prev[cand &&& 0x7FFF]! (fuel - 1) bestLen k
         slotBase lens dists
-  else (lens, dists)
+  else (lens, dists, bestLen)
 termination_by fuel
 decreasing_by all_goals omega
 
@@ -115,9 +139,9 @@ def chainWalkAllFast (data : ByteArray) (prev : Array Nat) (pos maxLen : Nat)
     (hpm : pos + maxLen ≤ data.size) (cand fuel bestLen k slotBase : Nat)
     (lens dists : Array Nat) (hps : min chainWinSize data.size ≤ prev.size)
     (hsl : slotBase + optCacheSlots ≤ lens.size)
-    (hsd : slotBase + optCacheSlots ≤ dists.size) : Array Nat × Array Nat :=
-  if fuel = 0 then (lens, dists)
-  else if hk : optCacheSlots ≤ k then (lens, dists)
+    (hsd : slotBase + optCacheSlots ≤ dists.size) : Array Nat × Array Nat × Nat :=
+  if fuel = 0 then (lens, dists, bestLen)
+  else if hk : optCacheSlots ≤ k then (lens, dists, bestLen)
   else if hc : cand < pos ∧ pos - cand ≤ 32768 then
     have hcand : cand + maxLen ≤ data.size := by omega
     -- Prefilter (#2622): a candidate is recorded only if it beats `bestLen`; if its
@@ -136,14 +160,14 @@ def chainWalkAllFast (data : ByteArray) (prev : Array Nat) (pos maxLen : Nat)
       have hbl : slotBase + k < lens.size := by omega
       have hbd : slotBase + k < dists.size := by omega
       if min optNiceLen maxLen ≤ ml then
-        (lens.set (slotBase + k) ml hbl, dists.set (slotBase + k) (pos - cand) hbd)
+        (lens.set (slotBase + k) ml hbl, dists.set (slotBase + k) (pos - cand) hbd, ml)
       else chainWalkAllFast data prev pos maxLen hpm (prev[cand &&& 0x7FFF]'(by have := winMask_lt cand; have := Nat.and_le_left (n := cand) (m := 0x7FFF); omega)) (fuel - 1) ml (k + 1)
         slotBase (lens.set (slotBase + k) ml hbl) (dists.set (slotBase + k) (pos - cand) hbd)
         hps (by simpa using hsl) (by simpa using hsd)
     else
       chainWalkAllFast data prev pos maxLen hpm (prev[cand &&& 0x7FFF]'(by have := winMask_lt cand; have := Nat.and_le_left (n := cand) (m := 0x7FFF); omega)) (fuel - 1) bestLen k
         slotBase lens dists hps hsl hsd
-  else (lens, dists)
+  else (lens, dists, bestLen)
 termination_by fuel
 decreasing_by all_goals omega
 
@@ -154,7 +178,7 @@ decreasing_by all_goals omega
     arrays `slots * r`), so the wrapper is value-identical to `chainWalkAll`. -/
 @[inline] def chainWalkAllGuarded (data : ByteArray) (prev : Array Nat) (pos maxLen : Nat)
     (hpm : pos + maxLen ≤ data.size) (cand fuel bestLen k slotBase : Nat)
-    (lens dists : Array Nat) : Array Nat × Array Nat :=
+    (lens dists : Array Nat) : Array Nat × Array Nat × Nat :=
   if hg : min chainWinSize data.size ≤ prev.size ∧ slotBase + optCacheSlots ≤ lens.size ∧
       slotBase + optCacheSlots ≤ dists.size then
     chainWalkAllFast data prev pos maxLen hpm cand fuel bestLen k slotBase lens dists
@@ -172,7 +196,7 @@ private theorem chainWalkAll_fst_size (data : ByteArray) (prev : Array Nat) (pos
 
 private theorem chainWalkAll_snd_size (data : ByteArray) (prev : Array Nat) (pos maxLen : Nat)
     (hpm : pos + maxLen ≤ data.size) (cand fuel bestLen k slotBase : Nat) (lens dists : Array Nat) :
-    (chainWalkAll data prev pos maxLen hpm cand fuel bestLen k slotBase lens dists).2.size =
+    (chainWalkAll data prev pos maxLen hpm cand fuel bestLen k slotBase lens dists).2.1.size =
       dists.size := by
   fun_induction chainWalkAll data prev pos maxLen hpm cand fuel bestLen k slotBase lens dists <;>
     simp_all (config := { zetaDelta := true })
@@ -192,7 +216,7 @@ private theorem chainWalkAllFast_snd_size (data : ByteArray) (prev : Array Nat) 
     (hps : min chainWinSize data.size ≤ prev.size) (hsl : slotBase + optCacheSlots ≤ lens.size)
     (hsd : slotBase + optCacheSlots ≤ dists.size) :
     (chainWalkAllFast data prev pos maxLen hpm cand fuel bestLen k slotBase lens dists
-      hps hsl hsd).2.size = dists.size := by
+      hps hsl hsd).2.1.size = dists.size := by
   fun_induction chainWalkAllFast data prev pos maxLen hpm cand fuel bestLen k slotBase lens dists
     hps hsl hsd <;> simp_all (config := { zetaDelta := true }) [Array.size_set]
 
@@ -211,7 +235,7 @@ private theorem chainWalkAllGuarded_fst_size (data : ByteArray) (prev : Array Na
 private theorem chainWalkAllGuarded_snd_size (data : ByteArray) (prev : Array Nat)
     (pos maxLen : Nat) (hpm : pos + maxLen ≤ data.size) (cand fuel bestLen k slotBase : Nat)
     (lens dists : Array Nat) :
-    (chainWalkAllGuarded data prev pos maxLen hpm cand fuel bestLen k slotBase lens dists).2.size =
+    (chainWalkAllGuarded data prev pos maxLen hpm cand fuel bestLen k slotBase lens dists).2.1.size =
       dists.size := by
   unfold chainWalkAllGuarded
   split
@@ -230,20 +254,53 @@ private theorem chainWalkAllGuarded_snd_size (data : ByteArray) (prev : Array Na
   let c := (data[pos + 2]'(by omega)).toUInt32
   ((a ^^^ (b <<< 5) ^^^ (c <<< 10)).toNat % hashSize)
 
-/-- Build the candidate cache for region `[base, base + r)`: at **every**
-    position (the DP can land anywhere, so none may be skipped) insert the
-    position into the hash chains and record its candidate frontier.
+/-- Hash-insert positions `[base + j, base + stop)` into the chains without
+    searching or caching them — libdeflate's `bt_matchfinder_skip_byte`, used
+    for the interior of a long match. Later positions can still find matches
+    reaching back into the skipped span (the chain stays complete), but the
+    span itself costs no chain walk. Stops early at the first position too
+    close to the end to hash (positions only advance, so all later ones are
+    too). Heuristic — only mutates the chain state, never the cache. -/
+def insertChainRange (data : ByteArray) (hashTable prev : Array Nat)
+    (base j stop : Nat) : Array Nat × Array Nat :=
+  if j < stop then
+    let pos := base + j
+    if hlt : pos + 2 < data.size then
+      let h := hash3opt data pos 65536 hlt
+      let head := headProbeGuarded hashTable h
+      let hashTable := guardedSet hashTable h pos
+      let prev := guardedSet prev (pos &&& 0x7FFF) head
+      insertChainRange data hashTable prev base (j + 1) stop
+    else (hashTable, prev)
+  else (hashTable, prev)
+termination_by stop - j
+decreasing_by omega
+
+/-- Build the candidate cache for region `[base, base + r)`: **every** position
+    is inserted into the hash chains (the DP can land anywhere, so the chain
+    must stay complete), and every *searched* position also records its
+    candidate frontier. The one exception is the interior of a long match, which
+    is inserted but not searched or cached (see skip-ahead below).
     `hashTable`/`prev` are the same global chain state `lz77Chain` uses
     (sentinel `data.size`), threaded across regions so distances legally
     reach up to 32 KiB into prior regions. Returns the filled cache and the
     updated chain state.
 
-    `depth`/`slots` are passed as parameters (callers supply `optChainDepth`/
-    `optCacheSlots`): literal constants in the body make the well-founded
-    elaboration attempt deep reduction of the `chainWalkAll` application and
-    blow the recursion limit. -/
+    `depth`/`slots`/`niceSkip` are passed as parameters (callers supply
+    `optChainDepth`/`optCacheSlots`/`optNiceSkip`): literal constants in the
+    body make the well-founded elaboration attempt deep reduction of the
+    `chainWalkAll` application and blow the recursion limit.
+
+    Skip-ahead (#2740): when the deepest candidate recorded at a position
+    reaches `niceSkip`, the interior of that match — the next `bestLen - 1`
+    positions, clamped to the region end — is only hash-inserted into the
+    chains (`insertChainRange`), never searched or cached, and the search
+    resumes past it. This is libdeflate's `nice_len` skip: a long repeated
+    region costs one chain walk instead of one per byte, at a small ratio
+    cost (the DP sees the long match at its start and takes it; interior
+    positions with no cached candidate fall back to a literal). -/
 def buildCache (data : ByteArray) (hashTable : Array Nat) (prev : Array Nat)
-    (depth slots base r j : Nat)
+    (depth slots niceSkip base r j : Nat)
     (lens dists : Array Nat) : Array Nat × Array Nat × Array Nat × Array Nat :=
   if hj : j < r then
     let pos := base + j
@@ -256,27 +313,46 @@ def buildCache (data : ByteArray) (hashTable : Array Nat) (prev : Array Nat)
       have hpm : pos + maxLen ≤ data.size := by omega
       let cache := chainWalkAllGuarded data prev pos maxLen hpm head depth
         0 0 (slots * j) lens dists
-      buildCache data hashTable prev depth slots base r (j + 1) cache.1 cache.2
+      -- `cache.2.2` is the longest match the walk found at `pos` (it threads the
+      -- running best out), so the skip decision costs nothing beyond the walk.
+      let best := cache.2.2
+      if hsk : niceSkip ≤ best ∧ 1 ≤ best then
+        -- skip the match interior: hash-insert positions `(j, j + best)` only,
+        -- then resume the search at `j + best`. The interior insert is clamped
+        -- to the region end (`min (j + best) r`) so no next-region position is
+        -- inserted twice; if `j + best ≥ r` the resumed call returns at once.
+        let hp := insertChainRange data hashTable prev base (j + 1) (min (j + best) r)
+        buildCache data hp.1 hp.2 depth slots niceSkip base r (j + best) cache.1 cache.2.1
+      else
+        buildCache data hashTable prev depth slots niceSkip base r (j + 1) cache.1 cache.2.1
     else
-      buildCache data hashTable prev depth slots base r (j + 1) lens dists
+      buildCache data hashTable prev depth slots niceSkip base r (j + 1) lens dists
   else (lens, dists, hashTable, prev)
 termination_by r - j
-decreasing_by all_goals omega
+decreasing_by
+  -- The `j + 1` calls close by plain omega. The skip call recurses at
+  -- `j + best`: rewrite `r - (j + best)` to `(r - j) - best` and apply
+  -- `Nat.sub_lt` with `0 < r - j` (from `hj`) and `0 < best` (from `hsk`) —
+  -- omega will not decompose the `r - j` measure atom on its own.
+  all_goals first
+    | omega
+    | (rw [Nat.sub_add_eq]; exact Nat.sub_lt (Nat.sub_pos_of_lt hj) hsk.2)
 
 /-- `buildCache` only feeds the cache arrays through `chainWalkAllGuarded`
     (size-preserving), so the returned `lens`/`dists` keep their input sizes.
     This is the chain that lets `fillRegion`/`scanCands` read the cache slots
     with proven bounds. -/
 private theorem buildCache_fst_size (data : ByteArray) (hashTable prev : Array Nat)
-    (depth slots base r j : Nat) (lens dists : Array Nat) :
-    (buildCache data hashTable prev depth slots base r j lens dists).1.size = lens.size := by
-  fun_induction buildCache data hashTable prev depth slots base r j lens dists <;>
+    (depth slots niceSkip base r j : Nat) (lens dists : Array Nat) :
+    (buildCache data hashTable prev depth slots niceSkip base r j lens dists).1.size = lens.size := by
+  fun_induction buildCache data hashTable prev depth slots niceSkip base r j lens dists <;>
     simp_all (config := { zetaDelta := true }) [chainWalkAllGuarded_fst_size]
 
 private theorem buildCache_snd_fst_size (data : ByteArray) (hashTable prev : Array Nat)
-    (depth slots base r j : Nat) (lens dists : Array Nat) :
-    (buildCache data hashTable prev depth slots base r j lens dists).2.1.size = dists.size := by
-  fun_induction buildCache data hashTable prev depth slots base r j lens dists <;>
+    (depth slots niceSkip base r j : Nat) (lens dists : Array Nat) :
+    (buildCache data hashTable prev depth slots niceSkip base r j lens dists).2.1.size =
+      dists.size := by
+  fun_induction buildCache data hashTable prev depth slots niceSkip base r j lens dists <;>
     simp_all (config := { zetaDelta := true }) [chainWalkAllGuarded_snd_size]
 
 /-! ## Cost model
@@ -596,27 +672,27 @@ decreasing_by all_goals omega
     choices. Round 1 prices with the static tables; round 2 refits to the
     region's own round-1 parse. Returns the updated chain state and choice
     arrays. -/
-def fillRegionRounds (data : ByteArray) (depth slots base r : Nat)
+def fillRegionRounds (data : ByteArray) (depth slots niceSkip base r : Nat)
     (slit slen sdist : Array Nat) (hashTable : Array Nat) (prev : Array Nat)
     (chLen chDist : Array Nat)
     (hr : base + r ≤ data.size) (hslit : 256 ≤ slit.size)
     (hchL : data.size ≤ chLen.size) (hchD : data.size ≤ chDist.size) :
     Array Nat × Array Nat × Array Nat × Array Nat :=
   let cache := buildCache data hashTable prev
-    depth slots base r 0 (Array.replicate (slots * r) 0) (Array.replicate (slots * r) 0)
+    depth slots niceSkip base r 0 (Array.replicate (slots * r) 0) (Array.replicate (slots * r) 0)
   let cacheLens := cache.1
   let cacheDists := cache.2.1
   -- The cache arrays are built `slots * r`-sized and `buildCache` preserves
   -- size, so the DP's cache-slot reads (in `scanCands`) are provably in range.
   have hcl : slots * r ≤ cacheLens.size := by
     have : cacheLens.size = slots * r := by
-      show (buildCache data hashTable prev depth slots base r 0
+      show (buildCache data hashTable prev depth slots niceSkip base r 0
         (Array.replicate (slots * r) 0) (Array.replicate (slots * r) 0)).1.size = slots * r
       rw [buildCache_fst_size, Array.size_replicate]
     omega
   have hcd : slots * r ≤ cacheDists.size := by
     have : cacheDists.size = slots * r := by
-      show (buildCache data hashTable prev depth slots base r 0
+      show (buildCache data hashTable prev depth slots niceSkip base r 0
         (Array.replicate (slots * r) 0) (Array.replicate (slots * r) 0)).2.1.size = slots * r
       rw [buildCache_snd_fst_size, Array.size_replicate]
     omega
@@ -649,22 +725,22 @@ def fillRegionRounds (data : ByteArray) (depth slots base r : Nat)
 
 /-- `fillRegionRounds` only `set!`s the choice arrays, so it preserves their
     sizes (both DP rounds go through `fillRegion`). -/
-private theorem fillRegionRounds_chLen_size (data : ByteArray) (depth slots base r : Nat)
+private theorem fillRegionRounds_chLen_size (data : ByteArray) (depth slots niceSkip base r : Nat)
     (slit slen sdist : Array Nat) (hashTable : Array Nat) (prev : Array Nat)
     (chLen chDist : Array Nat)
     (hr : base + r ≤ data.size) (hslit : 256 ≤ slit.size)
     (hchL : data.size ≤ chLen.size) (hchD : data.size ≤ chDist.size) :
-    (fillRegionRounds data depth slots base r slit slen sdist hashTable prev chLen chDist
+    (fillRegionRounds data depth slots niceSkip base r slit slen sdist hashTable prev chLen chDist
       hr hslit hchL hchD).2.2.1.size = chLen.size := by
   unfold fillRegionRounds
   simp only [fillRegion_fst_size]
 
-private theorem fillRegionRounds_chDist_size (data : ByteArray) (depth slots base r : Nat)
+private theorem fillRegionRounds_chDist_size (data : ByteArray) (depth slots niceSkip base r : Nat)
     (slit slen sdist : Array Nat) (hashTable : Array Nat) (prev : Array Nat)
     (chLen chDist : Array Nat)
     (hr : base + r ≤ data.size) (hslit : 256 ≤ slit.size)
     (hchL : data.size ≤ chLen.size) (hchD : data.size ≤ chDist.size) :
-    (fillRegionRounds data depth slots base r slit slen sdist hashTable prev chLen chDist
+    (fillRegionRounds data depth slots niceSkip base r slit slen sdist hashTable prev chLen chDist
       hr hslit hchL hchD).2.2.2.size = chDist.size := by
   unfold fillRegionRounds
   simp only [fillRegion_snd_size]
@@ -682,7 +758,7 @@ private theorem fillRegionRounds_chDist_size (data : ByteArray) (depth slots bas
     the result is identical to the unfueled loop. Marked `private`: the fuel
     parameter is a footgun (too little fuel silently yields a partial fill), so
     only `computeChoices` (which passes `data.size`) may call it. -/
-private def computeChoicesLoop (data : ByteArray) (depth slots regionSize : Nat)
+private def computeChoicesLoop (data : ByteArray) (depth slots niceSkip regionSize : Nat)
     (slit slen sdist : Array Nat) (hashTable : Array Nat) (prev : Array Nat) (base : Nat)
     (chLen chDist : Array Nat) (hslit : 256 ≤ slit.size)
     (hchL : data.size ≤ chLen.size) (hchD : data.size ≤ chDist.size) (fuel : Nat) :
@@ -693,15 +769,15 @@ private def computeChoicesLoop (data : ByteArray) (depth slots regionSize : Nat)
     if hb : base < data.size ∧ 0 < regionSize then
       let r := min regionSize (data.size - base)
       have hr : base + r ≤ data.size := by omega
-      let result := fillRegionRounds data depth slots base r
+      let result := fillRegionRounds data depth slots niceSkip base r
         slit slen sdist hashTable prev chLen chDist hr hslit hchL hchD
       have hchL' : data.size ≤ result.2.2.1.size := Nat.le_trans hchL
-        (Nat.le_of_eq (fillRegionRounds_chLen_size data depth slots base r slit slen sdist
+        (Nat.le_of_eq (fillRegionRounds_chLen_size data depth slots niceSkip base r slit slen sdist
           hashTable prev chLen chDist hr hslit hchL hchD).symm)
       have hchD' : data.size ≤ result.2.2.2.size := Nat.le_trans hchD
-        (Nat.le_of_eq (fillRegionRounds_chDist_size data depth slots base r slit slen sdist
+        (Nat.le_of_eq (fillRegionRounds_chDist_size data depth slots niceSkip base r slit slen sdist
           hashTable prev chLen chDist hr hslit hchL hchD).symm)
-      computeChoicesLoop data depth slots regionSize slit slen sdist result.1 result.2.1
+      computeChoicesLoop data depth slots niceSkip regionSize slit slen sdist result.1 result.2.1
         (base + r) result.2.2.1 result.2.2.2 hslit hchL' hchD' fuel
     else (chLen, chDist)
 
@@ -711,7 +787,7 @@ private def computeChoicesLoop (data : ByteArray) (depth slots regionSize : Nat)
     Heuristic only: consumed by the re-verifying emitter `optimalEmit`. -/
 def computeChoices (data : ByteArray) : Array Nat × Array Nat :=
   let st := staticCostTables
-  computeChoicesLoop data optChainDepth optCacheSlots optRegionSize st.1 st.2.1 st.2.2
+  computeChoicesLoop data optChainDepth optCacheSlots optNiceSkip optRegionSize st.1 st.2.1 st.2.2
     (Array.replicate 65536 data.size) (Array.replicate (min chainWinSize data.size) data.size)
     0 (Array.replicate data.size 1) (Array.replicate data.size 0)
     (by have h : st.1.size = 256 := staticCostTables_fst_size; omega)
@@ -863,12 +939,12 @@ decreasing_by omega
 /-- One region of the L9-fast parse: build the candidate cache (at `depth`) and
     run a single static-cost backward DP over it. No round-2 refit. Returns the
     threaded chain state and choice arrays. -/
-def fillRegionFastRound (data : ByteArray) (depth slots base r : Nat)
+def fillRegionFastRound (data : ByteArray) (depth slots niceSkip base r : Nat)
     (slit slen sdist : Array Nat) (hashTable : Array Nat) (prev : Array Nat)
     (chLen chDist : Array Nat)
     (hr : base + r ≤ data.size) (hslit : 256 ≤ slit.size) :
     Array Nat × Array Nat × Array Nat × Array Nat :=
-  let cache := buildCache data hashTable prev depth slots base r 0
+  let cache := buildCache data hashTable prev depth slots niceSkip base r 0
     (Array.replicate (slots * r) 0) (Array.replicate (slots * r) 0)
   let cacheLens := cache.1
   let cacheDists := cache.2.1
@@ -886,7 +962,7 @@ def fillRegionFastRound (data : ByteArray) (depth slots base r : Nat)
     No `chLen`/`chDist` size hypotheses are threaded: the single-round fill
     never reads them back (no region-token collection), so only their `set!`s
     matter. Fuel = `data.size` bounds the region count as in the exact loop. -/
-private def computeChoicesFastLoop (data : ByteArray) (depth slots regionSize : Nat)
+private def computeChoicesFastLoop (data : ByteArray) (depth slots niceSkip regionSize : Nat)
     (slit slen sdist : Array Nat) (hashTable : Array Nat) (prev : Array Nat) (base : Nat)
     (chLen chDist : Array Nat) (hslit : 256 ≤ slit.size) (fuel : Nat) :
     Array Nat × Array Nat :=
@@ -896,9 +972,9 @@ private def computeChoicesFastLoop (data : ByteArray) (depth slots regionSize : 
     if hb : base < data.size ∧ 0 < regionSize then
       let r := min regionSize (data.size - base)
       have hr : base + r ≤ data.size := by omega
-      let result := fillRegionFastRound data depth slots base r
+      let result := fillRegionFastRound data depth slots niceSkip base r
         slit slen sdist hashTable prev chLen chDist hr hslit
-      computeChoicesFastLoop data depth slots regionSize slit slen sdist result.1 result.2.1
+      computeChoicesFastLoop data depth slots niceSkip regionSize slit slen sdist result.1 result.2.1
         (base + r) result.2.2.1 result.2.2.2 hslit fuel
     else (chLen, chDist)
 
@@ -907,7 +983,8 @@ private def computeChoicesFastLoop (data : ByteArray) (depth slots regionSize : 
     Heuristic only — consumed by the re-verifying emitter. -/
 def computeChoicesFast (data : ByteArray) : Array Nat × Array Nat :=
   let st := staticCostTables
-  computeChoicesFastLoop data fastChainDepth optCacheSlots optRegionSize st.1 st.2.1 st.2.2
+  computeChoicesFastLoop data fastChainDepth optCacheSlots fastNiceSkip optRegionSize
+    st.1 st.2.1 st.2.2
     (Array.replicate 65536 data.size) (Array.replicate (min chainWinSize data.size) data.size)
     0 (Array.replicate data.size 1) (Array.replicate data.size 0)
     (by have h : st.1.size = 256 := staticCostTables_fst_size; omega)

--- a/ZipBench.lean
+++ b/ZipBench.lean
@@ -227,6 +227,13 @@ where
     | "compress-libdeflate" =>
       let _ ← Libdeflate.compress data level.toUInt8
       pure ()
+    -- One-shot native compressed size (deterministic; no timing loop). Used to
+    -- sweep ratio-only knobs cheaply across a whole corpus without paying the
+    -- `compress-pareto` warmup/rep cost. Prints `size out ratio%`.
+    | "csize" =>
+      let out := Zip.Native.Deflate.deflateRaw data level.toUInt8
+      let ratio : Float := 100.0 * out.size.toFloat / data.size.toFloat
+      IO.println s!"size={data.size} lvl={level}: out={out.size} ratio={ratio.toString.take 5}%"
     -- P0 diagnostic: separate the one-time dense-table CAF build (paid on the
     -- first distance lookup of the process) from steady-state per-call cost.
     -- Builds `nin` distinct inputs (perturb one byte) to defeat CSE/memoisation,

--- a/ZipTest/OptimalParse.lean
+++ b/ZipTest/OptimalParse.lean
@@ -18,7 +18,7 @@ open Zip.Native.Deflate
 private def cacheFor (data : ByteArray) : Array Nat × Array Nat :=
   let (lens, dists, _, _) := buildCache data
     (Array.replicate 65536 data.size) (Array.replicate (min chainWinSize data.size) data.size)
-    optChainDepth optCacheSlots 0 data.size 0
+    optChainDepth optCacheSlots optNiceSkip 0 data.size 0
     (Array.replicate (optCacheSlots * data.size) 0)
     (Array.replicate (optCacheSlots * data.size) 0)
   (lens, dists)

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p72b3fc89f5)">
+   <g clip-path="url(#p5e9d22fe80)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDUlEQVR4nO3YTYpc1x2H4f6SEKIRccCKLIwxgXjkacgga8gkC8kKsousIBDIKFMT4qFnXoI/gglYMXZHskWr1emurptZ5oL38LeL51nBr7jFue89x/sf/rod8dNyfTm9YJ3rl9MLlthub6YnLHP86PH0hDXuPZhesM7JyfSCNW6vpxesc3yYz2x78Wx6wjKH+cQAAAYJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2NlXRxfTG5a43V9PT1jmnZ/9cnrCMufbk+kJSxy/ej49YZlPXn82PWGJd+8/np6wzG5/Mz1hicu7wz33b/a76QlL/ObRe9MTlnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHjl//92zY9YoXXu8vpCcu8vX84PWGd3c30gjUuL6YXrPOLD6YXLHG5XU1PWOZQz8e3t/PpCcs8O3o+PWGJpxffT09Yxg0WAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxM7OX1xMb1ji/Oz+9IR1rr+ZXrDMdvnD9IQ19vvpBcscP/x2esISh3yGnJ89mp6wxv0H0wuWefr6ZnrCEtvVv6cnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdrZdfDO9gTe1308vgP/bvv7n9IQ1Tnx//uQ4G/kRcYIAAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7OwP3/1resMSL67vpics8+mzl9MTlvno97+dnrDEk4fvT09Y5sM//2V6whK/+9XPpycs8+WL6+kJvKG//+OL6QlLXP3pj9MTlnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHj3f7jbXrECnf73fSEZU6OD7eLT6+vpiescXo2vWCdV8+nFyyxf+vp9IRltm0/PWGJ0wO+M7jdDvOddm93mL/r6MgNFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMTOpgfw5k6/+2p6wjLby/9MT1hjt5tesMzug19PT1jiZNtPT1jmbjvM/+PpdrivtHtX309PWGL7+vPpCcu4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY/wD9DY34hJ0bGAAAAABJRU5ErkJggg==" id="image26d75d35bb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDUlEQVR4nO3YTYpc1x2H4f6SEKIRccCKLIwxgXjkacgga8gkC8kKsousIBDIKFMT4qFnXoI/gglYMXZHskWr1emurptZ5oL38LeL51nBr7jFue89x/sf/rod8dNyfTm9YJ3rl9MLlthub6YnLHP86PH0hDXuPZhesM7JyfSCNW6vpxesc3yYz2x78Wx6wjKH+cQAAAYJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2NlXRxfTG5a43V9PT1jmnZ/9cnrCMufbk+kJSxy/ej49YZlPXn82PWGJd+8/np6wzG5/Mz1hicu7wz33b/a76QlL/ObRe9MTlnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHjl//92zY9YoXXu8vpCcu8vX84PWGd3c30gjUuL6YXrPOLD6YXLHG5XU1PWOZQz8e3t/PpCcs8O3o+PWGJpxffT09Yxg0WAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxM7OX1xMb1ji/Oz+9IR1rr+ZXrDMdvnD9IQ19vvpBcscP/x2esISh3yGnJ89mp6wxv0H0wuWefr6ZnrCEtvVv6cnLOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgdrZdfDO9gTe1308vgP/bvv7n9IQ1Tnx//uQ4G/kRcYIAAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBA7OwP3/1resMSL67vpics8+mzl9MTlvno97+dnrDEk4fvT09Y5sM//2V6whK/+9XPpycs8+WL6+kJvKG//+OL6QlLXP3pj9MTlnGDBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALHj3f7jbXrECnf73fSEZU6OD7eLT6+vpiescXo2vWCdV8+nFyyxf+vp9IRltm0/PWGJ0wO+M7jdDvOddm93mL/r6MgNFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMTOpgfw5k6/+2p6wjLby/9MT1hjt5tesMzug19PT1jiZNtPT1jmbjvM/+PpdrivtHtX309PWGL7+vPpCcu4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY/wD9DY34hJ0bGAAAAABJRU5ErkJggg==" id="imagefaca7305a9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m705889b539" d="M 0 0 
+       <path id="m7ba4a52b53" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m705889b539" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m705889b539" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m705889b539" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m705889b539" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m705889b539" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m705889b539" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m705889b539" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m705889b539" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m705889b539" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m705889b539" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m705889b539" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7ba4a52b53" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mdd4ee07ef5" d="M 0 0 
+       <path id="m9e303ed699" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e303ed699" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e303ed699" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e303ed699" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e303ed699" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e303ed699" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e303ed699" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e303ed699" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mdd4ee07ef5" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e303ed699" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2177,18 +2177,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image90bff458bb" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image1efea431a3" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="md41e12b8ea" d="M 0 0 
+       <path id="mcd1c933f8f" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md41e12b8ea" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd1c933f8f" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2211,7 +2211,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#md41e12b8ea" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd1c933f8f" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2225,7 +2225,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md41e12b8ea" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd1c933f8f" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2239,7 +2239,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#md41e12b8ea" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd1c933f8f" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2252,7 +2252,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md41e12b8ea" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd1c933f8f" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2265,7 +2265,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#md41e12b8ea" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd1c933f8f" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2278,7 +2278,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md41e12b8ea" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd1c933f8f" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2939,8 +2939,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(20.059766 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.001562 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3055,109 +3055,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p72b3fc89f5">
+  <clipPath id="p5e9d22fe80">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m3c7f01c44b" d="M 0 0 
+       <path id="m0ecfb2f37f" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3c7f01c44b" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ecfb2f37f" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m3c7f01c44b" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ecfb2f37f" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m3c7f01c44b" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ecfb2f37f" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m3c7f01c44b" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ecfb2f37f" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m3c7f01c44b" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ecfb2f37f" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m3c7f01c44b" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ecfb2f37f" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m3c7f01c44b" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0ecfb2f37f" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m666f521d96" d="M 0 0 
+       <path id="mfb77c38e23" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m666f521d96" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb77c38e23" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m666f521d96" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb77c38e23" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m666f521d96" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfb77c38e23" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mbf5922e189" d="M 0 0 
+       <path id="mb5a439007f" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mbf5922e189" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb5a439007f" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(103.348822 313.500074) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(105.541635 307.810372) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m968caa4214" d="M -2.5 2.5 
+     <path id="m7e7ff69de2" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1bc8dd2d0a)">
-     <use xlink:href="#m968caa4214" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m968caa4214" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m968caa4214" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m968caa4214" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m968caa4214" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m968caa4214" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m968caa4214" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m968caa4214" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m968caa4214" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p45e92861ce)">
+     <use xlink:href="#m7e7ff69de2" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7ff69de2" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7ff69de2" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7ff69de2" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7ff69de2" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7ff69de2" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7ff69de2" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7ff69de2" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e7ff69de2" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.211803
 L 310.240844 102.355284 
 L 309.257387 102.498333 
 L 308.273931 102.64095 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.64095 
@@ -1853,7 +1853,7 @@ L 273.545396 115.495372
 L 272.773651 115.744903 
 L 272.001906 115.993127 
 L 271.230161 116.240058 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.240058 
@@ -1905,7 +1905,7 @@ L 221.171803 119.753456
 L 220.059395 119.828647 
 L 218.946988 119.90372 
 L 217.83458 119.978674 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 119.978674 
@@ -1957,7 +1957,7 @@ L 179.624997 137.397353
 L 178.775895 137.720164 
 L 177.926794 138.04079 
 L 177.077692 138.359262 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.359262 
@@ -2009,7 +2009,7 @@ L 163.767861 156.658214
 L 163.472087 156.994351 
 L 163.176313 157.328121 
 L 162.880539 157.659557 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.659557 
@@ -2061,7 +2061,7 @@ L 160.875139 164.650114
 L 160.830574 164.794326 
 L 160.78601 164.9381 
 L 160.741445 165.081439 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.081439 
@@ -2113,7 +2113,7 @@ L 154.390101 182.353217
 L 154.24896 182.673779 
 L 154.107819 182.992187 
 L 153.966678 183.30847 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.30847 
@@ -2165,26 +2165,26 @@ L 151.73818 193.734619
 L 151.688658 193.942139 
 L 151.639136 194.148754 
 L 151.589614 194.354473 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m89d7d82d68" d="M 0 -2.5 
+     <path id="m76af97ab4a" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1bc8dd2d0a)">
-     <use xlink:href="#m89d7d82d68" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89d7d82d68" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89d7d82d68" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89d7d82d68" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89d7d82d68" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89d7d82d68" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89d7d82d68" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89d7d82d68" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m89d7d82d68" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p45e92861ce)">
+     <use xlink:href="#m76af97ab4a" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m76af97ab4a" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m76af97ab4a" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m76af97ab4a" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m76af97ab4a" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m76af97ab4a" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m76af97ab4a" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m76af97ab4a" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m76af97ab4a" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.610561
 L 294.051648 97.995945 
 L 288.886486 98.37822 
 L 283.721324 98.757435 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 98.757435 
@@ -2289,7 +2289,7 @@ L 222.934499 119.784103
 L 221.583681 120.159977 
 L 220.232863 120.532893 
 L 218.882044 120.902897 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 120.902897 
@@ -2341,7 +2341,7 @@ L 189.411904 126.368029
 L 188.757012 126.482596 
 L 188.10212 126.596887 
 L 187.447228 126.710903 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 126.710903 
@@ -2393,7 +2393,7 @@ L 177.036521 137.569875
 L 176.805172 137.785045 
 L 176.573823 137.999242 
 L 176.342474 138.212475 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.212475 
@@ -2445,7 +2445,7 @@ L 163.884824 160.054818
 L 163.607987 160.442131 
 L 163.33115 160.826303 
 L 163.054314 161.207386 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.207386 
@@ -2497,7 +2497,7 @@ L 162.263275 168.244909
 L 162.245696 168.390018 
 L 162.228118 168.534683 
 L 162.210539 168.678909 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.678909 
@@ -2549,7 +2549,7 @@ L 159.485481 175.228819
 L 159.424925 175.364567 
 L 159.364368 175.499927 
 L 159.303811 175.634901 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.634901 
@@ -2601,30 +2601,30 @@ L 157.888296 179.180942
 L 157.85684 179.256806 
 L 157.825384 179.332549 
 L 157.793928 179.408171 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m30967b80a9" d="M -0 3.535534 
+     <path id="ma97b2b130c" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1bc8dd2d0a)">
-     <use xlink:href="#m30967b80a9" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m30967b80a9" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p45e92861ce)">
+     <use xlink:href="#ma97b2b130c" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma97b2b130c" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.99106
 L 205.766837 81.29344 
 L 204.771342 81.593904 
 L 203.775848 81.892474 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.892474 
@@ -2729,7 +2729,7 @@ L 188.032264 88.395253
 L 187.682406 88.530091 
 L 187.332549 88.664546 
 L 186.982691 88.798621 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.798621 
@@ -2781,7 +2781,7 @@ L 180.229518 90.954599
 L 180.079447 91.001413 
 L 179.929376 91.048181 
 L 179.779306 91.094902 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.094902 
@@ -2833,7 +2833,7 @@ L 158.995974 98.861987
 L 158.534122 99.02092 
 L 158.07227 99.179321 
 L 157.610419 99.337194 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.337194 
@@ -2885,7 +2885,7 @@ L 149.27802 107.306615
 L 149.092855 107.469343 
 L 148.907691 107.631514 
 L 148.722526 107.793132 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.793132 
@@ -2937,7 +2937,7 @@ L 144.65906 120.462338
 L 144.568761 120.708742 
 L 144.478462 120.95387 
 L 144.388162 121.197738 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.197738 
@@ -2989,7 +2989,7 @@ L 128.153555 143.293159
 L 127.792786 143.68398 
 L 127.432016 144.071604 
 L 127.071247 144.456083 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.456083 
@@ -3041,7 +3041,7 @@ L 124.653192 151.618794
 L 124.599457 151.76629 
 L 124.545723 151.913329 
 L 124.491988 152.059912 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.059912 
@@ -3093,7 +3093,7 @@ L 94.606058 205.368437
 L 93.941926 206.074323 
 L 93.277794 206.769849 
 L 92.613662 207.455314 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.455314 
@@ -3145,7 +3145,7 @@ L 87.677774 224.060225
 L 87.568088 224.37049 
 L 87.458402 224.678737 
 L 87.348715 224.984992 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 224.984992 
@@ -3197,23 +3197,23 @@ L 86.134388 240.678828
 L 86.107403 240.974786 
 L 86.080418 241.268907 
 L 86.053433 241.561213 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m4032d69e6f" d="M -0 2.5 
+     <path id="m511383fcfe" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1bc8dd2d0a)">
-     <use xlink:href="#m4032d69e6f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p45e92861ce)">
+     <use xlink:href="#m511383fcfe" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="mb85b068f18" d="M -0.833333 2.5 
+     <path id="m9fb77cfb8c" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1bc8dd2d0a)">
-     <use xlink:href="#mb85b068f18" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb85b068f18" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb85b068f18" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb85b068f18" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb85b068f18" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb85b068f18" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb85b068f18" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb85b068f18" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb85b068f18" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p45e92861ce)">
+     <use xlink:href="#m9fb77cfb8c" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fb77cfb8c" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fb77cfb8c" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fb77cfb8c" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fb77cfb8c" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fb77cfb8c" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fb77cfb8c" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fb77cfb8c" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fb77cfb8c" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 180.888961
 L 282.301002 180.947904 
 L 280.549589 181.006774 
 L 278.798176 181.06557 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 181.06557 
@@ -3342,7 +3342,7 @@ L 252.902686 188.238912
 L 252.327231 188.386611 
 L 251.751776 188.53385 
 L 251.17632 188.680634 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 188.680634 
@@ -3394,7 +3394,7 @@ L 203.954921 186.473055
 L 202.905557 186.42281 
 L 201.856192 186.372512 
 L 200.806828 186.322161 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 186.322161 
@@ -3446,7 +3446,7 @@ L 171.740947 201.881696
 L 171.095038 202.175521 
 L 170.44913 202.467535 
 L 169.803221 202.757761 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 202.757761 
@@ -3498,7 +3498,7 @@ L 162.409549 210.675366
 L 162.245246 210.837123 
 L 162.080942 210.99833 
 L 161.916638 211.158991 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 211.158991 
@@ -3550,7 +3550,7 @@ L 158.898325 213.866476
 L 158.831251 213.92492 
 L 158.764178 213.983292 
 L 158.697104 214.041592 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 214.041592 
@@ -3602,7 +3602,7 @@ L 154.543684 229.493591
 L 154.451386 229.785704 
 L 154.359088 230.076027 
 L 154.26679 230.364582 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 230.364582 
@@ -3654,11 +3654,11 @@ L 153.16961 235.985723
 L 153.145228 236.103367 
 L 153.120846 236.220719 
 L 153.096464 236.337782 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="mf2b72a28e2" d="M -1.25 2.5 
+     <path id="mcd957e1222" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1bc8dd2d0a)">
-     <use xlink:href="#mf2b72a28e2" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2b72a28e2" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2b72a28e2" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2b72a28e2" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2b72a28e2" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2b72a28e2" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2b72a28e2" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2b72a28e2" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf2b72a28e2" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p45e92861ce)">
+     <use xlink:href="#mcd957e1222" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd957e1222" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd957e1222" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd957e1222" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd957e1222" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd957e1222" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd957e1222" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd957e1222" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd957e1222" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 147.037933
 L 252.377414 147.089635 
 L 251.306944 147.141281 
 L 250.236474 147.192871 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 147.192871 
@@ -3787,7 +3787,7 @@ L 226.969772 152.467777
 L 226.452735 152.578579 
 L 225.935697 152.689122 
 L 225.418659 152.799409 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 152.799409 
@@ -3839,7 +3839,7 @@ L 213.147044 158.556257
 L 212.874341 158.676569 
 L 212.601639 158.796576 
 L 212.328936 158.91628 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 158.91628 
@@ -3891,7 +3891,7 @@ L 209.236323 156.954621
 L 209.167599 156.910092 
 L 209.098874 156.865522 
 L 209.030149 156.82091 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 156.82091 
@@ -3943,7 +3943,7 @@ L 198.265399 167.356927
 L 198.026182 167.566396 
 L 197.786966 167.774943 
 L 197.547749 167.982576 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 167.982576 
@@ -3995,7 +3995,7 @@ L 194.989815 169.398061
 L 194.932972 169.429041 
 L 194.876129 169.460001 
 L 194.819287 169.49094 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 169.49094 
@@ -4047,7 +4047,7 @@ L 193.228821 176.568565
 L 193.193478 176.714439 
 L 193.158134 176.859866 
 L 193.12279 177.004847 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 177.004847 
@@ -4099,11 +4099,11 @@ L 192.818243 181.564429
 L 192.811475 181.660932 
 L 192.804707 181.75724 
 L 192.79794 181.853352 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m6c534cbad0" d="M 0 -2.5 
+     <path id="mf4220e5749" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p1bc8dd2d0a)">
-     <use xlink:href="#m6c534cbad0" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6c534cbad0" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6c534cbad0" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6c534cbad0" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6c534cbad0" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6c534cbad0" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6c534cbad0" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6c534cbad0" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m6c534cbad0" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p45e92861ce)">
+     <use xlink:href="#mf4220e5749" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf4220e5749" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf4220e5749" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf4220e5749" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf4220e5749" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf4220e5749" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf4220e5749" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf4220e5749" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf4220e5749" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 117.963319
 L 206.45578 117.9566 
 L 206.45578 117.949879 
 L 206.45578 117.943158 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 117.943158 
@@ -4230,7 +4230,7 @@ L 206.45578 118.018397
 L 206.45578 118.020068 
 L 206.45578 118.021738 
 L 206.45578 118.023409 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.023409 
@@ -4282,7 +4282,7 @@ L 206.45578 118.009588
 L 206.45578 118.00928 
 L 206.45578 118.008973 
 L 206.45578 118.008666 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.008666 
@@ -4334,7 +4334,7 @@ L 173.935517 132.674231
 L 173.212844 132.953702 
 L 172.490172 133.231533 
 L 171.767499 133.507746 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 133.507746 
@@ -4386,7 +4386,7 @@ L 164.056872 143.78437
 L 163.885524 143.989231 
 L 163.714177 144.193211 
 L 163.54283 144.396316 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.396316 
@@ -4438,7 +4438,7 @@ L 160.385378 149.94789
 L 160.315212 150.064163 
 L 160.245047 150.180152 
 L 160.174881 150.295858 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 150.295858 
@@ -4490,7 +4490,7 @@ L 154.553946 167.637484
 L 154.429036 167.959116 
 L 154.304126 168.27858 
 L 154.179217 168.595905 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 168.595905 
@@ -4542,11 +4542,11 @@ L 152.549264 177.771325
 L 152.513043 177.956336 
 L 152.476822 178.140629 
 L 152.4406 178.324207 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m48de64e3ef" d="M 0 -2.5 
+     <path id="ma54fbb8234" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1bc8dd2d0a)">
-     <use xlink:href="#m48de64e3ef" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m48de64e3ef" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m48de64e3ef" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m48de64e3ef" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m48de64e3ef" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m48de64e3ef" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m48de64e3ef" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m48de64e3ef" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m48de64e3ef" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p45e92861ce)">
+     <use xlink:href="#ma54fbb8234" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma54fbb8234" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma54fbb8234" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma54fbb8234" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma54fbb8234" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma54fbb8234" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma54fbb8234" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma54fbb8234" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma54fbb8234" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 174.939703
 L 592.834055 174.969152 
 L 592.450726 174.998584 
 L 592.067397 175.027997 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 175.027997 
@@ -4669,7 +4669,7 @@ L 538.386544 181.016797
 L 537.193636 181.14165 
 L 536.000728 181.266176 
 L 534.807821 181.390376 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 181.390376 
@@ -4721,7 +4721,7 @@ L 340.74006 177.010188
 L 336.427443 176.9081 
 L 332.114826 176.805792 
 L 327.802209 176.703263 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.703263 
@@ -4773,7 +4773,7 @@ L 279.085397 186.459613
 L 278.002801 186.655155 
 L 276.920205 186.849893 
 L 275.83761 187.043834 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 187.043834 
@@ -4825,7 +4825,7 @@ L 259.350398 198.484046
 L 258.984015 198.709377 
 L 258.617633 198.933642 
 L 258.25125 199.15685 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 199.15685 
@@ -4877,7 +4877,7 @@ L 256.869193 203.812849
 L 256.838481 203.911293 
 L 256.807768 204.009533 
 L 256.777056 204.107569 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 204.107569 
@@ -4929,7 +4929,7 @@ L 249.270304 217.480153
 L 249.103487 217.738369 
 L 248.93667 217.995185 
 L 248.769854 218.250617 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 218.250617 
@@ -4981,7 +4981,7 @@ L 246.421172 227.44791
 L 246.368979 227.633321 
 L 246.316786 227.818009 
 L 246.264594 228.00198 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m6354c62893" d="M 0 3.5 
+      <path id="m531bbf9339" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m6354c62893" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m531bbf9339" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m968caa4214" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7e7ff69de2" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m89d7d82d68" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m76af97ab4a" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m30967b80a9" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma97b2b130c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m4032d69e6f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m511383fcfe" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#mb85b068f18" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9fb77cfb8c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#mf2b72a28e2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcd957e1222" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m6c534cbad0" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mf4220e5749" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m48de64e3ef" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma54fbb8234" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,17 +5416,17 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p1bc8dd2d0a)">
-     <use xlink:href="#m6354c62893" x="289.669676" y="170.254203" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6354c62893" x="223.847406" y="178.9334" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6354c62893" x="212.215046" y="182.437536" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6354c62893" x="189.634638" y="189.604975" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6354c62893" x="188.534126" y="190.642027" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6354c62893" x="185.32129" y="193.451183" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6354c62893" x="165.179564" y="205.631101" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6354c62893" x="150.950891" y="250.636885" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6354c62893" x="118.987151" y="289.09912" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6354c62893" x="98.348822" y="318.500074" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p45e92861ce)">
+     <use xlink:href="#m531bbf9339" x="289.669676" y="170.254203" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m531bbf9339" x="223.847406" y="178.9334" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m531bbf9339" x="212.215046" y="182.437536" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m531bbf9339" x="189.634638" y="189.604975" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m531bbf9339" x="188.534126" y="190.642027" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m531bbf9339" x="185.32129" y="193.451183" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m531bbf9339" x="165.179564" y="205.631101" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m531bbf9339" x="150.950891" y="250.636885" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m531bbf9339" x="119.37967" y="288.201372" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m531bbf9339" x="100.541635" y="312.810372" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
@@ -5479,7 +5479,7 @@ L 227.961298 178.435116
 L 226.590001 178.601793 
 L 225.218703 178.767887 
 L 223.847406 178.9334 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
     <path d="M 223.847406 178.9334 
@@ -5531,7 +5531,7 @@ L 212.942069 182.225958
 L 212.699728 182.296589 
 L 212.457387 182.367115 
 L 212.215046 182.437536 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
     <path d="M 212.215046 182.437536 
@@ -5583,7 +5583,7 @@ L 191.045914 189.187408
 L 190.575489 189.327006 
 L 190.105064 189.466195 
 L 189.634638 189.604975 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
     <path d="M 189.634638 189.604975 
@@ -5635,7 +5635,7 @@ L 188.602908 190.577872
 L 188.579981 190.599267 
 L 188.557054 190.620652 
 L 188.534126 190.642027 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
     <path d="M 188.534126 190.642027 
@@ -5687,7 +5687,7 @@ L 185.522092 193.280406
 L 185.455158 193.3374 
 L 185.388224 193.394326 
 L 185.32129 193.451183 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
     <path d="M 185.32129 193.451183 
@@ -5739,7 +5739,7 @@ L 166.438422 204.955015
 L 166.018802 205.181451 
 L 165.599183 205.406809 
 L 165.179564 205.631101 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
     <path d="M 165.179564 205.631101 
@@ -5791,111 +5791,111 @@ L 151.840183 248.785151
 L 151.543753 249.41047 
 L 151.247322 250.027645 
 L 150.950891 250.636885 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
     <path d="M 150.950891 250.636885 
-L 150.28498 251.856692 
-L 149.619069 253.045887 
-L 148.953158 254.205968 
-L 148.287246 255.338329 
-L 147.621335 256.444261 
-L 146.955424 257.524971 
-L 146.289513 258.581584 
-L 145.623601 259.615151 
-L 144.95769 260.626656 
-L 144.291779 261.617021 
-L 143.625868 262.587111 
-L 142.959956 263.537741 
-L 142.294045 264.469675 
-L 141.628134 265.383635 
-L 140.962223 266.280301 
-L 140.296311 267.160315 
-L 139.6304 268.024285 
-L 138.964489 268.872785 
-L 138.298578 269.706359 
-L 137.632666 270.525524 
-L 136.966755 271.330769 
-L 136.300844 272.122559 
-L 135.634933 272.901337 
-L 134.969021 273.667523 
-L 134.30311 274.421519 
-L 133.637199 275.163705 
-L 132.971288 275.894446 
-L 132.305376 276.614091 
-L 131.639465 277.32297 
-L 130.973554 278.021401 
-L 130.307643 278.709687 
-L 129.641731 279.38812 
-L 128.97582 280.056977 
-L 128.309909 280.716525 
-L 127.643998 281.367019 
-L 126.978086 282.008705 
-L 126.312175 282.641818 
-L 125.646264 283.266584 
-L 124.980353 283.88322 
-L 124.314441 284.491935 
-L 123.64853 285.092931 
-L 122.982619 285.686399 
-L 122.316708 286.272528 
-L 121.650796 286.851495 
-L 120.984885 287.423474 
-L 120.318974 287.988632 
-L 119.653063 288.547128 
-L 118.987151 289.09912 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+L 150.293158 251.81602 
+L 149.635424 252.966525 
+L 148.97769 254.08976 
+L 148.319956 255.186986 
+L 147.662223 256.259382 
+L 147.004489 257.308045 
+L 146.346755 258.334004 
+L 145.689021 259.338221 
+L 145.031288 260.321599 
+L 144.373554 261.284984 
+L 143.71582 262.229174 
+L 143.058086 263.154918 
+L 142.400352 264.062924 
+L 141.742619 264.953859 
+L 141.084885 265.828352 
+L 140.427151 266.686999 
+L 139.769417 267.530365 
+L 139.111684 268.358984 
+L 138.45395 269.173363 
+L 137.796216 269.973982 
+L 137.138482 270.7613 
+L 136.480748 271.535751 
+L 135.823015 272.297748 
+L 135.165281 273.047687 
+L 134.507547 273.785942 
+L 133.849813 274.512872 
+L 133.19208 275.22882 
+L 132.534346 275.934112 
+L 131.876612 276.629061 
+L 131.218878 277.313965 
+L 130.561145 277.989112 
+L 129.903411 278.654775 
+L 129.245677 279.311216 
+L 128.587943 279.958689 
+L 127.930209 280.597434 
+L 127.272476 281.227684 
+L 126.614742 281.849662 
+L 125.957008 282.463583 
+L 125.299274 283.069651 
+L 124.641541 283.668066 
+L 123.983807 284.259019 
+L 123.326073 284.842693 
+L 122.668339 285.419265 
+L 122.010605 285.988906 
+L 121.352872 286.551782 
+L 120.695138 287.10805 
+L 120.037404 287.657864 
+L 119.37967 288.201372 
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 118.987151 289.09912 
-L 118.557186 289.94037 
-L 118.127221 290.766947 
-L 117.697256 291.579353 
-L 117.267291 292.378066 
-L 116.837325 293.16354 
-L 116.40736 293.936206 
-L 115.977395 294.696477 
-L 115.54743 295.444742 
-L 115.117465 296.181376 
-L 114.687499 296.906734 
-L 114.257534 297.621157 
-L 113.827569 298.324969 
-L 113.397604 299.018481 
-L 112.967639 299.701989 
-L 112.537673 300.37578 
-L 112.107708 301.040124 
-L 111.677743 301.695283 
-L 111.247778 302.341508 
-L 110.817813 302.97904 
-L 110.387847 303.608108 
-L 109.957882 304.228934 
-L 109.527917 304.841733 
-L 109.097952 305.446708 
-L 108.667987 306.044057 
-L 108.238021 306.63397 
-L 107.808056 307.21663 
-L 107.378091 307.792213 
-L 106.948126 308.360889 
-L 106.518161 308.922821 
-L 106.088195 309.478168 
-L 105.65823 310.027082 
-L 105.228265 310.569711 
-L 104.7983 311.106196 
-L 104.368335 311.636676 
-L 103.938369 312.161284 
-L 103.508404 312.680147 
-L 103.078439 313.193391 
-L 102.648474 313.701135 
-L 102.218509 314.203497 
-L 101.788543 314.700589 
-L 101.358578 315.192521 
-L 100.928613 315.679399 
-L 100.498648 316.161326 
-L 100.068683 316.6384 
-L 99.638717 317.11072 
-L 99.208752 317.578379 
-L 98.778787 318.041467 
-L 98.348822 318.500074 
-" clip-path="url(#p1bc8dd2d0a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.37967 288.201372 
+L 118.987211 288.86883 
+L 118.594752 289.527018 
+L 118.202293 290.176189 
+L 117.809834 290.816588 
+L 117.417375 291.448447 
+L 117.024916 292.071993 
+L 116.632457 292.68744 
+L 116.239998 293.294997 
+L 115.847539 293.894863 
+L 115.45508 294.48723 
+L 115.062621 295.072284 
+L 114.670162 295.650203 
+L 114.277703 296.221159 
+L 113.885243 296.785317 
+L 113.492784 297.342839 
+L 113.100325 297.893877 
+L 112.707866 298.438582 
+L 112.315407 298.977096 
+L 111.922948 299.50956 
+L 111.530489 300.036107 
+L 111.13803 300.556868 
+L 110.745571 301.071969 
+L 110.353112 301.58153 
+L 109.960653 302.085671 
+L 109.568194 302.584505 
+L 109.175735 303.078142 
+L 108.783276 303.566691 
+L 108.390817 304.050254 
+L 107.998358 304.528932 
+L 107.605898 305.002824 
+L 107.213439 305.472023 
+L 106.82098 305.936623 
+L 106.428521 306.396712 
+L 106.036062 306.852377 
+L 105.643603 307.303702 
+L 105.251144 307.750769 
+L 104.858685 308.193658 
+L 104.466226 308.632446 
+L 104.073767 309.067208 
+L 103.681308 309.498018 
+L 103.288849 309.924947 
+L 102.89639 310.348064 
+L 102.503931 310.767436 
+L 102.111472 311.18313 
+L 101.719013 311.595209 
+L 101.326553 312.003735 
+L 100.934094 312.40877 
+L 100.541635 312.810372 
+" clip-path="url(#p45e92861ce)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.059766 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.001562 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6459,109 +6459,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1bc8dd2d0a">
+  <clipPath id="p45e92861ce">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p7af755313f)">
+   <g clip-path="url(#p1ac558e6f1)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+0lEQVR4nO3YsaplZx2H4b1nzjmcSXBAmcSQUmIhSLBI4zSpcyfp7CwlfUqvIfEGAkFCbESx0UIsBLUTCUMyiZOZcM6Zfdb2Ekbhk3/Y7/NcwW/BWt96+fbblx8cd6fm6efTC5Y6fnFaz7Pb7Xb//PlH0xOW+sefn01PWO7tD9+ZnrDc/idvTU9Ya39nesF6Tz6bXrDe5f3pBUv96vvvT09Y7gS/JACA/54YAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI218fPj5Oj1jtuNumJyy1P8FmPb9zMT1hqZvtanrCcud/+cP0hOUOP344PWGpw3YzPWG5Z4cn0xOWe3Bix8Pz+w+mJyx3en9ZAID/gRgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEg7O3/21fSG9a6/mV6w1nGbXrDevfvTC5a6mB7wf3B88mx6wnLnXz+enrDU+XaYnrDcvVM8766eTi9Y6vzs9E48N0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2T47TI1Y7HrfpCUttJ/Y8u91ud37nYnrCUrfHw/SE5e4+fTw9Yb3vvDq9YKnn2830hOW+uPrX9ITlXrs+m56w1Pbd16cnLOdmCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIO/vjo99Nb1juzm4/PWGpV156MD1hudvtMD1hqYu7l9MTlnv3N7+dnrDcez/94fSEpQ7HbXrCcr/4/d+mJyz38PWXpycs9e6bD6cnLOdmCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn757e/Pk6PWO3m9mp6wlL39pfTE3iBm/1hesJy/77+fHrCct+7fG16wlLbcZuesNxX14+mJyz3+Pqz6QlL/eD+m9MTlnMzBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLT9tn16nB4BfAsdbqYXrHd2Mb2AF7i6/WZ6wnKXd1+ansALuBkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tnuuE1vWG+v8b71DjfTC5bazs6mJyz3px/9bHrCcm/99ZfTE9a6e3rv3e3xMD1hvUd/n16w1qtvTC9YTjUAAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAg7T9w24kn6oVK9AAAAABJRU5ErkJggg==" id="imageedeff1431a" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI+0lEQVR4nO3YsaplZx2H4b1nzjmcSXBAmcSQUmIhSLBI4zSpcyfp7CwlfUqvIfEGAkFCbESx0UIsBLUTCUMyiZOZcM6Zfdb2Ekbhk3/Y7/NcwW/BWt96+fbblx8cd6fm6efTC5Y6fnFaz7Pb7Xb//PlH0xOW+sefn01PWO7tD9+ZnrDc/idvTU9Ya39nesF6Tz6bXrDe5f3pBUv96vvvT09Y7gS/JACA/54YAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI218fPj5Oj1jtuNumJyy1P8FmPb9zMT1hqZvtanrCcud/+cP0hOUOP344PWGpw3YzPWG5Z4cn0xOWe3Bix8Pz+w+mJyx3en9ZAID/gRgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEg7O3/21fSG9a6/mV6w1nGbXrDevfvTC5a6mB7wf3B88mx6wnLnXz+enrDU+XaYnrDcvVM8766eTi9Y6vzs9E48N0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2T47TI1Y7HrfpCUttJ/Y8u91ud37nYnrCUrfHw/SE5e4+fTw9Yb3vvDq9YKnn2830hOW+uPrX9ITlXrs+m56w1Pbd16cnLOdmCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIO/vjo99Nb1juzm4/PWGpV156MD1hudvtMD1hqYu7l9MTlnv3N7+dnrDcez/94fSEpQ7HbXrCcr/4/d+mJyz38PWXpycs9e6bD6cnLOdmCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGn757e/Pk6PWO3m9mp6wlL39pfTE3iBm/1hesJy/77+fHrCct+7fG16wlLbcZuesNxX14+mJyz3+Pqz6QlL/eD+m9MTlnMzBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgLT9tn16nB4BfAsdbqYXrHd2Mb2AF7i6/WZ6wnKXd1+ansALuBkCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBA2tnuuE1vWG+v8b71DjfTC5bazs6mJyz3px/9bHrCcm/99ZfTE9a6e3rv3e3xMD1hvUd/n16w1qtvTC9YTjUAAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAg7T9w24kn6oVK9AAAAABJRU5ErkJggg==" id="image53a92f3ee2" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m9dd5d6d7d6" d="M 0 0 
+       <path id="m9484910494" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9dd5d6d7d6" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9484910494" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="md4e4fd9c2e" d="M 0 0 
+       <path id="m309131da7f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m309131da7f" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m309131da7f" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m309131da7f" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m309131da7f" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m309131da7f" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m309131da7f" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m309131da7f" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md4e4fd9c2e" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m309131da7f" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2093,18 +2093,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image9bc6f4c546" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imaged4579cfc40" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m5c4ea6dab1" d="M 0 0 
+       <path id="m64fcc7c6ee" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2147,7 +2147,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2164,7 +2164,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2181,7 +2181,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2197,7 +2197,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2213,7 +2213,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2245,7 +2245,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m5c4ea6dab1" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m64fcc7c6ee" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2883,8 +2883,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(20.059766 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.001562 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7af755313f">
+  <clipPath id="p1ac558e6f1">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.280469pt" height="386.202469pt" viewBox="0 0 568.280469 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.396875pt" height="386.202469pt" viewBox="0 0 570.396875 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 568.280469 386.202469 
-L 568.280469 0 
+L 570.396875 386.202469 
+L 570.396875 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.265234 104.1264 
-L 290.890234 104.1264 
-L 290.890234 74.7432 
-L 186.265234 74.7432 
+    <path d="M 187.323438 104.1264 
+L 291.948438 104.1264 
+L 291.948438 74.7432 
+L 187.323438 74.7432 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 290.890234 104.1264 
-L 395.515234 104.1264 
-L 395.515234 74.7432 
-L 290.890234 74.7432 
+    <path d="M 291.948438 104.1264 
+L 396.573438 104.1264 
+L 396.573438 74.7432 
+L 291.948438 74.7432 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.515234 104.1264 
-L 500.140234 104.1264 
-L 500.140234 74.7432 
-L 395.515234 74.7432 
+    <path d="M 396.573438 104.1264 
+L 501.198438 104.1264 
+L 501.198438 74.7432 
+L 396.573438 74.7432 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.265234 133.5096 
-L 290.890234 133.5096 
-L 290.890234 104.1264 
-L 186.265234 104.1264 
+    <path d="M 187.323438 133.5096 
+L 291.948438 133.5096 
+L 291.948438 104.1264 
+L 187.323438 104.1264 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 290.890234 133.5096 
-L 395.515234 133.5096 
-L 395.515234 104.1264 
-L 290.890234 104.1264 
+    <path d="M 291.948438 133.5096 
+L 396.573438 133.5096 
+L 396.573438 104.1264 
+L 291.948438 104.1264 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.515234 133.5096 
-L 500.140234 133.5096 
-L 500.140234 104.1264 
-L 395.515234 104.1264 
+    <path d="M 396.573438 133.5096 
+L 501.198438 133.5096 
+L 501.198438 104.1264 
+L 396.573438 104.1264 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.265234 162.8928 
-L 290.890234 162.8928 
-L 290.890234 133.5096 
-L 186.265234 133.5096 
+    <path d="M 187.323438 162.8928 
+L 291.948438 162.8928 
+L 291.948438 133.5096 
+L 187.323438 133.5096 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 290.890234 162.8928 
-L 395.515234 162.8928 
-L 395.515234 133.5096 
-L 290.890234 133.5096 
+    <path d="M 291.948438 162.8928 
+L 396.573438 162.8928 
+L 396.573438 133.5096 
+L 291.948438 133.5096 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.515234 162.8928 
-L 500.140234 162.8928 
-L 500.140234 133.5096 
-L 395.515234 133.5096 
+    <path d="M 396.573438 162.8928 
+L 501.198438 162.8928 
+L 501.198438 133.5096 
+L 396.573438 133.5096 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.265234 192.276 
-L 290.890234 192.276 
-L 290.890234 162.8928 
-L 186.265234 162.8928 
+    <path d="M 187.323438 192.276 
+L 291.948438 192.276 
+L 291.948438 162.8928 
+L 187.323438 162.8928 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 290.890234 192.276 
-L 395.515234 192.276 
-L 395.515234 162.8928 
-L 290.890234 162.8928 
+    <path d="M 291.948438 192.276 
+L 396.573438 192.276 
+L 396.573438 162.8928 
+L 291.948438 162.8928 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.515234 192.276 
-L 500.140234 192.276 
-L 500.140234 162.8928 
-L 395.515234 162.8928 
+    <path d="M 396.573438 192.276 
+L 501.198438 192.276 
+L 501.198438 162.8928 
+L 396.573438 162.8928 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.265234 221.6592 
-L 290.890234 221.6592 
-L 290.890234 192.276 
-L 186.265234 192.276 
+    <path d="M 187.323438 221.6592 
+L 291.948438 221.6592 
+L 291.948438 192.276 
+L 187.323438 192.276 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 290.890234 221.6592 
-L 395.515234 221.6592 
-L 395.515234 192.276 
-L 290.890234 192.276 
+    <path d="M 291.948438 221.6592 
+L 396.573438 221.6592 
+L 396.573438 192.276 
+L 291.948438 192.276 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.515234 221.6592 
-L 500.140234 221.6592 
-L 500.140234 192.276 
-L 395.515234 192.276 
+    <path d="M 396.573438 221.6592 
+L 501.198438 221.6592 
+L 501.198438 192.276 
+L 396.573438 192.276 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.265234 251.0424 
-L 290.890234 251.0424 
-L 290.890234 221.6592 
-L 186.265234 221.6592 
+    <path d="M 187.323438 251.0424 
+L 291.948438 251.0424 
+L 291.948438 221.6592 
+L 187.323438 221.6592 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 290.890234 251.0424 
-L 395.515234 251.0424 
-L 395.515234 221.6592 
-L 290.890234 221.6592 
+    <path d="M 291.948438 251.0424 
+L 396.573438 251.0424 
+L 396.573438 221.6592 
+L 291.948438 221.6592 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #fa9656; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #fa9656; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.515234 251.0424 
-L 500.140234 251.0424 
-L 500.140234 221.6592 
-L 395.515234 221.6592 
+    <path d="M 396.573438 251.0424 
+L 501.198438 251.0424 
+L 501.198438 221.6592 
+L 396.573438 221.6592 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.265234 280.4256 
-L 290.890234 280.4256 
-L 290.890234 251.0424 
-L 186.265234 251.0424 
+    <path d="M 187.323438 280.4256 
+L 291.948438 280.4256 
+L 291.948438 251.0424 
+L 187.323438 251.0424 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 290.890234 280.4256 
-L 395.515234 280.4256 
-L 395.515234 251.0424 
-L 290.890234 251.0424 
+    <path d="M 291.948438 280.4256 
+L 396.573438 280.4256 
+L 396.573438 251.0424 
+L 291.948438 251.0424 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.515234 280.4256 
-L 500.140234 280.4256 
-L 500.140234 251.0424 
-L 395.515234 251.0424 
+    <path d="M 396.573438 280.4256 
+L 501.198438 280.4256 
+L 501.198438 251.0424 
+L 396.573438 251.0424 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.265234 309.8088 
-L 290.890234 309.8088 
-L 290.890234 280.4256 
-L 186.265234 280.4256 
+    <path d="M 187.323438 309.8088 
+L 291.948438 309.8088 
+L 291.948438 280.4256 
+L 187.323438 280.4256 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 290.890234 309.8088 
-L 395.515234 309.8088 
-L 395.515234 280.4256 
-L 290.890234 280.4256 
+    <path d="M 291.948438 309.8088 
+L 396.573438 309.8088 
+L 396.573438 280.4256 
+L 291.948438 280.4256 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.515234 309.8088 
-L 500.140234 309.8088 
-L 500.140234 280.4256 
-L 395.515234 280.4256 
+    <path d="M 396.573438 309.8088 
+L 501.198438 309.8088 
+L 501.198438 280.4256 
+L 396.573438 280.4256 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.265234 339.192 
-L 290.890234 339.192 
-L 290.890234 309.8088 
-L 186.265234 309.8088 
+    <path d="M 187.323438 339.192 
+L 291.948438 339.192 
+L 291.948438 309.8088 
+L 187.323438 309.8088 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 290.890234 339.192 
-L 395.515234 339.192 
-L 395.515234 309.8088 
-L 290.890234 309.8088 
+    <path d="M 291.948438 339.192 
+L 396.573438 339.192 
+L 396.573438 309.8088 
+L 291.948438 309.8088 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.515234 339.192 
-L 500.140234 339.192 
-L 500.140234 309.8088 
-L 395.515234 309.8088 
+    <path d="M 396.573438 339.192 
+L 501.198438 339.192 
+L 501.198438 309.8088 
+L 396.573438 309.8088 
 z
-" clip-path="url(#p9cd57fcbb3)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pfef4d56b4b)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.2525 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.310703 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.536719 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.594922 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.108828 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.167031 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.460547 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.51875 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.190234 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.248438 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.126484 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(335.567734 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.625938 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.192734 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.828359 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.886563 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.126484 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.112734 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.192734 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.091484 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.149687 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.126484 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.112734 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.192734 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.397734 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.455938 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.126484 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.112734 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.192734 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(118.553984 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.612188 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.126484 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.112734 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.192734 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(96.899609 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(97.957813 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.304 -->
-    <g transform="translate(225.925859 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.984063 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1700,7 +1700,7 @@ z
    </g>
    <g id="text_27">
     <!-- 26 -->
-    <g transform="translate(337.636484 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.694687 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884 
 L 3897 884 
@@ -1761,7 +1761,7 @@ z
    </g>
    <g id="text_28">
     <!-- 208 -->
-    <g transform="translate(439.478359 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.536563 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
 Q 1891 2088 1709 1903 
@@ -1810,7 +1810,7 @@ z
    </g>
    <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(95.014609 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(96.072813 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1939,7 +1939,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(227.126484 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1949,14 +1949,14 @@ z
    </g>
    <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(338.112734 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(440.192734 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1964,7 +1964,7 @@ z
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(97.521484 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.579688 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2020,7 +2020,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(227.126484 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2030,21 +2030,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(338.112734 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(442.737734 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.795938 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.235859 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.294063 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2055,7 +2055,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.126484 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2065,13 +2065,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(340.657734 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.715937 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.827734 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.885938 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2087,7 +2087,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(133.648984 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.707188 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2270,7 +2270,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2457,110 +2457,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9cd57fcbb3">
-   <rect x="81.640234" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pfef4d56b4b">
+   <rect x="82.698438" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p40a50ea330)">
+   <g clip-path="url(#pc4cca4aa6e)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ80lEQVR4nO3Yv46cZx2GYc/OeI0dRzjEOAIkiwaoQIqgouEMKDgMSlp6Smpaek6ACkSFhBB0oSMKKcARf0Ica3dnd5YjoLLe+7f+dF1H8Iy+eee9v9md/vnL23tbdryYXsDrOF1PL1hrdza9YK3rq+kFaz16Mr1grcuX0wvW2p9PL+B1bP37ef5oesFSG7/9AAC4awQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACpwx+PH05vWOpwtp+esNTp9nZ6wlLP3n42PWGpD//7t+kJa238FfebX3gyPWGp44Pz6QlL/enFB9MTlvrO029MT1jq8vw0PWGp3e7V9ISlNn49AABw1whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTh+dtfn96w1JMHz6YnLPXJxcfTE5b66qttvyM9fvfb0xOW2u8O0xOWOt07TU9Y6sv3nk5PWOr66dX0hKXee/R8esJSx9O2n99bV9v+fdn27Q4AwJ0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASB12u2036GfHf01PWOrh/vH0hKVu3v3S9ISl/v7pn6cnLPXy6mJ6wlLffed70xOWutpPL1jr8+Nn0xN4Df+5fDE9Ya0Hz6YXLLXt+gQA4M4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApHY3v/vJ7fSIpU6n6QXw/515B3yj+X15s239/G39++n5vdE2/vQAALhrBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnDe3/4y/SGpc4O227sFx98Mj1hqV/8+P3pCUv97Pf/mJ6w1A+ef3F6wlK/+u1fpycs9dMffWt6wlI//81H0xOW+uH7X5mesNRHn15OT1jq+197a3rCUtuuMwAA7hwBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaHW9+fTs9YqX99fX0hLXODtML1rq+mF6w1vmj6QVr7Tb+jnt7ml6w1tH5e6PdbPv+O+62ff7ub7xfNn47AABw1whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSh4ubV9Mblnp4//H0hKVuTtfTE5a6f/FyesJSn+9P0xOWenjY9vk7u9n2+bu38c/378sX0xOWemf/ZHrCUvf359MT1rq5mF6wlH9AAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL/A7yZgLa2ceZGAAAAAElFTkSuQmCC" id="imaged698f36fd6" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ80lEQVR4nO3Yv46cZx2GYc/OeI0dRzjEOAIkiwaoQIqgouEMKDgMSlp6Smpaek6ACkSFhBB0oSMKKcARf0Ica3dnd5YjoLLe+7f+dF1H8Iy+eee9v9md/vnL23tbdryYXsDrOF1PL1hrdza9YK3rq+kFaz16Mr1grcuX0wvW2p9PL+B1bP37ef5oesFSG7/9AAC4awQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACpwx+PH05vWOpwtp+esNTp9nZ6wlLP3n42PWGpD//7t+kJa238FfebX3gyPWGp44Pz6QlL/enFB9MTlvrO029MT1jq8vw0PWGp3e7V9ISlNn49AABw1whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNTh+dtfn96w1JMHz6YnLPXJxcfTE5b66qttvyM9fvfb0xOW2u8O0xOWOt07TU9Y6sv3nk5PWOr66dX0hKXee/R8esJSx9O2n99bV9v+fdn27Q4AwJ0jQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASB12u2036GfHf01PWOrh/vH0hKVu3v3S9ISl/v7pn6cnLPXy6mJ6wlLffed70xOWutpPL1jr8+Nn0xN4Df+5fDE9Ya0Hz6YXLLXt+gQA4M4RoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApHY3v/vJ7fSIpU6n6QXw/515B3yj+X15s239/G39++n5vdE2/vQAALhrBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKnDe3/4y/SGpc4O227sFx98Mj1hqV/8+P3pCUv97Pf/mJ6w1A+ef3F6wlK/+u1fpycs9dMffWt6wlI//81H0xOW+uH7X5mesNRHn15OT1jq+197a3rCUtuuMwAA7hwBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaHW9+fTs9YqX99fX0hLXODtML1rq+mF6w1vmj6QVr7Tb+jnt7ml6w1tH5e6PdbPv+O+62ff7ub7xfNn47AABw1whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSh4ubV9Mblnp4//H0hKVuTtfTE5a6f/FyesJSn+9P0xOWenjY9vk7u9n2+bu38c/378sX0xOWemf/ZHrCUvf359MT1rq5mF6wlH9AAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL/A7yZgLa2ceZGAAAAAElFTkSuQmCC" id="image6dd5fa2257" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m6e348fb301" d="M 0 0 
+       <path id="m23a1a32520" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6e348fb301" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m6e348fb301" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m6e348fb301" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6e348fb301" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m6e348fb301" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6e348fb301" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m6e348fb301" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6e348fb301" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m6e348fb301" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6e348fb301" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m6e348fb301" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6e348fb301" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m23a1a32520" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m2a645aad02" d="M 0 0 
+       <path id="ma7106b914c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2a645aad02" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7106b914c" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2a645aad02" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7106b914c" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m2a645aad02" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7106b914c" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m2a645aad02" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7106b914c" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m2a645aad02" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7106b914c" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m2a645aad02" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7106b914c" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m2a645aad02" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7106b914c" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m2a645aad02" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma7106b914c" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2191,18 +2191,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image2552ce6f69" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image2dccb08e1b" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="ma13c141384" d="M 0 0 
+       <path id="md81d9db3c6" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma13c141384" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md81d9db3c6" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2225,7 +2225,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma13c141384" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md81d9db3c6" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2239,7 +2239,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma13c141384" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md81d9db3c6" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2253,7 +2253,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma13c141384" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md81d9db3c6" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2266,7 +2266,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma13c141384" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md81d9db3c6" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2279,7 +2279,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma13c141384" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md81d9db3c6" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2292,7 +2292,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#ma13c141384" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md81d9db3c6" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2908,8 +2908,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.059766 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.001562 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3046,109 +3046,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p40a50ea330">
+  <clipPath id="pc4cca4aa6e">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m5b513b6efd" d="M 0 0 
+       <path id="mdf2377db75" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5b513b6efd" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf2377db75" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5b513b6efd" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf2377db75" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5b513b6efd" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf2377db75" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5b513b6efd" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf2377db75" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5b513b6efd" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf2377db75" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m5b513b6efd" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf2377db75" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m5b513b6efd" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdf2377db75" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mf1dd8325d7" d="M 0 0 
+       <path id="m4e8f14d759" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf1dd8325d7" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e8f14d759" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf1dd8325d7" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e8f14d759" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf1dd8325d7" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e8f14d759" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mbef475ce14" d="M 0 0 
+       <path id="m208af1114a" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mbef475ce14" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m208af1114a" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(100.319203 333.5714) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.149529 323.932112) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="mc31b32c70f" d="M -2.5 2.5 
+     <path id="m7aace1751b" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbbb7115c6)">
-     <use xlink:href="#mc31b32c70f" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc31b32c70f" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc31b32c70f" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc31b32c70f" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc31b32c70f" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc31b32c70f" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc31b32c70f" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc31b32c70f" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc31b32c70f" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb9bf2d5554)">
+     <use xlink:href="#m7aace1751b" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aace1751b" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aace1751b" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aace1751b" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aace1751b" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aace1751b" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aace1751b" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aace1751b" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7aace1751b" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 111.868554
 L 326.02264 111.96025 
 L 324.91204 112.051791 
 L 323.801439 112.143178 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 112.143178 
@@ -1807,7 +1807,7 @@ L 275.861725 127.410211
 L 274.796398 127.705019 
 L 273.731071 127.99823 
 L 272.665744 128.289861 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 128.289861 
@@ -1859,7 +1859,7 @@ L 237.512385 129.68632
 L 236.7312 129.716946 
 L 235.950014 129.747556 
 L 235.168828 129.778148 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 129.778148 
@@ -1911,7 +1911,7 @@ L 189.28705 148.994297
 L 188.267455 149.352551 
 L 187.24786 149.708449 
 L 186.228265 150.062022 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 150.062022 
@@ -1963,7 +1963,7 @@ L 160.048483 171.011997
 L 159.46671 171.396655 
 L 158.884937 171.778598 
 L 158.303164 172.157864 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 172.157864 
@@ -2015,7 +2015,7 @@ L 150.040398 181.598676
 L 149.856781 181.790851 
 L 149.673164 181.982345 
 L 149.489547 182.173164 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.173164 
@@ -2067,7 +2067,7 @@ L 141.121061 201.502451
 L 140.935095 201.862455 
 L 140.749129 202.220079 
 L 140.563162 202.575355 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.575355 
@@ -2119,26 +2119,26 @@ L 139.083497 208.86883
 L 139.050616 209.000699 
 L 139.017734 209.132247 
 L 138.984853 209.263476 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m20e5a3a884" d="M 0 -2.5 
+     <path id="me4c8bb8640" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbbb7115c6)">
-     <use xlink:href="#m20e5a3a884" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20e5a3a884" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20e5a3a884" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20e5a3a884" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20e5a3a884" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20e5a3a884" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20e5a3a884" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20e5a3a884" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m20e5a3a884" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb9bf2d5554)">
+     <use xlink:href="#me4c8bb8640" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4c8bb8640" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4c8bb8640" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4c8bb8640" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4c8bb8640" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4c8bb8640" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4c8bb8640" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4c8bb8640" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4c8bb8640" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.20247
 L 331.988718 100.690952 
 L 325.934838 101.175064 
 L 319.880958 101.654884 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.654884 
@@ -2243,7 +2243,7 @@ L 217.131235 128.404389
 L 214.847908 128.871381 
 L 212.564581 129.334377 
 L 210.281253 129.793447 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.793447 
@@ -2295,7 +2295,7 @@ L 197.161712 133.343265
 L 196.870166 133.419565 
 L 196.578621 133.495757 
 L 196.287076 133.571842 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.571842 
@@ -2347,7 +2347,7 @@ L 177.31896 146.664131
 L 176.897447 146.921938 
 L 176.475933 147.178523 
 L 176.054419 147.433896 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.433896 
@@ -2399,7 +2399,7 @@ L 153.654726 173.470231
 L 153.156955 173.927574 
 L 152.659184 174.381084 
 L 152.161413 174.830826 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.830826 
@@ -2451,7 +2451,7 @@ L 147.060283 185.961812
 L 146.946925 186.184927 
 L 146.833566 186.407126 
 L 146.720208 186.628416 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.628416 
@@ -2503,7 +2503,7 @@ L 144.164409 195.79469
 L 144.107613 195.981745 
 L 144.050817 196.168156 
 L 143.994022 196.353927 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.353927 
@@ -2555,30 +2555,30 @@ L 142.749036 200.0341
 L 142.72137 200.113105 
 L 142.693704 200.191995 
 L 142.666037 200.270771 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="mec66f40677" d="M -0 3.535534 
+     <path id="md9e20a57c2" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbbb7115c6)">
-     <use xlink:href="#mec66f40677" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mec66f40677" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb9bf2d5554)">
+     <use xlink:href="#md9e20a57c2" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md9e20a57c2" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.665392
 L 244.888911 79.95196 
 L 243.864032 80.237018 
 L 242.839153 80.520583 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.520583 
@@ -2683,7 +2683,7 @@ L 219.787941 85.73042
 L 219.275692 85.840684 
 L 218.763443 85.950723 
 L 218.251194 86.060539 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.060539 
@@ -2735,7 +2735,7 @@ L 199.092247 89.895187
 L 198.666492 89.97739 
 L 198.240738 90.059468 
 L 197.814984 90.141422 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.141422 
@@ -2787,7 +2787,7 @@ L 168.343148 98.26681
 L 167.688219 98.434213 
 L 167.033289 98.601101 
 L 166.378359 98.767475 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 98.767475 
@@ -2839,7 +2839,7 @@ L 147.11464 109.552827
 L 146.686557 109.769695 
 L 146.258475 109.985696 
 L 145.830392 110.20084 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.20084 
@@ -2891,7 +2891,7 @@ L 135.300472 124.91473
 L 135.066474 125.20027 
 L 134.832476 125.484312 
 L 134.598477 125.76687 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 125.76687 
@@ -2943,7 +2943,7 @@ L 124.734843 147.930147
 L 124.515652 148.332777 
 L 124.29646 148.732435 
 L 124.077268 149.129162 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.129162 
@@ -2995,7 +2995,7 @@ L 122.56387 156.732863
 L 122.530239 156.890271 
 L 122.496607 157.047223 
 L 122.462976 157.203722 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.203722 
@@ -3047,7 +3047,7 @@ L 83.602758 217.017639
 L 82.739198 217.816123 
 L 81.875637 218.602997 
 L 81.012077 219.378594 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 219.378594 
@@ -3099,7 +3099,7 @@ L 77.665842 237.784894
 L 77.591481 238.130517 
 L 77.517121 238.473948 
 L 77.44276 238.815213 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 238.815213 
@@ -3151,23 +3151,23 @@ L 76.984008 251.144668
 L 76.973814 251.389134 
 L 76.96362 251.6325 
 L 76.953425 251.874777 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m0371099678" d="M -0 2.5 
+     <path id="ma63a97c6e1" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbbb7115c6)">
-     <use xlink:href="#m0371099678" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb9bf2d5554)">
+     <use xlink:href="#ma63a97c6e1" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m1a1cb11bce" d="M -0.833333 2.5 
+     <path id="mdac4e8324c" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbbb7115c6)">
-     <use xlink:href="#m1a1cb11bce" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a1cb11bce" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a1cb11bce" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a1cb11bce" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a1cb11bce" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a1cb11bce" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a1cb11bce" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a1cb11bce" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1a1cb11bce" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb9bf2d5554)">
+     <use xlink:href="#mdac4e8324c" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac4e8324c" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac4e8324c" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac4e8324c" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac4e8324c" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac4e8324c" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac4e8324c" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac4e8324c" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdac4e8324c" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 117.229073
 L 306.11717 117.494902 
 L 303.36982 117.759433 
 L 300.62247 118.022676 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 118.022676 
@@ -3296,7 +3296,7 @@ L 269.071051 125.234719
 L 268.369908 125.384559 
 L 267.668766 125.533985 
 L 266.967623 125.683 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 125.683 
@@ -3348,7 +3348,7 @@ L 228.598863 126.122913
 L 227.746224 126.132648 
 L 226.893585 126.142382 
 L 226.040946 126.152114 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 126.152114 
@@ -3400,7 +3400,7 @@ L 183.801673 143.118416
 L 182.863022 143.441102 
 L 181.924372 143.761876 
 L 180.985721 144.080759 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 144.080759 
@@ -3452,7 +3452,7 @@ L 165.475826 157.662961
 L 165.131161 157.929236 
 L 164.786497 158.194207 
 L 164.441833 158.457887 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 158.457887 
@@ -3504,7 +3504,7 @@ L 158.178848 166.505572
 L 158.03967 166.671493 
 L 157.900493 166.836907 
 L 157.761315 167.001817 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 167.001817 
@@ -3556,7 +3556,7 @@ L 151.674847 180.456413
 L 151.539592 180.720489 
 L 151.404337 180.983284 
 L 151.269082 181.244808 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 181.244808 
@@ -3608,11 +3608,11 @@ L 150.385962 186.640888
 L 150.366337 186.754896 
 L 150.346712 186.868665 
 L 150.327087 186.982195 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m2b8c5c5b26" d="M -1.25 2.5 
+     <path id="m8878730467" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbbb7115c6)">
-     <use xlink:href="#m2b8c5c5b26" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b8c5c5b26" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b8c5c5b26" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b8c5c5b26" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b8c5c5b26" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b8c5c5b26" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b8c5c5b26" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b8c5c5b26" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b8c5c5b26" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb9bf2d5554)">
+     <use xlink:href="#m8878730467" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8878730467" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8878730467" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8878730467" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8878730467" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8878730467" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8878730467" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8878730467" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8878730467" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 141.492222
 L 276.351005 141.626293 
 L 274.857964 141.760033 
 L 273.364924 141.893443 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 141.893443 
@@ -3741,7 +3741,7 @@ L 242.760262 147.575596
 L 242.080158 147.695331 
 L 241.400055 147.814802 
 L 240.719951 147.934009 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 147.934009 
@@ -3793,7 +3793,7 @@ L 222.564351 152.930779
 L 222.160893 153.036743 
 L 221.757435 153.142499 
 L 221.353978 153.24805 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 153.24805 
@@ -3845,7 +3845,7 @@ L 208.018647 155.070715
 L 207.722306 155.110529 
 L 207.425965 155.150315 
 L 207.129625 155.190071 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 155.190071 
@@ -3897,7 +3897,7 @@ L 182.693853 166.038872
 L 182.150836 166.256889 
 L 181.607819 166.474032 
 L 181.064802 166.690306 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.690306 
@@ -3949,7 +3949,7 @@ L 179.393584 170.067361
 L 179.356445 170.140065 
 L 179.319307 170.21267 
 L 179.282169 170.285179 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.285179 
@@ -4001,7 +4001,7 @@ L 177.817012 175.338922
 L 177.784453 175.446037 
 L 177.751894 175.552941 
 L 177.719335 175.659634 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.659634 
@@ -4053,11 +4053,11 @@ L 177.648651 180.712426
 L 177.64708 180.819522 
 L 177.645509 180.926407 
 L 177.643939 181.03308 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mcda5a313e1" d="M 0 -2.5 
+     <path id="m0a02d5c586" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pbbbb7115c6)">
-     <use xlink:href="#mcda5a313e1" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcda5a313e1" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcda5a313e1" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcda5a313e1" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcda5a313e1" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcda5a313e1" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcda5a313e1" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcda5a313e1" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mcda5a313e1" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pb9bf2d5554)">
+     <use xlink:href="#m0a02d5c586" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a02d5c586" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a02d5c586" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a02d5c586" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a02d5c586" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a02d5c586" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a02d5c586" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a02d5c586" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m0a02d5c586" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.101113
 L 226.871027 113.101614 
 L 226.871027 113.102116 
 L 226.871027 113.102618 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.102618 
@@ -4184,7 +4184,7 @@ L 226.871027 113.241886
 L 226.871027 113.244976 
 L 226.871027 113.248067 
 L 226.871027 113.251157 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.251157 
@@ -4236,7 +4236,7 @@ L 226.871027 113.165529
 L 226.871027 113.163625 
 L 226.871027 113.16172 
 L 226.871027 113.159816 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.159816 
@@ -4288,7 +4288,7 @@ L 180.837336 131.090576
 L 179.814365 131.428693 
 L 178.791394 131.764711 
 L 177.768423 132.098656 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.098656 
@@ -4340,7 +4340,7 @@ L 161.462117 144.555386
 L 161.099755 144.802091 
 L 160.737393 145.047676 
 L 160.37503 145.292152 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.292152 
@@ -4392,7 +4392,7 @@ L 154.394483 152.007915
 L 154.261581 152.148084 
 L 154.12868 152.287891 
 L 153.995779 152.427338 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.427338 
@@ -4444,7 +4444,7 @@ L 147.537442 166.80191
 L 147.393924 167.081716 
 L 147.250405 167.360084 
 L 147.106887 167.637027 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 167.637027 
@@ -4496,11 +4496,11 @@ L 145.948902 174.483819
 L 145.923169 174.626551 
 L 145.897436 174.768906 
 L 145.871703 174.910889 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m3b162cb89b" d="M 0 -2.5 
+     <path id="m61084a9ed4" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbbb7115c6)">
-     <use xlink:href="#m3b162cb89b" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3b162cb89b" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3b162cb89b" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3b162cb89b" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3b162cb89b" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3b162cb89b" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3b162cb89b" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3b162cb89b" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3b162cb89b" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pb9bf2d5554)">
+     <use xlink:href="#m61084a9ed4" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61084a9ed4" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61084a9ed4" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61084a9ed4" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61084a9ed4" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61084a9ed4" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61084a9ed4" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61084a9ed4" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m61084a9ed4" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 176.312658
 L 529.583102 176.354957 
 L 528.363847 176.397222 
 L 527.144592 176.439455 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 176.439455 
@@ -4623,7 +4623,7 @@ L 461.70225 184.0537
 L 460.247976 184.211312 
 L 458.793701 184.368466 
 L 457.339427 184.525165 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 184.525165 
@@ -4675,7 +4675,7 @@ L 302.450749 179.565773
 L 299.008779 179.450234 
 L 295.566808 179.334447 
 L 292.124837 179.218412 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 179.218412 
@@ -4727,7 +4727,7 @@ L 246.191563 190.241103
 L 245.170823 190.462265 
 L 244.150084 190.682527 
 L 243.129344 190.901895 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.901895 
@@ -4779,7 +4779,7 @@ L 215.390639 204.06672
 L 214.774224 204.325785 
 L 214.157808 204.583617 
 L 213.541392 204.840226 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.840226 
@@ -4831,7 +4831,7 @@ L 205.113797 212.010949
 L 204.926517 212.159987 
 L 204.739237 212.308616 
 L 204.551957 212.456838 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.456838 
@@ -4883,7 +4883,7 @@ L 196.403329 227.996875
 L 196.222248 228.296222 
 L 196.041168 228.593923 
 L 195.860087 228.889995 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.889995 
@@ -4935,7 +4935,7 @@ L 194.134867 234.076634
 L 194.096529 234.18643 
 L 194.058191 234.296004 
 L 194.019853 234.405357 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m533d69b66c" d="M 0 3.5 
+      <path id="md71ea08d68" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m533d69b66c" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#md71ea08d68" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#mc31b32c70f" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7aace1751b" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m20e5a3a884" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me4c8bb8640" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#mec66f40677" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md9e20a57c2" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m0371099678" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma63a97c6e1" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m1a1cb11bce" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdac4e8324c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m2b8c5c5b26" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8878730467" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mcda5a313e1" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m0a02d5c586" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m3b162cb89b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m61084a9ed4" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,17 +5370,17 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#pbbbb7115c6)">
-     <use xlink:href="#m533d69b66c" x="319.643112" y="135.866393" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m533d69b66c" x="269.129958" y="149.996859" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m533d69b66c" x="247.452898" y="154.653035" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m533d69b66c" x="210.483065" y="166.559544" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m533d69b66c" x="208.196568" y="168.292731" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m533d69b66c" x="197.379782" y="173.102943" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m533d69b66c" x="187.620351" y="187.562061" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m533d69b66c" x="157.246106" y="244.18749" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m533d69b66c" x="123.427553" y="301.770983" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m533d69b66c" x="95.319203" y="338.5714" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pb9bf2d5554)">
+     <use xlink:href="#md71ea08d68" x="319.643112" y="135.866393" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md71ea08d68" x="269.129958" y="149.996859" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md71ea08d68" x="247.452898" y="154.653035" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md71ea08d68" x="210.483065" y="166.559544" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md71ea08d68" x="208.196568" y="168.292731" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md71ea08d68" x="197.379782" y="173.102943" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md71ea08d68" x="187.620351" y="187.562061" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md71ea08d68" x="157.246106" y="244.18749" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md71ea08d68" x="128.707405" y="299.638966" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md71ea08d68" x="99.149529" y="328.932112" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
@@ -5433,7 +5433,7 @@ L 272.28703 149.213953
 L 271.234673 149.476182 
 L 270.182316 149.737147 
 L 269.129958 149.996859 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
     <path d="M 269.129958 149.996859 
@@ -5485,7 +5485,7 @@ L 248.807714 154.373471
 L 248.356109 154.466819 
 L 247.904503 154.560007 
 L 247.452898 154.653035 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
     <path d="M 247.452898 154.653035 
@@ -5537,7 +5537,7 @@ L 212.793679 165.887404
 L 212.023475 166.112379 
 L 211.25327 166.336424 
 L 210.483065 166.559544 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
     <path d="M 210.483065 166.559544 
@@ -5589,7 +5589,7 @@ L 208.339474 168.186018
 L 208.291839 168.221612 
 L 208.244203 168.257183 
 L 208.196568 168.292731 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
     <path d="M 208.196568 168.292731 
@@ -5641,7 +5641,7 @@ L 198.055831 172.814511
 L 197.830482 172.910826 
 L 197.605132 173.00697 
 L 197.379782 173.102943 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
     <path d="M 197.379782 173.102943 
@@ -5693,7 +5693,7 @@ L 188.230315 186.763151
 L 188.026994 187.030767 
 L 187.823672 187.297066 
 L 187.620351 187.562061 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
     <path d="M 187.620351 187.562061 
@@ -5745,111 +5745,111 @@ L 159.144497 241.947345
 L 158.5117 242.70441 
 L 157.878903 243.45103 
 L 157.246106 244.18749 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
     <path d="M 157.246106 244.18749 
-L 156.541553 246.286216 
-L 155.837 248.306583 
-L 155.132447 250.254231 
-L 154.427894 252.134214 
-L 153.72334 253.951077 
-L 153.018787 255.70892 
-L 152.314234 257.411458 
-L 151.609681 259.062064 
-L 150.905128 260.663814 
-L 150.200574 262.219516 
-L 149.496021 263.731744 
-L 148.791468 265.202863 
-L 148.086915 266.635048 
-L 147.382362 268.030306 
-L 146.677808 269.390495 
-L 145.973255 270.717335 
-L 145.268702 272.01242 
-L 144.564149 273.277237 
-L 143.859596 274.513167 
-L 143.155042 275.7215 
-L 142.450489 276.903443 
-L 141.745936 278.060123 
-L 141.041383 279.192597 
-L 140.33683 280.301859 
-L 139.632277 281.38884 
-L 138.927723 282.454418 
-L 138.22317 283.499419 
-L 137.518617 284.524624 
-L 136.814064 285.530768 
-L 136.109511 286.518547 
-L 135.404957 287.48862 
-L 134.700404 288.44161 
-L 133.995851 289.378109 
-L 133.291298 290.298677 
-L 132.586745 291.203848 
-L 131.882191 292.094127 
-L 131.177638 292.969998 
-L 130.473085 293.831919 
-L 129.768532 294.680328 
-L 129.063979 295.515641 
-L 128.359425 296.338257 
-L 127.654872 297.148556 
-L 126.950319 297.946901 
-L 126.245766 298.73364 
-L 125.541213 299.509106 
-L 124.836659 300.273617 
-L 124.132106 301.027478 
-L 123.427553 301.770983 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+L 156.65155 246.164662 
+L 156.056994 248.072139 
+L 155.462438 249.914667 
+L 154.867881 251.696524 
+L 154.273325 253.421579 
+L 153.678769 255.093341 
+L 153.084212 256.715004 
+L 152.489656 258.289485 
+L 151.8951 259.819452 
+L 151.300544 261.307351 
+L 150.705987 262.755436 
+L 150.111431 264.16578 
+L 149.516875 265.540303 
+L 148.922318 266.880777 
+L 148.327762 268.188851 
+L 147.733206 269.466052 
+L 147.13865 270.713804 
+L 146.544093 271.933436 
+L 145.949537 273.126186 
+L 145.354981 274.293215 
+L 144.760424 275.435607 
+L 144.165868 276.554383 
+L 143.571312 277.650498 
+L 142.976756 278.724852 
+L 142.382199 279.778293 
+L 141.787643 280.81162 
+L 141.193087 281.825585 
+L 140.598531 282.820901 
+L 140.003974 283.798242 
+L 139.409418 284.758246 
+L 138.814862 285.701517 
+L 138.220305 286.628628 
+L 137.625749 287.540124 
+L 137.031193 288.436521 
+L 136.436637 289.318313 
+L 135.84208 290.185967 
+L 135.247524 291.03993 
+L 134.652968 291.880627 
+L 134.058411 292.708463 
+L 133.463855 293.523827 
+L 132.869299 294.327089 
+L 132.274743 295.118602 
+L 131.680186 295.898705 
+L 131.08563 296.667723 
+L 130.491074 297.425967 
+L 129.896517 298.173733 
+L 129.301961 298.911308 
+L 128.707405 299.638966 
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 123.427553 301.770983 
-L 122.841962 302.858002 
-L 122.256372 303.923617 
-L 121.670781 304.968654 
-L 121.08519 305.993893 
-L 120.4996 307.00007 
-L 119.914009 307.987881 
-L 119.328419 308.957985 
-L 118.742828 309.911004 
-L 118.157237 310.847531 
-L 117.571647 311.768127 
-L 116.986056 312.673324 
-L 116.400465 313.56363 
-L 115.814875 314.439526 
-L 115.229284 315.301471 
-L 114.643693 316.149903 
-L 114.058103 316.985239 
-L 113.472512 317.807877 
-L 112.886922 318.618197 
-L 112.301331 319.416563 
-L 111.71574 320.203322 
-L 111.13015 320.978808 
-L 110.544559 321.743338 
-L 109.958968 322.497218 
-L 109.373378 323.24074 
-L 108.787787 323.974186 
-L 108.202197 324.697824 
-L 107.616606 325.411913 
-L 107.031015 326.116703 
-L 106.445425 326.812433 
-L 105.859834 327.499331 
-L 105.274243 328.17762 
-L 104.688653 328.847514 
-L 104.103062 329.509216 
-L 103.517471 330.162925 
-L 102.931881 330.808833 
-L 102.34629 331.447122 
-L 101.7607 332.07797 
-L 101.175109 332.70155 
-L 100.589518 333.318026 
-L 100.003928 333.927559 
-L 99.418337 334.530303 
-L 98.832746 335.126408 
-L 98.247156 335.716018 
-L 97.661565 336.299274 
-L 97.075974 336.876311 
-L 96.490384 337.44726 
-L 95.904793 338.012249 
-L 95.319203 338.5714 
-" clip-path="url(#pbbbb7115c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 128.707405 299.638966 
+L 128.091616 300.442717 
+L 127.475827 301.234705 
+L 126.860038 302.015271 
+L 126.244249 302.784737 
+L 125.62846 303.543417 
+L 125.01267 304.291608 
+L 124.396881 305.029595 
+L 123.781092 305.757655 
+L 123.165303 306.476049 
+L 122.549514 307.185032 
+L 121.933725 307.884847 
+L 121.317936 308.575729 
+L 120.702147 309.257901 
+L 120.086358 309.931581 
+L 119.470569 310.596978 
+L 118.85478 311.254294 
+L 118.238991 311.903721 
+L 117.623201 312.545447 
+L 117.007412 313.179653 
+L 116.391623 313.806513 
+L 115.775834 314.426195 
+L 115.160045 315.038862 
+L 114.544256 315.64467 
+L 113.928467 316.243772 
+L 113.312678 316.836314 
+L 112.696889 317.422439 
+L 112.0811 318.002284 
+L 111.465311 318.575981 
+L 110.849522 319.143661 
+L 110.233733 319.705448 
+L 109.617943 320.261463 
+L 109.002154 320.811824 
+L 108.386365 321.356644 
+L 107.770576 321.896034 
+L 107.154787 322.430101 
+L 106.538998 322.958949 
+L 105.923209 323.482679 
+L 105.30742 324.001389 
+L 104.691631 324.515174 
+L 104.075842 325.024128 
+L 103.460053 325.52834 
+L 102.844264 326.027897 
+L 102.228474 326.522886 
+L 101.612685 327.013388 
+L 100.996896 327.499484 
+L 100.381107 327.981253 
+L 99.765318 328.458771 
+L 99.149529 328.932112 
+" clip-path="url(#pb9bf2d5554)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.059766 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.001562 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6371,109 +6371,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pbbbb7115c6">
+  <clipPath id="pb9bf2d5554">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p69daa5491c)">
+   <g clip-path="url(#pc3a7eadb8d)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKAklEQVR4nO3Yv6ueZx3H8fPknDQxJ81JgtZiFdEUl1oFF4mgU0EQHdwdRP8CFycncXJ1UEcXt1KcJEM7CvG3dbJYf+APQmxMGkuanpycx7/gPUi5+MrD6/UXfOC+ue73fW1Ob/1wu7eDjn98Y3rCEmdfeH56wjKbpz4wPWGJ7W9/Nz1hic0nnpuesMT2wf3pCcvc/uZL0xOWeOo7X5yesMTm6vunJ6xx/GB6wTKnP9/N8/7M9AAAAP5/iUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLmP8cvbadHrHD479vTE5Z449KF6QnLvH3y1vSEJT705vH0hCXefN/T0xOWON2eTk9Y5srB1ekJa9z5y/SCJe5f2c3n9eSf/zA9YZntxz49PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSDwzu3pjesceHy9IIlttvj6QnLfPCVX05PWOOFL0wvWOLojX9OT1jj9GR6wTqHO3p+nLs4vWCJS//aze/z3Q9fm56wzJW/vTo9YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaPHp8Yzs9YoX923+anrDErSefmJ6wzFuP7k1PWOLaX+9NT1ji5OOfmZ6wxIOT+9MTljnavzw9YYnt67+YnrDEw48+Pz1hifOv3pyesMw7n7w+PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vzk9W9sp0escPX84fSEJV67d2d6wjJf/96vpycs8Ztvf2l6whJH546mJyzxrZ/9anrCMp975vz0hCW+fO369IQlXvn7zekJS1w8u5vv4d7e3t6Lf7w7PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2jx6fGM7PWKFu+/cnp6wxOHBpekJy7x27/fTE5Z49vJz0xOW2G5PpycscfFkd/+h/3G6m+fiM4fPTk9Y4uHjB9MTltjVs2Nvb29v/8zB9IQldvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrY3xxMb1jivftXpyessf/E9IJljs4dTU9Y4vDg0vSEJR5vT6YnLHF6dnf/oZ/eXpiewP9gV7/Px9uH0xOWuf/O7ekJS+zuqQgAwLsmFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASJvT05e30yNWePT9H0xPWOLs174yPWGdMwfTC5bY3nx5esISm+ufn56wxtv3phcs8/C7P5qesMS5r352esISpx/51PSEJc789MXpCetceM/0giXcLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAADpvx9umTWu9YozAAAAAElFTkSuQmCC" id="image2d7dda09a7" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAKAklEQVR4nO3Yv6ueZx3H8fPknDQxJ81JgtZiFdEUl1oFF4mgU0EQHdwdRP8CFycncXJ1UEcXt1KcJEM7CvG3dbJYf+APQmxMGkuanpycx7/gPUi5+MrD6/UXfOC+ue73fW1Ob/1wu7eDjn98Y3rCEmdfeH56wjKbpz4wPWGJ7W9/Nz1hic0nnpuesMT2wf3pCcvc/uZL0xOWeOo7X5yesMTm6vunJ6xx/GB6wTKnP9/N8/7M9AAAAP5/iUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAANLmP8cvbadHrHD479vTE5Z449KF6QnLvH3y1vSEJT705vH0hCXefN/T0xOWON2eTk9Y5srB1ekJa9z5y/SCJe5f2c3n9eSf/zA9YZntxz49PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSDwzu3pjesceHy9IIlttvj6QnLfPCVX05PWOOFL0wvWOLojX9OT1jj9GR6wTqHO3p+nLs4vWCJS//aze/z3Q9fm56wzJW/vTo9YQk3iwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEDaPHp8Yzs9YoX923+anrDErSefmJ6wzFuP7k1PWOLaX+9NT1ji5OOfmZ6wxIOT+9MTljnavzw9YYnt67+YnrDEw48+Pz1hifOv3pyesMw7n7w+PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2vzk9W9sp0escPX84fSEJV67d2d6wjJf/96vpycs8Ztvf2l6whJH546mJyzxrZ/9anrCMp975vz0hCW+fO369IQlXvn7zekJS1w8u5vv4d7e3t6Lf7w7PWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA2jx6fGM7PWKFu+/cnp6wxOHBpekJy7x27/fTE5Z49vJz0xOW2G5PpycscfFkd/+h/3G6m+fiM4fPTk9Y4uHjB9MTltjVs2Nvb29v/8zB9IQldvdUBADgXROLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrY3xxMb1jivftXpyessf/E9IJljs4dTU9Y4vDg0vSEJR5vT6YnLHF6dnf/oZ/eXpiewP9gV7/Px9uH0xOWuf/O7ekJS+zuqQgAwLsmFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASJvT05e30yNWePT9H0xPWOLs174yPWGdMwfTC5bY3nx5esISm+ufn56wxtv3phcs8/C7P5qesMS5r352esISpx/51PSEJc789MXpCetceM/0giXcLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAADpvx9umTWu9YozAAAAAElFTkSuQmCC" id="image0e7ef49e9b" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me30f276119" d="M 0 0 
+       <path id="m5ab8d8ecfc" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me30f276119" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me30f276119" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me30f276119" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me30f276119" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me30f276119" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me30f276119" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me30f276119" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me30f276119" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me30f276119" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me30f276119" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me30f276119" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me30f276119" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ab8d8ecfc" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m0e5f07caef" d="M 0 0 
+       <path id="md541e250a5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0e5f07caef" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md541e250a5" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0e5f07caef" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md541e250a5" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m0e5f07caef" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md541e250a5" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0e5f07caef" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md541e250a5" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m0e5f07caef" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md541e250a5" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0e5f07caef" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md541e250a5" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m0e5f07caef" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md541e250a5" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0e5f07caef" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md541e250a5" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2101,18 +2101,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image0a7c5aeb41" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagee241b7f2e6" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m1158211d4c" d="M 0 0 
+       <path id="ma27107b62b" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1158211d4c" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma27107b62b" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2138,7 +2138,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1158211d4c" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma27107b62b" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2155,7 +2155,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m1158211d4c" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma27107b62b" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2171,7 +2171,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1158211d4c" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma27107b62b" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2187,7 +2187,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m1158211d4c" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma27107b62b" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2780,8 +2780,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(47.059766 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.001562 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2918,109 +2918,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p69daa5491c">
+  <clipPath id="pc3a7eadb8d">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.280469pt" height="386.202469pt" viewBox="0 0 568.280469 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.396875pt" height="386.202469pt" viewBox="0 0 570.396875 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 568.280469 386.202469 
-L 568.280469 0 
+L 570.396875 386.202469 
+L 570.396875 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.265234 104.1264 
-L 290.890234 104.1264 
-L 290.890234 74.7432 
-L 186.265234 74.7432 
+    <path d="M 187.323438 104.1264 
+L 291.948438 104.1264 
+L 291.948438 74.7432 
+L 187.323438 74.7432 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 290.890234 104.1264 
-L 395.515234 104.1264 
-L 395.515234 74.7432 
-L 290.890234 74.7432 
+    <path d="M 291.948438 104.1264 
+L 396.573438 104.1264 
+L 396.573438 74.7432 
+L 291.948438 74.7432 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.515234 104.1264 
-L 500.140234 104.1264 
-L 500.140234 74.7432 
-L 395.515234 74.7432 
+    <path d="M 396.573438 104.1264 
+L 501.198438 104.1264 
+L 501.198438 74.7432 
+L 396.573438 74.7432 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.265234 133.5096 
-L 290.890234 133.5096 
-L 290.890234 104.1264 
-L 186.265234 104.1264 
+    <path d="M 187.323438 133.5096 
+L 291.948438 133.5096 
+L 291.948438 104.1264 
+L 187.323438 104.1264 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 290.890234 133.5096 
-L 395.515234 133.5096 
-L 395.515234 104.1264 
-L 290.890234 104.1264 
+    <path d="M 291.948438 133.5096 
+L 396.573438 133.5096 
+L 396.573438 104.1264 
+L 291.948438 104.1264 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.515234 133.5096 
-L 500.140234 133.5096 
-L 500.140234 104.1264 
-L 395.515234 104.1264 
+    <path d="M 396.573438 133.5096 
+L 501.198438 133.5096 
+L 501.198438 104.1264 
+L 396.573438 104.1264 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.265234 162.8928 
-L 290.890234 162.8928 
-L 290.890234 133.5096 
-L 186.265234 133.5096 
+    <path d="M 187.323438 162.8928 
+L 291.948438 162.8928 
+L 291.948438 133.5096 
+L 187.323438 133.5096 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 290.890234 162.8928 
-L 395.515234 162.8928 
-L 395.515234 133.5096 
-L 290.890234 133.5096 
+    <path d="M 291.948438 162.8928 
+L 396.573438 162.8928 
+L 396.573438 133.5096 
+L 291.948438 133.5096 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.515234 162.8928 
-L 500.140234 162.8928 
-L 500.140234 133.5096 
-L 395.515234 133.5096 
+    <path d="M 396.573438 162.8928 
+L 501.198438 162.8928 
+L 501.198438 133.5096 
+L 396.573438 133.5096 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.265234 192.276 
-L 290.890234 192.276 
-L 290.890234 162.8928 
-L 186.265234 162.8928 
+    <path d="M 187.323438 192.276 
+L 291.948438 192.276 
+L 291.948438 162.8928 
+L 187.323438 162.8928 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 290.890234 192.276 
-L 395.515234 192.276 
-L 395.515234 162.8928 
-L 290.890234 162.8928 
+    <path d="M 291.948438 192.276 
+L 396.573438 192.276 
+L 396.573438 162.8928 
+L 291.948438 162.8928 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.515234 192.276 
-L 500.140234 192.276 
-L 500.140234 162.8928 
-L 395.515234 162.8928 
+    <path d="M 396.573438 192.276 
+L 501.198438 192.276 
+L 501.198438 162.8928 
+L 396.573438 162.8928 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.265234 221.6592 
-L 290.890234 221.6592 
-L 290.890234 192.276 
-L 186.265234 192.276 
+    <path d="M 187.323438 221.6592 
+L 291.948438 221.6592 
+L 291.948438 192.276 
+L 187.323438 192.276 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 290.890234 221.6592 
-L 395.515234 221.6592 
-L 395.515234 192.276 
-L 290.890234 192.276 
+    <path d="M 291.948438 221.6592 
+L 396.573438 221.6592 
+L 396.573438 192.276 
+L 291.948438 192.276 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.515234 221.6592 
-L 500.140234 221.6592 
-L 500.140234 192.276 
-L 395.515234 192.276 
+    <path d="M 396.573438 221.6592 
+L 501.198438 221.6592 
+L 501.198438 192.276 
+L 396.573438 192.276 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.265234 251.0424 
-L 290.890234 251.0424 
-L 290.890234 221.6592 
-L 186.265234 221.6592 
+    <path d="M 187.323438 251.0424 
+L 291.948438 251.0424 
+L 291.948438 221.6592 
+L 187.323438 221.6592 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 290.890234 251.0424 
-L 395.515234 251.0424 
-L 395.515234 221.6592 
-L 290.890234 221.6592 
+    <path d="M 291.948438 251.0424 
+L 396.573438 251.0424 
+L 396.573438 221.6592 
+L 291.948438 221.6592 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.515234 251.0424 
-L 500.140234 251.0424 
-L 500.140234 221.6592 
-L 395.515234 221.6592 
+    <path d="M 396.573438 251.0424 
+L 501.198438 251.0424 
+L 501.198438 221.6592 
+L 396.573438 221.6592 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.265234 280.4256 
-L 290.890234 280.4256 
-L 290.890234 251.0424 
-L 186.265234 251.0424 
+    <path d="M 187.323438 280.4256 
+L 291.948438 280.4256 
+L 291.948438 251.0424 
+L 187.323438 251.0424 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 290.890234 280.4256 
-L 395.515234 280.4256 
-L 395.515234 251.0424 
-L 290.890234 251.0424 
+    <path d="M 291.948438 280.4256 
+L 396.573438 280.4256 
+L 396.573438 251.0424 
+L 291.948438 251.0424 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.515234 280.4256 
-L 500.140234 280.4256 
-L 500.140234 251.0424 
-L 395.515234 251.0424 
+    <path d="M 396.573438 280.4256 
+L 501.198438 280.4256 
+L 501.198438 251.0424 
+L 396.573438 251.0424 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.265234 309.8088 
-L 290.890234 309.8088 
-L 290.890234 280.4256 
-L 186.265234 280.4256 
+    <path d="M 187.323438 309.8088 
+L 291.948438 309.8088 
+L 291.948438 280.4256 
+L 187.323438 280.4256 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 290.890234 309.8088 
-L 395.515234 309.8088 
-L 395.515234 280.4256 
-L 290.890234 280.4256 
+    <path d="M 291.948438 309.8088 
+L 396.573438 309.8088 
+L 396.573438 280.4256 
+L 291.948438 280.4256 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.515234 309.8088 
-L 500.140234 309.8088 
-L 500.140234 280.4256 
-L 395.515234 280.4256 
+    <path d="M 396.573438 309.8088 
+L 501.198438 309.8088 
+L 501.198438 280.4256 
+L 396.573438 280.4256 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.265234 339.192 
-L 290.890234 339.192 
-L 290.890234 309.8088 
-L 186.265234 309.8088 
+    <path d="M 187.323438 339.192 
+L 291.948438 339.192 
+L 291.948438 309.8088 
+L 187.323438 309.8088 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 290.890234 339.192 
-L 395.515234 339.192 
-L 395.515234 309.8088 
-L 290.890234 309.8088 
+    <path d="M 291.948438 339.192 
+L 396.573438 339.192 
+L 396.573438 309.8088 
+L 291.948438 309.8088 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.515234 339.192 
-L 500.140234 339.192 
-L 500.140234 309.8088 
-L 395.515234 309.8088 
+    <path d="M 396.573438 339.192 
+L 501.198438 339.192 
+L 501.198438 309.8088 
+L 396.573438 309.8088 
 z
-" clip-path="url(#pfc6b3c0f6d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pf55c1d862f)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.2525 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.310703 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.536719 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.594922 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.108828 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.167031 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.460547 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.51875 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.190234 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.248438 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.126484 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(335.567734 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.625938 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.192734 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.828359 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.886563 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.126484 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.112734 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.192734 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.521484 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(98.579688 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.126484 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.112734 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.192734 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(118.553984 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.612188 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.126484 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.112734 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.192734 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.091484 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(128.149687 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.126484 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.112734 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.192734 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- lean-zip (native) -->
-    <g transform="translate(96.899609 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(97.957813 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1676,7 +1676,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.332 -->
-    <g transform="translate(225.925859 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(226.984063 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1770,7 +1770,7 @@ z
    </g>
    <g id="text_27">
     <!-- 37 -->
-    <g transform="translate(337.636484 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.694687 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
@@ -1789,7 +1789,7 @@ z
    </g>
    <g id="text_28">
     <!-- 258 -->
-    <g transform="translate(439.478359 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.536563 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-35" d="M 678 4666 
 L 3669 4666 
@@ -1863,7 +1863,7 @@ z
    </g>
    <g id="text_29">
     <!-- miniz_oxide -->
-    <g transform="translate(110.397734 267.83025) scale(0.08 -0.08)">
+    <g transform="translate(111.455938 267.83025) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1922,7 +1922,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.322 -->
-    <g transform="translate(227.126484 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1932,14 +1932,14 @@ z
    </g>
    <g id="text_31">
     <!-- 36 -->
-    <g transform="translate(338.112734 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 532 -->
-    <g transform="translate(440.192734 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(441.250938 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1947,7 +1947,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.014609 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(96.072813 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2012,7 +2012,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.126484 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2022,21 +2022,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.112734 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.170938 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(442.737734 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.795938 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.235859 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.294063 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2047,7 +2047,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.126484 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.184688 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2057,13 +2057,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(340.657734 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.715937 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.827734 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.885938 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2079,7 +2079,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(150.741953 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.800156 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2223,7 +2223,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit e5a3c7f7  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-03T00:31:25Z  ·  Linux chungus x86_64  ·  commit 0d41c6ad  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2410,110 +2410,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3194.677734 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3258.300781 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3313.28125 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3376.904297 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3412.109375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3475.732422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3507.519531 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3539.306641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3571.09375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3602.880859 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3634.667969 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3662.451172 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3723.974609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3785.253906 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3848.632812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3912.109375 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3950.972656 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4012.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4071.333984 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4132.857422 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4207.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4235.445312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4296.96875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4358.248047 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4421.626953 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4485.25 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4518.941406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4578.121094 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4641.744141 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4673.53125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4737.154297 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4800.777344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4832.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4896.1875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4932.271484 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4971.134766 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5026.115234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5089.738281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5121.525391 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5153.3125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5185.099609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5216.886719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5248.673828 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5287.882812 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5351.261719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5390.125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5451.306641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5514.685547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5578.162109 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5641.541016 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5705.017578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5768.396484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5807.605469 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5839.392578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5923.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5954.96875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6052.380859 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6113.904297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6177.380859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6205.164062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6266.443359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6329.822266 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6361.609375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6413.708984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6477.087891 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6538.367188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6601.84375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6653.943359 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6717.322266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6778.503906 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6817.712891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6851.404297 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6883.191406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6924.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6985.583984 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7024.792969 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7052.576172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7113.757812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7145.544922 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7173.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7225.427734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7257.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7320.691406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7382.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.423828 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7482.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7619.722656 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7647.505859 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7710.884766 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7738.667969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7790.767578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7829.976562 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7857.759766 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3135.351562 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3198.974609 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3262.597656 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3317.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3442.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3505.957031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3537.744141 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3569.53125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3601.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3633.105469 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3664.892578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3692.675781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3754.199219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3815.478516 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3878.857422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3942.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3981.197266 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4042.378906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4101.558594 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4163.082031 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4204.195312 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4237.886719 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4265.669922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4327.193359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4388.472656 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4451.851562 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4515.474609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4549.166016 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4608.345703 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4671.96875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4703.755859 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4767.378906 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4831.001953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4862.789062 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4926.412109 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4962.496094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5001.359375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5056.339844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5119.962891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5151.75 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5183.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5215.324219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5247.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5278.898438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5318.107422 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5381.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5420.349609 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5544.910156 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5608.386719 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5671.765625 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5735.242188 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5798.621094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5837.830078 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5869.617188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5953.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5985.193359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6082.605469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6144.128906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6207.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6235.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6296.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6360.046875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6391.833984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6443.933594 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6507.3125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6568.591797 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6632.068359 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6684.167969 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6747.546875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6808.728516 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6847.9375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6881.628906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6913.416016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6954.529297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7015.808594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7055.017578 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7082.800781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7143.982422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7175.769531 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7203.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7255.652344 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7287.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7350.916016 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7412.439453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7451.648438 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7513.171875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7552.535156 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7649.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7677.730469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7741.109375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7768.892578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7820.992188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7860.201172 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7887.984375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pfc6b3c0f6d">
-   <rect x="81.640234" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pf55c1d862f">
+   <rect x="82.698438" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,17491 +1,17491 @@
 {
- "meta": {
-  "date": "2026-07-03T00:31:25Z",
-  "machine": "Linux chungus x86_64",
-  "git_commit": "e5a3c7f7",
-  "toolchain": "leanprover/lean4:v4.30.0-rc2",
-  "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
- },
- "results": [
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 60455,
-   "ratio": 0.3975,
-   "compress_mbps": 54.97,
-   "decompress_mbps": 187.38
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 56316,
-   "ratio": 0.3703,
-   "compress_mbps": 42.23,
-   "decompress_mbps": 213.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 55646,
-   "ratio": 0.3659,
-   "compress_mbps": 38.03,
-   "decompress_mbps": 233.09
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 54782,
-   "ratio": 0.3602,
-   "compress_mbps": 29.85,
-   "decompress_mbps": 235.95
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 54700,
-   "ratio": 0.3597,
-   "compress_mbps": 28.77,
-   "decompress_mbps": 238.04
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54535,
-   "ratio": 0.3586,
-   "compress_mbps": 26.45,
-   "decompress_mbps": 244.69
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54385,
-   "ratio": 0.3576,
-   "compress_mbps": 21.24,
-   "decompress_mbps": 245.06
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 54127,
-   "ratio": 0.3559,
-   "compress_mbps": 9.54,
-   "decompress_mbps": 245.55
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 53059,
-   "ratio": 0.3489,
-   "compress_mbps": 3.3,
-   "decompress_mbps": 242.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 53135,
-   "ratio": 0.4245,
-   "compress_mbps": 49.96,
-   "decompress_mbps": 180.32
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 50187,
-   "ratio": 0.4009,
-   "compress_mbps": 38.94,
-   "decompress_mbps": 196.51
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 49810,
-   "ratio": 0.3979,
-   "compress_mbps": 35.79,
-   "decompress_mbps": 214.24
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 49036,
-   "ratio": 0.3917,
-   "compress_mbps": 27.82,
-   "decompress_mbps": 218.14
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 48994,
-   "ratio": 0.3914,
-   "compress_mbps": 26.92,
-   "decompress_mbps": 219.56
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48934,
-   "ratio": 0.3909,
-   "compress_mbps": 25.58,
-   "decompress_mbps": 223.98
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48874,
-   "ratio": 0.3904,
-   "compress_mbps": 22.82,
-   "decompress_mbps": 224.04
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 48634,
-   "ratio": 0.3885,
-   "compress_mbps": 9.34,
-   "decompress_mbps": 223.94
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 47620,
-   "ratio": 0.3804,
-   "compress_mbps": 3.45,
-   "decompress_mbps": 224.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8476,
-   "ratio": 0.3445,
-   "compress_mbps": 39.89,
-   "decompress_mbps": 217.23
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8271,
-   "ratio": 0.3362,
-   "compress_mbps": 35.22,
-   "decompress_mbps": 224.64
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8158,
-   "ratio": 0.3316,
-   "compress_mbps": 34.4,
-   "decompress_mbps": 229.75
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 7991,
-   "ratio": 0.3248,
-   "compress_mbps": 31.43,
-   "decompress_mbps": 238.21
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 7984,
-   "ratio": 0.3245,
-   "compress_mbps": 30.95,
-   "decompress_mbps": 244.99
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7949,
-   "ratio": 0.3231,
-   "compress_mbps": 29.76,
-   "decompress_mbps": 246.58
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7929,
-   "ratio": 0.3223,
-   "compress_mbps": 25.95,
-   "decompress_mbps": 248.55
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7929,
-   "ratio": 0.3223,
-   "compress_mbps": 9.94,
-   "decompress_mbps": 249.94
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7801,
-   "ratio": 0.3171,
-   "compress_mbps": 4.27,
-   "decompress_mbps": 249.31
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3509,
-   "ratio": 0.3147,
-   "compress_mbps": 26.08,
-   "decompress_mbps": 151.57
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3269,
-   "ratio": 0.2932,
-   "compress_mbps": 24.14,
-   "decompress_mbps": 153.81
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3208,
-   "ratio": 0.2877,
-   "compress_mbps": 23.41,
-   "decompress_mbps": 157.24
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3147,
-   "ratio": 0.2822,
-   "compress_mbps": 21.89,
-   "decompress_mbps": 159.6
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3141,
-   "ratio": 0.2817,
-   "compress_mbps": 21.61,
-   "decompress_mbps": 161.54
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3133,
-   "ratio": 0.281,
-   "compress_mbps": 21.34,
-   "decompress_mbps": 161.88
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3128,
-   "ratio": 0.2805,
-   "compress_mbps": 19.27,
-   "decompress_mbps": 162.27
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3128,
-   "ratio": 0.2805,
-   "compress_mbps": 7.18,
-   "decompress_mbps": 162.33
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3056,
-   "ratio": 0.2741,
-   "compress_mbps": 4.2,
-   "decompress_mbps": 162.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1282,
-   "ratio": 0.3445,
-   "compress_mbps": 12.51,
-   "decompress_mbps": 71.4
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1225,
-   "ratio": 0.3292,
-   "compress_mbps": 11.95,
-   "decompress_mbps": 72.06
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1220,
-   "ratio": 0.3279,
-   "compress_mbps": 11.84,
-   "decompress_mbps": 71.99
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1213,
-   "ratio": 0.326,
-   "compress_mbps": 11.56,
-   "decompress_mbps": 72.48
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1213,
-   "ratio": 0.326,
-   "compress_mbps": 11.56,
-   "decompress_mbps": 72.47
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1213,
-   "ratio": 0.326,
-   "compress_mbps": 11.54,
-   "decompress_mbps": 72.81
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1209,
-   "ratio": 0.3249,
-   "compress_mbps": 11.28,
-   "decompress_mbps": 72.93
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1209,
-   "ratio": 0.3249,
-   "compress_mbps": 3.89,
-   "decompress_mbps": 72.82
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1205,
-   "ratio": 0.3238,
-   "compress_mbps": 3.52,
-   "decompress_mbps": 72.8
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 251793,
-   "ratio": 0.2445,
-   "compress_mbps": 104.94,
-   "decompress_mbps": 342.73
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 242565,
-   "ratio": 0.2356,
-   "compress_mbps": 78.17,
-   "decompress_mbps": 371.99
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 242532,
-   "ratio": 0.2355,
-   "compress_mbps": 65.23,
-   "decompress_mbps": 393.88
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 239898,
-   "ratio": 0.233,
-   "compress_mbps": 60.31,
-   "decompress_mbps": 413.35
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 239804,
-   "ratio": 0.2329,
-   "compress_mbps": 59.44,
-   "decompress_mbps": 399.75
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 239606,
-   "ratio": 0.2327,
-   "compress_mbps": 54.76,
-   "decompress_mbps": 413.34
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 214282,
-   "ratio": 0.2081,
-   "compress_mbps": 19.77,
-   "decompress_mbps": 416.68
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 200719,
-   "ratio": 0.1949,
-   "compress_mbps": 7.22,
-   "decompress_mbps": 423.75
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 183445,
-   "ratio": 0.1781,
-   "compress_mbps": 2.55,
-   "decompress_mbps": 425.93
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 160674,
-   "ratio": 0.3765,
-   "compress_mbps": 61.26,
-   "decompress_mbps": 198.55
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 149787,
-   "ratio": 0.351,
-   "compress_mbps": 46.35,
-   "decompress_mbps": 214.99
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 148055,
-   "ratio": 0.3469,
-   "compress_mbps": 41.66,
-   "decompress_mbps": 239.44
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 145888,
-   "ratio": 0.3419,
-   "compress_mbps": 32.45,
-   "decompress_mbps": 243.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 145758,
-   "ratio": 0.3416,
-   "compress_mbps": 31.54,
-   "decompress_mbps": 245.89
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 145454,
-   "ratio": 0.3408,
-   "compress_mbps": 28.96,
-   "decompress_mbps": 250.68
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 145077,
-   "ratio": 0.34,
-   "compress_mbps": 23.62,
-   "decompress_mbps": 251.84
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 144540,
-   "ratio": 0.3387,
-   "compress_mbps": 10.43,
-   "decompress_mbps": 251.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 140996,
-   "ratio": 0.3304,
-   "compress_mbps": 3.3,
-   "decompress_mbps": 251.73
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 212588,
-   "ratio": 0.4412,
-   "compress_mbps": 52.3,
-   "decompress_mbps": 171.03
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 199981,
-   "ratio": 0.415,
-   "compress_mbps": 38.93,
-   "decompress_mbps": 190.63
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 198551,
-   "ratio": 0.4121,
-   "compress_mbps": 35.02,
-   "decompress_mbps": 210.44
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 195797,
-   "ratio": 0.4063,
-   "compress_mbps": 25.64,
-   "decompress_mbps": 213.72
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 195462,
-   "ratio": 0.4056,
-   "compress_mbps": 24.25,
-   "decompress_mbps": 212.05
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 194965,
-   "ratio": 0.4046,
-   "compress_mbps": 22.38,
-   "decompress_mbps": 216.14
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 194724,
-   "ratio": 0.4041,
-   "compress_mbps": 19.43,
-   "decompress_mbps": 216.49
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 194380,
-   "ratio": 0.4034,
-   "compress_mbps": 8.84,
-   "decompress_mbps": 216.66
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 190711,
-   "ratio": 0.3958,
-   "compress_mbps": 3.13,
-   "decompress_mbps": 216.38
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 60161,
-   "ratio": 0.1172,
-   "compress_mbps": 160.01,
-   "decompress_mbps": 465.04
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 58873,
-   "ratio": 0.1147,
-   "compress_mbps": 123.86,
-   "decompress_mbps": 497.18
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 58327,
-   "ratio": 0.1137,
-   "compress_mbps": 108.63,
-   "decompress_mbps": 536.07
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 56347,
-   "ratio": 0.1098,
-   "compress_mbps": 85.54,
-   "decompress_mbps": 451.63
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 56324,
-   "ratio": 0.1097,
-   "compress_mbps": 83.2,
-   "decompress_mbps": 479.66
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 55811,
-   "ratio": 0.1087,
-   "compress_mbps": 71.72,
-   "decompress_mbps": 525.26
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 53748,
-   "ratio": 0.1047,
-   "compress_mbps": 38.11,
-   "decompress_mbps": 564.25
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 52897,
-   "ratio": 0.1031,
-   "compress_mbps": 16.52,
-   "decompress_mbps": 608.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 52729,
-   "ratio": 0.1027,
-   "compress_mbps": 3.22,
-   "decompress_mbps": 628.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 14249,
-   "ratio": 0.3726,
-   "compress_mbps": 29.56,
-   "decompress_mbps": 183.43
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 13825,
-   "ratio": 0.3615,
-   "compress_mbps": 27.04,
-   "decompress_mbps": 188.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13751,
-   "ratio": 0.3596,
-   "compress_mbps": 26.18,
-   "decompress_mbps": 191.71
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13379,
-   "ratio": 0.3499,
-   "compress_mbps": 23.81,
-   "decompress_mbps": 197.48
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13375,
-   "ratio": 0.3498,
-   "compress_mbps": 23.39,
-   "decompress_mbps": 208.8
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 13368,
-   "ratio": 0.3496,
-   "compress_mbps": 21.9,
-   "decompress_mbps": 213.07
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 13344,
-   "ratio": 0.349,
-   "compress_mbps": 17.53,
-   "decompress_mbps": 214.82
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 13028,
-   "ratio": 0.3407,
-   "compress_mbps": 5.34,
-   "decompress_mbps": 217.38
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 12501,
-   "ratio": 0.3269,
-   "compress_mbps": 3.34,
-   "decompress_mbps": 217.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1800,
-   "ratio": 0.4258,
-   "compress_mbps": 13.91,
-   "decompress_mbps": 77.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1750,
-   "ratio": 0.414,
-   "compress_mbps": 13.36,
-   "decompress_mbps": 76.84
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 13.31,
-   "decompress_mbps": 77.6
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1732,
-   "ratio": 0.4097,
-   "compress_mbps": 13.12,
-   "decompress_mbps": 78.13
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1732,
-   "ratio": 0.4097,
-   "compress_mbps": 13.14,
-   "decompress_mbps": 78.25
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1732,
-   "ratio": 0.4097,
-   "compress_mbps": 13.12,
-   "decompress_mbps": 78.28
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1729,
-   "ratio": 0.409,
-   "compress_mbps": 12.95,
-   "decompress_mbps": 78.07
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1729,
-   "ratio": 0.409,
-   "compress_mbps": 4.29,
-   "decompress_mbps": 78.52
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1708,
-   "ratio": 0.4041,
-   "compress_mbps": 4.06,
-   "decompress_mbps": 78.24
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 65130,
-   "ratio": 0.4282,
-   "compress_mbps": 118.84,
-   "decompress_mbps": 399.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 62270,
-   "ratio": 0.4094,
-   "compress_mbps": 101.78,
-   "decompress_mbps": 418.8
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 59488,
-   "ratio": 0.3911,
-   "compress_mbps": 67.0,
-   "decompress_mbps": 435.28
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 57679,
-   "ratio": 0.3792,
-   "compress_mbps": 71.67,
-   "decompress_mbps": 414.35
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 55616,
-   "ratio": 0.3657,
-   "compress_mbps": 41.81,
-   "decompress_mbps": 408.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54398,
-   "ratio": 0.3577,
-   "compress_mbps": 25.53,
-   "decompress_mbps": 421.51
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54253,
-   "ratio": 0.3567,
-   "compress_mbps": 21.45,
-   "decompress_mbps": 423.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 54164,
-   "ratio": 0.3561,
-   "compress_mbps": 16.99,
-   "decompress_mbps": 425.54
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 54164,
-   "ratio": 0.3561,
-   "compress_mbps": 16.98,
-   "decompress_mbps": 423.92
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 56791,
-   "ratio": 0.4537,
-   "compress_mbps": 115.6,
-   "decompress_mbps": 394.7
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 54652,
-   "ratio": 0.4366,
-   "compress_mbps": 97.78,
-   "decompress_mbps": 407.38
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 52663,
-   "ratio": 0.4207,
-   "compress_mbps": 62.36,
-   "decompress_mbps": 428.67
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 51266,
-   "ratio": 0.4095,
-   "compress_mbps": 67.4,
-   "decompress_mbps": 398.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 49622,
-   "ratio": 0.3964,
-   "compress_mbps": 37.32,
-   "decompress_mbps": 386.08
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48891,
-   "ratio": 0.3906,
-   "compress_mbps": 22.81,
-   "decompress_mbps": 395.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48801,
-   "ratio": 0.3898,
-   "compress_mbps": 20.02,
-   "decompress_mbps": 397.56
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 48772,
-   "ratio": 0.3896,
-   "compress_mbps": 18.15,
-   "decompress_mbps": 395.81
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 48772,
-   "ratio": 0.3896,
-   "compress_mbps": 18.14,
-   "decompress_mbps": 399.23
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 9028,
-   "ratio": 0.3669,
-   "compress_mbps": 414.75,
-   "decompress_mbps": 1058.33
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8811,
-   "ratio": 0.3581,
-   "compress_mbps": 218.08,
-   "decompress_mbps": 1085.71
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8616,
-   "ratio": 0.3502,
-   "compress_mbps": 163.26,
-   "decompress_mbps": 1104.41
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8219,
-   "ratio": 0.3341,
-   "compress_mbps": 116.35,
-   "decompress_mbps": 1113.96
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 8001,
-   "ratio": 0.3252,
-   "compress_mbps": 84.93,
-   "decompress_mbps": 1146.67
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7955,
-   "ratio": 0.3233,
-   "compress_mbps": 68.91,
-   "decompress_mbps": 1156.51
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7933,
-   "ratio": 0.3224,
-   "compress_mbps": 62.88,
-   "decompress_mbps": 1159.42
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7934,
-   "ratio": 0.3225,
-   "compress_mbps": 58.08,
-   "decompress_mbps": 1161.26
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7934,
-   "ratio": 0.3225,
-   "compress_mbps": 58.09,
-   "decompress_mbps": 1160.11
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3647,
-   "ratio": 0.3271,
-   "compress_mbps": 426.79,
-   "decompress_mbps": 1073.55
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3501,
-   "ratio": 0.314,
-   "compress_mbps": 408.84,
-   "decompress_mbps": 1117.67
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3393,
-   "ratio": 0.3043,
-   "compress_mbps": 338.35,
-   "decompress_mbps": 1147.08
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3215,
-   "ratio": 0.2883,
-   "compress_mbps": 271.93,
-   "decompress_mbps": 1175.75
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3140,
-   "ratio": 0.2816,
-   "compress_mbps": 205.2,
-   "decompress_mbps": 1205.2
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3116,
-   "ratio": 0.2795,
-   "compress_mbps": 154.1,
-   "decompress_mbps": 1215.53
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 131.87,
-   "decompress_mbps": 1216.78
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3109,
-   "ratio": 0.2788,
-   "compress_mbps": 111.18,
-   "decompress_mbps": 1216.5
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3109,
-   "ratio": 0.2788,
-   "compress_mbps": 110.92,
-   "decompress_mbps": 1220.83
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1326,
-   "ratio": 0.3564,
-   "compress_mbps": 317.29,
-   "decompress_mbps": 787.88
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1306,
-   "ratio": 0.351,
-   "compress_mbps": 310.71,
-   "decompress_mbps": 796.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1301,
-   "ratio": 0.3496,
-   "compress_mbps": 291.04,
-   "decompress_mbps": 799.42
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1228,
-   "ratio": 0.33,
-   "compress_mbps": 233.69,
-   "decompress_mbps": 825.26
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 198.9,
-   "decompress_mbps": 831.06
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 177.77,
-   "decompress_mbps": 832.23
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 170.71,
-   "decompress_mbps": 821.82
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 167.8,
-   "decompress_mbps": 826.61
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 168.26,
-   "decompress_mbps": 828.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 242293,
-   "ratio": 0.2353,
-   "compress_mbps": 261.91,
-   "decompress_mbps": 834.71
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 233553,
-   "ratio": 0.2268,
-   "compress_mbps": 248.46,
-   "decompress_mbps": 990.64
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 228222,
-   "ratio": 0.2216,
-   "compress_mbps": 195.71,
-   "decompress_mbps": 1047.56
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 223668,
-   "ratio": 0.2172,
-   "compress_mbps": 177.25,
-   "decompress_mbps": 1079.08
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 205994,
-   "ratio": 0.2,
-   "compress_mbps": 110.7,
-   "decompress_mbps": 1038.46
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 203986,
-   "ratio": 0.1981,
-   "compress_mbps": 50.06,
-   "decompress_mbps": 1033.64
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 207681,
-   "ratio": 0.2017,
-   "compress_mbps": 37.08,
-   "decompress_mbps": 1027.99
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 206827,
-   "ratio": 0.2009,
-   "compress_mbps": 7.29,
-   "decompress_mbps": 1001.69
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 207023,
-   "ratio": 0.201,
-   "compress_mbps": 3.43,
-   "decompress_mbps": 1007.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 174124,
-   "ratio": 0.408,
-   "compress_mbps": 124.52,
-   "decompress_mbps": 403.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 166150,
-   "ratio": 0.3893,
-   "compress_mbps": 105.75,
-   "decompress_mbps": 410.83
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 158784,
-   "ratio": 0.3721,
-   "compress_mbps": 70.62,
-   "decompress_mbps": 431.19
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 152782,
-   "ratio": 0.358,
-   "compress_mbps": 74.37,
-   "decompress_mbps": 417.63
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 147196,
-   "ratio": 0.3449,
-   "compress_mbps": 43.69,
-   "decompress_mbps": 412.43
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 144898,
-   "ratio": 0.3395,
-   "compress_mbps": 26.54,
-   "decompress_mbps": 422.22
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 144589,
-   "ratio": 0.3388,
-   "compress_mbps": 23.0,
-   "decompress_mbps": 422.54
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 144436,
-   "ratio": 0.3385,
-   "compress_mbps": 19.77,
-   "decompress_mbps": 426.62
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 144433,
-   "ratio": 0.3384,
-   "compress_mbps": 19.7,
-   "decompress_mbps": 427.06
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 228883,
-   "ratio": 0.475,
-   "compress_mbps": 108.85,
-   "decompress_mbps": 379.18
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 219047,
-   "ratio": 0.4546,
-   "compress_mbps": 91.35,
-   "decompress_mbps": 396.75
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 209408,
-   "ratio": 0.4346,
-   "compress_mbps": 55.73,
-   "decompress_mbps": 408.77
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 205916,
-   "ratio": 0.4273,
-   "compress_mbps": 62.79,
-   "decompress_mbps": 384.06
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 199188,
-   "ratio": 0.4134,
-   "compress_mbps": 33.23,
-   "decompress_mbps": 365.25
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 195255,
-   "ratio": 0.4052,
-   "compress_mbps": 19.51,
-   "decompress_mbps": 371.54
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 194657,
-   "ratio": 0.404,
-   "compress_mbps": 16.52,
-   "decompress_mbps": 368.04
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 194326,
-   "ratio": 0.4033,
-   "compress_mbps": 13.04,
-   "decompress_mbps": 372.62
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 194326,
-   "ratio": 0.4033,
-   "compress_mbps": 13.03,
-   "decompress_mbps": 376.86
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 65553,
-   "ratio": 0.1277,
-   "compress_mbps": 277.05,
-   "decompress_mbps": 898.35
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 63891,
-   "ratio": 0.1245,
-   "compress_mbps": 249.81,
-   "decompress_mbps": 925.37
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 62515,
-   "ratio": 0.1218,
-   "compress_mbps": 196.22,
-   "decompress_mbps": 996.47
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 58451,
-   "ratio": 0.1139,
-   "compress_mbps": 170.56,
-   "decompress_mbps": 705.74
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 57410,
-   "ratio": 0.1119,
-   "compress_mbps": 131.27,
-   "decompress_mbps": 733.83
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 56459,
-   "ratio": 0.11,
-   "compress_mbps": 77.73,
-   "decompress_mbps": 785.69
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 55358,
-   "ratio": 0.1079,
-   "compress_mbps": 60.89,
-   "decompress_mbps": 824.41
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 52991,
-   "ratio": 0.1033,
-   "compress_mbps": 27.8,
-   "decompress_mbps": 878.92
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 52215,
-   "ratio": 0.1017,
-   "compress_mbps": 9.91,
-   "decompress_mbps": 892.75
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 14112,
-   "ratio": 0.369,
-   "compress_mbps": 130.36,
-   "decompress_mbps": 944.12
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 13815,
-   "ratio": 0.3613,
-   "compress_mbps": 110.11,
-   "decompress_mbps": 978.68
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13795,
-   "ratio": 0.3607,
-   "compress_mbps": 79.64,
-   "decompress_mbps": 1014.48
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13375,
-   "ratio": 0.3498,
-   "compress_mbps": 81.09,
-   "decompress_mbps": 997.82
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13062,
-   "ratio": 0.3416,
-   "compress_mbps": 56.15,
-   "decompress_mbps": 1040.2
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 12984,
-   "ratio": 0.3395,
-   "compress_mbps": 33.24,
-   "decompress_mbps": 1062.14
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 12949,
-   "ratio": 0.3386,
-   "compress_mbps": 25.62,
-   "decompress_mbps": 1070.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 12894,
-   "ratio": 0.3372,
-   "compress_mbps": 11.1,
-   "decompress_mbps": 1080.36
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 12832,
-   "ratio": 0.3356,
-   "compress_mbps": 5.1,
-   "decompress_mbps": 1081.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1846,
-   "ratio": 0.4367,
-   "compress_mbps": 290.31,
-   "decompress_mbps": 710.34
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1820,
-   "ratio": 0.4306,
-   "compress_mbps": 284.39,
-   "decompress_mbps": 723.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1808,
-   "ratio": 0.4277,
-   "compress_mbps": 272.54,
-   "decompress_mbps": 726.34
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1749,
-   "ratio": 0.4138,
-   "compress_mbps": 226.28,
-   "decompress_mbps": 749.43
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 202.59,
-   "decompress_mbps": 753.91
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 199.81,
-   "decompress_mbps": 754.2
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 196.62,
-   "decompress_mbps": 753.91
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 197.1,
-   "decompress_mbps": 754.2
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 197.89,
-   "decompress_mbps": 752.93
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 76470,
-   "ratio": 0.5028,
-   "compress_mbps": 156.81,
-   "decompress_mbps": 442.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 62765,
-   "ratio": 0.4127,
-   "compress_mbps": 133.14,
-   "decompress_mbps": 491.57
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 57162,
-   "ratio": 0.3758,
-   "compress_mbps": 72.46,
-   "decompress_mbps": 549.38
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 56826,
-   "ratio": 0.3736,
-   "compress_mbps": 64.54,
-   "decompress_mbps": 540.99
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 55696,
-   "ratio": 0.3662,
-   "compress_mbps": 46.93,
-   "decompress_mbps": 528.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54440,
-   "ratio": 0.3579,
-   "compress_mbps": 26.59,
-   "decompress_mbps": 545.39
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54283,
-   "ratio": 0.3569,
-   "compress_mbps": 22.46,
-   "decompress_mbps": 546.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 54221,
-   "ratio": 0.3565,
-   "compress_mbps": 19.77,
-   "decompress_mbps": 546.31
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 54217,
-   "ratio": 0.3565,
-   "compress_mbps": 19.52,
-   "decompress_mbps": 546.07
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 64926,
-   "ratio": 0.5187,
-   "compress_mbps": 150.76,
-   "decompress_mbps": 420.61
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 54985,
-   "ratio": 0.4393,
-   "compress_mbps": 124.87,
-   "decompress_mbps": 468.91
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 51148,
-   "ratio": 0.4086,
-   "compress_mbps": 67.28,
-   "decompress_mbps": 536.64
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 50599,
-   "ratio": 0.4042,
-   "compress_mbps": 59.25,
-   "decompress_mbps": 526.29
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 49775,
-   "ratio": 0.3976,
-   "compress_mbps": 42.72,
-   "decompress_mbps": 513.76
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48967,
-   "ratio": 0.3912,
-   "compress_mbps": 25.03,
-   "decompress_mbps": 524.3
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48870,
-   "ratio": 0.3904,
-   "compress_mbps": 22.21,
-   "decompress_mbps": 523.8
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 48845,
-   "ratio": 0.3902,
-   "compress_mbps": 20.95,
-   "decompress_mbps": 522.13
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 48845,
-   "ratio": 0.3902,
-   "compress_mbps": 20.95,
-   "decompress_mbps": 524.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 10024,
-   "ratio": 0.4074,
-   "compress_mbps": 568.72,
-   "decompress_mbps": 906.86
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8577,
-   "ratio": 0.3486,
-   "compress_mbps": 269.07,
-   "decompress_mbps": 929.83
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8168,
-   "ratio": 0.332,
-   "compress_mbps": 155.49,
-   "decompress_mbps": 951.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8069,
-   "ratio": 0.328,
-   "compress_mbps": 116.17,
-   "decompress_mbps": 969.68
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 7997,
-   "ratio": 0.325,
-   "compress_mbps": 100.13,
-   "decompress_mbps": 1001.46
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7952,
-   "ratio": 0.3232,
-   "compress_mbps": 74.99,
-   "decompress_mbps": 1003.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7947,
-   "ratio": 0.323,
-   "compress_mbps": 72.24,
-   "decompress_mbps": 1009.09
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7947,
-   "ratio": 0.323,
-   "compress_mbps": 71.2,
-   "decompress_mbps": 1009.52
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7947,
-   "ratio": 0.323,
-   "compress_mbps": 70.94,
-   "decompress_mbps": 1010.39
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 4061,
-   "ratio": 0.3642,
-   "compress_mbps": 505.27,
-   "decompress_mbps": 857.33
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3446,
-   "ratio": 0.3091,
-   "compress_mbps": 303.09,
-   "decompress_mbps": 902.14
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3201,
-   "ratio": 0.2871,
-   "compress_mbps": 235.32,
-   "decompress_mbps": 933.5
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3168,
-   "ratio": 0.2841,
-   "compress_mbps": 196.56,
-   "decompress_mbps": 955.13
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3139,
-   "ratio": 0.2815,
-   "compress_mbps": 162.35,
-   "decompress_mbps": 979.95
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3115,
-   "ratio": 0.2794,
-   "compress_mbps": 116.87,
-   "decompress_mbps": 990.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 106.87,
-   "decompress_mbps": 991.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 103.44,
-   "decompress_mbps": 992.11
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 103.35,
-   "decompress_mbps": 992.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1410,
-   "ratio": 0.3789,
-   "compress_mbps": 365.35,
-   "decompress_mbps": 595.71
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1262,
-   "ratio": 0.3392,
-   "compress_mbps": 234.59,
-   "decompress_mbps": 602.38
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1238,
-   "ratio": 0.3327,
-   "compress_mbps": 206.3,
-   "decompress_mbps": 606.19
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1219,
-   "ratio": 0.3276,
-   "compress_mbps": 178.27,
-   "decompress_mbps": 624.32
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 163.31,
-   "decompress_mbps": 633.68
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 147.91,
-   "decompress_mbps": 631.88
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 147.05,
-   "decompress_mbps": 632.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 147.52,
-   "decompress_mbps": 634.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 147.39,
-   "decompress_mbps": 634.93
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 274412,
-   "ratio": 0.2665,
-   "compress_mbps": 452.12,
-   "decompress_mbps": 796.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 213239,
-   "ratio": 0.2071,
-   "compress_mbps": 274.72,
-   "decompress_mbps": 895.56
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 232107,
-   "ratio": 0.2254,
-   "compress_mbps": 137.22,
-   "decompress_mbps": 936.66
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 202733,
-   "ratio": 0.1969,
-   "compress_mbps": 130.42,
-   "decompress_mbps": 942.52
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 207803,
-   "ratio": 0.2018,
-   "compress_mbps": 84.44,
-   "decompress_mbps": 954.1
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 205270,
-   "ratio": 0.1993,
-   "compress_mbps": 27.28,
-   "decompress_mbps": 981.19
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 209951,
-   "ratio": 0.2039,
-   "compress_mbps": 19.33,
-   "decompress_mbps": 997.67
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 209656,
-   "ratio": 0.2036,
-   "compress_mbps": 12.25,
-   "decompress_mbps": 1008.86
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 209189,
-   "ratio": 0.2031,
-   "compress_mbps": 8.96,
-   "decompress_mbps": 1009.49
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 208640,
-   "ratio": 0.4889,
-   "compress_mbps": 157.34,
-   "decompress_mbps": 424.83
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 167329,
-   "ratio": 0.3921,
-   "compress_mbps": 138.54,
-   "decompress_mbps": 464.58
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 151097,
-   "ratio": 0.3541,
-   "compress_mbps": 73.57,
-   "decompress_mbps": 510.84
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 150035,
-   "ratio": 0.3516,
-   "compress_mbps": 66.59,
-   "decompress_mbps": 511.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 147375,
-   "ratio": 0.3453,
-   "compress_mbps": 48.11,
-   "decompress_mbps": 508.07
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 144908,
-   "ratio": 0.3396,
-   "compress_mbps": 28.06,
-   "decompress_mbps": 519.16
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 144562,
-   "ratio": 0.3387,
-   "compress_mbps": 24.64,
-   "decompress_mbps": 517.99
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 144449,
-   "ratio": 0.3385,
-   "compress_mbps": 22.41,
-   "decompress_mbps": 518.6
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 144438,
-   "ratio": 0.3385,
-   "compress_mbps": 22.31,
-   "decompress_mbps": 518.95
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 264549,
-   "ratio": 0.549,
-   "compress_mbps": 135.43,
-   "decompress_mbps": 376.95
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 223724,
-   "ratio": 0.4643,
-   "compress_mbps": 118.93,
-   "decompress_mbps": 422.83
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 204825,
-   "ratio": 0.4251,
-   "compress_mbps": 60.63,
-   "decompress_mbps": 478.39
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 203945,
-   "ratio": 0.4232,
-   "compress_mbps": 53.94,
-   "decompress_mbps": 474.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 199780,
-   "ratio": 0.4146,
-   "compress_mbps": 37.91,
-   "decompress_mbps": 457.62
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 195417,
-   "ratio": 0.4055,
-   "compress_mbps": 21.2,
-   "decompress_mbps": 468.93
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 194796,
-   "ratio": 0.4043,
-   "compress_mbps": 17.9,
-   "decompress_mbps": 467.61
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 194543,
-   "ratio": 0.4037,
-   "compress_mbps": 15.72,
-   "decompress_mbps": 467.24
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 194460,
-   "ratio": 0.4036,
-   "compress_mbps": 15.05,
-   "decompress_mbps": 468.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 67436,
-   "ratio": 0.1314,
-   "compress_mbps": 627.54,
-   "decompress_mbps": 1004.41
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 59257,
-   "ratio": 0.1155,
-   "compress_mbps": 278.61,
-   "decompress_mbps": 1060.4
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 58316,
-   "ratio": 0.1136,
-   "compress_mbps": 181.72,
-   "decompress_mbps": 1145.04
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 56291,
-   "ratio": 0.1097,
-   "compress_mbps": 185.03,
-   "decompress_mbps": 1154.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 56220,
-   "ratio": 0.1095,
-   "compress_mbps": 146.23,
-   "decompress_mbps": 1207.72
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 55972,
-   "ratio": 0.1091,
-   "compress_mbps": 74.5,
-   "decompress_mbps": 1263.85
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 55121,
-   "ratio": 0.1074,
-   "compress_mbps": 52.14,
-   "decompress_mbps": 1305.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 54124,
-   "ratio": 0.1055,
-   "compress_mbps": 36.7,
-   "decompress_mbps": 1378.02
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 53699,
-   "ratio": 0.1046,
-   "compress_mbps": 28.66,
-   "decompress_mbps": 1411.67
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 15612,
-   "ratio": 0.4083,
-   "compress_mbps": 502.51,
-   "decompress_mbps": 850.6
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 14133,
-   "ratio": 0.3696,
-   "compress_mbps": 145.19,
-   "decompress_mbps": 890.56
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13341,
-   "ratio": 0.3489,
-   "compress_mbps": 88.72,
-   "decompress_mbps": 911.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13289,
-   "ratio": 0.3475,
-   "compress_mbps": 83.64,
-   "decompress_mbps": 941.29
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13052,
-   "ratio": 0.3413,
-   "compress_mbps": 66.83,
-   "decompress_mbps": 973.4
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 12996,
-   "ratio": 0.3399,
-   "compress_mbps": 37.14,
-   "decompress_mbps": 986.7
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 12972,
-   "ratio": 0.3392,
-   "compress_mbps": 27.2,
-   "decompress_mbps": 990.88
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 12951,
-   "ratio": 0.3387,
-   "compress_mbps": 19.04,
-   "decompress_mbps": 996.63
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 12933,
-   "ratio": 0.3382,
-   "compress_mbps": 14.86,
-   "decompress_mbps": 1010.18
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1988,
-   "ratio": 0.4703,
-   "compress_mbps": 340.18,
-   "decompress_mbps": 548.09
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1802,
-   "ratio": 0.4263,
-   "compress_mbps": 218.94,
-   "decompress_mbps": 554.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 205.58,
-   "decompress_mbps": 558.57
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1732,
-   "ratio": 0.4097,
-   "compress_mbps": 171.81,
-   "decompress_mbps": 573.34
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 167.66,
-   "decompress_mbps": 582.37
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 166.66,
-   "decompress_mbps": 582.62
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 166.44,
-   "decompress_mbps": 580.03
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 167.1,
-   "decompress_mbps": 579.86
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 166.8,
-   "decompress_mbps": 579.36
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 59790,
-   "ratio": 0.3931,
-   "compress_mbps": 262.72,
-   "decompress_mbps": 1002.92
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 57173,
-   "ratio": 0.3759,
-   "compress_mbps": 181.24,
-   "decompress_mbps": 1076.37
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 56189,
-   "ratio": 0.3694,
-   "compress_mbps": 150.83,
-   "decompress_mbps": 1150.52
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 55816,
-   "ratio": 0.367,
-   "compress_mbps": 138.22,
-   "decompress_mbps": 1189.04
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 54758,
-   "ratio": 0.36,
-   "compress_mbps": 109.12,
-   "decompress_mbps": 1241.07
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54220,
-   "ratio": 0.3565,
-   "compress_mbps": 84.01,
-   "decompress_mbps": 1281.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 53801,
-   "ratio": 0.3537,
-   "compress_mbps": 61.34,
-   "decompress_mbps": 1284.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 53573,
-   "ratio": 0.3522,
-   "compress_mbps": 38.99,
-   "decompress_mbps": 1281.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 53546,
-   "ratio": 0.3521,
-   "compress_mbps": 34.49,
-   "decompress_mbps": 1286.38
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 52276,
-   "ratio": 0.4176,
-   "compress_mbps": 244.27,
-   "decompress_mbps": 941.62
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 50534,
-   "ratio": 0.4037,
-   "compress_mbps": 169.26,
-   "decompress_mbps": 994.53
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 49919,
-   "ratio": 0.3988,
-   "compress_mbps": 142.29,
-   "decompress_mbps": 1056.87
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 49715,
-   "ratio": 0.3972,
-   "compress_mbps": 131.62,
-   "decompress_mbps": 1092.43
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 48735,
-   "ratio": 0.3893,
-   "compress_mbps": 101.28,
-   "decompress_mbps": 1138.39
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48422,
-   "ratio": 0.3868,
-   "compress_mbps": 79.56,
-   "decompress_mbps": 1159.77
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48249,
-   "ratio": 0.3854,
-   "compress_mbps": 61.42,
-   "decompress_mbps": 1167.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 47977,
-   "ratio": 0.3833,
-   "compress_mbps": 43.01,
-   "decompress_mbps": 1163.26
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 47971,
-   "ratio": 0.3832,
-   "compress_mbps": 41.05,
-   "decompress_mbps": 1168.97
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8385,
-   "ratio": 0.3408,
-   "compress_mbps": 694.12,
-   "decompress_mbps": 956.86
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8380,
-   "ratio": 0.3406,
-   "compress_mbps": 439.72,
-   "decompress_mbps": 974.59
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8286,
-   "ratio": 0.3368,
-   "compress_mbps": 403.73,
-   "decompress_mbps": 993.24
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8163,
-   "ratio": 0.3318,
-   "compress_mbps": 378.68,
-   "decompress_mbps": 1003.78
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 8053,
-   "ratio": 0.3273,
-   "compress_mbps": 335.07,
-   "decompress_mbps": 1027.69
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7986,
-   "ratio": 0.3246,
-   "compress_mbps": 277.67,
-   "decompress_mbps": 1035.81
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7954,
-   "ratio": 0.3233,
-   "compress_mbps": 191.05,
-   "decompress_mbps": 1026.12
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7916,
-   "ratio": 0.3217,
-   "compress_mbps": 129.56,
-   "decompress_mbps": 1035.17
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7916,
-   "ratio": 0.3217,
-   "compress_mbps": 125.42,
-   "decompress_mbps": 1013.27
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3401,
-   "ratio": 0.305,
-   "compress_mbps": 586.93,
-   "decompress_mbps": 768.98
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3307,
-   "ratio": 0.2966,
-   "compress_mbps": 398.24,
-   "decompress_mbps": 792.95
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3242,
-   "ratio": 0.2908,
-   "compress_mbps": 371.5,
-   "decompress_mbps": 810.66
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3205,
-   "ratio": 0.2874,
-   "compress_mbps": 349.62,
-   "decompress_mbps": 821.62
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3150,
-   "ratio": 0.2825,
-   "compress_mbps": 313.81,
-   "decompress_mbps": 837.48
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3126,
-   "ratio": 0.2804,
-   "compress_mbps": 267.83,
-   "decompress_mbps": 842.46
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3106,
-   "ratio": 0.2786,
-   "compress_mbps": 206.71,
-   "decompress_mbps": 846.01
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3102,
-   "ratio": 0.2782,
-   "compress_mbps": 147.91,
-   "decompress_mbps": 842.39
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3102,
-   "ratio": 0.2782,
-   "compress_mbps": 140.39,
-   "decompress_mbps": 846.34
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1251,
-   "ratio": 0.3362,
-   "compress_mbps": 377.39,
-   "decompress_mbps": 426.98
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1228,
-   "ratio": 0.33,
-   "compress_mbps": 267.66,
-   "decompress_mbps": 433.76
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1219,
-   "ratio": 0.3276,
-   "compress_mbps": 258.72,
-   "decompress_mbps": 433.23
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1220,
-   "ratio": 0.3279,
-   "compress_mbps": 253.94,
-   "decompress_mbps": 439.29
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 240.44,
-   "decompress_mbps": 443.8
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 222.65,
-   "decompress_mbps": 441.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 203.53,
-   "decompress_mbps": 438.86
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1204,
-   "ratio": 0.3236,
-   "compress_mbps": 169.68,
-   "decompress_mbps": 444.08
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1204,
-   "ratio": 0.3236,
-   "compress_mbps": 169.88,
-   "decompress_mbps": 438.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 221813,
-   "ratio": 0.2154,
-   "compress_mbps": 593.83,
-   "decompress_mbps": 1009.94
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 199825,
-   "ratio": 0.1941,
-   "compress_mbps": 409.25,
-   "decompress_mbps": 1460.57
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 195675,
-   "ratio": 0.19,
-   "compress_mbps": 283.23,
-   "decompress_mbps": 1526.64
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 195664,
-   "ratio": 0.19,
-   "compress_mbps": 279.77,
-   "decompress_mbps": 1536.83
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 198900,
-   "ratio": 0.1932,
-   "compress_mbps": 239.94,
-   "decompress_mbps": 1127.82
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 199347,
-   "ratio": 0.1936,
-   "compress_mbps": 204.69,
-   "decompress_mbps": 1130.61
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 199777,
-   "ratio": 0.194,
-   "compress_mbps": 123.53,
-   "decompress_mbps": 1190.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 182094,
-   "ratio": 0.1768,
-   "compress_mbps": 25.66,
-   "decompress_mbps": 1169.78
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 181451,
-   "ratio": 0.1762,
-   "compress_mbps": 13.61,
-   "decompress_mbps": 1173.47
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 159063,
-   "ratio": 0.3727,
-   "compress_mbps": 263.86,
-   "decompress_mbps": 1029.34
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 152115,
-   "ratio": 0.3564,
-   "compress_mbps": 187.44,
-   "decompress_mbps": 1105.52
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 149162,
-   "ratio": 0.3495,
-   "compress_mbps": 156.82,
-   "decompress_mbps": 1189.07
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 148359,
-   "ratio": 0.3476,
-   "compress_mbps": 142.61,
-   "decompress_mbps": 1033.04
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 145353,
-   "ratio": 0.3406,
-   "compress_mbps": 113.35,
-   "decompress_mbps": 997.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 144209,
-   "ratio": 0.3379,
-   "compress_mbps": 87.48,
-   "decompress_mbps": 1037.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 143604,
-   "ratio": 0.3365,
-   "compress_mbps": 66.64,
-   "decompress_mbps": 1039.31
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 142086,
-   "ratio": 0.3329,
-   "compress_mbps": 44.24,
-   "decompress_mbps": 1035.21
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 142027,
-   "ratio": 0.3328,
-   "compress_mbps": 40.46,
-   "decompress_mbps": 1038.75
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 210662,
-   "ratio": 0.4372,
-   "compress_mbps": 228.71,
-   "decompress_mbps": 869.83
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 202881,
-   "ratio": 0.421,
-   "compress_mbps": 158.66,
-   "decompress_mbps": 939.95
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 200409,
-   "ratio": 0.4159,
-   "compress_mbps": 132.96,
-   "decompress_mbps": 1019.12
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 199678,
-   "ratio": 0.4144,
-   "compress_mbps": 122.96,
-   "decompress_mbps": 839.63
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 195798,
-   "ratio": 0.4063,
-   "compress_mbps": 93.4,
-   "decompress_mbps": 789.36
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 194029,
-   "ratio": 0.4027,
-   "compress_mbps": 71.6,
-   "decompress_mbps": 813.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 192773,
-   "ratio": 0.4001,
-   "compress_mbps": 50.41,
-   "decompress_mbps": 835.88
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 191739,
-   "ratio": 0.3979,
-   "compress_mbps": 33.69,
-   "decompress_mbps": 841.06
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 191676,
-   "ratio": 0.3978,
-   "compress_mbps": 31.1,
-   "decompress_mbps": 839.65
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 58079,
-   "ratio": 0.1132,
-   "compress_mbps": 373.38,
-   "decompress_mbps": 1687.98
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 57838,
-   "ratio": 0.1127,
-   "compress_mbps": 413.69,
-   "decompress_mbps": 1800.72
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 57554,
-   "ratio": 0.1121,
-   "compress_mbps": 394.76,
-   "decompress_mbps": 1899.42
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 57064,
-   "ratio": 0.1112,
-   "compress_mbps": 374.05,
-   "decompress_mbps": 1741.26
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 55743,
-   "ratio": 0.1086,
-   "compress_mbps": 343.45,
-   "decompress_mbps": 1793.36
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 55102,
-   "ratio": 0.1074,
-   "compress_mbps": 285.08,
-   "decompress_mbps": 1869.89
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 54742,
-   "ratio": 0.1067,
-   "compress_mbps": 193.03,
-   "decompress_mbps": 1929.26
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 53133,
-   "ratio": 0.1035,
-   "compress_mbps": 102.77,
-   "decompress_mbps": 1996.36
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 52186,
-   "ratio": 0.1017,
-   "compress_mbps": 72.32,
-   "decompress_mbps": 2031.74
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 14122,
-   "ratio": 0.3693,
-   "compress_mbps": 648.66,
-   "decompress_mbps": 823.66
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 13374,
-   "ratio": 0.3497,
-   "compress_mbps": 338.62,
-   "decompress_mbps": 879.23
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13293,
-   "ratio": 0.3476,
-   "compress_mbps": 257.73,
-   "decompress_mbps": 960.76
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13259,
-   "ratio": 0.3467,
-   "compress_mbps": 263.83,
-   "decompress_mbps": 960.86
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 12641,
-   "ratio": 0.3306,
-   "compress_mbps": 190.13,
-   "decompress_mbps": 990.29
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 12432,
-   "ratio": 0.3251,
-   "compress_mbps": 164.05,
-   "decompress_mbps": 1006.67
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 12439,
-   "ratio": 0.3253,
-   "compress_mbps": 122.43,
-   "decompress_mbps": 1013.21
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 12579,
-   "ratio": 0.3289,
-   "compress_mbps": 67.61,
-   "decompress_mbps": 1025.92
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 12574,
-   "ratio": 0.3288,
-   "compress_mbps": 47.47,
-   "decompress_mbps": 1031.58
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1777,
-   "ratio": 0.4204,
-   "compress_mbps": 386.35,
-   "decompress_mbps": 403.24
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1756,
-   "ratio": 0.4154,
-   "compress_mbps": 260.77,
-   "decompress_mbps": 408.51
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1746,
-   "ratio": 0.4131,
-   "compress_mbps": 257.14,
-   "decompress_mbps": 410.93
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1740,
-   "ratio": 0.4116,
-   "compress_mbps": 254.99,
-   "decompress_mbps": 414.73
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1722,
-   "ratio": 0.4074,
-   "compress_mbps": 240.47,
-   "decompress_mbps": 415.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1721,
-   "ratio": 0.4071,
-   "compress_mbps": 235.91,
-   "decompress_mbps": 415.29
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 234.75,
-   "decompress_mbps": 415.41
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1717,
-   "ratio": 0.4062,
-   "compress_mbps": 217.57,
-   "decompress_mbps": 417.83
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1717,
-   "ratio": 0.4062,
-   "compress_mbps": 216.75,
-   "decompress_mbps": 416.19
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4259644,
-   "ratio": 0.4179,
-   "compress_mbps": 55.48,
-   "decompress_mbps": 175.13
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 3977395,
-   "ratio": 0.3902,
-   "compress_mbps": 41.33,
-   "decompress_mbps": 190.42
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3945296,
-   "ratio": 0.3871,
-   "compress_mbps": 36.93,
-   "decompress_mbps": 209.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 3888037,
-   "ratio": 0.3815,
-   "compress_mbps": 27.75,
-   "decompress_mbps": 213.35
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3882328,
-   "ratio": 0.3809,
-   "compress_mbps": 27.19,
-   "decompress_mbps": 212.35
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3873339,
-   "ratio": 0.38,
-   "compress_mbps": 24.92,
-   "decompress_mbps": 218.0
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3866648,
-   "ratio": 0.3794,
-   "compress_mbps": 20.84,
-   "decompress_mbps": 217.98
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3864805,
-   "ratio": 0.3792,
-   "compress_mbps": 9.49,
-   "decompress_mbps": 226.2
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3790405,
-   "ratio": 0.3719,
-   "compress_mbps": 3.22,
-   "decompress_mbps": 219.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 21267086,
-   "ratio": 0.4152,
-   "compress_mbps": 70.17,
-   "decompress_mbps": 192.7
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 20802983,
-   "ratio": 0.4061,
-   "compress_mbps": 56.03,
-   "decompress_mbps": 200.74
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 20665485,
-   "ratio": 0.4035,
-   "compress_mbps": 52.53,
-   "decompress_mbps": 200.3
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 20427823,
-   "ratio": 0.3988,
-   "compress_mbps": 41.38,
-   "decompress_mbps": 210.97
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 20413947,
-   "ratio": 0.3986,
-   "compress_mbps": 39.25,
-   "decompress_mbps": 224.27
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 20373541,
-   "ratio": 0.3978,
-   "compress_mbps": 34.33,
-   "decompress_mbps": 224.75
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 20251873,
-   "ratio": 0.3954,
-   "compress_mbps": 22.16,
-   "decompress_mbps": 225.66
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19172591,
-   "ratio": 0.3743,
-   "compress_mbps": 6.94,
-   "decompress_mbps": 226.33
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18705121,
-   "ratio": 0.3652,
-   "compress_mbps": 3.18,
-   "decompress_mbps": 224.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3864163,
-   "ratio": 0.3876,
-   "compress_mbps": 68.39,
-   "decompress_mbps": 205.5
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3734957,
-   "ratio": 0.3746,
-   "compress_mbps": 53.45,
-   "decompress_mbps": 214.49
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3708443,
-   "ratio": 0.3719,
-   "compress_mbps": 46.13,
-   "decompress_mbps": 224.58
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3712990,
-   "ratio": 0.3724,
-   "compress_mbps": 32.72,
-   "decompress_mbps": 208.12
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3707399,
-   "ratio": 0.3718,
-   "compress_mbps": 31.1,
-   "decompress_mbps": 203.21
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3701112,
-   "ratio": 0.3712,
-   "compress_mbps": 28.43,
-   "decompress_mbps": 196.91
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3704320,
-   "ratio": 0.3715,
-   "compress_mbps": 22.54,
-   "decompress_mbps": 212.23
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3609490,
-   "ratio": 0.362,
-   "compress_mbps": 8.27,
-   "decompress_mbps": 228.1
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3594656,
-   "ratio": 0.3605,
-   "compress_mbps": 2.98,
-   "decompress_mbps": 227.82
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3785443,
-   "ratio": 0.1128,
-   "compress_mbps": 200.7,
-   "decompress_mbps": 597.03
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 3761560,
-   "ratio": 0.1121,
-   "compress_mbps": 129.81,
-   "decompress_mbps": 670.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3606997,
-   "ratio": 0.1075,
-   "compress_mbps": 113.5,
-   "decompress_mbps": 745.87
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3340261,
-   "ratio": 0.0996,
-   "compress_mbps": 95.64,
-   "decompress_mbps": 742.09
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3336190,
-   "ratio": 0.0994,
-   "compress_mbps": 93.91,
-   "decompress_mbps": 830.01
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3217453,
-   "ratio": 0.0959,
-   "compress_mbps": 79.07,
-   "decompress_mbps": 839.94
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3126259,
-   "ratio": 0.0932,
-   "compress_mbps": 42.73,
-   "decompress_mbps": 903.26
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3112207,
-   "ratio": 0.0928,
-   "compress_mbps": 22.47,
-   "decompress_mbps": 892.73
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 3024127,
-   "ratio": 0.0901,
-   "compress_mbps": 2.74,
-   "decompress_mbps": 908.14
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3357083,
-   "ratio": 0.5457,
-   "compress_mbps": 48.27,
-   "decompress_mbps": 128.85
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3285077,
-   "ratio": 0.534,
-   "compress_mbps": 41.14,
-   "decompress_mbps": 132.57
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3272746,
-   "ratio": 0.532,
-   "compress_mbps": 39.54,
-   "decompress_mbps": 137.07
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3238986,
-   "ratio": 0.5265,
-   "compress_mbps": 32.38,
-   "decompress_mbps": 145.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3237944,
-   "ratio": 0.5263,
-   "compress_mbps": 32.14,
-   "decompress_mbps": 150.52
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3235767,
-   "ratio": 0.526,
-   "compress_mbps": 30.8,
-   "decompress_mbps": 153.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3232738,
-   "ratio": 0.5255,
-   "compress_mbps": 26.88,
-   "decompress_mbps": 154.07
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3165909,
-   "ratio": 0.5146,
-   "compress_mbps": 7.02,
-   "decompress_mbps": 156.75
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3054135,
-   "ratio": 0.4964,
-   "compress_mbps": 3.83,
-   "decompress_mbps": 156.25
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3838828,
-   "ratio": 0.3806,
-   "compress_mbps": 78.07,
-   "decompress_mbps": 230.29
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3792520,
-   "ratio": 0.376,
-   "compress_mbps": 59.51,
-   "decompress_mbps": 238.0
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3783171,
-   "ratio": 0.3751,
-   "compress_mbps": 57.57,
-   "decompress_mbps": 242.95
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3709091,
-   "ratio": 0.3678,
-   "compress_mbps": 51.26,
-   "decompress_mbps": 242.19
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3708716,
-   "ratio": 0.3677,
-   "compress_mbps": 51.45,
-   "decompress_mbps": 242.31
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3707113,
-   "ratio": 0.3676,
-   "compress_mbps": 51.47,
-   "decompress_mbps": 251.84
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3706769,
-   "ratio": 0.3675,
-   "compress_mbps": 47.47,
-   "decompress_mbps": 254.69
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3706769,
-   "ratio": 0.3675,
-   "compress_mbps": 12.78,
-   "decompress_mbps": 263.77
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3693258,
-   "ratio": 0.3662,
-   "compress_mbps": 5.0,
-   "decompress_mbps": 269.3
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2254442,
-   "ratio": 0.3402,
-   "compress_mbps": 69.34,
-   "decompress_mbps": 222.38
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2044843,
-   "ratio": 0.3086,
-   "compress_mbps": 48.71,
-   "decompress_mbps": 233.42
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 1992105,
-   "ratio": 0.3006,
-   "compress_mbps": 39.96,
-   "decompress_mbps": 254.89
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 1911755,
-   "ratio": 0.2885,
-   "compress_mbps": 27.89,
-   "decompress_mbps": 257.69
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1901448,
-   "ratio": 0.2869,
-   "compress_mbps": 25.9,
-   "decompress_mbps": 260.08
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1883344,
-   "ratio": 0.2842,
-   "compress_mbps": 21.06,
-   "decompress_mbps": 271.62
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1868258,
-   "ratio": 0.2819,
-   "compress_mbps": 13.38,
-   "decompress_mbps": 276.33
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1841388,
-   "ratio": 0.2779,
-   "compress_mbps": 7.82,
-   "decompress_mbps": 284.02
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1793832,
-   "ratio": 0.2707,
-   "compress_mbps": 2.48,
-   "decompress_mbps": 290.71
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 6406301,
-   "ratio": 0.2965,
-   "compress_mbps": 95.14,
-   "decompress_mbps": 293.3
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 6102377,
-   "ratio": 0.2824,
-   "compress_mbps": 72.18,
-   "decompress_mbps": 313.32
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 6022184,
-   "ratio": 0.2787,
-   "compress_mbps": 66.12,
-   "decompress_mbps": 325.67
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5904034,
-   "ratio": 0.2733,
-   "compress_mbps": 52.53,
-   "decompress_mbps": 336.24
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5899862,
-   "ratio": 0.2731,
-   "compress_mbps": 50.36,
-   "decompress_mbps": 342.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5881527,
-   "ratio": 0.2722,
-   "compress_mbps": 46.19,
-   "decompress_mbps": 351.91
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5830453,
-   "ratio": 0.2698,
-   "compress_mbps": 33.41,
-   "decompress_mbps": 352.37
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5407066,
-   "ratio": 0.2503,
-   "compress_mbps": 12.96,
-   "decompress_mbps": 327.8
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5225578,
-   "ratio": 0.2419,
-   "compress_mbps": 3.63,
-   "decompress_mbps": 355.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5612204,
-   "ratio": 0.7739,
-   "compress_mbps": 41.24,
-   "decompress_mbps": 129.07
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5533875,
-   "ratio": 0.7631,
-   "compress_mbps": 35.17,
-   "decompress_mbps": 132.08
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5522436,
-   "ratio": 0.7615,
-   "compress_mbps": 33.18,
-   "decompress_mbps": 136.64
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5500073,
-   "ratio": 0.7584,
-   "compress_mbps": 27.91,
-   "decompress_mbps": 139.09
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5498823,
-   "ratio": 0.7583,
-   "compress_mbps": 26.89,
-   "decompress_mbps": 136.43
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5497402,
-   "ratio": 0.7581,
-   "compress_mbps": 26.32,
-   "decompress_mbps": 138.94
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5496371,
-   "ratio": 0.7579,
-   "compress_mbps": 25.01,
-   "decompress_mbps": 138.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5429363,
-   "ratio": 0.7487,
-   "compress_mbps": 6.35,
-   "decompress_mbps": 141.33
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5301868,
-   "ratio": 0.7311,
-   "compress_mbps": 3.77,
-   "decompress_mbps": 141.55
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13727247,
-   "ratio": 0.3311,
-   "compress_mbps": 71.12,
-   "decompress_mbps": 223.0
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 12940398,
-   "ratio": 0.3121,
-   "compress_mbps": 54.34,
-   "decompress_mbps": 241.35
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12703756,
-   "ratio": 0.3064,
-   "compress_mbps": 50.41,
-   "decompress_mbps": 262.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12294598,
-   "ratio": 0.2966,
-   "compress_mbps": 39.65,
-   "decompress_mbps": 267.14
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12269076,
-   "ratio": 0.2959,
-   "compress_mbps": 37.96,
-   "decompress_mbps": 272.69
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12184584,
-   "ratio": 0.2939,
-   "compress_mbps": 33.32,
-   "decompress_mbps": 269.98
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12109369,
-   "ratio": 0.2921,
-   "compress_mbps": 25.31,
-   "decompress_mbps": 281.5
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12106058,
-   "ratio": 0.292,
-   "compress_mbps": 11.79,
-   "decompress_mbps": 282.72
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11868965,
-   "ratio": 0.2863,
-   "compress_mbps": 3.34,
-   "decompress_mbps": 282.41
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6438176,
-   "ratio": 0.7597,
-   "compress_mbps": 39.06,
-   "decompress_mbps": 126.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6392101,
-   "ratio": 0.7543,
-   "compress_mbps": 37.61,
-   "decompress_mbps": 126.96
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6392124,
-   "ratio": 0.7543,
-   "compress_mbps": 37.91,
-   "decompress_mbps": 128.38
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6368722,
-   "ratio": 0.7515,
-   "compress_mbps": 35.88,
-   "decompress_mbps": 116.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6368719,
-   "ratio": 0.7515,
-   "compress_mbps": 35.44,
-   "decompress_mbps": 117.83
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 6368719,
-   "ratio": 0.7515,
-   "compress_mbps": 35.43,
-   "decompress_mbps": 118.63
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 6368717,
-   "ratio": 0.7515,
-   "compress_mbps": 35.68,
-   "decompress_mbps": 118.83
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 6278507,
-   "ratio": 0.7409,
-   "compress_mbps": 4.9,
-   "decompress_mbps": 120.21
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5949045,
-   "ratio": 0.702,
-   "compress_mbps": 4.53,
-   "decompress_mbps": 121.14
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 858525,
-   "ratio": 0.1606,
-   "compress_mbps": 151.44,
-   "decompress_mbps": 419.29
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 846807,
-   "ratio": 0.1584,
-   "compress_mbps": 101.03,
-   "decompress_mbps": 455.3
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 806798,
-   "ratio": 0.1509,
-   "compress_mbps": 92.34,
-   "decompress_mbps": 503.3
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 746239,
-   "ratio": 0.1396,
-   "compress_mbps": 73.56,
-   "decompress_mbps": 547.92
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 743257,
-   "ratio": 0.139,
-   "compress_mbps": 71.46,
-   "decompress_mbps": 596.7
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 721315,
-   "ratio": 0.1349,
-   "compress_mbps": 64.91,
-   "decompress_mbps": 648.89
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 703742,
-   "ratio": 0.1317,
-   "compress_mbps": 42.29,
-   "decompress_mbps": 664.81
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 674362,
-   "ratio": 0.1262,
-   "compress_mbps": 20.92,
-   "decompress_mbps": 676.13
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 656466,
-   "ratio": 0.1228,
-   "compress_mbps": 2.96,
-   "decompress_mbps": 664.14
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4585612,
-   "ratio": 0.4499,
-   "compress_mbps": 113.67,
-   "decompress_mbps": 354.82
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4389474,
-   "ratio": 0.4307,
-   "compress_mbps": 96.07,
-   "decompress_mbps": 375.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 4192079,
-   "ratio": 0.4113,
-   "compress_mbps": 59.36,
-   "decompress_mbps": 412.28
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 4095021,
-   "ratio": 0.4018,
-   "compress_mbps": 66.19,
-   "decompress_mbps": 389.42
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3949169,
-   "ratio": 0.3875,
-   "compress_mbps": 35.97,
-   "decompress_mbps": 376.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3871628,
-   "ratio": 0.3799,
-   "compress_mbps": 21.24,
-   "decompress_mbps": 384.89
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3858876,
-   "ratio": 0.3786,
-   "compress_mbps": 17.58,
-   "decompress_mbps": 387.13
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3854729,
-   "ratio": 0.3782,
-   "compress_mbps": 15.07,
-   "decompress_mbps": 385.46
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3854729,
-   "ratio": 0.3782,
-   "compress_mbps": 15.07,
-   "decompress_mbps": 391.3
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20577220,
-   "ratio": 0.4017,
-   "compress_mbps": 113.25,
-   "decompress_mbps": 364.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 20247697,
-   "ratio": 0.3953,
-   "compress_mbps": 100.51,
-   "decompress_mbps": 370.0
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19987880,
-   "ratio": 0.3902,
-   "compress_mbps": 75.64,
-   "decompress_mbps": 340.24
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19512665,
-   "ratio": 0.381,
-   "compress_mbps": 71.76,
-   "decompress_mbps": 363.34
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 19213507,
-   "ratio": 0.3751,
-   "compress_mbps": 51.35,
-   "decompress_mbps": 370.37
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19089118,
-   "ratio": 0.3727,
-   "compress_mbps": 33.44,
-   "decompress_mbps": 376.59
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19061204,
-   "ratio": 0.3721,
-   "compress_mbps": 27.31,
-   "decompress_mbps": 380.14
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19040998,
-   "ratio": 0.3717,
-   "compress_mbps": 15.24,
-   "decompress_mbps": 379.76
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 19044390,
-   "ratio": 0.3718,
-   "compress_mbps": 9.54,
-   "decompress_mbps": 385.45
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3828360,
-   "ratio": 0.384,
-   "compress_mbps": 144.91,
-   "decompress_mbps": 453.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3798539,
-   "ratio": 0.381,
-   "compress_mbps": 128.29,
-   "decompress_mbps": 497.36
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3674568,
-   "ratio": 0.3685,
-   "compress_mbps": 80.47,
-   "decompress_mbps": 515.99
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3680923,
-   "ratio": 0.3692,
-   "compress_mbps": 89.36,
-   "decompress_mbps": 457.6
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3698707,
-   "ratio": 0.371,
-   "compress_mbps": 48.13,
-   "decompress_mbps": 427.63
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3675935,
-   "ratio": 0.3687,
-   "compress_mbps": 26.41,
-   "decompress_mbps": 437.75
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3670281,
-   "ratio": 0.3681,
-   "compress_mbps": 20.84,
-   "decompress_mbps": 444.31
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3661103,
-   "ratio": 0.3672,
-   "compress_mbps": 10.94,
-   "decompress_mbps": 458.18
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3660788,
-   "ratio": 0.3672,
-   "compress_mbps": 9.47,
-   "decompress_mbps": 459.79
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 4624591,
-   "ratio": 0.1378,
-   "compress_mbps": 332.0,
-   "decompress_mbps": 831.27
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 4303176,
-   "ratio": 0.1282,
-   "compress_mbps": 310.37,
-   "decompress_mbps": 841.9
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 4010156,
-   "ratio": 0.1195,
-   "compress_mbps": 257.47,
-   "decompress_mbps": 926.52
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3713866,
-   "ratio": 0.1107,
-   "compress_mbps": 212.08,
-   "decompress_mbps": 896.37
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3378136,
-   "ratio": 0.1007,
-   "compress_mbps": 166.1,
-   "decompress_mbps": 954.98
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3200182,
-   "ratio": 0.0954,
-   "compress_mbps": 113.17,
-   "decompress_mbps": 986.8
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3141278,
-   "ratio": 0.0936,
-   "compress_mbps": 90.33,
-   "decompress_mbps": 999.02
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3031199,
-   "ratio": 0.0903,
-   "compress_mbps": 39.16,
-   "decompress_mbps": 1017.12
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2987995,
-   "ratio": 0.0891,
-   "compress_mbps": 21.44,
-   "decompress_mbps": 1033.52
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3290526,
-   "ratio": 0.5349,
-   "compress_mbps": 79.06,
-   "decompress_mbps": 257.16
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3238282,
-   "ratio": 0.5264,
-   "compress_mbps": 72.38,
-   "decompress_mbps": 263.21
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3193366,
-   "ratio": 0.5191,
-   "compress_mbps": 57.0,
-   "decompress_mbps": 265.33
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3158012,
-   "ratio": 0.5133,
-   "compress_mbps": 55.65,
-   "decompress_mbps": 268.5
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3115309,
-   "ratio": 0.5064,
-   "compress_mbps": 39.25,
-   "decompress_mbps": 269.0
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3097288,
-   "ratio": 0.5034,
-   "compress_mbps": 26.28,
-   "decompress_mbps": 264.86
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3094363,
-   "ratio": 0.503,
-   "compress_mbps": 21.86,
-   "decompress_mbps": 268.09
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3093026,
-   "ratio": 0.5028,
-   "compress_mbps": 16.97,
-   "decompress_mbps": 270.33
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3092920,
-   "ratio": 0.5027,
-   "compress_mbps": 15.53,
-   "decompress_mbps": 269.1
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 4076385,
-   "ratio": 0.4042,
-   "compress_mbps": 125.81,
-   "decompress_mbps": 474.99
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3991014,
-   "ratio": 0.3957,
-   "compress_mbps": 117.17,
-   "decompress_mbps": 494.44
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3934055,
-   "ratio": 0.3901,
-   "compress_mbps": 93.6,
-   "decompress_mbps": 511.59
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3825092,
-   "ratio": 0.3793,
-   "compress_mbps": 85.49,
-   "decompress_mbps": 513.7
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3752932,
-   "ratio": 0.3721,
-   "compress_mbps": 64.41,
-   "decompress_mbps": 496.1
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3695164,
-   "ratio": 0.3664,
-   "compress_mbps": 49.22,
-   "decompress_mbps": 507.36
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3676881,
-   "ratio": 0.3646,
-   "compress_mbps": 38.17,
-   "decompress_mbps": 515.91
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3673171,
-   "ratio": 0.3642,
-   "compress_mbps": 31.92,
-   "decompress_mbps": 519.6
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3673171,
-   "ratio": 0.3642,
-   "compress_mbps": 31.92,
-   "decompress_mbps": 519.23
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2376424,
-   "ratio": 0.3586,
-   "compress_mbps": 130.38,
-   "decompress_mbps": 393.75
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2259060,
-   "ratio": 0.3409,
-   "compress_mbps": 112.03,
-   "decompress_mbps": 411.76
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2135664,
-   "ratio": 0.3223,
-   "compress_mbps": 72.25,
-   "decompress_mbps": 435.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 2052793,
-   "ratio": 0.3098,
-   "compress_mbps": 81.67,
-   "decompress_mbps": 430.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1932127,
-   "ratio": 0.2915,
-   "compress_mbps": 45.23,
-   "decompress_mbps": 432.43
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1860865,
-   "ratio": 0.2808,
-   "compress_mbps": 22.82,
-   "decompress_mbps": 440.25
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1838671,
-   "ratio": 0.2774,
-   "compress_mbps": 15.96,
-   "decompress_mbps": 441.72
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1823235,
-   "ratio": 0.2751,
-   "compress_mbps": 8.12,
-   "decompress_mbps": 436.13
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1823190,
-   "ratio": 0.2751,
-   "compress_mbps": 8.15,
-   "decompress_mbps": 439.5
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 6329449,
-   "ratio": 0.2929,
-   "compress_mbps": 169.74,
-   "decompress_mbps": 460.79
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 6128866,
-   "ratio": 0.2837,
-   "compress_mbps": 155.55,
-   "decompress_mbps": 557.06
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5982546,
-   "ratio": 0.2769,
-   "compress_mbps": 125.39,
-   "decompress_mbps": 581.02
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5656400,
-   "ratio": 0.2618,
-   "compress_mbps": 116.92,
-   "decompress_mbps": 576.69
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5511352,
-   "ratio": 0.2551,
-   "compress_mbps": 82.58,
-   "decompress_mbps": 587.65
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5451399,
-   "ratio": 0.2523,
-   "compress_mbps": 56.59,
-   "decompress_mbps": 593.88
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5417123,
-   "ratio": 0.2507,
-   "compress_mbps": 46.71,
-   "decompress_mbps": 596.81
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5404364,
-   "ratio": 0.2501,
-   "compress_mbps": 32.73,
-   "decompress_mbps": 602.78
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5402704,
-   "ratio": 0.2501,
-   "compress_mbps": 29.69,
-   "decompress_mbps": 390.04
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5567768,
-   "ratio": 0.7678,
-   "compress_mbps": 32.89,
-   "decompress_mbps": 211.48
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5504009,
-   "ratio": 0.759,
-   "compress_mbps": 38.32,
-   "decompress_mbps": 168.63
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5439339,
-   "ratio": 0.7501,
-   "compress_mbps": 29.43,
-   "decompress_mbps": 230.72
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5394604,
-   "ratio": 0.7439,
-   "compress_mbps": 32.68,
-   "decompress_mbps": 256.53
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5370116,
-   "ratio": 0.7405,
-   "compress_mbps": 28.44,
-   "decompress_mbps": 312.67
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5331793,
-   "ratio": 0.7352,
-   "compress_mbps": 20.53,
-   "decompress_mbps": 329.4
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5327677,
-   "ratio": 0.7347,
-   "compress_mbps": 21.16,
-   "decompress_mbps": 348.44
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5325914,
-   "ratio": 0.7344,
-   "compress_mbps": 18.96,
-   "decompress_mbps": 349.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5325914,
-   "ratio": 0.7344,
-   "compress_mbps": 18.95,
-   "decompress_mbps": 346.98
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 14991236,
-   "ratio": 0.3616,
-   "compress_mbps": 136.65,
-   "decompress_mbps": 380.3
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 14249692,
-   "ratio": 0.3437,
-   "compress_mbps": 120.34,
-   "decompress_mbps": 401.81
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 13627761,
-   "ratio": 0.3287,
-   "compress_mbps": 87.73,
-   "decompress_mbps": 414.55
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 13001990,
-   "ratio": 0.3136,
-   "compress_mbps": 85.4,
-   "decompress_mbps": 395.8
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12445991,
-   "ratio": 0.3002,
-   "compress_mbps": 55.03,
-   "decompress_mbps": 392.94
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12213941,
-   "ratio": 0.2946,
-   "compress_mbps": 36.53,
-   "decompress_mbps": 400.31
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12130416,
-   "ratio": 0.2926,
-   "compress_mbps": 29.65,
-   "decompress_mbps": 401.43
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12073697,
-   "ratio": 0.2912,
-   "compress_mbps": 21.5,
-   "decompress_mbps": 403.07
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 12073469,
-   "ratio": 0.2912,
-   "compress_mbps": 21.33,
-   "decompress_mbps": 403.44
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6033926,
-   "ratio": 0.712,
-   "compress_mbps": 75.49,
-   "decompress_mbps": 294.33
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 5997474,
-   "ratio": 0.7077,
-   "compress_mbps": 68.78,
-   "decompress_mbps": 305.32
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 5966621,
-   "ratio": 0.7041,
-   "compress_mbps": 55.63,
-   "decompress_mbps": 312.38
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6091108,
-   "ratio": 0.7188,
-   "compress_mbps": 46.09,
-   "decompress_mbps": 267.15
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6053566,
-   "ratio": 0.7143,
-   "compress_mbps": 37.26,
-   "decompress_mbps": 274.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 6045111,
-   "ratio": 0.7134,
-   "compress_mbps": 34.97,
-   "decompress_mbps": 276.79
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 6045034,
-   "ratio": 0.7133,
-   "compress_mbps": 34.92,
-   "decompress_mbps": 278.07
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 6045032,
-   "ratio": 0.7133,
-   "compress_mbps": 34.97,
-   "decompress_mbps": 277.28
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 6045032,
-   "ratio": 0.7133,
-   "compress_mbps": 34.94,
-   "decompress_mbps": 277.39
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 965242,
-   "ratio": 0.1806,
-   "compress_mbps": 264.31,
-   "decompress_mbps": 697.56
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 887265,
-   "ratio": 0.166,
-   "compress_mbps": 246.22,
-   "decompress_mbps": 752.4
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 822167,
-   "ratio": 0.1538,
-   "compress_mbps": 191.48,
-   "decompress_mbps": 797.39
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 807518,
-   "ratio": 0.1511,
-   "compress_mbps": 169.01,
-   "decompress_mbps": 768.34
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 730574,
-   "ratio": 0.1367,
-   "compress_mbps": 121.75,
-   "decompress_mbps": 815.59
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 687991,
-   "ratio": 0.1287,
-   "compress_mbps": 79.31,
-   "decompress_mbps": 872.54
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 673933,
-   "ratio": 0.1261,
-   "compress_mbps": 64.99,
-   "decompress_mbps": 887.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 659518,
-   "ratio": 0.1234,
-   "compress_mbps": 43.0,
-   "decompress_mbps": 884.96
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 658899,
-   "ratio": 0.1233,
-   "compress_mbps": 39.85,
-   "decompress_mbps": 896.88
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 5363862,
-   "ratio": 0.5263,
-   "compress_mbps": 141.65,
-   "decompress_mbps": 389.91
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4438205,
-   "ratio": 0.4354,
-   "compress_mbps": 128.9,
-   "decompress_mbps": 428.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 4054333,
-   "ratio": 0.3978,
-   "compress_mbps": 63.86,
-   "decompress_mbps": 475.64
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 4038550,
-   "ratio": 0.3962,
-   "compress_mbps": 57.76,
-   "decompress_mbps": 469.09
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3954920,
-   "ratio": 0.388,
-   "compress_mbps": 40.27,
-   "decompress_mbps": 462.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3872874,
-   "ratio": 0.38,
-   "compress_mbps": 22.58,
-   "decompress_mbps": 470.25
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3859937,
-   "ratio": 0.3787,
-   "compress_mbps": 18.83,
-   "decompress_mbps": 472.38
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3855935,
-   "ratio": 0.3783,
-   "compress_mbps": 17.07,
-   "decompress_mbps": 469.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3855791,
-   "ratio": 0.3783,
-   "compress_mbps": 17.01,
-   "decompress_mbps": 470.52
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 22334882,
-   "ratio": 0.4361,
-   "compress_mbps": 233.89,
-   "decompress_mbps": 370.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 20150366,
-   "ratio": 0.3934,
-   "compress_mbps": 119.97,
-   "decompress_mbps": 375.66
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19495014,
-   "ratio": 0.3806,
-   "compress_mbps": 70.13,
-   "decompress_mbps": 389.58
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19424978,
-   "ratio": 0.3792,
-   "compress_mbps": 71.02,
-   "decompress_mbps": 402.97
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 19298736,
-   "ratio": 0.3768,
-   "compress_mbps": 54.1,
-   "decompress_mbps": 393.93
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19179167,
-   "ratio": 0.3744,
-   "compress_mbps": 29.69,
-   "decompress_mbps": 422.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19151324,
-   "ratio": 0.3739,
-   "compress_mbps": 21.89,
-   "decompress_mbps": 422.25
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19144373,
-   "ratio": 0.3738,
-   "compress_mbps": 16.59,
-   "decompress_mbps": 407.62
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 19141383,
-   "ratio": 0.3737,
-   "compress_mbps": 14.17,
-   "decompress_mbps": 420.85
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 4249731,
-   "ratio": 0.4262,
-   "compress_mbps": 313.35,
-   "decompress_mbps": 528.94
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3775479,
-   "ratio": 0.3787,
-   "compress_mbps": 156.84,
-   "decompress_mbps": 517.84
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3656966,
-   "ratio": 0.3668,
-   "compress_mbps": 79.84,
-   "decompress_mbps": 574.15
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3740378,
-   "ratio": 0.3751,
-   "compress_mbps": 67.57,
-   "decompress_mbps": 534.79
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3713604,
-   "ratio": 0.3725,
-   "compress_mbps": 48.45,
-   "decompress_mbps": 501.84
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3683556,
-   "ratio": 0.3694,
-   "compress_mbps": 24.87,
-   "decompress_mbps": 515.42
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3683797,
-   "ratio": 0.3695,
-   "compress_mbps": 18.98,
-   "decompress_mbps": 521.98
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3684477,
-   "ratio": 0.3695,
-   "compress_mbps": 14.34,
-   "decompress_mbps": 540.16
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3679414,
-   "ratio": 0.369,
-   "compress_mbps": 12.34,
-   "decompress_mbps": 542.45
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 5594622,
-   "ratio": 0.1667,
-   "compress_mbps": 433.55,
-   "decompress_mbps": 834.3
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 4179532,
-   "ratio": 0.1246,
-   "compress_mbps": 327.38,
-   "decompress_mbps": 926.24
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3542329,
-   "ratio": 0.1056,
-   "compress_mbps": 211.33,
-   "decompress_mbps": 842.8
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3323363,
-   "ratio": 0.099,
-   "compress_mbps": 197.38,
-   "decompress_mbps": 872.41
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3230343,
-   "ratio": 0.0963,
-   "compress_mbps": 161.61,
-   "decompress_mbps": 952.97
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3123421,
-   "ratio": 0.0931,
-   "compress_mbps": 95.69,
-   "decompress_mbps": 997.1
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3093778,
-   "ratio": 0.0922,
-   "compress_mbps": 70.53,
-   "decompress_mbps": 972.37
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3067318,
-   "ratio": 0.0914,
-   "compress_mbps": 50.06,
-   "decompress_mbps": 1013.07
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 3050695,
-   "ratio": 0.0909,
-   "compress_mbps": 41.98,
-   "decompress_mbps": 1022.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3543611,
-   "ratio": 0.576,
-   "compress_mbps": 169.2,
-   "decompress_mbps": 269.98
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3226818,
-   "ratio": 0.5245,
-   "compress_mbps": 86.03,
-   "decompress_mbps": 287.07
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3144140,
-   "ratio": 0.5111,
-   "compress_mbps": 52.6,
-   "decompress_mbps": 297.45
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3129833,
-   "ratio": 0.5087,
-   "compress_mbps": 51.39,
-   "decompress_mbps": 324.03
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3114809,
-   "ratio": 0.5063,
-   "compress_mbps": 40.29,
-   "decompress_mbps": 338.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3095705,
-   "ratio": 0.5032,
-   "compress_mbps": 25.04,
-   "decompress_mbps": 345.03
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3090055,
-   "ratio": 0.5023,
-   "compress_mbps": 20.39,
-   "decompress_mbps": 345.41
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3087665,
-   "ratio": 0.5019,
-   "compress_mbps": 17.41,
-   "decompress_mbps": 345.4
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3087158,
-   "ratio": 0.5018,
-   "compress_mbps": 16.29,
-   "decompress_mbps": 345.8
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 5419510,
-   "ratio": 0.5373,
-   "compress_mbps": 243.36,
-   "decompress_mbps": 535.63
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3982547,
-   "ratio": 0.3949,
-   "compress_mbps": 122.38,
-   "decompress_mbps": 550.66
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3806102,
-   "ratio": 0.3774,
-   "compress_mbps": 80.86,
-   "decompress_mbps": 568.24
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3761477,
-   "ratio": 0.373,
-   "compress_mbps": 78.11,
-   "decompress_mbps": 603.06
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3740298,
-   "ratio": 0.3709,
-   "compress_mbps": 67.07,
-   "decompress_mbps": 611.24
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3686116,
-   "ratio": 0.3655,
-   "compress_mbps": 49.52,
-   "decompress_mbps": 637.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3668442,
-   "ratio": 0.3637,
-   "compress_mbps": 38.85,
-   "decompress_mbps": 662.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3665072,
-   "ratio": 0.3634,
-   "compress_mbps": 33.15,
-   "decompress_mbps": 657.03
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3665057,
-   "ratio": 0.3634,
-   "compress_mbps": 32.94,
-   "decompress_mbps": 653.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2842321,
-   "ratio": 0.4289,
-   "compress_mbps": 193.08,
-   "decompress_mbps": 443.97
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2232180,
-   "ratio": 0.3368,
-   "compress_mbps": 151.04,
-   "decompress_mbps": 514.91
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2003056,
-   "ratio": 0.3022,
-   "compress_mbps": 81.92,
-   "decompress_mbps": 551.48
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 1985375,
-   "ratio": 0.2996,
-   "compress_mbps": 74.08,
-   "decompress_mbps": 566.46
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1933775,
-   "ratio": 0.2918,
-   "compress_mbps": 51.93,
-   "decompress_mbps": 538.73
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1858103,
-   "ratio": 0.2804,
-   "compress_mbps": 22.05,
-   "decompress_mbps": 541.6
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1840414,
-   "ratio": 0.2777,
-   "compress_mbps": 15.15,
-   "decompress_mbps": 550.69
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1831679,
-   "ratio": 0.2764,
-   "compress_mbps": 11.76,
-   "decompress_mbps": 543.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1827137,
-   "ratio": 0.2757,
-   "compress_mbps": 10.16,
-   "decompress_mbps": 544.36
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 7089759,
-   "ratio": 0.3281,
-   "compress_mbps": 290.79,
-   "decompress_mbps": 557.71
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 5966231,
-   "ratio": 0.2761,
-   "compress_mbps": 174.66,
-   "decompress_mbps": 619.46
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5611838,
-   "ratio": 0.2597,
-   "compress_mbps": 111.67,
-   "decompress_mbps": 648.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5535436,
-   "ratio": 0.2562,
-   "compress_mbps": 105.54,
-   "decompress_mbps": 672.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5480971,
-   "ratio": 0.2537,
-   "compress_mbps": 81.52,
-   "decompress_mbps": 680.77
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5437556,
-   "ratio": 0.2517,
-   "compress_mbps": 49.47,
-   "decompress_mbps": 697.31
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5432108,
-   "ratio": 0.2514,
-   "compress_mbps": 40.48,
-   "decompress_mbps": 694.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5428571,
-   "ratio": 0.2512,
-   "compress_mbps": 33.62,
-   "decompress_mbps": 700.3
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5425526,
-   "ratio": 0.2511,
-   "compress_mbps": 30.51,
-   "decompress_mbps": 703.33
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5900800,
-   "ratio": 0.8137,
-   "compress_mbps": 188.47,
-   "decompress_mbps": 324.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5523611,
-   "ratio": 0.7617,
-   "compress_mbps": 69.45,
-   "decompress_mbps": 340.66
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5393086,
-   "ratio": 0.7437,
-   "compress_mbps": 40.33,
-   "decompress_mbps": 351.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5401582,
-   "ratio": 0.7448,
-   "compress_mbps": 40.72,
-   "decompress_mbps": 367.5
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5371274,
-   "ratio": 0.7407,
-   "compress_mbps": 31.31,
-   "decompress_mbps": 358.37
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5330096,
-   "ratio": 0.735,
-   "compress_mbps": 20.8,
-   "decompress_mbps": 365.39
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5325437,
-   "ratio": 0.7343,
-   "compress_mbps": 18.98,
-   "decompress_mbps": 366.05
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5323934,
-   "ratio": 0.7341,
-   "compress_mbps": 18.05,
-   "decompress_mbps": 364.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323621,
-   "ratio": 0.7341,
-   "compress_mbps": 17.67,
-   "decompress_mbps": 364.02
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 17587173,
-   "ratio": 0.4242,
-   "compress_mbps": 185.73,
-   "decompress_mbps": 379.13
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 14171707,
-   "ratio": 0.3418,
-   "compress_mbps": 149.15,
-   "decompress_mbps": 409.08
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12774851,
-   "ratio": 0.3081,
-   "compress_mbps": 85.71,
-   "decompress_mbps": 440.79
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12612554,
-   "ratio": 0.3042,
-   "compress_mbps": 76.13,
-   "decompress_mbps": 444.75
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12392339,
-   "ratio": 0.2989,
-   "compress_mbps": 58.1,
-   "decompress_mbps": 457.17
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12158314,
-   "ratio": 0.2933,
-   "compress_mbps": 34.41,
-   "decompress_mbps": 463.08
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12107840,
-   "ratio": 0.292,
-   "compress_mbps": 27.64,
-   "decompress_mbps": 466.33
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12081311,
-   "ratio": 0.2914,
-   "compress_mbps": 22.88,
-   "decompress_mbps": 462.63
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 12081011,
-   "ratio": 0.2914,
-   "compress_mbps": 22.78,
-   "decompress_mbps": 460.01
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6527324,
-   "ratio": 0.7703,
-   "compress_mbps": 238.95,
-   "decompress_mbps": 330.7
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6051483,
-   "ratio": 0.7141,
-   "compress_mbps": 75.62,
-   "decompress_mbps": 332.39
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6010123,
-   "ratio": 0.7092,
-   "compress_mbps": 52.06,
-   "decompress_mbps": 334.45
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6024815,
-   "ratio": 0.711,
-   "compress_mbps": 44.63,
-   "decompress_mbps": 286.25
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6005181,
-   "ratio": 0.7086,
-   "compress_mbps": 40.44,
-   "decompress_mbps": 293.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5997508,
-   "ratio": 0.7077,
-   "compress_mbps": 37.97,
-   "decompress_mbps": 295.42
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 5997403,
-   "ratio": 0.7077,
-   "compress_mbps": 37.87,
-   "decompress_mbps": 295.69
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 5997403,
-   "ratio": 0.7077,
-   "compress_mbps": 37.82,
-   "decompress_mbps": 295.45
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5997403,
-   "ratio": 0.7077,
-   "compress_mbps": 37.76,
-   "decompress_mbps": 292.96
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 1147652,
-   "ratio": 0.2147,
-   "compress_mbps": 388.67,
-   "decompress_mbps": 761.65
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 919639,
-   "ratio": 0.172,
-   "compress_mbps": 262.86,
-   "decompress_mbps": 956.95
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 752341,
-   "ratio": 0.1407,
-   "compress_mbps": 167.46,
-   "decompress_mbps": 1057.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 735537,
-   "ratio": 0.1376,
-   "compress_mbps": 161.37,
-   "decompress_mbps": 1037.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 706789,
-   "ratio": 0.1322,
-   "compress_mbps": 123.5,
-   "decompress_mbps": 1129.34
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 676279,
-   "ratio": 0.1265,
-   "compress_mbps": 69.53,
-   "decompress_mbps": 1219.4
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 668772,
-   "ratio": 0.1251,
-   "compress_mbps": 55.97,
-   "decompress_mbps": 1208.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 665340,
-   "ratio": 0.1245,
-   "compress_mbps": 47.61,
-   "decompress_mbps": 1208.14
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 664273,
-   "ratio": 0.1243,
-   "compress_mbps": 45.85,
-   "decompress_mbps": 1218.11
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": 243.85,
-   "decompress_mbps": 801.13
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4053259,
-   "ratio": 0.3977,
-   "compress_mbps": 170.19,
-   "decompress_mbps": 864.66
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": 140.0,
-   "decompress_mbps": 934.98
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 3972869,
-   "ratio": 0.3898,
-   "compress_mbps": 127.83,
-   "decompress_mbps": 825.71
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3894026,
-   "ratio": 0.3821,
-   "compress_mbps": 99.29,
-   "decompress_mbps": 791.29
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": 75.65,
-   "decompress_mbps": 819.18
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3837515,
-   "ratio": 0.3765,
-   "compress_mbps": 55.71,
-   "decompress_mbps": 796.16
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3811467,
-   "ratio": 0.374,
-   "compress_mbps": 36.03,
-   "decompress_mbps": 816.32
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": 32.76,
-   "decompress_mbps": 816.68
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": 242.16,
-   "decompress_mbps": 676.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 19374226,
-   "ratio": 0.3783,
-   "compress_mbps": 185.69,
-   "decompress_mbps": 710.78
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": 173.04,
-   "decompress_mbps": 727.76
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19145385,
-   "ratio": 0.3738,
-   "compress_mbps": 162.62,
-   "decompress_mbps": 728.74
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 18878875,
-   "ratio": 0.3686,
-   "compress_mbps": 142.62,
-   "decompress_mbps": 741.83
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": 117.71,
-   "decompress_mbps": 750.56
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 18749947,
-   "ratio": 0.3661,
-   "compress_mbps": 87.16,
-   "decompress_mbps": 759.3
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 18718540,
-   "ratio": 0.3655,
-   "compress_mbps": 47.56,
-   "decompress_mbps": 766.6
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": 33.49,
-   "decompress_mbps": 676.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": 293.42,
-   "decompress_mbps": 755.42
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3707407,
-   "ratio": 0.3718,
-   "compress_mbps": 217.45,
-   "decompress_mbps": 768.84
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": 185.43,
-   "decompress_mbps": 809.7
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3660011,
-   "ratio": 0.3671,
-   "compress_mbps": 171.62,
-   "decompress_mbps": 751.11
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3664245,
-   "ratio": 0.3675,
-   "compress_mbps": 141.37,
-   "decompress_mbps": 712.85
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": 106.84,
-   "decompress_mbps": 739.26
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3635323,
-   "ratio": 0.3646,
-   "compress_mbps": 68.34,
-   "decompress_mbps": 735.43
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3624778,
-   "ratio": 0.3635,
-   "compress_mbps": 43.04,
-   "decompress_mbps": 773.18
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": 38.87,
-   "decompress_mbps": 757.44
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": 609.02,
-   "decompress_mbps": 1491.69
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 3714632,
-   "ratio": 0.1107,
-   "compress_mbps": 462.85,
-   "decompress_mbps": 1747.31
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": 427.07,
-   "decompress_mbps": 1882.3
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3431843,
-   "ratio": 0.1023,
-   "compress_mbps": 388.74,
-   "decompress_mbps": 1763.39
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3268188,
-   "ratio": 0.0974,
-   "compress_mbps": 346.67,
-   "decompress_mbps": 1777.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": 264.16,
-   "decompress_mbps": 1787.13
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3032499,
-   "ratio": 0.0904,
-   "compress_mbps": 186.41,
-   "decompress_mbps": 1846.22
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 2949097,
-   "ratio": 0.0879,
-   "compress_mbps": 97.63,
-   "decompress_mbps": 1789.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": 69.23,
-   "decompress_mbps": 1757.94
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": 166.26,
-   "decompress_mbps": 462.6
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3150806,
-   "ratio": 0.5121,
-   "compress_mbps": 128.39,
-   "decompress_mbps": 483.21
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": 120.82,
-   "decompress_mbps": 502.43
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3129676,
-   "ratio": 0.5087,
-   "compress_mbps": 116.89,
-   "decompress_mbps": 518.56
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3079277,
-   "ratio": 0.5005,
-   "compress_mbps": 99.99,
-   "decompress_mbps": 536.74
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": 88.82,
-   "decompress_mbps": 533.12
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3068123,
-   "ratio": 0.4987,
-   "compress_mbps": 76.38,
-   "decompress_mbps": 542.11
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3067299,
-   "ratio": 0.4986,
-   "compress_mbps": 55.33,
-   "decompress_mbps": 533.57
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": 49.23,
-   "decompress_mbps": 507.58
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": 285.16,
-   "decompress_mbps": 772.78
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3839158,
-   "ratio": 0.3807,
-   "compress_mbps": 213.22,
-   "decompress_mbps": 914.82
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": 197.74,
-   "decompress_mbps": 936.61
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3789325,
-   "ratio": 0.3757,
-   "compress_mbps": 179.66,
-   "decompress_mbps": 954.8
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3666476,
-   "ratio": 0.3635,
-   "compress_mbps": 157.89,
-   "decompress_mbps": 942.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": 142.43,
-   "decompress_mbps": 987.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3659491,
-   "ratio": 0.3628,
-   "compress_mbps": 135.11,
-   "decompress_mbps": 999.79
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3654863,
-   "ratio": 0.3624,
-   "compress_mbps": 114.32,
-   "decompress_mbps": 1009.23
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": 114.27,
-   "decompress_mbps": 1001.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": 300.85,
-   "decompress_mbps": 858.37
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2082309,
-   "ratio": 0.3142,
-   "compress_mbps": 214.77,
-   "decompress_mbps": 1130.12
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": 178.67,
-   "decompress_mbps": 1236.6
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 1990952,
-   "ratio": 0.3004,
-   "compress_mbps": 157.4,
-   "decompress_mbps": 1146.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1921113,
-   "ratio": 0.2899,
-   "compress_mbps": 127.99,
-   "decompress_mbps": 1093.81
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": 86.94,
-   "decompress_mbps": 1090.38
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1832695,
-   "ratio": 0.2765,
-   "compress_mbps": 46.02,
-   "decompress_mbps": 1103.5
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1809967,
-   "ratio": 0.2731,
-   "compress_mbps": 24.27,
-   "decompress_mbps": 1063.53
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": 19.83,
-   "decompress_mbps": 1054.62
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": 338.52,
-   "decompress_mbps": 979.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 5695942,
-   "ratio": 0.2636,
-   "compress_mbps": 258.0,
-   "decompress_mbps": 1031.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": 233.32,
-   "decompress_mbps": 1100.86
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5553432,
-   "ratio": 0.257,
-   "compress_mbps": 216.59,
-   "decompress_mbps": 1079.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5416713,
-   "ratio": 0.2507,
-   "compress_mbps": 186.71,
-   "decompress_mbps": 1066.93
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": 142.78,
-   "decompress_mbps": 1079.29
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5310181,
-   "ratio": 0.2458,
-   "compress_mbps": 100.23,
-   "decompress_mbps": 1069.71
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5272761,
-   "ratio": 0.244,
-   "compress_mbps": 62.39,
-   "decompress_mbps": 1089.17
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": 50.04,
-   "decompress_mbps": 1101.61
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": 162.23,
-   "decompress_mbps": 485.07
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5417142,
-   "ratio": 0.747,
-   "compress_mbps": 116.65,
-   "decompress_mbps": 518.27
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": 105.25,
-   "decompress_mbps": 528.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5391125,
-   "ratio": 0.7434,
-   "compress_mbps": 99.31,
-   "decompress_mbps": 542.53
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5352212,
-   "ratio": 0.738,
-   "compress_mbps": 87.58,
-   "decompress_mbps": 513.46
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": 73.79,
-   "decompress_mbps": 526.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5325697,
-   "ratio": 0.7344,
-   "compress_mbps": 63.45,
-   "decompress_mbps": 513.46
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5324004,
-   "ratio": 0.7341,
-   "compress_mbps": 52.34,
-   "decompress_mbps": 522.62
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": 50.85,
-   "decompress_mbps": 511.04
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": 266.06,
-   "decompress_mbps": 891.09
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 13130705,
-   "ratio": 0.3167,
-   "compress_mbps": 199.84,
-   "decompress_mbps": 973.65
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": 176.74,
-   "decompress_mbps": 1015.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12601933,
-   "ratio": 0.304,
-   "compress_mbps": 161.98,
-   "decompress_mbps": 899.79
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12310776,
-   "ratio": 0.2969,
-   "compress_mbps": 131.58,
-   "decompress_mbps": 879.58
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": 104.62,
-   "decompress_mbps": 887.92
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12025296,
-   "ratio": 0.2901,
-   "compress_mbps": 75.01,
-   "decompress_mbps": 892.91
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 11893824,
-   "ratio": 0.2869,
-   "compress_mbps": 45.87,
-   "decompress_mbps": 886.31
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": 39.46,
-   "decompress_mbps": 930.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": 145.39,
-   "decompress_mbps": 523.59
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6058412,
-   "ratio": 0.7149,
-   "compress_mbps": 120.35,
-   "decompress_mbps": 529.46
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": 120.3,
-   "decompress_mbps": 539.19
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6058363,
-   "ratio": 0.7149,
-   "compress_mbps": 120.03,
-   "decompress_mbps": 437.57
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 5998400,
-   "ratio": 0.7078,
-   "compress_mbps": 108.52,
-   "decompress_mbps": 459.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": 108.55,
-   "decompress_mbps": 463.75
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 5998439,
-   "ratio": 0.7078,
-   "compress_mbps": 108.18,
-   "decompress_mbps": 462.69
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": 90.15,
-   "decompress_mbps": 462.82
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": 90.18,
-   "decompress_mbps": 454.72
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": 492.83,
-   "decompress_mbps": 1270.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 843475,
-   "ratio": 0.1578,
-   "compress_mbps": 363.79,
-   "decompress_mbps": 1801.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": 337.16,
-   "decompress_mbps": 1867.27
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 747602,
-   "ratio": 0.1399,
-   "compress_mbps": 304.24,
-   "decompress_mbps": 1819.5
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 718615,
-   "ratio": 0.1344,
-   "compress_mbps": 263.07,
-   "decompress_mbps": 1830.67
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": 206.4,
-   "decompress_mbps": 1920.08
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 664859,
-   "ratio": 0.1244,
-   "compress_mbps": 142.72,
-   "decompress_mbps": 1906.99
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 650835,
-   "ratio": 0.1218,
-   "compress_mbps": 81.56,
-   "decompress_mbps": 1892.16
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": 68.13,
-   "decompress_mbps": 1902.14
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 65708,
-   "ratio": 0.432,
-   "compress_mbps": 42.56,
-   "decompress_mbps": 61.17
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 60259,
-   "ratio": 0.3962,
-   "compress_mbps": 26.21,
-   "decompress_mbps": 68.33
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 58544,
-   "ratio": 0.3849,
-   "compress_mbps": 21.92,
-   "decompress_mbps": 69.11
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 56238,
-   "ratio": 0.3698,
-   "compress_mbps": 21.46,
-   "decompress_mbps": 70.96
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 54764,
-   "ratio": 0.3601,
-   "compress_mbps": 16.16,
-   "decompress_mbps": 71.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54311,
-   "ratio": 0.3571,
-   "compress_mbps": 10.7,
-   "decompress_mbps": 71.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54262,
-   "ratio": 0.3568,
-   "compress_mbps": 9.8,
-   "decompress_mbps": 72.02
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 54247,
-   "ratio": 0.3567,
-   "compress_mbps": 9.57,
-   "decompress_mbps": 72.02
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 54247,
-   "ratio": 0.3567,
-   "compress_mbps": 9.65,
-   "decompress_mbps": 72.57
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 56882,
-   "ratio": 0.4544,
-   "compress_mbps": 37.25,
-   "decompress_mbps": 55.92
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 52826,
-   "ratio": 0.422,
-   "compress_mbps": 23.05,
-   "decompress_mbps": 62.21
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 51625,
-   "ratio": 0.4124,
-   "compress_mbps": 22.69,
-   "decompress_mbps": 65.27
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 50034,
-   "ratio": 0.3997,
-   "compress_mbps": 22.5,
-   "decompress_mbps": 65.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 48912,
-   "ratio": 0.3907,
-   "compress_mbps": 12.62,
-   "decompress_mbps": 65.42
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48738,
-   "ratio": 0.3893,
-   "compress_mbps": 11.77,
-   "decompress_mbps": 65.61
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48719,
-   "ratio": 0.3892,
-   "compress_mbps": 9.97,
-   "decompress_mbps": 65.88
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 48716,
-   "ratio": 0.3892,
-   "compress_mbps": 9.9,
-   "decompress_mbps": 68.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 48716,
-   "ratio": 0.3892,
-   "compress_mbps": 12.58,
-   "decompress_mbps": 64.73
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8988,
-   "ratio": 0.3653,
-   "compress_mbps": 36.94,
-   "decompress_mbps": 103.46
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8564,
-   "ratio": 0.3481,
-   "compress_mbps": 43.51,
-   "decompress_mbps": 102.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8390,
-   "ratio": 0.341,
-   "compress_mbps": 28.97,
-   "decompress_mbps": 97.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8167,
-   "ratio": 0.332,
-   "compress_mbps": 37.49,
-   "decompress_mbps": 98.37
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 7965,
-   "ratio": 0.3237,
-   "compress_mbps": 28.72,
-   "decompress_mbps": 88.78
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7916,
-   "ratio": 0.3217,
-   "compress_mbps": 22.76,
-   "decompress_mbps": 104.8
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7900,
-   "ratio": 0.3211,
-   "compress_mbps": 21.67,
-   "decompress_mbps": 85.25
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7900,
-   "ratio": 0.3211,
-   "compress_mbps": 20.13,
-   "decompress_mbps": 105.7
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7900,
-   "ratio": 0.3211,
-   "compress_mbps": 27.55,
-   "decompress_mbps": 92.8
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3731,
-   "ratio": 0.3346,
-   "compress_mbps": 18.9,
-   "decompress_mbps": 80.13
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3491,
-   "ratio": 0.3131,
-   "compress_mbps": 23.63,
-   "decompress_mbps": 84.66
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3384,
-   "ratio": 0.3035,
-   "compress_mbps": 22.04,
-   "decompress_mbps": 89.77
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3220,
-   "ratio": 0.2888,
-   "compress_mbps": 21.08,
-   "decompress_mbps": 86.53
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3138,
-   "ratio": 0.2814,
-   "compress_mbps": 17.11,
-   "decompress_mbps": 93.05
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3118,
-   "ratio": 0.2796,
-   "compress_mbps": 15.03,
-   "decompress_mbps": 100.03
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3116,
-   "ratio": 0.2795,
-   "compress_mbps": 14.26,
-   "decompress_mbps": 96.56
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3116,
-   "ratio": 0.2795,
-   "compress_mbps": 14.4,
-   "decompress_mbps": 104.06
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3116,
-   "ratio": 0.2795,
-   "compress_mbps": 15.81,
-   "decompress_mbps": 101.86
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1352,
-   "ratio": 0.3633,
-   "compress_mbps": 8.47,
-   "decompress_mbps": 63.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1287,
-   "ratio": 0.3459,
-   "compress_mbps": 11.63,
-   "decompress_mbps": 60.62
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1284,
-   "ratio": 0.3451,
-   "compress_mbps": 11.67,
-   "decompress_mbps": 62.5
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1226,
-   "ratio": 0.3295,
-   "compress_mbps": 11.31,
-   "decompress_mbps": 66.96
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1211,
-   "ratio": 0.3255,
-   "compress_mbps": 9.84,
-   "decompress_mbps": 63.24
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1211,
-   "ratio": 0.3255,
-   "compress_mbps": 10.84,
-   "decompress_mbps": 63.7
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1211,
-   "ratio": 0.3255,
-   "compress_mbps": 10.02,
-   "decompress_mbps": 64.11
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1211,
-   "ratio": 0.3255,
-   "compress_mbps": 10.74,
-   "decompress_mbps": 80.94
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1211,
-   "ratio": 0.3255,
-   "compress_mbps": 11.17,
-   "decompress_mbps": 63.88
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 245423,
-   "ratio": 0.2383,
-   "compress_mbps": 123.71,
-   "decompress_mbps": 127.4
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 229642,
-   "ratio": 0.223,
-   "compress_mbps": 92.84,
-   "decompress_mbps": 151.73
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 225678,
-   "ratio": 0.2192,
-   "compress_mbps": 109.83,
-   "decompress_mbps": 153.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 218218,
-   "ratio": 0.2119,
-   "compress_mbps": 99.82,
-   "decompress_mbps": 163.61
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 210550,
-   "ratio": 0.2045,
-   "compress_mbps": 48.7,
-   "decompress_mbps": 154.12
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 207949,
-   "ratio": 0.2019,
-   "compress_mbps": 27.88,
-   "decompress_mbps": 168.6
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 207413,
-   "ratio": 0.2014,
-   "compress_mbps": 18.82,
-   "decompress_mbps": 151.74
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 207478,
-   "ratio": 0.2015,
-   "compress_mbps": 6.77,
-   "decompress_mbps": 153.16
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 207482,
-   "ratio": 0.2015,
-   "compress_mbps": 3.56,
-   "decompress_mbps": 157.49
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 175980,
-   "ratio": 0.4124,
-   "compress_mbps": 43.31,
-   "decompress_mbps": 64.49
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 160455,
-   "ratio": 0.376,
-   "compress_mbps": 70.41,
-   "decompress_mbps": 72.33
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 156690,
-   "ratio": 0.3672,
-   "compress_mbps": 32.21,
-   "decompress_mbps": 74.1
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 149064,
-   "ratio": 0.3493,
-   "compress_mbps": 36.48,
-   "decompress_mbps": 75.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 145616,
-   "ratio": 0.3412,
-   "compress_mbps": 20.01,
-   "decompress_mbps": 76.95
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 144773,
-   "ratio": 0.3392,
-   "compress_mbps": 17.53,
-   "decompress_mbps": 76.34
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 144603,
-   "ratio": 0.3388,
-   "compress_mbps": 19.93,
-   "decompress_mbps": 75.91
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 144573,
-   "ratio": 0.3388,
-   "compress_mbps": 16.49,
-   "decompress_mbps": 80.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 144570,
-   "ratio": 0.3388,
-   "compress_mbps": 15.68,
-   "decompress_mbps": 75.93
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 228837,
-   "ratio": 0.4749,
-   "compress_mbps": 35.31,
-   "decompress_mbps": 54.63
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 211248,
-   "ratio": 0.4384,
-   "compress_mbps": 31.57,
-   "decompress_mbps": 61.56
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 205619,
-   "ratio": 0.4267,
-   "compress_mbps": 25.52,
-   "decompress_mbps": 67.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 200595,
-   "ratio": 0.4163,
-   "compress_mbps": 34.86,
-   "decompress_mbps": 66.46
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 195418,
-   "ratio": 0.4055,
-   "compress_mbps": 18.88,
-   "decompress_mbps": 65.35
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 194148,
-   "ratio": 0.4029,
-   "compress_mbps": 15.2,
-   "decompress_mbps": 66.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 193994,
-   "ratio": 0.4026,
-   "compress_mbps": 16.61,
-   "decompress_mbps": 66.46
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 193991,
-   "ratio": 0.4026,
-   "compress_mbps": 14.97,
-   "decompress_mbps": 65.37
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 193991,
-   "ratio": 0.4026,
-   "compress_mbps": 14.75,
-   "decompress_mbps": 80.17
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 60990,
-   "ratio": 0.1188,
-   "compress_mbps": 240.46,
-   "decompress_mbps": 173.43
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 61650,
-   "ratio": 0.1201,
-   "compress_mbps": 103.12,
-   "decompress_mbps": 188.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 60035,
-   "ratio": 0.117,
-   "compress_mbps": 90.48,
-   "decompress_mbps": 205.17
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 57005,
-   "ratio": 0.1111,
-   "compress_mbps": 91.56,
-   "decompress_mbps": 195.56
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 55779,
-   "ratio": 0.1087,
-   "compress_mbps": 81.64,
-   "decompress_mbps": 263.29
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 54970,
-   "ratio": 0.1071,
-   "compress_mbps": 69.16,
-   "decompress_mbps": 204.84
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 53922,
-   "ratio": 0.1051,
-   "compress_mbps": 76.91,
-   "decompress_mbps": 217.15
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 51977,
-   "ratio": 0.1013,
-   "compress_mbps": 17.63,
-   "decompress_mbps": 275.85
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 51474,
-   "ratio": 0.1003,
-   "compress_mbps": 6.71,
-   "decompress_mbps": 239.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 14783,
-   "ratio": 0.3866,
-   "compress_mbps": 32.71,
-   "decompress_mbps": 70.98
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 14101,
-   "ratio": 0.3688,
-   "compress_mbps": 33.16,
-   "decompress_mbps": 78.17
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13975,
-   "ratio": 0.3655,
-   "compress_mbps": 28.17,
-   "decompress_mbps": 75.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13632,
-   "ratio": 0.3565,
-   "compress_mbps": 30.93,
-   "decompress_mbps": 100.62
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13302,
-   "ratio": 0.3479,
-   "compress_mbps": 25.78,
-   "decompress_mbps": 79.98
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 13279,
-   "ratio": 0.3473,
-   "compress_mbps": 21.9,
-   "decompress_mbps": 77.99
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 13274,
-   "ratio": 0.3471,
-   "compress_mbps": 19.14,
-   "decompress_mbps": 84.74
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 13260,
-   "ratio": 0.3468,
-   "compress_mbps": 7.15,
-   "decompress_mbps": 80.47
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 13260,
-   "ratio": 0.3468,
-   "compress_mbps": 4.57,
-   "decompress_mbps": 79.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1862,
-   "ratio": 0.4405,
-   "compress_mbps": 9.05,
-   "decompress_mbps": 61.67
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1803,
-   "ratio": 0.4265,
-   "compress_mbps": 12.61,
-   "decompress_mbps": 58.6
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1791,
-   "ratio": 0.4237,
-   "compress_mbps": 12.87,
-   "decompress_mbps": 60.15
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1746,
-   "ratio": 0.4131,
-   "compress_mbps": 12.23,
-   "decompress_mbps": 60.76
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1725,
-   "ratio": 0.4081,
-   "compress_mbps": 10.95,
-   "decompress_mbps": 59.77
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1725,
-   "ratio": 0.4081,
-   "compress_mbps": 11.32,
-   "decompress_mbps": 59.78
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1725,
-   "ratio": 0.4081,
-   "compress_mbps": 10.98,
-   "decompress_mbps": 65.28
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1725,
-   "ratio": 0.4081,
-   "compress_mbps": 11.09,
-   "decompress_mbps": 61.29
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1725,
-   "ratio": 0.4081,
-   "compress_mbps": 11.55,
-   "decompress_mbps": 61.79
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4623589,
-   "ratio": 0.4536,
-   "compress_mbps": 87.88,
-   "decompress_mbps": 121.47
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4241525,
-   "ratio": 0.4161,
-   "compress_mbps": 59.05,
-   "decompress_mbps": 124.77
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 4123202,
-   "ratio": 0.4045,
-   "compress_mbps": 61.06,
-   "decompress_mbps": 116.15
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 3985937,
-   "ratio": 0.3911,
-   "compress_mbps": 60.91,
-   "decompress_mbps": 204.23
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3883839,
-   "ratio": 0.3811,
-   "compress_mbps": 35.59,
-   "decompress_mbps": 119.76
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3860437,
-   "ratio": 0.3788,
-   "compress_mbps": 27.93,
-   "decompress_mbps": 202.6
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3857076,
-   "ratio": 0.3784,
-   "compress_mbps": 25.13,
-   "decompress_mbps": 126.89
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3856651,
-   "ratio": 0.3784,
-   "compress_mbps": 24.66,
-   "decompress_mbps": 202.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3856651,
-   "ratio": 0.3784,
-   "compress_mbps": 24.68,
-   "decompress_mbps": 116.01
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 21508211,
-   "ratio": 0.4199,
-   "compress_mbps": 143.1,
-   "decompress_mbps": 239.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 20538783,
-   "ratio": 0.401,
-   "compress_mbps": 103.18,
-   "decompress_mbps": 229.73
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 20334352,
-   "ratio": 0.397,
-   "compress_mbps": 88.51,
-   "decompress_mbps": 208.07
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19886937,
-   "ratio": 0.3883,
-   "compress_mbps": 86.76,
-   "decompress_mbps": 244.41
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 19582363,
-   "ratio": 0.3823,
-   "compress_mbps": 65.59,
-   "decompress_mbps": 239.15
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19512479,
-   "ratio": 0.381,
-   "compress_mbps": 43.56,
-   "decompress_mbps": 220.01
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19489160,
-   "ratio": 0.3805,
-   "compress_mbps": 32.93,
-   "decompress_mbps": 227.82
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19475109,
-   "ratio": 0.3802,
-   "compress_mbps": 18.63,
-   "decompress_mbps": 225.38
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 19476276,
-   "ratio": 0.3802,
-   "compress_mbps": 10.28,
-   "decompress_mbps": 247.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3967718,
-   "ratio": 0.3979,
-   "compress_mbps": 146.76,
-   "decompress_mbps": 172.01
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3773274,
-   "ratio": 0.3784,
-   "compress_mbps": 105.47,
-   "decompress_mbps": 124.64
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3670460,
-   "ratio": 0.3681,
-   "compress_mbps": 77.56,
-   "decompress_mbps": 182.34
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3655100,
-   "ratio": 0.3666,
-   "compress_mbps": 87.36,
-   "decompress_mbps": 107.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3620881,
-   "ratio": 0.3632,
-   "compress_mbps": 51.01,
-   "decompress_mbps": 125.34
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3606626,
-   "ratio": 0.3617,
-   "compress_mbps": 33.83,
-   "decompress_mbps": 183.58
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3605405,
-   "ratio": 0.3616,
-   "compress_mbps": 31.23,
-   "decompress_mbps": 130.79
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3601635,
-   "ratio": 0.3612,
-   "compress_mbps": 26.28,
-   "decompress_mbps": 133.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3601151,
-   "ratio": 0.3612,
-   "compress_mbps": 19.51,
-   "decompress_mbps": 120.72
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 4501482,
-   "ratio": 0.1342,
-   "compress_mbps": 294.72,
-   "decompress_mbps": 451.24
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 3875891,
-   "ratio": 0.1155,
-   "compress_mbps": 315.51,
-   "decompress_mbps": 356.45
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3731525,
-   "ratio": 0.1112,
-   "compress_mbps": 288.4,
-   "decompress_mbps": 372.55
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3542242,
-   "ratio": 0.1056,
-   "compress_mbps": 236.86,
-   "decompress_mbps": 484.44
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3239184,
-   "ratio": 0.0965,
-   "compress_mbps": 175.14,
-   "decompress_mbps": 539.55
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3113927,
-   "ratio": 0.0928,
-   "compress_mbps": 120.53,
-   "decompress_mbps": 330.65
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3063520,
-   "ratio": 0.0913,
-   "compress_mbps": 84.76,
-   "decompress_mbps": 331.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 2961320,
-   "ratio": 0.0883,
-   "compress_mbps": 29.61,
-   "decompress_mbps": 401.64
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2940087,
-   "ratio": 0.0876,
-   "compress_mbps": 20.54,
-   "decompress_mbps": 474.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3462708,
-   "ratio": 0.5628,
-   "compress_mbps": 65.77,
-   "decompress_mbps": 109.92
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3327399,
-   "ratio": 0.5408,
-   "compress_mbps": 71.78,
-   "decompress_mbps": 84.48
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3297422,
-   "ratio": 0.536,
-   "compress_mbps": 66.06,
-   "decompress_mbps": 89.69
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3249485,
-   "ratio": 0.5282,
-   "compress_mbps": 64.02,
-   "decompress_mbps": 122.88
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3220046,
-   "ratio": 0.5234,
-   "compress_mbps": 49.81,
-   "decompress_mbps": 90.58
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3213239,
-   "ratio": 0.5223,
-   "compress_mbps": 43.12,
-   "decompress_mbps": 91.3
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3212009,
-   "ratio": 0.5221,
-   "compress_mbps": 39.44,
-   "decompress_mbps": 177.12
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3211575,
-   "ratio": 0.522,
-   "compress_mbps": 27.92,
-   "decompress_mbps": 92.84
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3211561,
-   "ratio": 0.522,
-   "compress_mbps": 29.68,
-   "decompress_mbps": 92.12
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 4334497,
-   "ratio": 0.4298,
-   "compress_mbps": 130.93,
-   "decompress_mbps": 133.29
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3900156,
-   "ratio": 0.3867,
-   "compress_mbps": 131.77,
-   "decompress_mbps": 116.9
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3876099,
-   "ratio": 0.3843,
-   "compress_mbps": 122.94,
-   "decompress_mbps": 133.81
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3782364,
-   "ratio": 0.375,
-   "compress_mbps": 110.84,
-   "decompress_mbps": 135.49
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3679310,
-   "ratio": 0.3648,
-   "compress_mbps": 89.42,
-   "decompress_mbps": 136.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3679424,
-   "ratio": 0.3648,
-   "compress_mbps": 87.41,
-   "decompress_mbps": 128.99
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3679163,
-   "ratio": 0.3648,
-   "compress_mbps": 83.39,
-   "decompress_mbps": 141.56
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3679169,
-   "ratio": 0.3648,
-   "compress_mbps": 82.21,
-   "decompress_mbps": 140.66
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3679169,
-   "ratio": 0.3648,
-   "compress_mbps": 81.84,
-   "decompress_mbps": 196.94
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2496363,
-   "ratio": 0.3767,
-   "compress_mbps": 96.93,
-   "decompress_mbps": 111.19
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2202601,
-   "ratio": 0.3324,
-   "compress_mbps": 92.65,
-   "decompress_mbps": 102.3
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2103089,
-   "ratio": 0.3173,
-   "compress_mbps": 49.73,
-   "decompress_mbps": 242.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 1999697,
-   "ratio": 0.3017,
-   "compress_mbps": 75.29,
-   "decompress_mbps": 121.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1892143,
-   "ratio": 0.2855,
-   "compress_mbps": 37.29,
-   "decompress_mbps": 108.65
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1838372,
-   "ratio": 0.2774,
-   "compress_mbps": 20.3,
-   "decompress_mbps": 108.77
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1828850,
-   "ratio": 0.276,
-   "compress_mbps": 15.87,
-   "decompress_mbps": 115.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1823159,
-   "ratio": 0.2751,
-   "compress_mbps": 12.46,
-   "decompress_mbps": 114.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1823159,
-   "ratio": 0.2751,
-   "compress_mbps": 12.53,
-   "decompress_mbps": 97.46
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 6447290,
-   "ratio": 0.2984,
-   "compress_mbps": 187.76,
-   "decompress_mbps": 292.5
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 6030257,
-   "ratio": 0.2791,
-   "compress_mbps": 147.85,
-   "decompress_mbps": 241.28
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5928121,
-   "ratio": 0.2744,
-   "compress_mbps": 128.5,
-   "decompress_mbps": 269.87
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5615804,
-   "ratio": 0.2599,
-   "compress_mbps": 121.57,
-   "decompress_mbps": 280.75
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5496738,
-   "ratio": 0.2544,
-   "compress_mbps": 80.22,
-   "decompress_mbps": 336.14
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5464184,
-   "ratio": 0.2529,
-   "compress_mbps": 62.73,
-   "decompress_mbps": 195.35
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5429645,
-   "ratio": 0.2513,
-   "compress_mbps": 47.93,
-   "decompress_mbps": 214.77
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5418135,
-   "ratio": 0.2508,
-   "compress_mbps": 36.65,
-   "decompress_mbps": 241.37
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5416628,
-   "ratio": 0.2507,
-   "compress_mbps": 33.67,
-   "decompress_mbps": 233.28
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5759187,
-   "ratio": 0.7942,
-   "compress_mbps": 91.27,
-   "decompress_mbps": 158.91
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5619390,
-   "ratio": 0.7749,
-   "compress_mbps": 49.54,
-   "decompress_mbps": 94.64
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5560914,
-   "ratio": 0.7668,
-   "compress_mbps": 43.81,
-   "decompress_mbps": 115.78
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5544069,
-   "ratio": 0.7645,
-   "compress_mbps": 44.58,
-   "decompress_mbps": 94.11
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5518257,
-   "ratio": 0.7609,
-   "compress_mbps": 36.73,
-   "decompress_mbps": 163.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5508662,
-   "ratio": 0.7596,
-   "compress_mbps": 33.77,
-   "decompress_mbps": 95.01
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5507534,
-   "ratio": 0.7595,
-   "compress_mbps": 35.09,
-   "decompress_mbps": 95.76
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5507183,
-   "ratio": 0.7594,
-   "compress_mbps": 32.41,
-   "decompress_mbps": 94.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5507183,
-   "ratio": 0.7594,
-   "compress_mbps": 32.5,
-   "decompress_mbps": 117.56
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 15230651,
-   "ratio": 0.3674,
-   "compress_mbps": 123.36,
-   "decompress_mbps": 184.33
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 13822040,
-   "ratio": 0.3334,
-   "compress_mbps": 96.36,
-   "decompress_mbps": 194.1
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 13397592,
-   "ratio": 0.3232,
-   "compress_mbps": 83.62,
-   "decompress_mbps": 202.34
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12759940,
-   "ratio": 0.3078,
-   "compress_mbps": 80.4,
-   "decompress_mbps": 223.21
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12274278,
-   "ratio": 0.2961,
-   "compress_mbps": 54.6,
-   "decompress_mbps": 216.16
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12131738,
-   "ratio": 0.2926,
-   "compress_mbps": 40.41,
-   "decompress_mbps": 218.2
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12060450,
-   "ratio": 0.2909,
-   "compress_mbps": 33.43,
-   "decompress_mbps": 203.45
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12036900,
-   "ratio": 0.2903,
-   "compress_mbps": 29.91,
-   "decompress_mbps": 206.04
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 12036900,
-   "ratio": 0.2903,
-   "compress_mbps": 30.01,
-   "decompress_mbps": 223.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6653052,
-   "ratio": 0.7851,
-   "compress_mbps": 124.38,
-   "decompress_mbps": 152.55
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6305035,
-   "ratio": 0.744,
-   "compress_mbps": 53.84,
-   "decompress_mbps": 154.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6302730,
-   "ratio": 0.7438,
-   "compress_mbps": 52.94,
-   "decompress_mbps": 119.64
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6299134,
-   "ratio": 0.7433,
-   "compress_mbps": 52.14,
-   "decompress_mbps": 156.45
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6289022,
-   "ratio": 0.7421,
-   "compress_mbps": 64.63,
-   "decompress_mbps": 159.21
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 6289013,
-   "ratio": 0.7421,
-   "compress_mbps": 50.64,
-   "decompress_mbps": 156.7
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 6289013,
-   "ratio": 0.7421,
-   "compress_mbps": 50.91,
-   "decompress_mbps": 165.38
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 6289012,
-   "ratio": 0.7421,
-   "compress_mbps": 64.4,
-   "decompress_mbps": 157.39
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 6289012,
-   "ratio": 0.7421,
-   "compress_mbps": 64.37,
-   "decompress_mbps": 98.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 989456,
-   "ratio": 0.1851,
-   "compress_mbps": 243.16,
-   "decompress_mbps": 153.25
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 839766,
-   "ratio": 0.1571,
-   "compress_mbps": 178.46,
-   "decompress_mbps": 169.75
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 800619,
-   "ratio": 0.1498,
-   "compress_mbps": 181.16,
-   "decompress_mbps": 178.28
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 776397,
-   "ratio": 0.1452,
-   "compress_mbps": 149.67,
-   "decompress_mbps": 185.03
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 712679,
-   "ratio": 0.1333,
-   "compress_mbps": 103.54,
-   "decompress_mbps": 199.06
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 683707,
-   "ratio": 0.1279,
-   "compress_mbps": 93.5,
-   "decompress_mbps": 512.66
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 668601,
-   "ratio": 0.1251,
-   "compress_mbps": 70.7,
-   "decompress_mbps": 209.33
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 659106,
-   "ratio": 0.1233,
-   "compress_mbps": 42.04,
-   "decompress_mbps": 216.57
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 658920,
-   "ratio": 0.1233,
-   "compress_mbps": 42.13,
-   "decompress_mbps": 256.07
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 62797,
-   "ratio": 0.4129,
-   "compress_mbps": 75.96,
-   "decompress_mbps": 132.29
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 59605,
-   "ratio": 0.3919,
-   "compress_mbps": 62.87,
-   "decompress_mbps": 131.77
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 57675,
-   "ratio": 0.3792,
-   "compress_mbps": 53.89,
-   "decompress_mbps": 124.29
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 56500,
-   "ratio": 0.3715,
-   "compress_mbps": 38.93,
-   "decompress_mbps": 131.16
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 56440,
-   "ratio": 0.3711,
-   "compress_mbps": 38.82,
-   "decompress_mbps": 130.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 55443,
-   "ratio": 0.3645,
-   "compress_mbps": 32.14,
-   "decompress_mbps": 146.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 55373,
-   "ratio": 0.3641,
-   "compress_mbps": 31.65,
-   "decompress_mbps": 130.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 55352,
-   "ratio": 0.3639,
-   "compress_mbps": 31.32,
-   "decompress_mbps": 136.96
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 55352,
-   "ratio": 0.3639,
-   "compress_mbps": 31.37,
-   "decompress_mbps": 135.72
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 55063,
-   "ratio": 0.4399,
-   "compress_mbps": 74.97,
-   "decompress_mbps": 117.68
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 52932,
-   "ratio": 0.4229,
-   "compress_mbps": 60.75,
-   "decompress_mbps": 116.27
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 51597,
-   "ratio": 0.4122,
-   "compress_mbps": 44.1,
-   "decompress_mbps": 116.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 50780,
-   "ratio": 0.4057,
-   "compress_mbps": 43.18,
-   "decompress_mbps": 120.67
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 50767,
-   "ratio": 0.4056,
-   "compress_mbps": 42.85,
-   "decompress_mbps": 122.05
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 50160,
-   "ratio": 0.4007,
-   "compress_mbps": 33.03,
-   "decompress_mbps": 128.52
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 50138,
-   "ratio": 0.4005,
-   "compress_mbps": 31.52,
-   "decompress_mbps": 124.51
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 50138,
-   "ratio": 0.4005,
-   "compress_mbps": 32.14,
-   "decompress_mbps": 125.83
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 50138,
-   "ratio": 0.4005,
-   "compress_mbps": 35.79,
-   "decompress_mbps": 124.35
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8730,
-   "ratio": 0.3548,
-   "compress_mbps": 46.94,
-   "decompress_mbps": 123.4
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8457,
-   "ratio": 0.3437,
-   "compress_mbps": 43.65,
-   "decompress_mbps": 119.12
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8353,
-   "ratio": 0.3395,
-   "compress_mbps": 64.98,
-   "decompress_mbps": 109.7
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8301,
-   "ratio": 0.3374,
-   "compress_mbps": 42.45,
-   "decompress_mbps": 124.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 8212,
-   "ratio": 0.3338,
-   "compress_mbps": 58.84,
-   "decompress_mbps": 103.81
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 8172,
-   "ratio": 0.3322,
-   "compress_mbps": 48.55,
-   "decompress_mbps": 108.53
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 8171,
-   "ratio": 0.3321,
-   "compress_mbps": 50.28,
-   "decompress_mbps": 109.3
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 8171,
-   "ratio": 0.3321,
-   "compress_mbps": 49.23,
-   "decompress_mbps": 109.09
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 8171,
-   "ratio": 0.3321,
-   "compress_mbps": 53.75,
-   "decompress_mbps": 109.08
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3475,
-   "ratio": 0.3117,
-   "compress_mbps": 109.11,
-   "decompress_mbps": 96.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3305,
-   "ratio": 0.2964,
-   "compress_mbps": 102.67,
-   "decompress_mbps": 101.78
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3225,
-   "ratio": 0.2892,
-   "compress_mbps": 91.21,
-   "decompress_mbps": 104.25
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3192,
-   "ratio": 0.2863,
-   "compress_mbps": 100.3,
-   "decompress_mbps": 104.85
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3180,
-   "ratio": 0.2852,
-   "compress_mbps": 100.47,
-   "decompress_mbps": 98.18
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3168,
-   "ratio": 0.2841,
-   "compress_mbps": 94.55,
-   "decompress_mbps": 99.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3168,
-   "ratio": 0.2841,
-   "compress_mbps": 95.62,
-   "decompress_mbps": 95.6
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3168,
-   "ratio": 0.2841,
-   "compress_mbps": 91.52,
-   "decompress_mbps": 121.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3168,
-   "ratio": 0.2841,
-   "compress_mbps": 83.09,
-   "decompress_mbps": 95.05
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1275,
-   "ratio": 0.3426,
-   "compress_mbps": 59.58,
-   "decompress_mbps": 44.37
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1247,
-   "ratio": 0.3351,
-   "compress_mbps": 59.47,
-   "decompress_mbps": 52.13
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1239,
-   "ratio": 0.333,
-   "compress_mbps": 56.69,
-   "decompress_mbps": 51.11
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1238,
-   "ratio": 0.3327,
-   "compress_mbps": 58.55,
-   "decompress_mbps": 50.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1239,
-   "ratio": 0.333,
-   "compress_mbps": 48.99,
-   "decompress_mbps": 51.01
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1237,
-   "ratio": 0.3324,
-   "compress_mbps": 56.51,
-   "decompress_mbps": 50.1
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1237,
-   "ratio": 0.3324,
-   "compress_mbps": 55.71,
-   "decompress_mbps": 51.27
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1237,
-   "ratio": 0.3324,
-   "compress_mbps": 50.22,
-   "decompress_mbps": 48.37
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1237,
-   "ratio": 0.3324,
-   "compress_mbps": 55.39,
-   "decompress_mbps": 48.56
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 226284,
-   "ratio": 0.2197,
-   "compress_mbps": 113.28,
-   "decompress_mbps": 183.05
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 221369,
-   "ratio": 0.215,
-   "compress_mbps": 90.24,
-   "decompress_mbps": 255.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 218607,
-   "ratio": 0.2123,
-   "compress_mbps": 78.67,
-   "decompress_mbps": 187.61
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 217919,
-   "ratio": 0.2116,
-   "compress_mbps": 69.94,
-   "decompress_mbps": 195.29
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 217919,
-   "ratio": 0.2116,
-   "compress_mbps": 70.92,
-   "decompress_mbps": 195.59
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 217312,
-   "ratio": 0.211,
-   "compress_mbps": 44.09,
-   "decompress_mbps": 191.18
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 215966,
-   "ratio": 0.2097,
-   "compress_mbps": 31.15,
-   "decompress_mbps": 191.54
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 215930,
-   "ratio": 0.2097,
-   "compress_mbps": 14.32,
-   "decompress_mbps": 194.26
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 215912,
-   "ratio": 0.2097,
-   "compress_mbps": 11.1,
-   "decompress_mbps": 210.59
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 167622,
-   "ratio": 0.3928,
-   "compress_mbps": 64.39,
-   "decompress_mbps": 116.3
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 158003,
-   "ratio": 0.3702,
-   "compress_mbps": 64.34,
-   "decompress_mbps": 139.36
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 152928,
-   "ratio": 0.3584,
-   "compress_mbps": 46.67,
-   "decompress_mbps": 141.08
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 149886,
-   "ratio": 0.3512,
-   "compress_mbps": 33.71,
-   "decompress_mbps": 136.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 149767,
-   "ratio": 0.3509,
-   "compress_mbps": 39.31,
-   "decompress_mbps": 138
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 147818,
-   "ratio": 0.3464,
-   "compress_mbps": 33.18,
-   "decompress_mbps": 150.78
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 147733,
-   "ratio": 0.3462,
-   "compress_mbps": 32.42,
-   "decompress_mbps": 154.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 147709,
-   "ratio": 0.3461,
-   "compress_mbps": 32.15,
-   "decompress_mbps": 151.45
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 147705,
-   "ratio": 0.3461,
-   "compress_mbps": 32.65,
-   "decompress_mbps": 138.19
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 222866,
-   "ratio": 0.4625,
-   "compress_mbps": 58.92,
-   "decompress_mbps": 105.16
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 212925,
-   "ratio": 0.4419,
-   "compress_mbps": 49.52,
-   "decompress_mbps": 118.08
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 206913,
-   "ratio": 0.4294,
-   "compress_mbps": 40.5,
-   "decompress_mbps": 116.88
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 202875,
-   "ratio": 0.421,
-   "compress_mbps": 33.54,
-   "decompress_mbps": 111.31
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 202867,
-   "ratio": 0.421,
-   "compress_mbps": 33.57,
-   "decompress_mbps": 117.4
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 199818,
-   "ratio": 0.4147,
-   "compress_mbps": 28.4,
-   "decompress_mbps": 114.8
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 199664,
-   "ratio": 0.4144,
-   "compress_mbps": 27.76,
-   "decompress_mbps": 105.02
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 199634,
-   "ratio": 0.4143,
-   "compress_mbps": 28.19,
-   "decompress_mbps": 106.5
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 199634,
-   "ratio": 0.4143,
-   "compress_mbps": 27.99,
-   "decompress_mbps": 121
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 60580,
-   "ratio": 0.118,
-   "compress_mbps": 118.15,
-   "decompress_mbps": 253.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 59663,
-   "ratio": 0.1163,
-   "compress_mbps": 131.11,
-   "decompress_mbps": 295.73
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 59465,
-   "ratio": 0.1159,
-   "compress_mbps": 100.74,
-   "decompress_mbps": 295.91
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 59353,
-   "ratio": 0.1156,
-   "compress_mbps": 95.09,
-   "decompress_mbps": 302.88
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 58830,
-   "ratio": 0.1146,
-   "compress_mbps": 107.76,
-   "decompress_mbps": 221.47
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 57884,
-   "ratio": 0.1128,
-   "compress_mbps": 56.85,
-   "decompress_mbps": 285.29
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 57206,
-   "ratio": 0.1115,
-   "compress_mbps": 46.17,
-   "decompress_mbps": 299.77
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 56545,
-   "ratio": 0.1102,
-   "compress_mbps": 23.09,
-   "decompress_mbps": 280.1
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 56454,
-   "ratio": 0.11,
-   "compress_mbps": 9.11,
-   "decompress_mbps": 300.36
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 14194,
-   "ratio": 0.3712,
-   "compress_mbps": 83.27,
-   "decompress_mbps": 134.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 13770,
-   "ratio": 0.3601,
-   "compress_mbps": 74.14,
-   "decompress_mbps": 116.53
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13611,
-   "ratio": 0.3559,
-   "compress_mbps": 66.24,
-   "decompress_mbps": 115.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13534,
-   "ratio": 0.3539,
-   "compress_mbps": 61.31,
-   "decompress_mbps": 117.96
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13527,
-   "ratio": 0.3537,
-   "compress_mbps": 61.97,
-   "decompress_mbps": 148.27
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 13438,
-   "ratio": 0.3514,
-   "compress_mbps": 51.17,
-   "decompress_mbps": 142.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 13419,
-   "ratio": 0.3509,
-   "compress_mbps": 47.83,
-   "decompress_mbps": 125.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 13404,
-   "ratio": 0.3505,
-   "compress_mbps": 41.2,
-   "decompress_mbps": 118.77
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 13390,
-   "ratio": 0.3502,
-   "compress_mbps": 35.78,
-   "decompress_mbps": 116.99
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1832,
-   "ratio": 0.4334,
-   "compress_mbps": 41.01,
-   "decompress_mbps": 45
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1776,
-   "ratio": 0.4202,
-   "compress_mbps": 58.71,
-   "decompress_mbps": 64.9
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1764,
-   "ratio": 0.4173,
-   "compress_mbps": 57.37,
-   "decompress_mbps": 62.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1763,
-   "ratio": 0.4171,
-   "compress_mbps": 56.88,
-   "decompress_mbps": 53.28
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 59.36,
-   "decompress_mbps": 48.79
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 40.25,
-   "decompress_mbps": 47.27
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 57.06,
-   "decompress_mbps": 48.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 58.67,
-   "decompress_mbps": 52.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 58.3,
-   "decompress_mbps": 62.91
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4462632,
-   "ratio": 0.4378,
-   "compress_mbps": 61.62,
-   "decompress_mbps": 170.85
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4244833,
-   "ratio": 0.4165,
-   "compress_mbps": 50.24,
-   "decompress_mbps": 201.42
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 4112285,
-   "ratio": 0.4035,
-   "compress_mbps": 42.04,
-   "decompress_mbps": 178.21
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 4020435,
-   "ratio": 0.3945,
-   "compress_mbps": 35.5,
-   "decompress_mbps": 142.52
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 4019177,
-   "ratio": 0.3943,
-   "compress_mbps": 35.31,
-   "decompress_mbps": 170.54
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3956464,
-   "ratio": 0.3882,
-   "compress_mbps": 28.75,
-   "decompress_mbps": 164.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3953310,
-   "ratio": 0.3879,
-   "compress_mbps": 28.47,
-   "decompress_mbps": 198.87
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3952872,
-   "ratio": 0.3878,
-   "compress_mbps": 29.08,
-   "decompress_mbps": 220.53
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3952872,
-   "ratio": 0.3878,
-   "compress_mbps": 29.21,
-   "decompress_mbps": 218.12
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20177423,
-   "ratio": 0.3939,
-   "compress_mbps": 72.68,
-   "decompress_mbps": 209.54
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 19759467,
-   "ratio": 0.3858,
-   "compress_mbps": 63.85,
-   "decompress_mbps": 193.45
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19583171,
-   "ratio": 0.3823,
-   "compress_mbps": 57.14,
-   "decompress_mbps": 206.47
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19479125,
-   "ratio": 0.3803,
-   "compress_mbps": 51.03,
-   "decompress_mbps": 205.14
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 19423693,
-   "ratio": 0.3792,
-   "compress_mbps": 49.13,
-   "decompress_mbps": 200.07
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19337683,
-   "ratio": 0.3775,
-   "compress_mbps": 36.05,
-   "decompress_mbps": 188.48
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19323922,
-   "ratio": 0.3773,
-   "compress_mbps": 29.08,
-   "decompress_mbps": 193.94
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19314797,
-   "ratio": 0.3771,
-   "compress_mbps": 19.5,
-   "decompress_mbps": 225.36
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 19312663,
-   "ratio": 0.377,
-   "compress_mbps": 11.12,
-   "decompress_mbps": 219.23
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3762978,
-   "ratio": 0.3774,
-   "compress_mbps": 78.68,
-   "decompress_mbps": 163.86
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3711615,
-   "ratio": 0.3723,
-   "compress_mbps": 68.1,
-   "decompress_mbps": 196.85
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3663131,
-   "ratio": 0.3674,
-   "compress_mbps": 57.01,
-   "decompress_mbps": 241.11
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3631512,
-   "ratio": 0.3642,
-   "compress_mbps": 49.21,
-   "decompress_mbps": 221.03
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3630867,
-   "ratio": 0.3642,
-   "compress_mbps": 48.78,
-   "decompress_mbps": 216.62
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3615953,
-   "ratio": 0.3627,
-   "compress_mbps": 37.72,
-   "decompress_mbps": 247.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3615518,
-   "ratio": 0.3626,
-   "compress_mbps": 35.3,
-   "decompress_mbps": 189.82
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3613845,
-   "ratio": 0.3625,
-   "compress_mbps": 30.03,
-   "decompress_mbps": 255.34
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3614283,
-   "ratio": 0.3625,
-   "compress_mbps": 26.24,
-   "decompress_mbps": 222.16
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 4418800,
-   "ratio": 0.1317,
-   "compress_mbps": 133,
-   "decompress_mbps": 338.57
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 4026774,
-   "ratio": 0.12,
-   "compress_mbps": 123.44,
-   "decompress_mbps": 339.7
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3837798,
-   "ratio": 0.1144,
-   "compress_mbps": 116.34,
-   "decompress_mbps": 370.54
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3751023,
-   "ratio": 0.1118,
-   "compress_mbps": 110.1,
-   "decompress_mbps": 361.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3643468,
-   "ratio": 0.1086,
-   "compress_mbps": 101.98,
-   "decompress_mbps": 371.36
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3379481,
-   "ratio": 0.1007,
-   "compress_mbps": 68.99,
-   "decompress_mbps": 366.05
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3354082,
-   "ratio": 0.1,
-   "compress_mbps": 61.49,
-   "decompress_mbps": 366.51
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3330028,
-   "ratio": 0.0992,
-   "compress_mbps": 49.65,
-   "decompress_mbps": 396.52
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 3327482,
-   "ratio": 0.0992,
-   "compress_mbps": 37.41,
-   "decompress_mbps": 367.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3233790,
-   "ratio": 0.5256,
-   "compress_mbps": 52.65,
-   "decompress_mbps": 141.02
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3184644,
-   "ratio": 0.5176,
-   "compress_mbps": 48.35,
-   "decompress_mbps": 141.34
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3160521,
-   "ratio": 0.5137,
-   "compress_mbps": 44.16,
-   "decompress_mbps": 134.37
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3141929,
-   "ratio": 0.5107,
-   "compress_mbps": 40.04,
-   "decompress_mbps": 150.29
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3138514,
-   "ratio": 0.5101,
-   "compress_mbps": 39.11,
-   "decompress_mbps": 134.68
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3126843,
-   "ratio": 0.5082,
-   "compress_mbps": 32.81,
-   "decompress_mbps": 149.93
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3126796,
-   "ratio": 0.5082,
-   "compress_mbps": 30.63,
-   "decompress_mbps": 145.05
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3126322,
-   "ratio": 0.5082,
-   "compress_mbps": 27.28,
-   "decompress_mbps": 153.07
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3126286,
-   "ratio": 0.5082,
-   "compress_mbps": 23.43,
-   "decompress_mbps": 154.77
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 4076349,
-   "ratio": 0.4042,
-   "compress_mbps": 79.56,
-   "decompress_mbps": 217.72
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3914739,
-   "ratio": 0.3881,
-   "compress_mbps": 72.11,
-   "decompress_mbps": 235.6
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3845160,
-   "ratio": 0.3812,
-   "compress_mbps": 68.92,
-   "decompress_mbps": 265.95
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3822047,
-   "ratio": 0.379,
-   "compress_mbps": 65.9,
-   "decompress_mbps": 249.1
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3799472,
-   "ratio": 0.3767,
-   "compress_mbps": 60.47,
-   "decompress_mbps": 196.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3783861,
-   "ratio": 0.3752,
-   "compress_mbps": 59.24,
-   "decompress_mbps": 206.2
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3783432,
-   "ratio": 0.3751,
-   "compress_mbps": 57.5,
-   "decompress_mbps": 276.55
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3783342,
-   "ratio": 0.3751,
-   "compress_mbps": 57.79,
-   "decompress_mbps": 278.67
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3783342,
-   "ratio": 0.3751,
-   "compress_mbps": 57.86,
-   "decompress_mbps": 279.64
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2261112,
-   "ratio": 0.3412,
-   "compress_mbps": 71.4,
-   "decompress_mbps": 216.97
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2128691,
-   "ratio": 0.3212,
-   "compress_mbps": 58.57,
-   "decompress_mbps": 197.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2049023,
-   "ratio": 0.3092,
-   "compress_mbps": 48.53,
-   "decompress_mbps": 209.61
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 1990249,
-   "ratio": 0.3003,
-   "compress_mbps": 41.12,
-   "decompress_mbps": 207.91
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1975224,
-   "ratio": 0.298,
-   "compress_mbps": 39.61,
-   "decompress_mbps": 151.52
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1910262,
-   "ratio": 0.2882,
-   "compress_mbps": 28.21,
-   "decompress_mbps": 164.32
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1902923,
-   "ratio": 0.2871,
-   "compress_mbps": 25.04,
-   "decompress_mbps": 221.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1900964,
-   "ratio": 0.2868,
-   "compress_mbps": 23.45,
-   "decompress_mbps": 227.66
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1900958,
-   "ratio": 0.2868,
-   "compress_mbps": 24.4,
-   "decompress_mbps": 207.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 6016919,
-   "ratio": 0.2785,
-   "compress_mbps": 92.31,
-   "decompress_mbps": 250.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 5767272,
-   "ratio": 0.2669,
-   "compress_mbps": 81.02,
-   "decompress_mbps": 287.18
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5669548,
-   "ratio": 0.2624,
-   "compress_mbps": 75.87,
-   "decompress_mbps": 211.21
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5619947,
-   "ratio": 0.2601,
-   "compress_mbps": 68.8,
-   "decompress_mbps": 271.25
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5586034,
-   "ratio": 0.2585,
-   "compress_mbps": 64.77,
-   "decompress_mbps": 270.13
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5540130,
-   "ratio": 0.2564,
-   "compress_mbps": 50.72,
-   "decompress_mbps": 269.04
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5537271,
-   "ratio": 0.2563,
-   "compress_mbps": 45.58,
-   "decompress_mbps": 209.67
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5530686,
-   "ratio": 0.256,
-   "compress_mbps": 35.75,
-   "decompress_mbps": 303.18
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5529823,
-   "ratio": 0.2559,
-   "compress_mbps": 31.59,
-   "decompress_mbps": 227.31
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5602819,
-   "ratio": 0.7726,
-   "compress_mbps": 47.72,
-   "decompress_mbps": 166.89
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5504019,
-   "ratio": 0.759,
-   "compress_mbps": 42.76,
-   "decompress_mbps": 153.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5452816,
-   "ratio": 0.7519,
-   "compress_mbps": 38.01,
-   "decompress_mbps": 153.91
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5425752,
-   "ratio": 0.7482,
-   "compress_mbps": 35.6,
-   "decompress_mbps": 177.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5425752,
-   "ratio": 0.7482,
-   "compress_mbps": 36.17,
-   "decompress_mbps": 176.78
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5407602,
-   "ratio": 0.7457,
-   "compress_mbps": 30.72,
-   "decompress_mbps": 153.42
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5406417,
-   "ratio": 0.7455,
-   "compress_mbps": 30.08,
-   "decompress_mbps": 155.44
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5406380,
-   "ratio": 0.7455,
-   "compress_mbps": 30.76,
-   "decompress_mbps": 154.32
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5406380,
-   "ratio": 0.7455,
-   "compress_mbps": 30.68,
-   "decompress_mbps": 117.26
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 14342407,
-   "ratio": 0.3459,
-   "compress_mbps": 73.52,
-   "decompress_mbps": 197.71
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 13424966,
-   "ratio": 0.3238,
-   "compress_mbps": 63.27,
-   "decompress_mbps": 213.25
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 13061399,
-   "ratio": 0.315,
-   "compress_mbps": 56.27,
-   "decompress_mbps": 222.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12877207,
-   "ratio": 0.3106,
-   "compress_mbps": 49.84,
-   "decompress_mbps": 208.96
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12671090,
-   "ratio": 0.3056,
-   "compress_mbps": 47.71,
-   "decompress_mbps": 209.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12511088,
-   "ratio": 0.3018,
-   "compress_mbps": 40.67,
-   "decompress_mbps": 235.26
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12503313,
-   "ratio": 0.3016,
-   "compress_mbps": 39.02,
-   "decompress_mbps": 224.89
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12502263,
-   "ratio": 0.3016,
-   "compress_mbps": 39.56,
-   "decompress_mbps": 227.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 12502263,
-   "ratio": 0.3016,
-   "compress_mbps": 39.56,
-   "decompress_mbps": 225.48
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6022390,
-   "ratio": 0.7107,
-   "compress_mbps": 54.31,
-   "decompress_mbps": 145.97
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 5997124,
-   "ratio": 0.7077,
-   "compress_mbps": 48.84,
-   "decompress_mbps": 145.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 5979254,
-   "ratio": 0.7056,
-   "compress_mbps": 43.2,
-   "decompress_mbps": 149.3
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 5967955,
-   "ratio": 0.7042,
-   "compress_mbps": 42.03,
-   "decompress_mbps": 178.27
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 5967953,
-   "ratio": 0.7042,
-   "compress_mbps": 42.1,
-   "decompress_mbps": 155.23
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5965386,
-   "ratio": 0.7039,
-   "compress_mbps": 41.26,
-   "decompress_mbps": 150.17
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 5965383,
-   "ratio": 0.7039,
-   "compress_mbps": 41,
-   "decompress_mbps": 152.03
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 5965383,
-   "ratio": 0.7039,
-   "compress_mbps": 40.8,
-   "decompress_mbps": 151.14
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5965383,
-   "ratio": 0.7039,
-   "compress_mbps": 41.86,
-   "decompress_mbps": 155
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 985606,
-   "ratio": 0.1844,
-   "compress_mbps": 111.12,
-   "decompress_mbps": 305.94
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 852636,
-   "ratio": 0.1595,
-   "compress_mbps": 102.74,
-   "decompress_mbps": 250.95
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 814293,
-   "ratio": 0.1523,
-   "compress_mbps": 96.19,
-   "decompress_mbps": 221.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 788388,
-   "ratio": 0.1475,
-   "compress_mbps": 89.39,
-   "decompress_mbps": 250.71
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 749390,
-   "ratio": 0.1402,
-   "compress_mbps": 83.47,
-   "decompress_mbps": 304.92
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 706892,
-   "ratio": 0.1322,
-   "compress_mbps": 64.12,
-   "decompress_mbps": 266.99
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 705695,
-   "ratio": 0.132,
-   "compress_mbps": 64.27,
-   "decompress_mbps": 329.56
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 703904,
-   "ratio": 0.1317,
-   "compress_mbps": 61.16,
-   "decompress_mbps": 268.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 703900,
-   "ratio": 0.1317,
-   "compress_mbps": 60.89,
-   "decompress_mbps": 396.78
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 56099,
-   "ratio": 0.3689,
-   "compress_mbps": 88.44,
-   "decompress_mbps": 310.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 56099,
-   "ratio": 0.3689,
-   "compress_mbps": 87.92,
-   "decompress_mbps": 310.59
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 56099,
-   "ratio": 0.3689,
-   "compress_mbps": 88.84,
-   "decompress_mbps": 310.08
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 56099,
-   "ratio": 0.3689,
-   "compress_mbps": 88.64,
-   "decompress_mbps": 314.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 54531,
-   "ratio": 0.3585,
-   "compress_mbps": 55.46,
-   "decompress_mbps": 303.62
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54068,
-   "ratio": 0.3555,
-   "compress_mbps": 42.11,
-   "decompress_mbps": 310.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54003,
-   "ratio": 0.3551,
-   "compress_mbps": 37.45,
-   "decompress_mbps": 307.64
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 53974,
-   "ratio": 0.3549,
-   "compress_mbps": 33.15,
-   "decompress_mbps": 306.21
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 53974,
-   "ratio": 0.3549,
-   "compress_mbps": 33.03,
-   "decompress_mbps": 307.58
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 50031,
-   "ratio": 0.3997,
-   "compress_mbps": 82.91,
-   "decompress_mbps": 273.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 50031,
-   "ratio": 0.3997,
-   "compress_mbps": 83.46,
-   "decompress_mbps": 272.35
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 50031,
-   "ratio": 0.3997,
-   "compress_mbps": 84.13,
-   "decompress_mbps": 272.98
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 50031,
-   "ratio": 0.3997,
-   "compress_mbps": 83.95,
-   "decompress_mbps": 268.75
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 48753,
-   "ratio": 0.3895,
-   "compress_mbps": 50.79,
-   "decompress_mbps": 277.44
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48557,
-   "ratio": 0.3879,
-   "compress_mbps": 40.8,
-   "decompress_mbps": 274.84
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48523,
-   "ratio": 0.3876,
-   "compress_mbps": 38.65,
-   "decompress_mbps": 273.33
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 48522,
-   "ratio": 0.3876,
-   "compress_mbps": 37.86,
-   "decompress_mbps": 276.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 48522,
-   "ratio": 0.3876,
-   "compress_mbps": 37.9,
-   "decompress_mbps": 276.0
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8182,
-   "ratio": 0.3326,
-   "compress_mbps": 164.27,
-   "decompress_mbps": 279.42
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8182,
-   "ratio": 0.3326,
-   "compress_mbps": 172.17,
-   "decompress_mbps": 279.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8182,
-   "ratio": 0.3326,
-   "compress_mbps": 171.79,
-   "decompress_mbps": 279.43
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8182,
-   "ratio": 0.3326,
-   "compress_mbps": 170.54,
-   "decompress_mbps": 279.22
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 7965,
-   "ratio": 0.3237,
-   "compress_mbps": 110.55,
-   "decompress_mbps": 288.06
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7914,
-   "ratio": 0.3217,
-   "compress_mbps": 87.16,
-   "decompress_mbps": 290.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7895,
-   "ratio": 0.3209,
-   "compress_mbps": 80.21,
-   "decompress_mbps": 290.06
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7896,
-   "ratio": 0.3209,
-   "compress_mbps": 73.83,
-   "decompress_mbps": 287.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7896,
-   "ratio": 0.3209,
-   "compress_mbps": 74.8,
-   "decompress_mbps": 285.58
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3218,
-   "ratio": 0.2886,
-   "compress_mbps": 167.43,
-   "decompress_mbps": 252.93
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3218,
-   "ratio": 0.2886,
-   "compress_mbps": 171.07,
-   "decompress_mbps": 257.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3218,
-   "ratio": 0.2886,
-   "compress_mbps": 171.82,
-   "decompress_mbps": 258.29
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3218,
-   "ratio": 0.2886,
-   "compress_mbps": 166.85,
-   "decompress_mbps": 256.2
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3136,
-   "ratio": 0.2813,
-   "compress_mbps": 143.33,
-   "decompress_mbps": 259.73
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3115,
-   "ratio": 0.2794,
-   "compress_mbps": 126.88,
-   "decompress_mbps": 263.65
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 116.0,
-   "decompress_mbps": 266.62
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 105.81,
-   "decompress_mbps": 262.03
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 108.16,
-   "decompress_mbps": 263.41
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1221,
-   "ratio": 0.3281,
-   "compress_mbps": 119.04,
-   "decompress_mbps": 119.21
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1221,
-   "ratio": 0.3281,
-   "compress_mbps": 114.29,
-   "decompress_mbps": 121.57
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1221,
-   "ratio": 0.3281,
-   "compress_mbps": 111.93,
-   "decompress_mbps": 114.91
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1221,
-   "ratio": 0.3281,
-   "compress_mbps": 113.37,
-   "decompress_mbps": 116.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 104.47,
-   "decompress_mbps": 117.21
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 101.17,
-   "decompress_mbps": 116.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 99.01,
-   "decompress_mbps": 115.26
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 100.66,
-   "decompress_mbps": 116.17
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 100.75,
-   "decompress_mbps": 117.41
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 227063,
-   "ratio": 0.2205,
-   "compress_mbps": 226.33,
-   "decompress_mbps": 462.07
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 227063,
-   "ratio": 0.2205,
-   "compress_mbps": 232.22,
-   "decompress_mbps": 461.76
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 227063,
-   "ratio": 0.2205,
-   "compress_mbps": 226.95,
-   "decompress_mbps": 462.59
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 227063,
-   "ratio": 0.2205,
-   "compress_mbps": 231.82,
-   "decompress_mbps": 462.46
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 218313,
-   "ratio": 0.212,
-   "compress_mbps": 163.75,
-   "decompress_mbps": 447.06
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 215095,
-   "ratio": 0.2089,
-   "compress_mbps": 107.22,
-   "decompress_mbps": 448.7
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 213213,
-   "ratio": 0.2071,
-   "compress_mbps": 73.07,
-   "decompress_mbps": 450.65
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 210955,
-   "ratio": 0.2049,
-   "compress_mbps": 9.42,
-   "decompress_mbps": 452.49
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 210981,
-   "ratio": 0.2049,
-   "compress_mbps": 4.64,
-   "decompress_mbps": 454.09
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 148927,
-   "ratio": 0.349,
-   "compress_mbps": 92.55,
-   "decompress_mbps": 304.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 148927,
-   "ratio": 0.349,
-   "compress_mbps": 92.89,
-   "decompress_mbps": 306.86
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 148927,
-   "ratio": 0.349,
-   "compress_mbps": 92.22,
-   "decompress_mbps": 306.2
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 148927,
-   "ratio": 0.349,
-   "compress_mbps": 92.33,
-   "decompress_mbps": 304.41
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 145024,
-   "ratio": 0.3398,
-   "compress_mbps": 57.83,
-   "decompress_mbps": 305.53
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 144159,
-   "ratio": 0.3378,
-   "compress_mbps": 44.56,
-   "decompress_mbps": 304.1
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 143991,
-   "ratio": 0.3374,
-   "compress_mbps": 40.14,
-   "decompress_mbps": 306.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 143941,
-   "ratio": 0.3373,
-   "compress_mbps": 36.87,
-   "decompress_mbps": 306.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 143939,
-   "ratio": 0.3373,
-   "compress_mbps": 37.03,
-   "decompress_mbps": 305.69
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 200074,
-   "ratio": 0.4152,
-   "compress_mbps": 81.26,
-   "decompress_mbps": 255.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 200074,
-   "ratio": 0.4152,
-   "compress_mbps": 80.9,
-   "decompress_mbps": 255.49
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 200074,
-   "ratio": 0.4152,
-   "compress_mbps": 81.21,
-   "decompress_mbps": 255.67
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 200074,
-   "ratio": 0.4152,
-   "compress_mbps": 81.07,
-   "decompress_mbps": 256.32
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 194496,
-   "ratio": 0.4036,
-   "compress_mbps": 46.0,
-   "decompress_mbps": 247.64
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 193176,
-   "ratio": 0.4009,
-   "compress_mbps": 34.56,
-   "decompress_mbps": 253.55
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 192991,
-   "ratio": 0.4005,
-   "compress_mbps": 31.43,
-   "decompress_mbps": 250.63
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 192980,
-   "ratio": 0.4005,
-   "compress_mbps": 29.91,
-   "decompress_mbps": 251.77
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 192980,
-   "ratio": 0.4005,
-   "compress_mbps": 29.82,
-   "decompress_mbps": 253.98
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 57484,
-   "ratio": 0.112,
-   "compress_mbps": 294.39,
-   "decompress_mbps": 724.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 57484,
-   "ratio": 0.112,
-   "compress_mbps": 294.6,
-   "decompress_mbps": 721.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 57484,
-   "ratio": 0.112,
-   "compress_mbps": 294.93,
-   "decompress_mbps": 721.32
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 57484,
-   "ratio": 0.112,
-   "compress_mbps": 295.58,
-   "decompress_mbps": 727.0
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 56050,
-   "ratio": 0.1092,
-   "compress_mbps": 229.82,
-   "decompress_mbps": 759.78
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 55292,
-   "ratio": 0.1077,
-   "compress_mbps": 153.4,
-   "decompress_mbps": 778.62
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 54651,
-   "ratio": 0.1065,
-   "compress_mbps": 124.47,
-   "decompress_mbps": 790.77
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 52583,
-   "ratio": 0.1025,
-   "compress_mbps": 46.92,
-   "decompress_mbps": 823.54
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 51816,
-   "ratio": 0.101,
-   "compress_mbps": 15.63,
-   "decompress_mbps": 833.02
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 13765,
-   "ratio": 0.36,
-   "compress_mbps": 119.63,
-   "decompress_mbps": 301.35
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 13765,
-   "ratio": 0.36,
-   "compress_mbps": 118.87,
-   "decompress_mbps": 304.63
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13765,
-   "ratio": 0.36,
-   "compress_mbps": 120.64,
-   "decompress_mbps": 303.05
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13765,
-   "ratio": 0.36,
-   "compress_mbps": 118.25,
-   "decompress_mbps": 303.27
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13290,
-   "ratio": 0.3475,
-   "compress_mbps": 89.99,
-   "decompress_mbps": 316.05
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 13258,
-   "ratio": 0.3467,
-   "compress_mbps": 68.72,
-   "decompress_mbps": 317.08
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 13246,
-   "ratio": 0.3464,
-   "compress_mbps": 57.01,
-   "decompress_mbps": 319.69
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 13236,
-   "ratio": 0.3461,
-   "compress_mbps": 25.4,
-   "decompress_mbps": 320.24
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 13233,
-   "ratio": 0.3461,
-   "compress_mbps": 16.12,
-   "decompress_mbps": 322.36
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 95.7,
-   "decompress_mbps": 132.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 98.31,
-   "decompress_mbps": 133.01
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 97.54,
-   "decompress_mbps": 132.07
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 100.39,
-   "decompress_mbps": 132.0
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 95.29,
-   "decompress_mbps": 132.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 95.54,
-   "decompress_mbps": 134.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 93.18,
-   "decompress_mbps": 133.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 95.09,
-   "decompress_mbps": 134.19
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 92.21,
-   "decompress_mbps": 134.59
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 3974126,
-   "ratio": 0.3899,
-   "compress_mbps": 84.07,
-   "decompress_mbps": 273.96
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 3974126,
-   "ratio": 0.3899,
-   "compress_mbps": 84.3,
-   "decompress_mbps": 273.56
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3974126,
-   "ratio": 0.3899,
-   "compress_mbps": 83.99,
-   "decompress_mbps": 274.36
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 3974126,
-   "ratio": 0.3899,
-   "compress_mbps": 84.24,
-   "decompress_mbps": 272.3
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3863846,
-   "ratio": 0.3791,
-   "compress_mbps": 49.03,
-   "decompress_mbps": 267.64
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3838854,
-   "ratio": 0.3766,
-   "compress_mbps": 37.71,
-   "decompress_mbps": 272.4
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3835182,
-   "ratio": 0.3763,
-   "compress_mbps": 33.64,
-   "decompress_mbps": 271.15
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3834518,
-   "ratio": 0.3762,
-   "compress_mbps": 31.63,
-   "decompress_mbps": 269.9
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3834518,
-   "ratio": 0.3762,
-   "compress_mbps": 31.46,
-   "decompress_mbps": 270.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 19877952,
-   "ratio": 0.3881,
-   "compress_mbps": 103.55,
-   "decompress_mbps": 250.87
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 19877952,
-   "ratio": 0.3881,
-   "compress_mbps": 103.76,
-   "decompress_mbps": 251.19
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19877952,
-   "ratio": 0.3881,
-   "compress_mbps": 103.86,
-   "decompress_mbps": 251.37
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19877952,
-   "ratio": 0.3881,
-   "compress_mbps": 103.63,
-   "decompress_mbps": 251.14
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 19578840,
-   "ratio": 0.3822,
-   "compress_mbps": 78.52,
-   "decompress_mbps": 258.92
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19492445,
-   "ratio": 0.3806,
-   "compress_mbps": 58.0,
-   "decompress_mbps": 261.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19463481,
-   "ratio": 0.38,
-   "compress_mbps": 46.5,
-   "decompress_mbps": 263.14
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19444704,
-   "ratio": 0.3796,
-   "compress_mbps": 22.81,
-   "decompress_mbps": 262.15
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 19440748,
-   "ratio": 0.3796,
-   "compress_mbps": 13.07,
-   "decompress_mbps": 263.2
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3662279,
-   "ratio": 0.3673,
-   "compress_mbps": 112.24,
-   "decompress_mbps": 259.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3662279,
-   "ratio": 0.3673,
-   "compress_mbps": 112.65,
-   "decompress_mbps": 260.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3662279,
-   "ratio": 0.3673,
-   "compress_mbps": 111.43,
-   "decompress_mbps": 257.26
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3662279,
-   "ratio": 0.3673,
-   "compress_mbps": 112.43,
-   "decompress_mbps": 258.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3637736,
-   "ratio": 0.3648,
-   "compress_mbps": 65.79,
-   "decompress_mbps": 267.17
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3621530,
-   "ratio": 0.3632,
-   "compress_mbps": 46.42,
-   "decompress_mbps": 268.5
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3623924,
-   "ratio": 0.3635,
-   "compress_mbps": 42.48,
-   "decompress_mbps": 270.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3623112,
-   "ratio": 0.3634,
-   "compress_mbps": 33.07,
-   "decompress_mbps": 270.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3623382,
-   "ratio": 0.3634,
-   "compress_mbps": 24.87,
-   "decompress_mbps": 268.67
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3580057,
-   "ratio": 0.1067,
-   "compress_mbps": 306.93,
-   "decompress_mbps": 882.12
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 3580057,
-   "ratio": 0.1067,
-   "compress_mbps": 309.49,
-   "decompress_mbps": 879.51
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3580057,
-   "ratio": 0.1067,
-   "compress_mbps": 306.65,
-   "decompress_mbps": 865.76
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3580057,
-   "ratio": 0.1067,
-   "compress_mbps": 309.44,
-   "decompress_mbps": 876.41
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3268887,
-   "ratio": 0.0974,
-   "compress_mbps": 229.13,
-   "decompress_mbps": 923.49
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3131445,
-   "ratio": 0.0933,
-   "compress_mbps": 163.5,
-   "decompress_mbps": 955.29
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3080217,
-   "ratio": 0.0918,
-   "compress_mbps": 129.46,
-   "decompress_mbps": 960.33
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 2978354,
-   "ratio": 0.0888,
-   "compress_mbps": 57.16,
-   "decompress_mbps": 973.32
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2947971,
-   "ratio": 0.0879,
-   "compress_mbps": 34.51,
-   "decompress_mbps": 973.37
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3221973,
-   "ratio": 0.5237,
-   "compress_mbps": 72.44,
-   "decompress_mbps": 182.53
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3221973,
-   "ratio": 0.5237,
-   "compress_mbps": 72.2,
-   "decompress_mbps": 182.46
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3221973,
-   "ratio": 0.5237,
-   "compress_mbps": 72.32,
-   "decompress_mbps": 182.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3221973,
-   "ratio": 0.5237,
-   "compress_mbps": 72.36,
-   "decompress_mbps": 183.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3178914,
-   "ratio": 0.5167,
-   "compress_mbps": 55.82,
-   "decompress_mbps": 189.9
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3174170,
-   "ratio": 0.5159,
-   "compress_mbps": 49.39,
-   "decompress_mbps": 191.24
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3172734,
-   "ratio": 0.5157,
-   "compress_mbps": 45.82,
-   "decompress_mbps": 191.56
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3171353,
-   "ratio": 0.5155,
-   "compress_mbps": 38.64,
-   "decompress_mbps": 191.37
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3171299,
-   "ratio": 0.5155,
-   "compress_mbps": 34.82,
-   "decompress_mbps": 191.12
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3791952,
-   "ratio": 0.376,
-   "compress_mbps": 123.34,
-   "decompress_mbps": 273.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3791952,
-   "ratio": 0.376,
-   "compress_mbps": 122.2,
-   "decompress_mbps": 272.47
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3791952,
-   "ratio": 0.376,
-   "compress_mbps": 121.33,
-   "decompress_mbps": 269.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3791952,
-   "ratio": 0.376,
-   "compress_mbps": 122.45,
-   "decompress_mbps": 274.58
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3654027,
-   "ratio": 0.3623,
-   "compress_mbps": 95.52,
-   "decompress_mbps": 276.5
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3652732,
-   "ratio": 0.3622,
-   "compress_mbps": 91.8,
-   "decompress_mbps": 276.29
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3652496,
-   "ratio": 0.3621,
-   "compress_mbps": 87.07,
-   "decompress_mbps": 275.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3652505,
-   "ratio": 0.3621,
-   "compress_mbps": 87.05,
-   "decompress_mbps": 277.5
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3652505,
-   "ratio": 0.3621,
-   "compress_mbps": 87.07,
-   "decompress_mbps": 276.53
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2009824,
-   "ratio": 0.3033,
-   "compress_mbps": 100.62,
-   "decompress_mbps": 354.06
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2009824,
-   "ratio": 0.3033,
-   "compress_mbps": 100.0,
-   "decompress_mbps": 353.82
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2009824,
-   "ratio": 0.3033,
-   "compress_mbps": 99.59,
-   "decompress_mbps": 351.77
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 2009824,
-   "ratio": 0.3033,
-   "compress_mbps": 99.81,
-   "decompress_mbps": 354.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1892183,
-   "ratio": 0.2855,
-   "compress_mbps": 53.63,
-   "decompress_mbps": 353.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1837957,
-   "ratio": 0.2773,
-   "compress_mbps": 30.64,
-   "decompress_mbps": 360.81
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1826603,
-   "ratio": 0.2756,
-   "compress_mbps": 24.41,
-   "decompress_mbps": 362.4
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1818702,
-   "ratio": 0.2744,
-   "compress_mbps": 16.09,
-   "decompress_mbps": 362.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1818702,
-   "ratio": 0.2744,
-   "compress_mbps": 15.95,
-   "decompress_mbps": 359.54
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5633558,
-   "ratio": 0.2607,
-   "compress_mbps": 146.11,
-   "decompress_mbps": 399.24
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 5633558,
-   "ratio": 0.2607,
-   "compress_mbps": 145.88,
-   "decompress_mbps": 400.49
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5633558,
-   "ratio": 0.2607,
-   "compress_mbps": 146.06,
-   "decompress_mbps": 396.62
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5633558,
-   "ratio": 0.2607,
-   "compress_mbps": 144.39,
-   "decompress_mbps": 379.0
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5501344,
-   "ratio": 0.2546,
-   "compress_mbps": 103.33,
-   "decompress_mbps": 402.09
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5464646,
-   "ratio": 0.2529,
-   "compress_mbps": 79.54,
-   "decompress_mbps": 407.14
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5429975,
-   "ratio": 0.2513,
-   "compress_mbps": 66.81,
-   "decompress_mbps": 408.73
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5419566,
-   "ratio": 0.2508,
-   "compress_mbps": 49.41,
-   "decompress_mbps": 410.08
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5417952,
-   "ratio": 0.2508,
-   "compress_mbps": 45.54,
-   "decompress_mbps": 407.63
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5481930,
-   "ratio": 0.7559,
-   "compress_mbps": 60.47,
-   "decompress_mbps": 161.38
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5481930,
-   "ratio": 0.7559,
-   "compress_mbps": 60.25,
-   "decompress_mbps": 161.25
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5481930,
-   "ratio": 0.7559,
-   "compress_mbps": 60.34,
-   "decompress_mbps": 161.47
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5481930,
-   "ratio": 0.7559,
-   "compress_mbps": 60.28,
-   "decompress_mbps": 159.84
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5450496,
-   "ratio": 0.7516,
-   "compress_mbps": 46.56,
-   "decompress_mbps": 163.89
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5440281,
-   "ratio": 0.7502,
-   "compress_mbps": 42.07,
-   "decompress_mbps": 164.58
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5439077,
-   "ratio": 0.75,
-   "compress_mbps": 40.6,
-   "decompress_mbps": 164.64
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5438787,
-   "ratio": 0.75,
-   "compress_mbps": 39.98,
-   "decompress_mbps": 163.79
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5438787,
-   "ratio": 0.75,
-   "compress_mbps": 39.92,
-   "decompress_mbps": 165.07
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 12756531,
-   "ratio": 0.3077,
-   "compress_mbps": 108.43,
-   "decompress_mbps": 313.19
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 12756531,
-   "ratio": 0.3077,
-   "compress_mbps": 108.96,
-   "decompress_mbps": 316.83
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12756531,
-   "ratio": 0.3077,
-   "compress_mbps": 108.45,
-   "decompress_mbps": 312.18
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12756531,
-   "ratio": 0.3077,
-   "compress_mbps": 108.89,
-   "decompress_mbps": 315.83
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12238874,
-   "ratio": 0.2952,
-   "compress_mbps": 72.34,
-   "decompress_mbps": 317.65
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12086531,
-   "ratio": 0.2915,
-   "compress_mbps": 53.58,
-   "decompress_mbps": 323.18
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12020742,
-   "ratio": 0.2899,
-   "compress_mbps": 46.37,
-   "decompress_mbps": 319.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 11987253,
-   "ratio": 0.2891,
-   "compress_mbps": 38.17,
-   "decompress_mbps": 322.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11987245,
-   "ratio": 0.2891,
-   "compress_mbps": 38.15,
-   "decompress_mbps": 319.56
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6273039,
-   "ratio": 0.7402,
-   "compress_mbps": 60.53,
-   "decompress_mbps": 146.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6273039,
-   "ratio": 0.7402,
-   "compress_mbps": 60.39,
-   "decompress_mbps": 146.09
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6273039,
-   "ratio": 0.7402,
-   "compress_mbps": 60.11,
-   "decompress_mbps": 146.99
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6273039,
-   "ratio": 0.7402,
-   "compress_mbps": 60.42,
-   "decompress_mbps": 146.5
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6244483,
-   "ratio": 0.7369,
-   "compress_mbps": 55.4,
-   "decompress_mbps": 148.54
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 6244482,
-   "ratio": 0.7369,
-   "compress_mbps": 55.47,
-   "decompress_mbps": 148.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 6244482,
-   "ratio": 0.7369,
-   "compress_mbps": 55.08,
-   "decompress_mbps": 147.42
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 6244480,
-   "ratio": 0.7369,
-   "compress_mbps": 55.49,
-   "decompress_mbps": 148.22
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 6244480,
-   "ratio": 0.7369,
-   "compress_mbps": 55.43,
-   "decompress_mbps": 147.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 785041,
-   "ratio": 0.1469,
-   "compress_mbps": 230.66,
-   "decompress_mbps": 673.8
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 785041,
-   "ratio": 0.1469,
-   "compress_mbps": 230.52,
-   "decompress_mbps": 670.21
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 785041,
-   "ratio": 0.1469,
-   "compress_mbps": 231.93,
-   "decompress_mbps": 669.9
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 785041,
-   "ratio": 0.1469,
-   "compress_mbps": 230.28,
-   "decompress_mbps": 671.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 716461,
-   "ratio": 0.134,
-   "compress_mbps": 166.09,
-   "decompress_mbps": 710.38
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 687053,
-   "ratio": 0.1285,
-   "compress_mbps": 124.29,
-   "decompress_mbps": 733.86
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 673597,
-   "ratio": 0.126,
-   "compress_mbps": 100.95,
-   "decompress_mbps": 744.02
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 662156,
-   "ratio": 0.1239,
-   "compress_mbps": 65.08,
-   "decompress_mbps": 750.21
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 661610,
-   "ratio": 0.1238,
-   "compress_mbps": 61.06,
-   "decompress_mbps": 754.5
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 73589,
-   "ratio": 0.4839,
-   "compress_mbps": 33.76,
-   "decompress_mbps": 57.05
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 69878,
-   "ratio": 0.4595,
-   "compress_mbps": 32.08,
-   "decompress_mbps": 58.09
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 66917,
-   "ratio": 0.44,
-   "compress_mbps": 26.68,
-   "decompress_mbps": 66.6
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 59388,
-   "ratio": 0.3905,
-   "compress_mbps": 31.26,
-   "decompress_mbps": 80.36
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 57062,
-   "ratio": 0.3752,
-   "compress_mbps": 22.77,
-   "decompress_mbps": 80.1
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 55472,
-   "ratio": 0.3647,
-   "compress_mbps": 16.23,
-   "decompress_mbps": 79.12
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 55265,
-   "ratio": 0.3634,
-   "compress_mbps": 14.29,
-   "decompress_mbps": 79.84
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 55168,
-   "ratio": 0.3627,
-   "compress_mbps": 11.91,
-   "decompress_mbps": 78.92
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 55168,
-   "ratio": 0.3627,
-   "compress_mbps": 11.93,
-   "decompress_mbps": 78.52
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 64551,
-   "ratio": 0.5157,
-   "compress_mbps": 31.89,
-   "decompress_mbps": 53.82
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 62089,
-   "ratio": 0.496,
-   "compress_mbps": 30.15,
-   "decompress_mbps": 57.83
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 58690,
-   "ratio": 0.4688,
-   "compress_mbps": 24.34,
-   "decompress_mbps": 59.96
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 53521,
-   "ratio": 0.4276,
-   "compress_mbps": 30.1,
-   "decompress_mbps": 79.96
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 51677,
-   "ratio": 0.4128,
-   "compress_mbps": 20.89,
-   "decompress_mbps": 78.97
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 50638,
-   "ratio": 0.4045,
-   "compress_mbps": 14.85,
-   "decompress_mbps": 82.68
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 50501,
-   "ratio": 0.4034,
-   "compress_mbps": 13.53,
-   "decompress_mbps": 79.57
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 50452,
-   "ratio": 0.403,
-   "compress_mbps": 12.59,
-   "decompress_mbps": 81.82
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 50452,
-   "ratio": 0.403,
-   "compress_mbps": 12.59,
-   "decompress_mbps": 81.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 9859,
-   "ratio": 0.4007,
-   "compress_mbps": 43.03,
-   "decompress_mbps": 111.15
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 10473,
-   "ratio": 0.4257,
-   "compress_mbps": 47.23,
-   "decompress_mbps": 149.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 10172,
-   "ratio": 0.4134,
-   "compress_mbps": 42.85,
-   "decompress_mbps": 148.23
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8692,
-   "ratio": 0.3533,
-   "compress_mbps": 40.47,
-   "decompress_mbps": 152.86
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 8440,
-   "ratio": 0.343,
-   "compress_mbps": 36.18,
-   "decompress_mbps": 157.16
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 8385,
-   "ratio": 0.3408,
-   "compress_mbps": 31.88,
-   "decompress_mbps": 158.84
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 8366,
-   "ratio": 0.34,
-   "compress_mbps": 29.95,
-   "decompress_mbps": 158.95
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 8367,
-   "ratio": 0.3401,
-   "compress_mbps": 28.71,
-   "decompress_mbps": 157.48
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 8367,
-   "ratio": 0.3401,
-   "compress_mbps": 28.72,
-   "decompress_mbps": 156.54
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 4822,
-   "ratio": 0.4325,
-   "compress_mbps": 54.35,
-   "decompress_mbps": 187.68
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 4593,
-   "ratio": 0.4119,
-   "compress_mbps": 52.8,
-   "decompress_mbps": 193.41
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 4381,
-   "ratio": 0.3929,
-   "compress_mbps": 49.8,
-   "decompress_mbps": 200.8
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3725,
-   "ratio": 0.3341,
-   "compress_mbps": 51.8,
-   "decompress_mbps": 202.76
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3614,
-   "ratio": 0.3241,
-   "compress_mbps": 43.83,
-   "decompress_mbps": 208.48
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3578,
-   "ratio": 0.3209,
-   "compress_mbps": 39.35,
-   "decompress_mbps": 209.91
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3572,
-   "ratio": 0.3204,
-   "compress_mbps": 36.83,
-   "decompress_mbps": 210.72
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3568,
-   "ratio": 0.32,
-   "compress_mbps": 34.7,
-   "decompress_mbps": 208.41
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3568,
-   "ratio": 0.32,
-   "compress_mbps": 33.66,
-   "decompress_mbps": 206.14
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1738,
-   "ratio": 0.4671,
-   "compress_mbps": 30.09,
-   "decompress_mbps": 176.72
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1709,
-   "ratio": 0.4593,
-   "compress_mbps": 30.1,
-   "decompress_mbps": 174.49
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1694,
-   "ratio": 0.4553,
-   "compress_mbps": 31.7,
-   "decompress_mbps": 180.35
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1458,
-   "ratio": 0.3918,
-   "compress_mbps": 29.73,
-   "decompress_mbps": 187.58
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1441,
-   "ratio": 0.3873,
-   "compress_mbps": 28.44,
-   "decompress_mbps": 189.94
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1440,
-   "ratio": 0.387,
-   "compress_mbps": 27.18,
-   "decompress_mbps": 189.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1440,
-   "ratio": 0.387,
-   "compress_mbps": 27.68,
-   "decompress_mbps": 190.15
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1440,
-   "ratio": 0.387,
-   "compress_mbps": 26.12,
-   "decompress_mbps": 189.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1440,
-   "ratio": 0.387,
-   "compress_mbps": 27.78,
-   "decompress_mbps": 191.2
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 260073,
-   "ratio": 0.2526,
-   "compress_mbps": 52.45,
-   "decompress_mbps": 56.85
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 296764,
-   "ratio": 0.2882,
-   "compress_mbps": 48.94,
-   "decompress_mbps": 76.97
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 288989,
-   "ratio": 0.2806,
-   "compress_mbps": 37.59,
-   "decompress_mbps": 77.33
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 246442,
-   "ratio": 0.2393,
-   "compress_mbps": 54.71,
-   "decompress_mbps": 83.32
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 218888,
-   "ratio": 0.2126,
-   "compress_mbps": 40.79,
-   "decompress_mbps": 76.86
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 217830,
-   "ratio": 0.2115,
-   "compress_mbps": 24.16,
-   "decompress_mbps": 88.24
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 221437,
-   "ratio": 0.215,
-   "compress_mbps": 19.26,
-   "decompress_mbps": 86.6
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 219666,
-   "ratio": 0.2133,
-   "compress_mbps": 5.49,
-   "decompress_mbps": 86.51
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 219921,
-   "ratio": 0.2136,
-   "compress_mbps": 2.77,
-   "decompress_mbps": 85.35
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 194588,
-   "ratio": 0.456,
-   "compress_mbps": 34.47,
-   "decompress_mbps": 51.9
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 185757,
-   "ratio": 0.4353,
-   "compress_mbps": 32.92,
-   "decompress_mbps": 49.65
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 175850,
-   "ratio": 0.4121,
-   "compress_mbps": 27.11,
-   "decompress_mbps": 59.21
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 155951,
-   "ratio": 0.3654,
-   "compress_mbps": 31.95,
-   "decompress_mbps": 73.02
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 150274,
-   "ratio": 0.3521,
-   "compress_mbps": 23.12,
-   "decompress_mbps": 71.4
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 147958,
-   "ratio": 0.3467,
-   "compress_mbps": 16.73,
-   "decompress_mbps": 72.74
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 147522,
-   "ratio": 0.3457,
-   "compress_mbps": 14.93,
-   "decompress_mbps": 70.21
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 147331,
-   "ratio": 0.3452,
-   "compress_mbps": 13.5,
-   "decompress_mbps": 68.78
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 147328,
-   "ratio": 0.3452,
-   "compress_mbps": 13.48,
-   "decompress_mbps": 70.75
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 256904,
-   "ratio": 0.5331,
-   "compress_mbps": 29.73,
-   "decompress_mbps": 46.55
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 245675,
-   "ratio": 0.5098,
-   "compress_mbps": 28.42,
-   "decompress_mbps": 50.05
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 231519,
-   "ratio": 0.4805,
-   "compress_mbps": 22.58,
-   "decompress_mbps": 56.23
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 210028,
-   "ratio": 0.4359,
-   "compress_mbps": 27.54,
-   "decompress_mbps": 64.61
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 203312,
-   "ratio": 0.4219,
-   "compress_mbps": 18.52,
-   "decompress_mbps": 61.6
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 199287,
-   "ratio": 0.4136,
-   "compress_mbps": 12.88,
-   "decompress_mbps": 65.73
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 198474,
-   "ratio": 0.4119,
-   "compress_mbps": 11.21,
-   "decompress_mbps": 66.4
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 198080,
-   "ratio": 0.4111,
-   "compress_mbps": 8.88,
-   "decompress_mbps": 65.36
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 198080,
-   "ratio": 0.4111,
-   "compress_mbps": 8.84,
-   "decompress_mbps": 65.03
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 71229,
-   "ratio": 0.1388,
-   "compress_mbps": 82.96,
-   "decompress_mbps": 136.59
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 69946,
-   "ratio": 0.1363,
-   "compress_mbps": 78.92,
-   "decompress_mbps": 137.96
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 68538,
-   "ratio": 0.1335,
-   "compress_mbps": 69.23,
-   "decompress_mbps": 151.76
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 61320,
-   "ratio": 0.1195,
-   "compress_mbps": 65.87,
-   "decompress_mbps": 164.26
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 59993,
-   "ratio": 0.1169,
-   "compress_mbps": 57.15,
-   "decompress_mbps": 169.1
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 58637,
-   "ratio": 0.1143,
-   "compress_mbps": 41.42,
-   "decompress_mbps": 166.25
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 58209,
-   "ratio": 0.1134,
-   "compress_mbps": 35.38,
-   "decompress_mbps": 173.09
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 55749,
-   "ratio": 0.1086,
-   "compress_mbps": 19.35,
-   "decompress_mbps": 176.71
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 54927,
-   "ratio": 0.107,
-   "compress_mbps": 7.52,
-   "decompress_mbps": 176.17
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 16399,
-   "ratio": 0.4288,
-   "compress_mbps": 36.37,
-   "decompress_mbps": 86.67
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 15933,
-   "ratio": 0.4167,
-   "compress_mbps": 33.72,
-   "decompress_mbps": 88.83
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 15739,
-   "ratio": 0.4116,
-   "compress_mbps": 28.05,
-   "decompress_mbps": 87.94
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13834,
-   "ratio": 0.3618,
-   "compress_mbps": 31.73,
-   "decompress_mbps": 108.86
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13463,
-   "ratio": 0.3521,
-   "compress_mbps": 25.96,
-   "decompress_mbps": 111.56
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 13353,
-   "ratio": 0.3492,
-   "compress_mbps": 18.86,
-   "decompress_mbps": 111.15
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 13317,
-   "ratio": 0.3482,
-   "compress_mbps": 15.93,
-   "decompress_mbps": 113.26
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 13255,
-   "ratio": 0.3466,
-   "compress_mbps": 8.38,
-   "decompress_mbps": 110.11
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 13171,
-   "ratio": 0.3444,
-   "compress_mbps": 4.16,
-   "decompress_mbps": 114.39
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 2512,
-   "ratio": 0.5943,
-   "compress_mbps": 29.63,
-   "decompress_mbps": 155.88
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 2477,
-   "ratio": 0.586,
-   "compress_mbps": 29.51,
-   "decompress_mbps": 158.96
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 2452,
-   "ratio": 0.5801,
-   "compress_mbps": 30.37,
-   "decompress_mbps": 157.34
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 2110,
-   "ratio": 0.4992,
-   "compress_mbps": 29.99,
-   "decompress_mbps": 162.81
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 2086,
-   "ratio": 0.4935,
-   "compress_mbps": 28.87,
-   "decompress_mbps": 169.5
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 2086,
-   "ratio": 0.4935,
-   "compress_mbps": 28.86,
-   "decompress_mbps": 167.98
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 2086,
-   "ratio": 0.4935,
-   "compress_mbps": 28.5,
-   "decompress_mbps": 169.54
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 2086,
-   "ratio": 0.4935,
-   "compress_mbps": 27.54,
-   "decompress_mbps": 169.65
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 2086,
-   "ratio": 0.4935,
-   "compress_mbps": 28.63,
-   "decompress_mbps": 169.5
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 5183792,
-   "ratio": 0.5086,
-   "compress_mbps": 31.31,
-   "decompress_mbps": 40.47
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4956750,
-   "ratio": 0.4863,
-   "compress_mbps": 29.97,
-   "decompress_mbps": 43.45
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 4644095,
-   "ratio": 0.4556,
-   "compress_mbps": 24.06,
-   "decompress_mbps": 47.94
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 4178564,
-   "ratio": 0.41,
-   "compress_mbps": 29.06,
-   "decompress_mbps": 61.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 4034632,
-   "ratio": 0.3958,
-   "compress_mbps": 19.92,
-   "decompress_mbps": 61.3
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3952244,
-   "ratio": 0.3878,
-   "compress_mbps": 13.83,
-   "decompress_mbps": 61.12
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3938822,
-   "ratio": 0.3864,
-   "compress_mbps": 12.23,
-   "decompress_mbps": 62.83
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3935171,
-   "ratio": 0.3861,
-   "compress_mbps": 10.76,
-   "decompress_mbps": 60.2
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3935171,
-   "ratio": 0.3861,
-   "compress_mbps": 10.72,
-   "decompress_mbps": 60.89
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 25320013,
-   "ratio": 0.4943,
-   "compress_mbps": 31.71,
-   "decompress_mbps": 34.88
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 24804084,
-   "ratio": 0.4843,
-   "compress_mbps": 30.3,
-   "decompress_mbps": 36.64
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 24241121,
-   "ratio": 0.4733,
-   "compress_mbps": 25.73,
-   "decompress_mbps": 37.97
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 20950547,
-   "ratio": 0.409,
-   "compress_mbps": 28.84,
-   "decompress_mbps": 44.03
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 20592289,
-   "ratio": 0.402,
-   "compress_mbps": 24.29,
-   "decompress_mbps": 46.14
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 20445232,
-   "ratio": 0.3992,
-   "compress_mbps": 18.69,
-   "decompress_mbps": 46.11
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 20407676,
-   "ratio": 0.3984,
-   "compress_mbps": 15.95,
-   "decompress_mbps": 46.63
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 20389473,
-   "ratio": 0.3981,
-   "compress_mbps": 10.13,
-   "decompress_mbps": 45.4
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 20386824,
-   "ratio": 0.398,
-   "compress_mbps": 6.82,
-   "decompress_mbps": 46.45
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3964698,
-   "ratio": 0.3976,
-   "compress_mbps": 37.98,
-   "decompress_mbps": 48.02
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3936391,
-   "ratio": 0.3948,
-   "compress_mbps": 35.52,
-   "decompress_mbps": 47.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3823540,
-   "ratio": 0.3835,
-   "compress_mbps": 27.78,
-   "decompress_mbps": 51.72
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3799601,
-   "ratio": 0.3811,
-   "compress_mbps": 33.02,
-   "decompress_mbps": 63.69
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3830938,
-   "ratio": 0.3842,
-   "compress_mbps": 22.58,
-   "decompress_mbps": 58.61
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3808303,
-   "ratio": 0.382,
-   "compress_mbps": 14.79,
-   "decompress_mbps": 57.61
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3802814,
-   "ratio": 0.3814,
-   "compress_mbps": 12.14,
-   "decompress_mbps": 57.87
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3800355,
-   "ratio": 0.3812,
-   "compress_mbps": 6.76,
-   "decompress_mbps": 59.01
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3799676,
-   "ratio": 0.3811,
-   "compress_mbps": 6.05,
-   "decompress_mbps": 59.07
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 4899547,
-   "ratio": 0.146,
-   "compress_mbps": 95.3,
-   "decompress_mbps": 131.63
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 4587004,
-   "ratio": 0.1367,
-   "compress_mbps": 94.92,
-   "decompress_mbps": 142.96
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 4229035,
-   "ratio": 0.126,
-   "compress_mbps": 90.43,
-   "decompress_mbps": 152.33
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3791322,
-   "ratio": 0.113,
-   "compress_mbps": 81.61,
-   "decompress_mbps": 160.66
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3449193,
-   "ratio": 0.1028,
-   "compress_mbps": 72.81,
-   "decompress_mbps": 168.1
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3269452,
-   "ratio": 0.0974,
-   "compress_mbps": 58.66,
-   "decompress_mbps": 173.37
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3211286,
-   "ratio": 0.0957,
-   "compress_mbps": 50.59,
-   "decompress_mbps": 173.62
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3101534,
-   "ratio": 0.0924,
-   "compress_mbps": 27.5,
-   "decompress_mbps": 174.42
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 3058177,
-   "ratio": 0.0911,
-   "compress_mbps": 16.6,
-   "decompress_mbps": 177.54
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 4024327,
-   "ratio": 0.6541,
-   "compress_mbps": 22.81,
-   "decompress_mbps": 29.95
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3953722,
-   "ratio": 0.6427,
-   "compress_mbps": 21.66,
-   "decompress_mbps": 30.5
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3887921,
-   "ratio": 0.632,
-   "compress_mbps": 18.47,
-   "decompress_mbps": 31.15
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3320440,
-   "ratio": 0.5397,
-   "compress_mbps": 21.3,
-   "decompress_mbps": 37.41
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3279338,
-   "ratio": 0.533,
-   "compress_mbps": 17.83,
-   "decompress_mbps": 38.07
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3254309,
-   "ratio": 0.529,
-   "compress_mbps": 14.0,
-   "decompress_mbps": 37.9
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3250139,
-   "ratio": 0.5283,
-   "compress_mbps": 12.22,
-   "decompress_mbps": 38.09
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3247018,
-   "ratio": 0.5278,
-   "compress_mbps": 10.17,
-   "decompress_mbps": 38.03
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3246865,
-   "ratio": 0.5278,
-   "compress_mbps": 9.51,
-   "decompress_mbps": 38.0
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 4471091,
-   "ratio": 0.4433,
-   "compress_mbps": 34.91,
-   "decompress_mbps": 69.94
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 4372105,
-   "ratio": 0.4335,
-   "compress_mbps": 33.82,
-   "decompress_mbps": 71.85
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 4305270,
-   "ratio": 0.4269,
-   "compress_mbps": 30.7,
-   "decompress_mbps": 73.16
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3920495,
-   "ratio": 0.3887,
-   "compress_mbps": 30.3,
-   "decompress_mbps": 64.84
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3853177,
-   "ratio": 0.382,
-   "compress_mbps": 26.63,
-   "decompress_mbps": 63.95
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3780878,
-   "ratio": 0.3749,
-   "compress_mbps": 23.38,
-   "decompress_mbps": 64.31
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3763880,
-   "ratio": 0.3732,
-   "compress_mbps": 20.2,
-   "decompress_mbps": 72.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3757719,
-   "ratio": 0.3726,
-   "compress_mbps": 18.3,
-   "decompress_mbps": 73.42
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3757719,
-   "ratio": 0.3726,
-   "compress_mbps": 18.25,
-   "decompress_mbps": 72.55
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2722387,
-   "ratio": 0.4108,
-   "compress_mbps": 38.01,
-   "decompress_mbps": 64.73
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2572544,
-   "ratio": 0.3882,
-   "compress_mbps": 36.87,
-   "decompress_mbps": 70.55
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2384328,
-   "ratio": 0.3598,
-   "compress_mbps": 29.15,
-   "decompress_mbps": 78.64
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 2112060,
-   "ratio": 0.3187,
-   "compress_mbps": 36.42,
-   "decompress_mbps": 85.62
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1991581,
-   "ratio": 0.3005,
-   "compress_mbps": 25.34,
-   "decompress_mbps": 91.01
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1917866,
-   "ratio": 0.2894,
-   "compress_mbps": 15.03,
-   "decompress_mbps": 90.85
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1895353,
-   "ratio": 0.286,
-   "compress_mbps": 11.08,
-   "decompress_mbps": 90.48
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1880740,
-   "ratio": 0.2838,
-   "compress_mbps": 5.59,
-   "decompress_mbps": 90.95
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1880711,
-   "ratio": 0.2838,
-   "compress_mbps": 5.56,
-   "decompress_mbps": 92.3
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 7441483,
-   "ratio": 0.3444,
-   "compress_mbps": 43.78,
-   "decompress_mbps": 66.88
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 7229248,
-   "ratio": 0.3346,
-   "compress_mbps": 43.14,
-   "decompress_mbps": 69.03
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 7083451,
-   "ratio": 0.3278,
-   "compress_mbps": 38.92,
-   "decompress_mbps": 71.31
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 6189639,
-   "ratio": 0.2865,
-   "compress_mbps": 42.2,
-   "decompress_mbps": 92.76
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 6053058,
-   "ratio": 0.2802,
-   "compress_mbps": 35.08,
-   "decompress_mbps": 96.18
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5988137,
-   "ratio": 0.2771,
-   "compress_mbps": 28.51,
-   "decompress_mbps": 101.1
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5949908,
-   "ratio": 0.2754,
-   "compress_mbps": 25.19,
-   "decompress_mbps": 103.3
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5936656,
-   "ratio": 0.2748,
-   "compress_mbps": 19.22,
-   "decompress_mbps": 106.46
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5934701,
-   "ratio": 0.2747,
-   "compress_mbps": 17.98,
-   "decompress_mbps": 105.25
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 6335542,
-   "ratio": 0.8736,
-   "compress_mbps": 18.44,
-   "decompress_mbps": 31.75
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 6247260,
-   "ratio": 0.8615,
-   "compress_mbps": 17.59,
-   "decompress_mbps": 48.2
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 6064713,
-   "ratio": 0.8363,
-   "compress_mbps": 15.15,
-   "decompress_mbps": 56.49
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5568111,
-   "ratio": 0.7678,
-   "compress_mbps": 17.55,
-   "decompress_mbps": 58.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5544524,
-   "ratio": 0.7646,
-   "compress_mbps": 14.42,
-   "decompress_mbps": 64.88
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5513056,
-   "ratio": 0.7602,
-   "compress_mbps": 11.94,
-   "decompress_mbps": 62.87
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5508915,
-   "ratio": 0.7596,
-   "compress_mbps": 11.32,
-   "decompress_mbps": 64.42
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5508365,
-   "ratio": 0.7596,
-   "compress_mbps": 10.52,
-   "decompress_mbps": 65.26
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5508365,
-   "ratio": 0.7596,
-   "compress_mbps": 10.57,
-   "decompress_mbps": 64.3
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 16776095,
-   "ratio": 0.4046,
-   "compress_mbps": 37.73,
-   "decompress_mbps": 50.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 16032651,
-   "ratio": 0.3867,
-   "compress_mbps": 36.24,
-   "decompress_mbps": 54.65
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 15180334,
-   "ratio": 0.3662,
-   "compress_mbps": 31.28,
-   "decompress_mbps": 51.85
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 13261924,
-   "ratio": 0.3199,
-   "compress_mbps": 35.24,
-   "decompress_mbps": 68.67
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12706028,
-   "ratio": 0.3065,
-   "compress_mbps": 27.63,
-   "decompress_mbps": 70.4
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12464158,
-   "ratio": 0.3006,
-   "compress_mbps": 21.0,
-   "decompress_mbps": 70.64
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12375954,
-   "ratio": 0.2985,
-   "compress_mbps": 18.31,
-   "decompress_mbps": 73.55
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12321552,
-   "ratio": 0.2972,
-   "compress_mbps": 14.45,
-   "decompress_mbps": 70.76
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 12320276,
-   "ratio": 0.2972,
-   "compress_mbps": 14.41,
-   "decompress_mbps": 70.34
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6799201,
-   "ratio": 0.8023,
-   "compress_mbps": 18.34,
-   "decompress_mbps": 18.29
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6800500,
-   "ratio": 0.8025,
-   "compress_mbps": 16.95,
-   "decompress_mbps": 18.49
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6803212,
-   "ratio": 0.8028,
-   "compress_mbps": 14.91,
-   "decompress_mbps": 18.44
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6264611,
-   "ratio": 0.7393,
-   "compress_mbps": 17.32,
-   "decompress_mbps": 24.91
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6217901,
-   "ratio": 0.7337,
-   "compress_mbps": 15.76,
-   "decompress_mbps": 25.36
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 6201999,
-   "ratio": 0.7319,
-   "compress_mbps": 15.32,
-   "decompress_mbps": 25.35
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 6201883,
-   "ratio": 0.7319,
-   "compress_mbps": 15.24,
-   "decompress_mbps": 25.06
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 6201887,
-   "ratio": 0.7319,
-   "compress_mbps": 15.22,
-   "decompress_mbps": 24.94
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 6201887,
-   "ratio": 0.7319,
-   "compress_mbps": 15.3,
-   "decompress_mbps": 24.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 1081679,
-   "ratio": 0.2024,
-   "compress_mbps": 74.26,
-   "decompress_mbps": 106.26
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 1001890,
-   "ratio": 0.1874,
-   "compress_mbps": 74.05,
-   "decompress_mbps": 118.21
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 921722,
-   "ratio": 0.1724,
-   "compress_mbps": 67.22,
-   "decompress_mbps": 127.75
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 849263,
-   "ratio": 0.1589,
-   "compress_mbps": 64.23,
-   "decompress_mbps": 142.53
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 771964,
-   "ratio": 0.1444,
-   "compress_mbps": 54.81,
-   "decompress_mbps": 144.22
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 728098,
-   "ratio": 0.1362,
-   "compress_mbps": 43.49,
-   "decompress_mbps": 150.41
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 713635,
-   "ratio": 0.1335,
-   "compress_mbps": 37.23,
-   "decompress_mbps": 154.84
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 699093,
-   "ratio": 0.1308,
-   "compress_mbps": 27.08,
-   "decompress_mbps": 146.56
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 698459,
-   "ratio": 0.1307,
-   "compress_mbps": 25.17,
-   "decompress_mbps": 148.81
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 10,
-   "out_size": 51721,
-   "ratio": 0.3401,
-   "compress_mbps": 12.25,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 11,
-   "out_size": 51662,
-   "ratio": 0.3397,
-   "compress_mbps": 8.43,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 12,
-   "out_size": 51662,
-   "ratio": 0.3397,
-   "compress_mbps": 5.17,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 10,
-   "out_size": 46657,
-   "ratio": 0.3727,
-   "compress_mbps": 13.72,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 11,
-   "out_size": 46515,
-   "ratio": 0.3716,
-   "compress_mbps": 9.35,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 12,
-   "out_size": 46469,
-   "ratio": 0.3712,
-   "compress_mbps": 7.14,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 10,
-   "out_size": 7725,
-   "ratio": 0.314,
-   "compress_mbps": 15.97,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 11,
-   "out_size": 7727,
-   "ratio": 0.3141,
-   "compress_mbps": 10.79,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 12,
-   "out_size": 7723,
-   "ratio": 0.3139,
-   "compress_mbps": 7.17,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 10,
-   "out_size": 3026,
-   "ratio": 0.2714,
-   "compress_mbps": 17.74,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 11,
-   "out_size": 3024,
-   "ratio": 0.2712,
-   "compress_mbps": 14.13,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 12,
-   "out_size": 3024,
-   "ratio": 0.2712,
-   "compress_mbps": 10.64,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 10,
-   "out_size": 1186,
-   "ratio": 0.3187,
-   "compress_mbps": 41.49,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 11,
-   "out_size": 1186,
-   "ratio": 0.3187,
-   "compress_mbps": 33.55,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 12,
-   "out_size": 1186,
-   "ratio": 0.3187,
-   "compress_mbps": 24.35,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 10,
-   "out_size": 179347,
-   "ratio": 0.1742,
-   "compress_mbps": 30.91,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 11,
-   "out_size": 179096,
-   "ratio": 0.1739,
-   "compress_mbps": 20.04,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 12,
-   "out_size": 179049,
-   "ratio": 0.1739,
-   "compress_mbps": 15.47,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 10,
-   "out_size": 138116,
-   "ratio": 0.3236,
-   "compress_mbps": 12.77,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 11,
-   "out_size": 137923,
-   "ratio": 0.3232,
-   "compress_mbps": 8.78,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 12,
-   "out_size": 137921,
-   "ratio": 0.3232,
-   "compress_mbps": 7.43,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 10,
-   "out_size": 185328,
-   "ratio": 0.3846,
-   "compress_mbps": 12.88,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 11,
-   "out_size": 184440,
-   "ratio": 0.3828,
-   "compress_mbps": 9.1,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 12,
-   "out_size": 184371,
-   "ratio": 0.3826,
-   "compress_mbps": 5.56,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 10,
-   "out_size": 51319,
-   "ratio": 0.1,
-   "compress_mbps": 12.87,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 11,
-   "out_size": 49675,
-   "ratio": 0.0968,
-   "compress_mbps": 6.13,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 12,
-   "out_size": 49194,
-   "ratio": 0.0959,
-   "compress_mbps": 3.65,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 10,
-   "out_size": 11975,
-   "ratio": 0.3132,
-   "compress_mbps": 20.05,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 11,
-   "out_size": 11966,
-   "ratio": 0.3129,
-   "compress_mbps": 13.4,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 12,
-   "out_size": 11965,
-   "ratio": 0.3129,
-   "compress_mbps": 10.77,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 10,
-   "out_size": 1692,
-   "ratio": 0.4003,
-   "compress_mbps": 54.22,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 11,
-   "out_size": 1690,
-   "ratio": 0.3998,
-   "compress_mbps": 45.3,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 12,
-   "out_size": 1690,
-   "ratio": 0.3998,
-   "compress_mbps": 29.74,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 10,
-   "out_size": 3681797,
-   "ratio": 0.3612,
-   "compress_mbps": 12.62,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 11,
-   "out_size": 3679289,
-   "ratio": 0.361,
-   "compress_mbps": 9.26,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": 7.67,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 10,
-   "out_size": 18268811,
-   "ratio": 0.3567,
-   "compress_mbps": 16.35,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 11,
-   "out_size": 18245674,
-   "ratio": 0.3562,
-   "compress_mbps": 11.71,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": 9.35,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 10,
-   "out_size": 3461494,
-   "ratio": 0.3472,
-   "compress_mbps": 18.28,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 11,
-   "out_size": 3446053,
-   "ratio": 0.3456,
-   "compress_mbps": 10.54,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": 5.38,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 10,
-   "out_size": 2782465,
-   "ratio": 0.0829,
-   "compress_mbps": 8.49,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 11,
-   "out_size": 2751857,
-   "ratio": 0.082,
-   "compress_mbps": 5.54,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": 4.07,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 10,
-   "out_size": 2995902,
-   "ratio": 0.487,
-   "compress_mbps": 19.22,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 11,
-   "out_size": 2994386,
-   "ratio": 0.4867,
-   "compress_mbps": 14.58,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": 12.48,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 10,
-   "out_size": 3608746,
-   "ratio": 0.3578,
-   "compress_mbps": 19.08,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 11,
-   "out_size": 3608161,
-   "ratio": 0.3578,
-   "compress_mbps": 14.81,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": 13.22,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 10,
-   "out_size": 1697693,
-   "ratio": 0.2562,
-   "compress_mbps": 8.9,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 11,
-   "out_size": 1696742,
-   "ratio": 0.256,
-   "compress_mbps": 6.68,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": 5.74,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 10,
-   "out_size": 5137640,
-   "ratio": 0.2378,
-   "compress_mbps": 16.05,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 11,
-   "out_size": 5122694,
-   "ratio": 0.2371,
-   "compress_mbps": 9.68,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": 7.0,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 10,
-   "out_size": 5250862,
-   "ratio": 0.7241,
-   "compress_mbps": 25.53,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 11,
-   "out_size": 5250747,
-   "ratio": 0.724,
-   "compress_mbps": 20.83,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": 19.39,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 10,
-   "out_size": 11526846,
-   "ratio": 0.278,
-   "compress_mbps": 10.51,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 11,
-   "out_size": 11520969,
-   "ratio": 0.2779,
-   "compress_mbps": 7.08,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": 6.12,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 10,
-   "out_size": 5748096,
-   "ratio": 0.6783,
-   "compress_mbps": 38.25,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 11,
-   "out_size": 5747172,
-   "ratio": 0.6782,
-   "compress_mbps": 29.45,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": 26.58,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 10,
-   "out_size": 637425,
-   "ratio": 0.1193,
-   "compress_mbps": 12.15,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 11,
-   "out_size": 630827,
-   "ratio": 0.118,
-   "compress_mbps": 7.32,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": 4.73,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 10,
-   "out_size": 52111,
-   "ratio": 0.3426,
-   "compress_mbps": 1.83,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 10,
-   "out_size": 46881,
-   "ratio": 0.3745,
-   "compress_mbps": 2.08,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 10,
-   "out_size": 7727,
-   "ratio": 0.3141,
-   "compress_mbps": 2.4,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 10,
-   "out_size": 3027,
-   "ratio": 0.2715,
-   "compress_mbps": 2.37,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 10,
-   "out_size": 1190,
-   "ratio": 0.3198,
-   "compress_mbps": 2.14,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 10,
-   "out_size": 178311,
-   "ratio": 0.1732,
-   "compress_mbps": 1.18,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 10,
-   "out_size": 138661,
-   "ratio": 0.3249,
-   "compress_mbps": 1.87,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 10,
-   "out_size": 186472,
-   "ratio": 0.387,
-   "compress_mbps": 1.81,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 10,
-   "out_size": 51490,
-   "ratio": 0.1003,
-   "compress_mbps": 1.05,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 10,
-   "out_size": 12278,
-   "ratio": 0.3211,
-   "compress_mbps": 1.82,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 10,
-   "out_size": 1696,
-   "ratio": 0.4012,
-   "compress_mbps": 2.54,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 10,
-   "out_size": 3712344,
-   "ratio": 0.3642,
-   "compress_mbps": 1.82,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 10,
-   "out_size": 18518350,
-   "ratio": 0.3615,
-   "compress_mbps": 1.63,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 10,
-   "out_size": 3520112,
-   "ratio": 0.3531,
-   "compress_mbps": 1.25,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 10,
-   "out_size": 2868751,
-   "ratio": 0.0855,
-   "compress_mbps": 0.88,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 10,
-   "out_size": 3017696,
-   "ratio": 0.4905,
-   "compress_mbps": 2.32,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 10,
-   "out_size": 3647083,
-   "ratio": 0.3616,
-   "compress_mbps": 2.77,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 10,
-   "out_size": 1724560,
-   "ratio": 0.2602,
-   "compress_mbps": 1.17,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 10,
-   "out_size": 5169629,
-   "ratio": 0.2393,
-   "compress_mbps": 1.66,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 10,
-   "out_size": 5261135,
-   "ratio": 0.7255,
-   "compress_mbps": 2.59,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 10,
-   "out_size": 11638957,
-   "ratio": 0.2807,
-   "compress_mbps": 1.62,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 10,
-   "out_size": 5825680,
-   "ratio": 0.6875,
-   "compress_mbps": 3.45,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 10,
-   "out_size": 637424,
-   "ratio": 0.1192,
-   "compress_mbps": 1.18,
-   "decompress_mbps": null
-  }
- ]
+  "meta": {
+    "date": "2026-07-03T00:31:25Z",
+    "machine": "Linux chungus x86_64",
+    "git_commit": "0d41c6ad",
+    "toolchain": "leanprover/lean4:v4.30.0-rc2",
+    "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
+  },
+  "results": [
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 60455,
+      "ratio": 0.3975,
+      "compress_mbps": 54.97,
+      "decompress_mbps": 187.38
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 56316,
+      "ratio": 0.3703,
+      "compress_mbps": 42.23,
+      "decompress_mbps": 213.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 55646,
+      "ratio": 0.3659,
+      "compress_mbps": 38.03,
+      "decompress_mbps": 233.09
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 54782,
+      "ratio": 0.3602,
+      "compress_mbps": 29.85,
+      "decompress_mbps": 235.95
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 54700,
+      "ratio": 0.3597,
+      "compress_mbps": 28.77,
+      "decompress_mbps": 238.04
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54535,
+      "ratio": 0.3586,
+      "compress_mbps": 26.45,
+      "decompress_mbps": 244.69
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 54385,
+      "ratio": 0.3576,
+      "compress_mbps": 21.24,
+      "decompress_mbps": 245.06
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 54127,
+      "ratio": 0.3559,
+      "compress_mbps": 9.54,
+      "decompress_mbps": 245.55
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 53082,
+      "ratio": 0.349,
+      "compress_mbps": 3.23,
+      "decompress_mbps": 242.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 53135,
+      "ratio": 0.4245,
+      "compress_mbps": 49.96,
+      "decompress_mbps": 180.32
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 50187,
+      "ratio": 0.4009,
+      "compress_mbps": 38.94,
+      "decompress_mbps": 196.51
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 49810,
+      "ratio": 0.3979,
+      "compress_mbps": 35.79,
+      "decompress_mbps": 214.24
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 49036,
+      "ratio": 0.3917,
+      "compress_mbps": 27.82,
+      "decompress_mbps": 218.14
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 48994,
+      "ratio": 0.3914,
+      "compress_mbps": 26.92,
+      "decompress_mbps": 219.56
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48934,
+      "ratio": 0.3909,
+      "compress_mbps": 25.58,
+      "decompress_mbps": 223.98
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48874,
+      "ratio": 0.3904,
+      "compress_mbps": 22.82,
+      "decompress_mbps": 224.04
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 48634,
+      "ratio": 0.3885,
+      "compress_mbps": 9.34,
+      "decompress_mbps": 223.94
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 47620,
+      "ratio": 0.3804,
+      "compress_mbps": 3.41,
+      "decompress_mbps": 224.53
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 8476,
+      "ratio": 0.3445,
+      "compress_mbps": 39.89,
+      "decompress_mbps": 217.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8271,
+      "ratio": 0.3362,
+      "compress_mbps": 35.22,
+      "decompress_mbps": 224.64
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8158,
+      "ratio": 0.3316,
+      "compress_mbps": 34.4,
+      "decompress_mbps": 229.75
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 7991,
+      "ratio": 0.3248,
+      "compress_mbps": 31.43,
+      "decompress_mbps": 238.21
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 7984,
+      "ratio": 0.3245,
+      "compress_mbps": 30.95,
+      "decompress_mbps": 244.99
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7949,
+      "ratio": 0.3231,
+      "compress_mbps": 29.76,
+      "decompress_mbps": 246.58
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7929,
+      "ratio": 0.3223,
+      "compress_mbps": 25.95,
+      "decompress_mbps": 248.55
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7929,
+      "ratio": 0.3223,
+      "compress_mbps": 9.94,
+      "decompress_mbps": 249.94
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7806,
+      "ratio": 0.3173,
+      "compress_mbps": 4.14,
+      "decompress_mbps": 249.31
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3509,
+      "ratio": 0.3147,
+      "compress_mbps": 26.08,
+      "decompress_mbps": 151.57
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3269,
+      "ratio": 0.2932,
+      "compress_mbps": 24.14,
+      "decompress_mbps": 153.81
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3208,
+      "ratio": 0.2877,
+      "compress_mbps": 23.41,
+      "decompress_mbps": 157.24
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3147,
+      "ratio": 0.2822,
+      "compress_mbps": 21.89,
+      "decompress_mbps": 159.6
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3141,
+      "ratio": 0.2817,
+      "compress_mbps": 21.61,
+      "decompress_mbps": 161.54
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3133,
+      "ratio": 0.281,
+      "compress_mbps": 21.34,
+      "decompress_mbps": 161.88
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3128,
+      "ratio": 0.2805,
+      "compress_mbps": 19.27,
+      "decompress_mbps": 162.27
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3128,
+      "ratio": 0.2805,
+      "compress_mbps": 7.18,
+      "decompress_mbps": 162.33
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3057,
+      "ratio": 0.2742,
+      "compress_mbps": 4.15,
+      "decompress_mbps": 162.59
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1282,
+      "ratio": 0.3445,
+      "compress_mbps": 12.51,
+      "decompress_mbps": 71.4
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1225,
+      "ratio": 0.3292,
+      "compress_mbps": 11.95,
+      "decompress_mbps": 72.06
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1220,
+      "ratio": 0.3279,
+      "compress_mbps": 11.84,
+      "decompress_mbps": 71.99
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1213,
+      "ratio": 0.326,
+      "compress_mbps": 11.56,
+      "decompress_mbps": 72.48
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1213,
+      "ratio": 0.326,
+      "compress_mbps": 11.56,
+      "decompress_mbps": 72.47
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1213,
+      "ratio": 0.326,
+      "compress_mbps": 11.54,
+      "decompress_mbps": 72.81
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1209,
+      "ratio": 0.3249,
+      "compress_mbps": 11.28,
+      "decompress_mbps": 72.93
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1209,
+      "ratio": 0.3249,
+      "compress_mbps": 3.89,
+      "decompress_mbps": 72.82
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1205,
+      "ratio": 0.3238,
+      "compress_mbps": 3.41,
+      "decompress_mbps": 72.8
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 251793,
+      "ratio": 0.2445,
+      "compress_mbps": 104.94,
+      "decompress_mbps": 342.73
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 242565,
+      "ratio": 0.2356,
+      "compress_mbps": 78.17,
+      "decompress_mbps": 371.99
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 242532,
+      "ratio": 0.2355,
+      "compress_mbps": 65.23,
+      "decompress_mbps": 393.88
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 239898,
+      "ratio": 0.233,
+      "compress_mbps": 60.31,
+      "decompress_mbps": 413.35
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 239804,
+      "ratio": 0.2329,
+      "compress_mbps": 59.44,
+      "decompress_mbps": 399.75
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 239606,
+      "ratio": 0.2327,
+      "compress_mbps": 54.76,
+      "decompress_mbps": 413.34
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 214282,
+      "ratio": 0.2081,
+      "compress_mbps": 19.77,
+      "decompress_mbps": 416.68
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 200719,
+      "ratio": 0.1949,
+      "compress_mbps": 7.22,
+      "decompress_mbps": 423.75
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 183445,
+      "ratio": 0.1781,
+      "compress_mbps": 2.51,
+      "decompress_mbps": 425.93
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 160674,
+      "ratio": 0.3765,
+      "compress_mbps": 61.26,
+      "decompress_mbps": 198.55
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 149787,
+      "ratio": 0.351,
+      "compress_mbps": 46.35,
+      "decompress_mbps": 214.99
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 148055,
+      "ratio": 0.3469,
+      "compress_mbps": 41.66,
+      "decompress_mbps": 239.44
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 145888,
+      "ratio": 0.3419,
+      "compress_mbps": 32.45,
+      "decompress_mbps": 243.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 145758,
+      "ratio": 0.3416,
+      "compress_mbps": 31.54,
+      "decompress_mbps": 245.89
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 145454,
+      "ratio": 0.3408,
+      "compress_mbps": 28.96,
+      "decompress_mbps": 250.68
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 145077,
+      "ratio": 0.34,
+      "compress_mbps": 23.62,
+      "decompress_mbps": 251.84
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 144540,
+      "ratio": 0.3387,
+      "compress_mbps": 10.43,
+      "decompress_mbps": 251.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 141031,
+      "ratio": 0.3305,
+      "compress_mbps": 3.23,
+      "decompress_mbps": 251.73
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 212588,
+      "ratio": 0.4412,
+      "compress_mbps": 52.3,
+      "decompress_mbps": 171.03
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 199981,
+      "ratio": 0.415,
+      "compress_mbps": 38.93,
+      "decompress_mbps": 190.63
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 198551,
+      "ratio": 0.4121,
+      "compress_mbps": 35.02,
+      "decompress_mbps": 210.44
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 195797,
+      "ratio": 0.4063,
+      "compress_mbps": 25.64,
+      "decompress_mbps": 213.72
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 195462,
+      "ratio": 0.4056,
+      "compress_mbps": 24.25,
+      "decompress_mbps": 212.05
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 194965,
+      "ratio": 0.4046,
+      "compress_mbps": 22.38,
+      "decompress_mbps": 216.14
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 194724,
+      "ratio": 0.4041,
+      "compress_mbps": 19.43,
+      "decompress_mbps": 216.49
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 194380,
+      "ratio": 0.4034,
+      "compress_mbps": 8.84,
+      "decompress_mbps": 216.66
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 190711,
+      "ratio": 0.3958,
+      "compress_mbps": 2.98,
+      "decompress_mbps": 216.38
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 60161,
+      "ratio": 0.1172,
+      "compress_mbps": 160.01,
+      "decompress_mbps": 465.04
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 58873,
+      "ratio": 0.1147,
+      "compress_mbps": 123.86,
+      "decompress_mbps": 497.18
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 58327,
+      "ratio": 0.1137,
+      "compress_mbps": 108.63,
+      "decompress_mbps": 536.07
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 56347,
+      "ratio": 0.1098,
+      "compress_mbps": 85.54,
+      "decompress_mbps": 451.63
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 56324,
+      "ratio": 0.1097,
+      "compress_mbps": 83.2,
+      "decompress_mbps": 479.66
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 55811,
+      "ratio": 0.1087,
+      "compress_mbps": 71.72,
+      "decompress_mbps": 525.26
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 53748,
+      "ratio": 0.1047,
+      "compress_mbps": 38.11,
+      "decompress_mbps": 564.25
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 52897,
+      "ratio": 0.1031,
+      "compress_mbps": 16.52,
+      "decompress_mbps": 608.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 52729,
+      "ratio": 0.1027,
+      "compress_mbps": 4.73,
+      "decompress_mbps": 628.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 14249,
+      "ratio": 0.3726,
+      "compress_mbps": 29.56,
+      "decompress_mbps": 183.43
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 13825,
+      "ratio": 0.3615,
+      "compress_mbps": 27.04,
+      "decompress_mbps": 188.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13751,
+      "ratio": 0.3596,
+      "compress_mbps": 26.18,
+      "decompress_mbps": 191.71
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13379,
+      "ratio": 0.3499,
+      "compress_mbps": 23.81,
+      "decompress_mbps": 197.48
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13375,
+      "ratio": 0.3498,
+      "compress_mbps": 23.39,
+      "decompress_mbps": 208.8
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 13368,
+      "ratio": 0.3496,
+      "compress_mbps": 21.9,
+      "decompress_mbps": 213.07
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 13344,
+      "ratio": 0.349,
+      "compress_mbps": 17.53,
+      "decompress_mbps": 214.82
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 13028,
+      "ratio": 0.3407,
+      "compress_mbps": 5.34,
+      "decompress_mbps": 217.38
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 12522,
+      "ratio": 0.3275,
+      "compress_mbps": 3.54,
+      "decompress_mbps": 217.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1800,
+      "ratio": 0.4258,
+      "compress_mbps": 13.91,
+      "decompress_mbps": 77.53
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1750,
+      "ratio": 0.414,
+      "compress_mbps": 13.36,
+      "decompress_mbps": 76.84
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1742,
+      "ratio": 0.4121,
+      "compress_mbps": 13.31,
+      "decompress_mbps": 77.6
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1732,
+      "ratio": 0.4097,
+      "compress_mbps": 13.12,
+      "decompress_mbps": 78.13
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1732,
+      "ratio": 0.4097,
+      "compress_mbps": 13.14,
+      "decompress_mbps": 78.25
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1732,
+      "ratio": 0.4097,
+      "compress_mbps": 13.12,
+      "decompress_mbps": 78.28
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1729,
+      "ratio": 0.409,
+      "compress_mbps": 12.95,
+      "decompress_mbps": 78.07
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1729,
+      "ratio": 0.409,
+      "compress_mbps": 4.29,
+      "decompress_mbps": 78.52
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1708,
+      "ratio": 0.4041,
+      "compress_mbps": 3.9,
+      "decompress_mbps": 78.24
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 65130,
+      "ratio": 0.4282,
+      "compress_mbps": 118.84,
+      "decompress_mbps": 399.29
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 62270,
+      "ratio": 0.4094,
+      "compress_mbps": 101.78,
+      "decompress_mbps": 418.8
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 59488,
+      "ratio": 0.3911,
+      "compress_mbps": 67.0,
+      "decompress_mbps": 435.28
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 57679,
+      "ratio": 0.3792,
+      "compress_mbps": 71.67,
+      "decompress_mbps": 414.35
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 55616,
+      "ratio": 0.3657,
+      "compress_mbps": 41.81,
+      "decompress_mbps": 408.93
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54398,
+      "ratio": 0.3577,
+      "compress_mbps": 25.53,
+      "decompress_mbps": 421.51
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 54253,
+      "ratio": 0.3567,
+      "compress_mbps": 21.45,
+      "decompress_mbps": 423.73
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 54164,
+      "ratio": 0.3561,
+      "compress_mbps": 16.99,
+      "decompress_mbps": 425.54
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 54164,
+      "ratio": 0.3561,
+      "compress_mbps": 16.98,
+      "decompress_mbps": 423.92
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 56791,
+      "ratio": 0.4537,
+      "compress_mbps": 115.6,
+      "decompress_mbps": 394.7
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 54652,
+      "ratio": 0.4366,
+      "compress_mbps": 97.78,
+      "decompress_mbps": 407.38
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 52663,
+      "ratio": 0.4207,
+      "compress_mbps": 62.36,
+      "decompress_mbps": 428.67
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 51266,
+      "ratio": 0.4095,
+      "compress_mbps": 67.4,
+      "decompress_mbps": 398.49
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 49622,
+      "ratio": 0.3964,
+      "compress_mbps": 37.32,
+      "decompress_mbps": 386.08
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48891,
+      "ratio": 0.3906,
+      "compress_mbps": 22.81,
+      "decompress_mbps": 395.49
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48801,
+      "ratio": 0.3898,
+      "compress_mbps": 20.02,
+      "decompress_mbps": 397.56
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 48772,
+      "ratio": 0.3896,
+      "compress_mbps": 18.15,
+      "decompress_mbps": 395.81
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 48772,
+      "ratio": 0.3896,
+      "compress_mbps": 18.14,
+      "decompress_mbps": 399.23
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 9028,
+      "ratio": 0.3669,
+      "compress_mbps": 414.75,
+      "decompress_mbps": 1058.33
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8811,
+      "ratio": 0.3581,
+      "compress_mbps": 218.08,
+      "decompress_mbps": 1085.71
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8616,
+      "ratio": 0.3502,
+      "compress_mbps": 163.26,
+      "decompress_mbps": 1104.41
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8219,
+      "ratio": 0.3341,
+      "compress_mbps": 116.35,
+      "decompress_mbps": 1113.96
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 8001,
+      "ratio": 0.3252,
+      "compress_mbps": 84.93,
+      "decompress_mbps": 1146.67
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7955,
+      "ratio": 0.3233,
+      "compress_mbps": 68.91,
+      "decompress_mbps": 1156.51
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7933,
+      "ratio": 0.3224,
+      "compress_mbps": 62.88,
+      "decompress_mbps": 1159.42
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7934,
+      "ratio": 0.3225,
+      "compress_mbps": 58.08,
+      "decompress_mbps": 1161.26
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7934,
+      "ratio": 0.3225,
+      "compress_mbps": 58.09,
+      "decompress_mbps": 1160.11
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3647,
+      "ratio": 0.3271,
+      "compress_mbps": 426.79,
+      "decompress_mbps": 1073.55
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3501,
+      "ratio": 0.314,
+      "compress_mbps": 408.84,
+      "decompress_mbps": 1117.67
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3393,
+      "ratio": 0.3043,
+      "compress_mbps": 338.35,
+      "decompress_mbps": 1147.08
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3215,
+      "ratio": 0.2883,
+      "compress_mbps": 271.93,
+      "decompress_mbps": 1175.75
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3140,
+      "ratio": 0.2816,
+      "compress_mbps": 205.2,
+      "decompress_mbps": 1205.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3116,
+      "ratio": 0.2795,
+      "compress_mbps": 154.1,
+      "decompress_mbps": 1215.53
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 131.87,
+      "decompress_mbps": 1216.78
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3109,
+      "ratio": 0.2788,
+      "compress_mbps": 111.18,
+      "decompress_mbps": 1216.5
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3109,
+      "ratio": 0.2788,
+      "compress_mbps": 110.92,
+      "decompress_mbps": 1220.83
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1326,
+      "ratio": 0.3564,
+      "compress_mbps": 317.29,
+      "decompress_mbps": 787.88
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1306,
+      "ratio": 0.351,
+      "compress_mbps": 310.71,
+      "decompress_mbps": 796.73
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1301,
+      "ratio": 0.3496,
+      "compress_mbps": 291.04,
+      "decompress_mbps": 799.42
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1228,
+      "ratio": 0.33,
+      "compress_mbps": 233.69,
+      "decompress_mbps": 825.26
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 198.9,
+      "decompress_mbps": 831.06
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 177.77,
+      "decompress_mbps": 832.23
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 170.71,
+      "decompress_mbps": 821.82
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 167.8,
+      "decompress_mbps": 826.61
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 168.26,
+      "decompress_mbps": 828.73
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 242293,
+      "ratio": 0.2353,
+      "compress_mbps": 261.91,
+      "decompress_mbps": 834.71
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 233553,
+      "ratio": 0.2268,
+      "compress_mbps": 248.46,
+      "decompress_mbps": 990.64
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 228222,
+      "ratio": 0.2216,
+      "compress_mbps": 195.71,
+      "decompress_mbps": 1047.56
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 223668,
+      "ratio": 0.2172,
+      "compress_mbps": 177.25,
+      "decompress_mbps": 1079.08
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 205994,
+      "ratio": 0.2,
+      "compress_mbps": 110.7,
+      "decompress_mbps": 1038.46
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 203986,
+      "ratio": 0.1981,
+      "compress_mbps": 50.06,
+      "decompress_mbps": 1033.64
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 207681,
+      "ratio": 0.2017,
+      "compress_mbps": 37.08,
+      "decompress_mbps": 1027.99
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 206827,
+      "ratio": 0.2009,
+      "compress_mbps": 7.29,
+      "decompress_mbps": 1001.69
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 207023,
+      "ratio": 0.201,
+      "compress_mbps": 3.43,
+      "decompress_mbps": 1007.49
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 174124,
+      "ratio": 0.408,
+      "compress_mbps": 124.52,
+      "decompress_mbps": 403.49
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 166150,
+      "ratio": 0.3893,
+      "compress_mbps": 105.75,
+      "decompress_mbps": 410.83
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 158784,
+      "ratio": 0.3721,
+      "compress_mbps": 70.62,
+      "decompress_mbps": 431.19
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 152782,
+      "ratio": 0.358,
+      "compress_mbps": 74.37,
+      "decompress_mbps": 417.63
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 147196,
+      "ratio": 0.3449,
+      "compress_mbps": 43.69,
+      "decompress_mbps": 412.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 144898,
+      "ratio": 0.3395,
+      "compress_mbps": 26.54,
+      "decompress_mbps": 422.22
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 144589,
+      "ratio": 0.3388,
+      "compress_mbps": 23.0,
+      "decompress_mbps": 422.54
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 144436,
+      "ratio": 0.3385,
+      "compress_mbps": 19.77,
+      "decompress_mbps": 426.62
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 144433,
+      "ratio": 0.3384,
+      "compress_mbps": 19.7,
+      "decompress_mbps": 427.06
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 228883,
+      "ratio": 0.475,
+      "compress_mbps": 108.85,
+      "decompress_mbps": 379.18
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 219047,
+      "ratio": 0.4546,
+      "compress_mbps": 91.35,
+      "decompress_mbps": 396.75
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 209408,
+      "ratio": 0.4346,
+      "compress_mbps": 55.73,
+      "decompress_mbps": 408.77
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 205916,
+      "ratio": 0.4273,
+      "compress_mbps": 62.79,
+      "decompress_mbps": 384.06
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 199188,
+      "ratio": 0.4134,
+      "compress_mbps": 33.23,
+      "decompress_mbps": 365.25
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 195255,
+      "ratio": 0.4052,
+      "compress_mbps": 19.51,
+      "decompress_mbps": 371.54
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 194657,
+      "ratio": 0.404,
+      "compress_mbps": 16.52,
+      "decompress_mbps": 368.04
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 194326,
+      "ratio": 0.4033,
+      "compress_mbps": 13.04,
+      "decompress_mbps": 372.62
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 194326,
+      "ratio": 0.4033,
+      "compress_mbps": 13.03,
+      "decompress_mbps": 376.86
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 65553,
+      "ratio": 0.1277,
+      "compress_mbps": 277.05,
+      "decompress_mbps": 898.35
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 63891,
+      "ratio": 0.1245,
+      "compress_mbps": 249.81,
+      "decompress_mbps": 925.37
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 62515,
+      "ratio": 0.1218,
+      "compress_mbps": 196.22,
+      "decompress_mbps": 996.47
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 58451,
+      "ratio": 0.1139,
+      "compress_mbps": 170.56,
+      "decompress_mbps": 705.74
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 57410,
+      "ratio": 0.1119,
+      "compress_mbps": 131.27,
+      "decompress_mbps": 733.83
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 56459,
+      "ratio": 0.11,
+      "compress_mbps": 77.73,
+      "decompress_mbps": 785.69
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 55358,
+      "ratio": 0.1079,
+      "compress_mbps": 60.89,
+      "decompress_mbps": 824.41
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 52991,
+      "ratio": 0.1033,
+      "compress_mbps": 27.8,
+      "decompress_mbps": 878.92
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 52215,
+      "ratio": 0.1017,
+      "compress_mbps": 9.91,
+      "decompress_mbps": 892.75
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 14112,
+      "ratio": 0.369,
+      "compress_mbps": 130.36,
+      "decompress_mbps": 944.12
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 13815,
+      "ratio": 0.3613,
+      "compress_mbps": 110.11,
+      "decompress_mbps": 978.68
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13795,
+      "ratio": 0.3607,
+      "compress_mbps": 79.64,
+      "decompress_mbps": 1014.48
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13375,
+      "ratio": 0.3498,
+      "compress_mbps": 81.09,
+      "decompress_mbps": 997.82
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13062,
+      "ratio": 0.3416,
+      "compress_mbps": 56.15,
+      "decompress_mbps": 1040.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 12984,
+      "ratio": 0.3395,
+      "compress_mbps": 33.24,
+      "decompress_mbps": 1062.14
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 12949,
+      "ratio": 0.3386,
+      "compress_mbps": 25.62,
+      "decompress_mbps": 1070.49
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 12894,
+      "ratio": 0.3372,
+      "compress_mbps": 11.1,
+      "decompress_mbps": 1080.36
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 12832,
+      "ratio": 0.3356,
+      "compress_mbps": 5.1,
+      "decompress_mbps": 1081.93
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1846,
+      "ratio": 0.4367,
+      "compress_mbps": 290.31,
+      "decompress_mbps": 710.34
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1820,
+      "ratio": 0.4306,
+      "compress_mbps": 284.39,
+      "decompress_mbps": 723.73
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1808,
+      "ratio": 0.4277,
+      "compress_mbps": 272.54,
+      "decompress_mbps": 726.34
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1749,
+      "ratio": 0.4138,
+      "compress_mbps": 226.28,
+      "decompress_mbps": 749.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 202.59,
+      "decompress_mbps": 753.91
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 199.81,
+      "decompress_mbps": 754.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 196.62,
+      "decompress_mbps": 753.91
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 197.1,
+      "decompress_mbps": 754.2
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 197.89,
+      "decompress_mbps": 752.93
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 76470,
+      "ratio": 0.5028,
+      "compress_mbps": 156.81,
+      "decompress_mbps": 442.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 62765,
+      "ratio": 0.4127,
+      "compress_mbps": 133.14,
+      "decompress_mbps": 491.57
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 57162,
+      "ratio": 0.3758,
+      "compress_mbps": 72.46,
+      "decompress_mbps": 549.38
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 56826,
+      "ratio": 0.3736,
+      "compress_mbps": 64.54,
+      "decompress_mbps": 540.99
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 55696,
+      "ratio": 0.3662,
+      "compress_mbps": 46.93,
+      "decompress_mbps": 528.35
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54440,
+      "ratio": 0.3579,
+      "compress_mbps": 26.59,
+      "decompress_mbps": 545.39
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 54283,
+      "ratio": 0.3569,
+      "compress_mbps": 22.46,
+      "decompress_mbps": 546.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 54221,
+      "ratio": 0.3565,
+      "compress_mbps": 19.77,
+      "decompress_mbps": 546.31
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 54217,
+      "ratio": 0.3565,
+      "compress_mbps": 19.52,
+      "decompress_mbps": 546.07
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 64926,
+      "ratio": 0.5187,
+      "compress_mbps": 150.76,
+      "decompress_mbps": 420.61
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 54985,
+      "ratio": 0.4393,
+      "compress_mbps": 124.87,
+      "decompress_mbps": 468.91
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 51148,
+      "ratio": 0.4086,
+      "compress_mbps": 67.28,
+      "decompress_mbps": 536.64
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 50599,
+      "ratio": 0.4042,
+      "compress_mbps": 59.25,
+      "decompress_mbps": 526.29
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 49775,
+      "ratio": 0.3976,
+      "compress_mbps": 42.72,
+      "decompress_mbps": 513.76
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48967,
+      "ratio": 0.3912,
+      "compress_mbps": 25.03,
+      "decompress_mbps": 524.3
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48870,
+      "ratio": 0.3904,
+      "compress_mbps": 22.21,
+      "decompress_mbps": 523.8
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 48845,
+      "ratio": 0.3902,
+      "compress_mbps": 20.95,
+      "decompress_mbps": 522.13
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 48845,
+      "ratio": 0.3902,
+      "compress_mbps": 20.95,
+      "decompress_mbps": 524.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 10024,
+      "ratio": 0.4074,
+      "compress_mbps": 568.72,
+      "decompress_mbps": 906.86
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8577,
+      "ratio": 0.3486,
+      "compress_mbps": 269.07,
+      "decompress_mbps": 929.83
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8168,
+      "ratio": 0.332,
+      "compress_mbps": 155.49,
+      "decompress_mbps": 951.35
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8069,
+      "ratio": 0.328,
+      "compress_mbps": 116.17,
+      "decompress_mbps": 969.68
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 7997,
+      "ratio": 0.325,
+      "compress_mbps": 100.13,
+      "decompress_mbps": 1001.46
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7952,
+      "ratio": 0.3232,
+      "compress_mbps": 74.99,
+      "decompress_mbps": 1003.47
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7947,
+      "ratio": 0.323,
+      "compress_mbps": 72.24,
+      "decompress_mbps": 1009.09
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7947,
+      "ratio": 0.323,
+      "compress_mbps": 71.2,
+      "decompress_mbps": 1009.52
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7947,
+      "ratio": 0.323,
+      "compress_mbps": 70.94,
+      "decompress_mbps": 1010.39
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 4061,
+      "ratio": 0.3642,
+      "compress_mbps": 505.27,
+      "decompress_mbps": 857.33
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3446,
+      "ratio": 0.3091,
+      "compress_mbps": 303.09,
+      "decompress_mbps": 902.14
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3201,
+      "ratio": 0.2871,
+      "compress_mbps": 235.32,
+      "decompress_mbps": 933.5
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3168,
+      "ratio": 0.2841,
+      "compress_mbps": 196.56,
+      "decompress_mbps": 955.13
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3139,
+      "ratio": 0.2815,
+      "compress_mbps": 162.35,
+      "decompress_mbps": 979.95
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3115,
+      "ratio": 0.2794,
+      "compress_mbps": 116.87,
+      "decompress_mbps": 990.27
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 106.87,
+      "decompress_mbps": 991.47
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 103.44,
+      "decompress_mbps": 992.11
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 103.35,
+      "decompress_mbps": 992.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1410,
+      "ratio": 0.3789,
+      "compress_mbps": 365.35,
+      "decompress_mbps": 595.71
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1262,
+      "ratio": 0.3392,
+      "compress_mbps": 234.59,
+      "decompress_mbps": 602.38
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1238,
+      "ratio": 0.3327,
+      "compress_mbps": 206.3,
+      "decompress_mbps": 606.19
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1219,
+      "ratio": 0.3276,
+      "compress_mbps": 178.27,
+      "decompress_mbps": 624.32
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 163.31,
+      "decompress_mbps": 633.68
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 147.91,
+      "decompress_mbps": 631.88
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 147.05,
+      "decompress_mbps": 632.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 147.52,
+      "decompress_mbps": 634.82
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1216,
+      "ratio": 0.3268,
+      "compress_mbps": 147.39,
+      "decompress_mbps": 634.93
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 274412,
+      "ratio": 0.2665,
+      "compress_mbps": 452.12,
+      "decompress_mbps": 796.51
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 213239,
+      "ratio": 0.2071,
+      "compress_mbps": 274.72,
+      "decompress_mbps": 895.56
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 232107,
+      "ratio": 0.2254,
+      "compress_mbps": 137.22,
+      "decompress_mbps": 936.66
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 202733,
+      "ratio": 0.1969,
+      "compress_mbps": 130.42,
+      "decompress_mbps": 942.52
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 207803,
+      "ratio": 0.2018,
+      "compress_mbps": 84.44,
+      "decompress_mbps": 954.1
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 205270,
+      "ratio": 0.1993,
+      "compress_mbps": 27.28,
+      "decompress_mbps": 981.19
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 209951,
+      "ratio": 0.2039,
+      "compress_mbps": 19.33,
+      "decompress_mbps": 997.67
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 209656,
+      "ratio": 0.2036,
+      "compress_mbps": 12.25,
+      "decompress_mbps": 1008.86
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 209189,
+      "ratio": 0.2031,
+      "compress_mbps": 8.96,
+      "decompress_mbps": 1009.49
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 208640,
+      "ratio": 0.4889,
+      "compress_mbps": 157.34,
+      "decompress_mbps": 424.83
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 167329,
+      "ratio": 0.3921,
+      "compress_mbps": 138.54,
+      "decompress_mbps": 464.58
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 151097,
+      "ratio": 0.3541,
+      "compress_mbps": 73.57,
+      "decompress_mbps": 510.84
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 150035,
+      "ratio": 0.3516,
+      "compress_mbps": 66.59,
+      "decompress_mbps": 511.35
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 147375,
+      "ratio": 0.3453,
+      "compress_mbps": 48.11,
+      "decompress_mbps": 508.07
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 144908,
+      "ratio": 0.3396,
+      "compress_mbps": 28.06,
+      "decompress_mbps": 519.16
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 144562,
+      "ratio": 0.3387,
+      "compress_mbps": 24.64,
+      "decompress_mbps": 517.99
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 144449,
+      "ratio": 0.3385,
+      "compress_mbps": 22.41,
+      "decompress_mbps": 518.6
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 144438,
+      "ratio": 0.3385,
+      "compress_mbps": 22.31,
+      "decompress_mbps": 518.95
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 264549,
+      "ratio": 0.549,
+      "compress_mbps": 135.43,
+      "decompress_mbps": 376.95
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 223724,
+      "ratio": 0.4643,
+      "compress_mbps": 118.93,
+      "decompress_mbps": 422.83
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 204825,
+      "ratio": 0.4251,
+      "compress_mbps": 60.63,
+      "decompress_mbps": 478.39
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 203945,
+      "ratio": 0.4232,
+      "compress_mbps": 53.94,
+      "decompress_mbps": 474.47
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 199780,
+      "ratio": 0.4146,
+      "compress_mbps": 37.91,
+      "decompress_mbps": 457.62
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 195417,
+      "ratio": 0.4055,
+      "compress_mbps": 21.2,
+      "decompress_mbps": 468.93
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 194796,
+      "ratio": 0.4043,
+      "compress_mbps": 17.9,
+      "decompress_mbps": 467.61
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 194543,
+      "ratio": 0.4037,
+      "compress_mbps": 15.72,
+      "decompress_mbps": 467.24
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 194460,
+      "ratio": 0.4036,
+      "compress_mbps": 15.05,
+      "decompress_mbps": 468.35
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 67436,
+      "ratio": 0.1314,
+      "compress_mbps": 627.54,
+      "decompress_mbps": 1004.41
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 59257,
+      "ratio": 0.1155,
+      "compress_mbps": 278.61,
+      "decompress_mbps": 1060.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 58316,
+      "ratio": 0.1136,
+      "compress_mbps": 181.72,
+      "decompress_mbps": 1145.04
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 56291,
+      "ratio": 0.1097,
+      "compress_mbps": 185.03,
+      "decompress_mbps": 1154.82
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 56220,
+      "ratio": 0.1095,
+      "compress_mbps": 146.23,
+      "decompress_mbps": 1207.72
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 55972,
+      "ratio": 0.1091,
+      "compress_mbps": 74.5,
+      "decompress_mbps": 1263.85
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 55121,
+      "ratio": 0.1074,
+      "compress_mbps": 52.14,
+      "decompress_mbps": 1305.51
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 54124,
+      "ratio": 0.1055,
+      "compress_mbps": 36.7,
+      "decompress_mbps": 1378.02
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 53699,
+      "ratio": 0.1046,
+      "compress_mbps": 28.66,
+      "decompress_mbps": 1411.67
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 15612,
+      "ratio": 0.4083,
+      "compress_mbps": 502.51,
+      "decompress_mbps": 850.6
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 14133,
+      "ratio": 0.3696,
+      "compress_mbps": 145.19,
+      "decompress_mbps": 890.56
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13341,
+      "ratio": 0.3489,
+      "compress_mbps": 88.72,
+      "decompress_mbps": 911.51
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13289,
+      "ratio": 0.3475,
+      "compress_mbps": 83.64,
+      "decompress_mbps": 941.29
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13052,
+      "ratio": 0.3413,
+      "compress_mbps": 66.83,
+      "decompress_mbps": 973.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 12996,
+      "ratio": 0.3399,
+      "compress_mbps": 37.14,
+      "decompress_mbps": 986.7
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 12972,
+      "ratio": 0.3392,
+      "compress_mbps": 27.2,
+      "decompress_mbps": 990.88
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 12951,
+      "ratio": 0.3387,
+      "compress_mbps": 19.04,
+      "decompress_mbps": 996.63
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 12933,
+      "ratio": 0.3382,
+      "compress_mbps": 14.86,
+      "decompress_mbps": 1010.18
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1988,
+      "ratio": 0.4703,
+      "compress_mbps": 340.18,
+      "decompress_mbps": 548.09
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1802,
+      "ratio": 0.4263,
+      "compress_mbps": 218.94,
+      "decompress_mbps": 554.27
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 205.58,
+      "decompress_mbps": 558.57
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1732,
+      "ratio": 0.4097,
+      "compress_mbps": 171.81,
+      "decompress_mbps": 573.34
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 167.66,
+      "decompress_mbps": 582.37
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 166.66,
+      "decompress_mbps": 582.62
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 166.44,
+      "decompress_mbps": 580.03
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 167.1,
+      "decompress_mbps": 579.86
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1730,
+      "ratio": 0.4093,
+      "compress_mbps": 166.8,
+      "decompress_mbps": 579.36
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 59790,
+      "ratio": 0.3931,
+      "compress_mbps": 262.72,
+      "decompress_mbps": 1002.92
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 57173,
+      "ratio": 0.3759,
+      "compress_mbps": 181.24,
+      "decompress_mbps": 1076.37
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 56189,
+      "ratio": 0.3694,
+      "compress_mbps": 150.83,
+      "decompress_mbps": 1150.52
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 55816,
+      "ratio": 0.367,
+      "compress_mbps": 138.22,
+      "decompress_mbps": 1189.04
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 54758,
+      "ratio": 0.36,
+      "compress_mbps": 109.12,
+      "decompress_mbps": 1241.07
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54220,
+      "ratio": 0.3565,
+      "compress_mbps": 84.01,
+      "decompress_mbps": 1281.1
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 53801,
+      "ratio": 0.3537,
+      "compress_mbps": 61.34,
+      "decompress_mbps": 1284.1
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 53573,
+      "ratio": 0.3522,
+      "compress_mbps": 38.99,
+      "decompress_mbps": 1281.45
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 53546,
+      "ratio": 0.3521,
+      "compress_mbps": 34.49,
+      "decompress_mbps": 1286.38
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 52276,
+      "ratio": 0.4176,
+      "compress_mbps": 244.27,
+      "decompress_mbps": 941.62
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 50534,
+      "ratio": 0.4037,
+      "compress_mbps": 169.26,
+      "decompress_mbps": 994.53
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 49919,
+      "ratio": 0.3988,
+      "compress_mbps": 142.29,
+      "decompress_mbps": 1056.87
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 49715,
+      "ratio": 0.3972,
+      "compress_mbps": 131.62,
+      "decompress_mbps": 1092.43
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 48735,
+      "ratio": 0.3893,
+      "compress_mbps": 101.28,
+      "decompress_mbps": 1138.39
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48422,
+      "ratio": 0.3868,
+      "compress_mbps": 79.56,
+      "decompress_mbps": 1159.77
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48249,
+      "ratio": 0.3854,
+      "compress_mbps": 61.42,
+      "decompress_mbps": 1167.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 47977,
+      "ratio": 0.3833,
+      "compress_mbps": 43.01,
+      "decompress_mbps": 1163.26
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 47971,
+      "ratio": 0.3832,
+      "compress_mbps": 41.05,
+      "decompress_mbps": 1168.97
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 8385,
+      "ratio": 0.3408,
+      "compress_mbps": 694.12,
+      "decompress_mbps": 956.86
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8380,
+      "ratio": 0.3406,
+      "compress_mbps": 439.72,
+      "decompress_mbps": 974.59
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8286,
+      "ratio": 0.3368,
+      "compress_mbps": 403.73,
+      "decompress_mbps": 993.24
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8163,
+      "ratio": 0.3318,
+      "compress_mbps": 378.68,
+      "decompress_mbps": 1003.78
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 8053,
+      "ratio": 0.3273,
+      "compress_mbps": 335.07,
+      "decompress_mbps": 1027.69
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7986,
+      "ratio": 0.3246,
+      "compress_mbps": 277.67,
+      "decompress_mbps": 1035.81
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7954,
+      "ratio": 0.3233,
+      "compress_mbps": 191.05,
+      "decompress_mbps": 1026.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7916,
+      "ratio": 0.3217,
+      "compress_mbps": 129.56,
+      "decompress_mbps": 1035.17
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7916,
+      "ratio": 0.3217,
+      "compress_mbps": 125.42,
+      "decompress_mbps": 1013.27
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3401,
+      "ratio": 0.305,
+      "compress_mbps": 586.93,
+      "decompress_mbps": 768.98
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3307,
+      "ratio": 0.2966,
+      "compress_mbps": 398.24,
+      "decompress_mbps": 792.95
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3242,
+      "ratio": 0.2908,
+      "compress_mbps": 371.5,
+      "decompress_mbps": 810.66
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3205,
+      "ratio": 0.2874,
+      "compress_mbps": 349.62,
+      "decompress_mbps": 821.62
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3150,
+      "ratio": 0.2825,
+      "compress_mbps": 313.81,
+      "decompress_mbps": 837.48
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3126,
+      "ratio": 0.2804,
+      "compress_mbps": 267.83,
+      "decompress_mbps": 842.46
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3106,
+      "ratio": 0.2786,
+      "compress_mbps": 206.71,
+      "decompress_mbps": 846.01
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3102,
+      "ratio": 0.2782,
+      "compress_mbps": 147.91,
+      "decompress_mbps": 842.39
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3102,
+      "ratio": 0.2782,
+      "compress_mbps": 140.39,
+      "decompress_mbps": 846.34
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1251,
+      "ratio": 0.3362,
+      "compress_mbps": 377.39,
+      "decompress_mbps": 426.98
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1228,
+      "ratio": 0.33,
+      "compress_mbps": 267.66,
+      "decompress_mbps": 433.76
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1219,
+      "ratio": 0.3276,
+      "compress_mbps": 258.72,
+      "decompress_mbps": 433.23
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1220,
+      "ratio": 0.3279,
+      "compress_mbps": 253.94,
+      "decompress_mbps": 439.29
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 240.44,
+      "decompress_mbps": 443.8
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 222.65,
+      "decompress_mbps": 441.15
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 203.53,
+      "decompress_mbps": 438.86
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1204,
+      "ratio": 0.3236,
+      "compress_mbps": 169.68,
+      "decompress_mbps": 444.08
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1204,
+      "ratio": 0.3236,
+      "compress_mbps": 169.88,
+      "decompress_mbps": 438.1
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 221813,
+      "ratio": 0.2154,
+      "compress_mbps": 593.83,
+      "decompress_mbps": 1009.94
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 199825,
+      "ratio": 0.1941,
+      "compress_mbps": 409.25,
+      "decompress_mbps": 1460.57
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 195675,
+      "ratio": 0.19,
+      "compress_mbps": 283.23,
+      "decompress_mbps": 1526.64
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 195664,
+      "ratio": 0.19,
+      "compress_mbps": 279.77,
+      "decompress_mbps": 1536.83
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 198900,
+      "ratio": 0.1932,
+      "compress_mbps": 239.94,
+      "decompress_mbps": 1127.82
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 199347,
+      "ratio": 0.1936,
+      "compress_mbps": 204.69,
+      "decompress_mbps": 1130.61
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 199777,
+      "ratio": 0.194,
+      "compress_mbps": 123.53,
+      "decompress_mbps": 1190.54
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 182094,
+      "ratio": 0.1768,
+      "compress_mbps": 25.66,
+      "decompress_mbps": 1169.78
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 181451,
+      "ratio": 0.1762,
+      "compress_mbps": 13.61,
+      "decompress_mbps": 1173.47
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 159063,
+      "ratio": 0.3727,
+      "compress_mbps": 263.86,
+      "decompress_mbps": 1029.34
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 152115,
+      "ratio": 0.3564,
+      "compress_mbps": 187.44,
+      "decompress_mbps": 1105.52
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 149162,
+      "ratio": 0.3495,
+      "compress_mbps": 156.82,
+      "decompress_mbps": 1189.07
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 148359,
+      "ratio": 0.3476,
+      "compress_mbps": 142.61,
+      "decompress_mbps": 1033.04
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 145353,
+      "ratio": 0.3406,
+      "compress_mbps": 113.35,
+      "decompress_mbps": 997.15
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 144209,
+      "ratio": 0.3379,
+      "compress_mbps": 87.48,
+      "decompress_mbps": 1037.45
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 143604,
+      "ratio": 0.3365,
+      "compress_mbps": 66.64,
+      "decompress_mbps": 1039.31
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 142086,
+      "ratio": 0.3329,
+      "compress_mbps": 44.24,
+      "decompress_mbps": 1035.21
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 142027,
+      "ratio": 0.3328,
+      "compress_mbps": 40.46,
+      "decompress_mbps": 1038.75
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 210662,
+      "ratio": 0.4372,
+      "compress_mbps": 228.71,
+      "decompress_mbps": 869.83
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 202881,
+      "ratio": 0.421,
+      "compress_mbps": 158.66,
+      "decompress_mbps": 939.95
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 200409,
+      "ratio": 0.4159,
+      "compress_mbps": 132.96,
+      "decompress_mbps": 1019.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 199678,
+      "ratio": 0.4144,
+      "compress_mbps": 122.96,
+      "decompress_mbps": 839.63
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 195798,
+      "ratio": 0.4063,
+      "compress_mbps": 93.4,
+      "decompress_mbps": 789.36
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 194029,
+      "ratio": 0.4027,
+      "compress_mbps": 71.6,
+      "decompress_mbps": 813.1
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 192773,
+      "ratio": 0.4001,
+      "compress_mbps": 50.41,
+      "decompress_mbps": 835.88
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 191739,
+      "ratio": 0.3979,
+      "compress_mbps": 33.69,
+      "decompress_mbps": 841.06
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 191676,
+      "ratio": 0.3978,
+      "compress_mbps": 31.1,
+      "decompress_mbps": 839.65
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 58079,
+      "ratio": 0.1132,
+      "compress_mbps": 373.38,
+      "decompress_mbps": 1687.98
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 57838,
+      "ratio": 0.1127,
+      "compress_mbps": 413.69,
+      "decompress_mbps": 1800.72
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 57554,
+      "ratio": 0.1121,
+      "compress_mbps": 394.76,
+      "decompress_mbps": 1899.42
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 57064,
+      "ratio": 0.1112,
+      "compress_mbps": 374.05,
+      "decompress_mbps": 1741.26
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 55743,
+      "ratio": 0.1086,
+      "compress_mbps": 343.45,
+      "decompress_mbps": 1793.36
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 55102,
+      "ratio": 0.1074,
+      "compress_mbps": 285.08,
+      "decompress_mbps": 1869.89
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 54742,
+      "ratio": 0.1067,
+      "compress_mbps": 193.03,
+      "decompress_mbps": 1929.26
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 53133,
+      "ratio": 0.1035,
+      "compress_mbps": 102.77,
+      "decompress_mbps": 1996.36
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 52186,
+      "ratio": 0.1017,
+      "compress_mbps": 72.32,
+      "decompress_mbps": 2031.74
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 14122,
+      "ratio": 0.3693,
+      "compress_mbps": 648.66,
+      "decompress_mbps": 823.66
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 13374,
+      "ratio": 0.3497,
+      "compress_mbps": 338.62,
+      "decompress_mbps": 879.23
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13293,
+      "ratio": 0.3476,
+      "compress_mbps": 257.73,
+      "decompress_mbps": 960.76
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13259,
+      "ratio": 0.3467,
+      "compress_mbps": 263.83,
+      "decompress_mbps": 960.86
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 12641,
+      "ratio": 0.3306,
+      "compress_mbps": 190.13,
+      "decompress_mbps": 990.29
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 12432,
+      "ratio": 0.3251,
+      "compress_mbps": 164.05,
+      "decompress_mbps": 1006.67
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 12439,
+      "ratio": 0.3253,
+      "compress_mbps": 122.43,
+      "decompress_mbps": 1013.21
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 12579,
+      "ratio": 0.3289,
+      "compress_mbps": 67.61,
+      "decompress_mbps": 1025.92
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 12574,
+      "ratio": 0.3288,
+      "compress_mbps": 47.47,
+      "decompress_mbps": 1031.58
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1777,
+      "ratio": 0.4204,
+      "compress_mbps": 386.35,
+      "decompress_mbps": 403.24
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1756,
+      "ratio": 0.4154,
+      "compress_mbps": 260.77,
+      "decompress_mbps": 408.51
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1746,
+      "ratio": 0.4131,
+      "compress_mbps": 257.14,
+      "decompress_mbps": 410.93
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1740,
+      "ratio": 0.4116,
+      "compress_mbps": 254.99,
+      "decompress_mbps": 414.73
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1722,
+      "ratio": 0.4074,
+      "compress_mbps": 240.47,
+      "decompress_mbps": 415.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1721,
+      "ratio": 0.4071,
+      "compress_mbps": 235.91,
+      "decompress_mbps": 415.29
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 234.75,
+      "decompress_mbps": 415.41
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1717,
+      "ratio": 0.4062,
+      "compress_mbps": 217.57,
+      "decompress_mbps": 417.83
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1717,
+      "ratio": 0.4062,
+      "compress_mbps": 216.75,
+      "decompress_mbps": 416.19
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4259644,
+      "ratio": 0.4179,
+      "compress_mbps": 55.48,
+      "decompress_mbps": 175.13
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 3977395,
+      "ratio": 0.3902,
+      "compress_mbps": 41.33,
+      "decompress_mbps": 190.42
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3945296,
+      "ratio": 0.3871,
+      "compress_mbps": 36.93,
+      "decompress_mbps": 209.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 3888037,
+      "ratio": 0.3815,
+      "compress_mbps": 27.75,
+      "decompress_mbps": 213.35
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3882328,
+      "ratio": 0.3809,
+      "compress_mbps": 27.19,
+      "decompress_mbps": 212.35
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3873339,
+      "ratio": 0.38,
+      "compress_mbps": 24.92,
+      "decompress_mbps": 218.0
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3866648,
+      "ratio": 0.3794,
+      "compress_mbps": 20.84,
+      "decompress_mbps": 217.98
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3864805,
+      "ratio": 0.3792,
+      "compress_mbps": 9.49,
+      "decompress_mbps": 226.2
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3790404,
+      "ratio": 0.3719,
+      "compress_mbps": 3.13,
+      "decompress_mbps": 219.59
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 21267086,
+      "ratio": 0.4152,
+      "compress_mbps": 70.17,
+      "decompress_mbps": 192.7
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 20802983,
+      "ratio": 0.4061,
+      "compress_mbps": 56.03,
+      "decompress_mbps": 200.74
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 20665485,
+      "ratio": 0.4035,
+      "compress_mbps": 52.53,
+      "decompress_mbps": 200.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 20427823,
+      "ratio": 0.3988,
+      "compress_mbps": 41.38,
+      "decompress_mbps": 210.97
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 20413947,
+      "ratio": 0.3986,
+      "compress_mbps": 39.25,
+      "decompress_mbps": 224.27
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 20373541,
+      "ratio": 0.3978,
+      "compress_mbps": 34.33,
+      "decompress_mbps": 224.75
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 20251873,
+      "ratio": 0.3954,
+      "compress_mbps": 22.16,
+      "decompress_mbps": 225.66
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19172591,
+      "ratio": 0.3743,
+      "compress_mbps": 6.94,
+      "decompress_mbps": 226.33
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18723512,
+      "ratio": 0.3655,
+      "compress_mbps": 3.21,
+      "decompress_mbps": 224.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3864163,
+      "ratio": 0.3876,
+      "compress_mbps": 68.39,
+      "decompress_mbps": 205.5
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3734957,
+      "ratio": 0.3746,
+      "compress_mbps": 53.45,
+      "decompress_mbps": 214.49
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3708443,
+      "ratio": 0.3719,
+      "compress_mbps": 46.13,
+      "decompress_mbps": 224.58
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3712990,
+      "ratio": 0.3724,
+      "compress_mbps": 32.72,
+      "decompress_mbps": 208.12
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3707399,
+      "ratio": 0.3718,
+      "compress_mbps": 31.1,
+      "decompress_mbps": 203.21
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3701112,
+      "ratio": 0.3712,
+      "compress_mbps": 28.43,
+      "decompress_mbps": 196.91
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3704320,
+      "ratio": 0.3715,
+      "compress_mbps": 22.54,
+      "decompress_mbps": 212.23
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3609490,
+      "ratio": 0.362,
+      "compress_mbps": 8.27,
+      "decompress_mbps": 228.1
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3598941,
+      "ratio": 0.361,
+      "compress_mbps": 3.58,
+      "decompress_mbps": 227.82
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3785443,
+      "ratio": 0.1128,
+      "compress_mbps": 200.7,
+      "decompress_mbps": 597.03
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 3761560,
+      "ratio": 0.1121,
+      "compress_mbps": 129.81,
+      "decompress_mbps": 670.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3606997,
+      "ratio": 0.1075,
+      "compress_mbps": 113.5,
+      "decompress_mbps": 745.87
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3340261,
+      "ratio": 0.0996,
+      "compress_mbps": 95.64,
+      "decompress_mbps": 742.09
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3336190,
+      "ratio": 0.0994,
+      "compress_mbps": 93.91,
+      "decompress_mbps": 830.01
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3217453,
+      "ratio": 0.0959,
+      "compress_mbps": 79.07,
+      "decompress_mbps": 839.94
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3126259,
+      "ratio": 0.0932,
+      "compress_mbps": 42.73,
+      "decompress_mbps": 903.26
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 3112207,
+      "ratio": 0.0928,
+      "compress_mbps": 22.47,
+      "decompress_mbps": 892.73
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 3083394,
+      "ratio": 0.0919,
+      "compress_mbps": 3.08,
+      "decompress_mbps": 908.14
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3357083,
+      "ratio": 0.5457,
+      "compress_mbps": 48.27,
+      "decompress_mbps": 128.85
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3285077,
+      "ratio": 0.534,
+      "compress_mbps": 41.14,
+      "decompress_mbps": 132.57
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3272746,
+      "ratio": 0.532,
+      "compress_mbps": 39.54,
+      "decompress_mbps": 137.07
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3238986,
+      "ratio": 0.5265,
+      "compress_mbps": 32.38,
+      "decompress_mbps": 145.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3237944,
+      "ratio": 0.5263,
+      "compress_mbps": 32.14,
+      "decompress_mbps": 150.52
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3235767,
+      "ratio": 0.526,
+      "compress_mbps": 30.8,
+      "decompress_mbps": 153.53
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3232738,
+      "ratio": 0.5255,
+      "compress_mbps": 26.88,
+      "decompress_mbps": 154.07
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3165909,
+      "ratio": 0.5146,
+      "compress_mbps": 7.02,
+      "decompress_mbps": 156.75
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3055775,
+      "ratio": 0.4967,
+      "compress_mbps": 3.72,
+      "decompress_mbps": 156.25
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3838828,
+      "ratio": 0.3806,
+      "compress_mbps": 78.07,
+      "decompress_mbps": 230.29
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3792520,
+      "ratio": 0.376,
+      "compress_mbps": 59.51,
+      "decompress_mbps": 238.0
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3783171,
+      "ratio": 0.3751,
+      "compress_mbps": 57.57,
+      "decompress_mbps": 242.95
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3709091,
+      "ratio": 0.3678,
+      "compress_mbps": 51.26,
+      "decompress_mbps": 242.19
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3708716,
+      "ratio": 0.3677,
+      "compress_mbps": 51.45,
+      "decompress_mbps": 242.31
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3707113,
+      "ratio": 0.3676,
+      "compress_mbps": 51.47,
+      "decompress_mbps": 251.84
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3706769,
+      "ratio": 0.3675,
+      "compress_mbps": 47.47,
+      "decompress_mbps": 254.69
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3706769,
+      "ratio": 0.3675,
+      "compress_mbps": 12.78,
+      "decompress_mbps": 263.77
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3693258,
+      "ratio": 0.3662,
+      "compress_mbps": 4.84,
+      "decompress_mbps": 269.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2254442,
+      "ratio": 0.3402,
+      "compress_mbps": 69.34,
+      "decompress_mbps": 222.38
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2044843,
+      "ratio": 0.3086,
+      "compress_mbps": 48.71,
+      "decompress_mbps": 233.42
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 1992105,
+      "ratio": 0.3006,
+      "compress_mbps": 39.96,
+      "decompress_mbps": 254.89
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 1911755,
+      "ratio": 0.2885,
+      "compress_mbps": 27.89,
+      "decompress_mbps": 257.69
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1901448,
+      "ratio": 0.2869,
+      "compress_mbps": 25.9,
+      "decompress_mbps": 260.08
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1883344,
+      "ratio": 0.2842,
+      "compress_mbps": 21.06,
+      "decompress_mbps": 271.62
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1868258,
+      "ratio": 0.2819,
+      "compress_mbps": 13.38,
+      "decompress_mbps": 276.33
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1841388,
+      "ratio": 0.2779,
+      "compress_mbps": 7.82,
+      "decompress_mbps": 284.02
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1794155,
+      "ratio": 0.2707,
+      "compress_mbps": 2.47,
+      "decompress_mbps": 290.71
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 6406301,
+      "ratio": 0.2965,
+      "compress_mbps": 95.14,
+      "decompress_mbps": 293.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 6102377,
+      "ratio": 0.2824,
+      "compress_mbps": 72.18,
+      "decompress_mbps": 313.32
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 6022184,
+      "ratio": 0.2787,
+      "compress_mbps": 66.12,
+      "decompress_mbps": 325.67
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5904034,
+      "ratio": 0.2733,
+      "compress_mbps": 52.53,
+      "decompress_mbps": 336.24
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5899862,
+      "ratio": 0.2731,
+      "compress_mbps": 50.36,
+      "decompress_mbps": 342.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5881527,
+      "ratio": 0.2722,
+      "compress_mbps": 46.19,
+      "decompress_mbps": 351.91
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5830453,
+      "ratio": 0.2698,
+      "compress_mbps": 33.41,
+      "decompress_mbps": 352.37
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5407066,
+      "ratio": 0.2503,
+      "compress_mbps": 12.96,
+      "decompress_mbps": 327.8
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5257833,
+      "ratio": 0.2433,
+      "compress_mbps": 3.99,
+      "decompress_mbps": 355.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5612204,
+      "ratio": 0.7739,
+      "compress_mbps": 41.24,
+      "decompress_mbps": 129.07
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5533875,
+      "ratio": 0.7631,
+      "compress_mbps": 35.17,
+      "decompress_mbps": 132.08
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5522436,
+      "ratio": 0.7615,
+      "compress_mbps": 33.18,
+      "decompress_mbps": 136.64
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5500073,
+      "ratio": 0.7584,
+      "compress_mbps": 27.91,
+      "decompress_mbps": 139.09
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5498823,
+      "ratio": 0.7583,
+      "compress_mbps": 26.89,
+      "decompress_mbps": 136.43
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5497402,
+      "ratio": 0.7581,
+      "compress_mbps": 26.32,
+      "decompress_mbps": 138.94
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5496371,
+      "ratio": 0.7579,
+      "compress_mbps": 25.01,
+      "decompress_mbps": 138.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5429363,
+      "ratio": 0.7487,
+      "compress_mbps": 6.35,
+      "decompress_mbps": 141.33
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5301868,
+      "ratio": 0.7311,
+      "compress_mbps": 3.62,
+      "decompress_mbps": 141.55
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13727247,
+      "ratio": 0.3311,
+      "compress_mbps": 71.12,
+      "decompress_mbps": 223.0
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 12940398,
+      "ratio": 0.3121,
+      "compress_mbps": 54.34,
+      "decompress_mbps": 241.35
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12703756,
+      "ratio": 0.3064,
+      "compress_mbps": 50.41,
+      "decompress_mbps": 262.78
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12294598,
+      "ratio": 0.2966,
+      "compress_mbps": 39.65,
+      "decompress_mbps": 267.14
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12269076,
+      "ratio": 0.2959,
+      "compress_mbps": 37.96,
+      "decompress_mbps": 272.69
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12184584,
+      "ratio": 0.2939,
+      "compress_mbps": 33.32,
+      "decompress_mbps": 269.98
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12109369,
+      "ratio": 0.2921,
+      "compress_mbps": 25.31,
+      "decompress_mbps": 281.5
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12106058,
+      "ratio": 0.292,
+      "compress_mbps": 11.79,
+      "decompress_mbps": 282.72
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11868997,
+      "ratio": 0.2863,
+      "compress_mbps": 3.24,
+      "decompress_mbps": 282.41
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6438176,
+      "ratio": 0.7597,
+      "compress_mbps": 39.06,
+      "decompress_mbps": 126.15
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6392101,
+      "ratio": 0.7543,
+      "compress_mbps": 37.61,
+      "decompress_mbps": 126.96
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6392124,
+      "ratio": 0.7543,
+      "compress_mbps": 37.91,
+      "decompress_mbps": 128.38
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6368722,
+      "ratio": 0.7515,
+      "compress_mbps": 35.88,
+      "decompress_mbps": 116.53
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6368719,
+      "ratio": 0.7515,
+      "compress_mbps": 35.44,
+      "decompress_mbps": 117.83
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 6368719,
+      "ratio": 0.7515,
+      "compress_mbps": 35.43,
+      "decompress_mbps": 118.63
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 6368717,
+      "ratio": 0.7515,
+      "compress_mbps": 35.68,
+      "decompress_mbps": 118.83
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 6278507,
+      "ratio": 0.7409,
+      "compress_mbps": 4.9,
+      "decompress_mbps": 120.21
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5949045,
+      "ratio": 0.702,
+      "compress_mbps": 4.32,
+      "decompress_mbps": 121.14
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 858525,
+      "ratio": 0.1606,
+      "compress_mbps": 151.44,
+      "decompress_mbps": 419.29
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 846807,
+      "ratio": 0.1584,
+      "compress_mbps": 101.03,
+      "decompress_mbps": 455.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 806798,
+      "ratio": 0.1509,
+      "compress_mbps": 92.34,
+      "decompress_mbps": 503.3
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 746239,
+      "ratio": 0.1396,
+      "compress_mbps": 73.56,
+      "decompress_mbps": 547.92
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 743257,
+      "ratio": 0.139,
+      "compress_mbps": 71.46,
+      "decompress_mbps": 596.7
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 721315,
+      "ratio": 0.1349,
+      "compress_mbps": 64.91,
+      "decompress_mbps": 648.89
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 703742,
+      "ratio": 0.1317,
+      "compress_mbps": 42.29,
+      "decompress_mbps": 664.81
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 674362,
+      "ratio": 0.1262,
+      "compress_mbps": 20.92,
+      "decompress_mbps": 676.13
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 669438,
+      "ratio": 0.1252,
+      "compress_mbps": 3.92,
+      "decompress_mbps": 664.14
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4585612,
+      "ratio": 0.4499,
+      "compress_mbps": 113.67,
+      "decompress_mbps": 354.82
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4389474,
+      "ratio": 0.4307,
+      "compress_mbps": 96.07,
+      "decompress_mbps": 375.93
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 4192079,
+      "ratio": 0.4113,
+      "compress_mbps": 59.36,
+      "decompress_mbps": 412.28
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 4095021,
+      "ratio": 0.4018,
+      "compress_mbps": 66.19,
+      "decompress_mbps": 389.42
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3949169,
+      "ratio": 0.3875,
+      "compress_mbps": 35.97,
+      "decompress_mbps": 376.93
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3871628,
+      "ratio": 0.3799,
+      "compress_mbps": 21.24,
+      "decompress_mbps": 384.89
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3858876,
+      "ratio": 0.3786,
+      "compress_mbps": 17.58,
+      "decompress_mbps": 387.13
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3854729,
+      "ratio": 0.3782,
+      "compress_mbps": 15.07,
+      "decompress_mbps": 385.46
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3854729,
+      "ratio": 0.3782,
+      "compress_mbps": 15.07,
+      "decompress_mbps": 391.3
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20577220,
+      "ratio": 0.4017,
+      "compress_mbps": 113.25,
+      "decompress_mbps": 364.49
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 20247697,
+      "ratio": 0.3953,
+      "compress_mbps": 100.51,
+      "decompress_mbps": 370.0
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19987880,
+      "ratio": 0.3902,
+      "compress_mbps": 75.64,
+      "decompress_mbps": 340.24
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19512665,
+      "ratio": 0.381,
+      "compress_mbps": 71.76,
+      "decompress_mbps": 363.34
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19213507,
+      "ratio": 0.3751,
+      "compress_mbps": 51.35,
+      "decompress_mbps": 370.37
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19089118,
+      "ratio": 0.3727,
+      "compress_mbps": 33.44,
+      "decompress_mbps": 376.59
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19061204,
+      "ratio": 0.3721,
+      "compress_mbps": 27.31,
+      "decompress_mbps": 380.14
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19040998,
+      "ratio": 0.3717,
+      "compress_mbps": 15.24,
+      "decompress_mbps": 379.76
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19044390,
+      "ratio": 0.3718,
+      "compress_mbps": 9.54,
+      "decompress_mbps": 385.45
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3828360,
+      "ratio": 0.384,
+      "compress_mbps": 144.91,
+      "decompress_mbps": 453.29
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3798539,
+      "ratio": 0.381,
+      "compress_mbps": 128.29,
+      "decompress_mbps": 497.36
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3674568,
+      "ratio": 0.3685,
+      "compress_mbps": 80.47,
+      "decompress_mbps": 515.99
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3680923,
+      "ratio": 0.3692,
+      "compress_mbps": 89.36,
+      "decompress_mbps": 457.6
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3698707,
+      "ratio": 0.371,
+      "compress_mbps": 48.13,
+      "decompress_mbps": 427.63
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3675935,
+      "ratio": 0.3687,
+      "compress_mbps": 26.41,
+      "decompress_mbps": 437.75
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3670281,
+      "ratio": 0.3681,
+      "compress_mbps": 20.84,
+      "decompress_mbps": 444.31
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3661103,
+      "ratio": 0.3672,
+      "compress_mbps": 10.94,
+      "decompress_mbps": 458.18
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3660788,
+      "ratio": 0.3672,
+      "compress_mbps": 9.47,
+      "decompress_mbps": 459.79
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 4624591,
+      "ratio": 0.1378,
+      "compress_mbps": 332.0,
+      "decompress_mbps": 831.27
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 4303176,
+      "ratio": 0.1282,
+      "compress_mbps": 310.37,
+      "decompress_mbps": 841.9
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 4010156,
+      "ratio": 0.1195,
+      "compress_mbps": 257.47,
+      "decompress_mbps": 926.52
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3713866,
+      "ratio": 0.1107,
+      "compress_mbps": 212.08,
+      "decompress_mbps": 896.37
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3378136,
+      "ratio": 0.1007,
+      "compress_mbps": 166.1,
+      "decompress_mbps": 954.98
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3200182,
+      "ratio": 0.0954,
+      "compress_mbps": 113.17,
+      "decompress_mbps": 986.8
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3141278,
+      "ratio": 0.0936,
+      "compress_mbps": 90.33,
+      "decompress_mbps": 999.02
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 3031199,
+      "ratio": 0.0903,
+      "compress_mbps": 39.16,
+      "decompress_mbps": 1017.12
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2987995,
+      "ratio": 0.0891,
+      "compress_mbps": 21.44,
+      "decompress_mbps": 1033.52
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3290526,
+      "ratio": 0.5349,
+      "compress_mbps": 79.06,
+      "decompress_mbps": 257.16
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3238282,
+      "ratio": 0.5264,
+      "compress_mbps": 72.38,
+      "decompress_mbps": 263.21
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3193366,
+      "ratio": 0.5191,
+      "compress_mbps": 57.0,
+      "decompress_mbps": 265.33
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3158012,
+      "ratio": 0.5133,
+      "compress_mbps": 55.65,
+      "decompress_mbps": 268.5
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3115309,
+      "ratio": 0.5064,
+      "compress_mbps": 39.25,
+      "decompress_mbps": 269.0
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3097288,
+      "ratio": 0.5034,
+      "compress_mbps": 26.28,
+      "decompress_mbps": 264.86
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3094363,
+      "ratio": 0.503,
+      "compress_mbps": 21.86,
+      "decompress_mbps": 268.09
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3093026,
+      "ratio": 0.5028,
+      "compress_mbps": 16.97,
+      "decompress_mbps": 270.33
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3092920,
+      "ratio": 0.5027,
+      "compress_mbps": 15.53,
+      "decompress_mbps": 269.1
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 4076385,
+      "ratio": 0.4042,
+      "compress_mbps": 125.81,
+      "decompress_mbps": 474.99
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3991014,
+      "ratio": 0.3957,
+      "compress_mbps": 117.17,
+      "decompress_mbps": 494.44
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3934055,
+      "ratio": 0.3901,
+      "compress_mbps": 93.6,
+      "decompress_mbps": 511.59
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3825092,
+      "ratio": 0.3793,
+      "compress_mbps": 85.49,
+      "decompress_mbps": 513.7
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3752932,
+      "ratio": 0.3721,
+      "compress_mbps": 64.41,
+      "decompress_mbps": 496.1
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3695164,
+      "ratio": 0.3664,
+      "compress_mbps": 49.22,
+      "decompress_mbps": 507.36
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3676881,
+      "ratio": 0.3646,
+      "compress_mbps": 38.17,
+      "decompress_mbps": 515.91
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3673171,
+      "ratio": 0.3642,
+      "compress_mbps": 31.92,
+      "decompress_mbps": 519.6
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3673171,
+      "ratio": 0.3642,
+      "compress_mbps": 31.92,
+      "decompress_mbps": 519.23
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2376424,
+      "ratio": 0.3586,
+      "compress_mbps": 130.38,
+      "decompress_mbps": 393.75
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2259060,
+      "ratio": 0.3409,
+      "compress_mbps": 112.03,
+      "decompress_mbps": 411.76
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2135664,
+      "ratio": 0.3223,
+      "compress_mbps": 72.25,
+      "decompress_mbps": 435.29
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 2052793,
+      "ratio": 0.3098,
+      "compress_mbps": 81.67,
+      "decompress_mbps": 430.73
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1932127,
+      "ratio": 0.2915,
+      "compress_mbps": 45.23,
+      "decompress_mbps": 432.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1860865,
+      "ratio": 0.2808,
+      "compress_mbps": 22.82,
+      "decompress_mbps": 440.25
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1838671,
+      "ratio": 0.2774,
+      "compress_mbps": 15.96,
+      "decompress_mbps": 441.72
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1823235,
+      "ratio": 0.2751,
+      "compress_mbps": 8.12,
+      "decompress_mbps": 436.13
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1823190,
+      "ratio": 0.2751,
+      "compress_mbps": 8.15,
+      "decompress_mbps": 439.5
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 6329449,
+      "ratio": 0.2929,
+      "compress_mbps": 169.74,
+      "decompress_mbps": 460.79
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 6128866,
+      "ratio": 0.2837,
+      "compress_mbps": 155.55,
+      "decompress_mbps": 557.06
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5982546,
+      "ratio": 0.2769,
+      "compress_mbps": 125.39,
+      "decompress_mbps": 581.02
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5656400,
+      "ratio": 0.2618,
+      "compress_mbps": 116.92,
+      "decompress_mbps": 576.69
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5511352,
+      "ratio": 0.2551,
+      "compress_mbps": 82.58,
+      "decompress_mbps": 587.65
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5451399,
+      "ratio": 0.2523,
+      "compress_mbps": 56.59,
+      "decompress_mbps": 593.88
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5417123,
+      "ratio": 0.2507,
+      "compress_mbps": 46.71,
+      "decompress_mbps": 596.81
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5404364,
+      "ratio": 0.2501,
+      "compress_mbps": 32.73,
+      "decompress_mbps": 602.78
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5402704,
+      "ratio": 0.2501,
+      "compress_mbps": 29.69,
+      "decompress_mbps": 390.04
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5567768,
+      "ratio": 0.7678,
+      "compress_mbps": 32.89,
+      "decompress_mbps": 211.48
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5504009,
+      "ratio": 0.759,
+      "compress_mbps": 38.32,
+      "decompress_mbps": 168.63
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5439339,
+      "ratio": 0.7501,
+      "compress_mbps": 29.43,
+      "decompress_mbps": 230.72
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5394604,
+      "ratio": 0.7439,
+      "compress_mbps": 32.68,
+      "decompress_mbps": 256.53
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5370116,
+      "ratio": 0.7405,
+      "compress_mbps": 28.44,
+      "decompress_mbps": 312.67
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5331793,
+      "ratio": 0.7352,
+      "compress_mbps": 20.53,
+      "decompress_mbps": 329.4
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5327677,
+      "ratio": 0.7347,
+      "compress_mbps": 21.16,
+      "decompress_mbps": 348.44
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5325914,
+      "ratio": 0.7344,
+      "compress_mbps": 18.96,
+      "decompress_mbps": 349.29
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5325914,
+      "ratio": 0.7344,
+      "compress_mbps": 18.95,
+      "decompress_mbps": 346.98
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 14991236,
+      "ratio": 0.3616,
+      "compress_mbps": 136.65,
+      "decompress_mbps": 380.3
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 14249692,
+      "ratio": 0.3437,
+      "compress_mbps": 120.34,
+      "decompress_mbps": 401.81
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 13627761,
+      "ratio": 0.3287,
+      "compress_mbps": 87.73,
+      "decompress_mbps": 414.55
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 13001990,
+      "ratio": 0.3136,
+      "compress_mbps": 85.4,
+      "decompress_mbps": 395.8
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12445991,
+      "ratio": 0.3002,
+      "compress_mbps": 55.03,
+      "decompress_mbps": 392.94
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12213941,
+      "ratio": 0.2946,
+      "compress_mbps": 36.53,
+      "decompress_mbps": 400.31
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12130416,
+      "ratio": 0.2926,
+      "compress_mbps": 29.65,
+      "decompress_mbps": 401.43
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12073697,
+      "ratio": 0.2912,
+      "compress_mbps": 21.5,
+      "decompress_mbps": 403.07
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12073469,
+      "ratio": 0.2912,
+      "compress_mbps": 21.33,
+      "decompress_mbps": 403.44
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6033926,
+      "ratio": 0.712,
+      "compress_mbps": 75.49,
+      "decompress_mbps": 294.33
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 5997474,
+      "ratio": 0.7077,
+      "compress_mbps": 68.78,
+      "decompress_mbps": 305.32
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 5966621,
+      "ratio": 0.7041,
+      "compress_mbps": 55.63,
+      "decompress_mbps": 312.38
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6091108,
+      "ratio": 0.7188,
+      "compress_mbps": 46.09,
+      "decompress_mbps": 267.15
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6053566,
+      "ratio": 0.7143,
+      "compress_mbps": 37.26,
+      "decompress_mbps": 274.93
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 6045111,
+      "ratio": 0.7134,
+      "compress_mbps": 34.97,
+      "decompress_mbps": 276.79
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 6045034,
+      "ratio": 0.7133,
+      "compress_mbps": 34.92,
+      "decompress_mbps": 278.07
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 6045032,
+      "ratio": 0.7133,
+      "compress_mbps": 34.97,
+      "decompress_mbps": 277.28
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 6045032,
+      "ratio": 0.7133,
+      "compress_mbps": 34.94,
+      "decompress_mbps": 277.39
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 965242,
+      "ratio": 0.1806,
+      "compress_mbps": 264.31,
+      "decompress_mbps": 697.56
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 887265,
+      "ratio": 0.166,
+      "compress_mbps": 246.22,
+      "decompress_mbps": 752.4
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 822167,
+      "ratio": 0.1538,
+      "compress_mbps": 191.48,
+      "decompress_mbps": 797.39
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 807518,
+      "ratio": 0.1511,
+      "compress_mbps": 169.01,
+      "decompress_mbps": 768.34
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 730574,
+      "ratio": 0.1367,
+      "compress_mbps": 121.75,
+      "decompress_mbps": 815.59
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 687991,
+      "ratio": 0.1287,
+      "compress_mbps": 79.31,
+      "decompress_mbps": 872.54
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 673933,
+      "ratio": 0.1261,
+      "compress_mbps": 64.99,
+      "decompress_mbps": 887.93
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 659518,
+      "ratio": 0.1234,
+      "compress_mbps": 43.0,
+      "decompress_mbps": 884.96
+    },
+    {
+      "compressor": "zlib",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 658899,
+      "ratio": 0.1233,
+      "compress_mbps": 39.85,
+      "decompress_mbps": 896.88
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 5363862,
+      "ratio": 0.5263,
+      "compress_mbps": 141.65,
+      "decompress_mbps": 389.91
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4438205,
+      "ratio": 0.4354,
+      "compress_mbps": 128.9,
+      "decompress_mbps": 428.47
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 4054333,
+      "ratio": 0.3978,
+      "compress_mbps": 63.86,
+      "decompress_mbps": 475.64
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 4038550,
+      "ratio": 0.3962,
+      "compress_mbps": 57.76,
+      "decompress_mbps": 469.09
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3954920,
+      "ratio": 0.388,
+      "compress_mbps": 40.27,
+      "decompress_mbps": 462.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3872874,
+      "ratio": 0.38,
+      "compress_mbps": 22.58,
+      "decompress_mbps": 470.25
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3859937,
+      "ratio": 0.3787,
+      "compress_mbps": 18.83,
+      "decompress_mbps": 472.38
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3855935,
+      "ratio": 0.3783,
+      "compress_mbps": 17.07,
+      "decompress_mbps": 469.47
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3855791,
+      "ratio": 0.3783,
+      "compress_mbps": 17.01,
+      "decompress_mbps": 470.52
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 22334882,
+      "ratio": 0.4361,
+      "compress_mbps": 233.89,
+      "decompress_mbps": 370.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 20150366,
+      "ratio": 0.3934,
+      "compress_mbps": 119.97,
+      "decompress_mbps": 375.66
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19495014,
+      "ratio": 0.3806,
+      "compress_mbps": 70.13,
+      "decompress_mbps": 389.58
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19424978,
+      "ratio": 0.3792,
+      "compress_mbps": 71.02,
+      "decompress_mbps": 402.97
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19298736,
+      "ratio": 0.3768,
+      "compress_mbps": 54.1,
+      "decompress_mbps": 393.93
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19179167,
+      "ratio": 0.3744,
+      "compress_mbps": 29.69,
+      "decompress_mbps": 422.35
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19151324,
+      "ratio": 0.3739,
+      "compress_mbps": 21.89,
+      "decompress_mbps": 422.25
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19144373,
+      "ratio": 0.3738,
+      "compress_mbps": 16.59,
+      "decompress_mbps": 407.62
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19141383,
+      "ratio": 0.3737,
+      "compress_mbps": 14.17,
+      "decompress_mbps": 420.85
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 4249731,
+      "ratio": 0.4262,
+      "compress_mbps": 313.35,
+      "decompress_mbps": 528.94
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3775479,
+      "ratio": 0.3787,
+      "compress_mbps": 156.84,
+      "decompress_mbps": 517.84
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3656966,
+      "ratio": 0.3668,
+      "compress_mbps": 79.84,
+      "decompress_mbps": 574.15
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3740378,
+      "ratio": 0.3751,
+      "compress_mbps": 67.57,
+      "decompress_mbps": 534.79
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3713604,
+      "ratio": 0.3725,
+      "compress_mbps": 48.45,
+      "decompress_mbps": 501.84
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3683556,
+      "ratio": 0.3694,
+      "compress_mbps": 24.87,
+      "decompress_mbps": 515.42
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3683797,
+      "ratio": 0.3695,
+      "compress_mbps": 18.98,
+      "decompress_mbps": 521.98
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3684477,
+      "ratio": 0.3695,
+      "compress_mbps": 14.34,
+      "decompress_mbps": 540.16
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3679414,
+      "ratio": 0.369,
+      "compress_mbps": 12.34,
+      "decompress_mbps": 542.45
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 5594622,
+      "ratio": 0.1667,
+      "compress_mbps": 433.55,
+      "decompress_mbps": 834.3
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 4179532,
+      "ratio": 0.1246,
+      "compress_mbps": 327.38,
+      "decompress_mbps": 926.24
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3542329,
+      "ratio": 0.1056,
+      "compress_mbps": 211.33,
+      "decompress_mbps": 842.8
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3323363,
+      "ratio": 0.099,
+      "compress_mbps": 197.38,
+      "decompress_mbps": 872.41
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3230343,
+      "ratio": 0.0963,
+      "compress_mbps": 161.61,
+      "decompress_mbps": 952.97
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3123421,
+      "ratio": 0.0931,
+      "compress_mbps": 95.69,
+      "decompress_mbps": 997.1
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3093778,
+      "ratio": 0.0922,
+      "compress_mbps": 70.53,
+      "decompress_mbps": 972.37
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 3067318,
+      "ratio": 0.0914,
+      "compress_mbps": 50.06,
+      "decompress_mbps": 1013.07
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 3050695,
+      "ratio": 0.0909,
+      "compress_mbps": 41.98,
+      "decompress_mbps": 1022.82
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3543611,
+      "ratio": 0.576,
+      "compress_mbps": 169.2,
+      "decompress_mbps": 269.98
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3226818,
+      "ratio": 0.5245,
+      "compress_mbps": 86.03,
+      "decompress_mbps": 287.07
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3144140,
+      "ratio": 0.5111,
+      "compress_mbps": 52.6,
+      "decompress_mbps": 297.45
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3129833,
+      "ratio": 0.5087,
+      "compress_mbps": 51.39,
+      "decompress_mbps": 324.03
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3114809,
+      "ratio": 0.5063,
+      "compress_mbps": 40.29,
+      "decompress_mbps": 338.27
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3095705,
+      "ratio": 0.5032,
+      "compress_mbps": 25.04,
+      "decompress_mbps": 345.03
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3090055,
+      "ratio": 0.5023,
+      "compress_mbps": 20.39,
+      "decompress_mbps": 345.41
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3087665,
+      "ratio": 0.5019,
+      "compress_mbps": 17.41,
+      "decompress_mbps": 345.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3087158,
+      "ratio": 0.5018,
+      "compress_mbps": 16.29,
+      "decompress_mbps": 345.8
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 5419510,
+      "ratio": 0.5373,
+      "compress_mbps": 243.36,
+      "decompress_mbps": 535.63
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3982547,
+      "ratio": 0.3949,
+      "compress_mbps": 122.38,
+      "decompress_mbps": 550.66
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3806102,
+      "ratio": 0.3774,
+      "compress_mbps": 80.86,
+      "decompress_mbps": 568.24
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3761477,
+      "ratio": 0.373,
+      "compress_mbps": 78.11,
+      "decompress_mbps": 603.06
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3740298,
+      "ratio": 0.3709,
+      "compress_mbps": 67.07,
+      "decompress_mbps": 611.24
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3686116,
+      "ratio": 0.3655,
+      "compress_mbps": 49.52,
+      "decompress_mbps": 637.82
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3668442,
+      "ratio": 0.3637,
+      "compress_mbps": 38.85,
+      "decompress_mbps": 662.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3665072,
+      "ratio": 0.3634,
+      "compress_mbps": 33.15,
+      "decompress_mbps": 657.03
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3665057,
+      "ratio": 0.3634,
+      "compress_mbps": 32.94,
+      "decompress_mbps": 653.51
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2842321,
+      "ratio": 0.4289,
+      "compress_mbps": 193.08,
+      "decompress_mbps": 443.97
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2232180,
+      "ratio": 0.3368,
+      "compress_mbps": 151.04,
+      "decompress_mbps": 514.91
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2003056,
+      "ratio": 0.3022,
+      "compress_mbps": 81.92,
+      "decompress_mbps": 551.48
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 1985375,
+      "ratio": 0.2996,
+      "compress_mbps": 74.08,
+      "decompress_mbps": 566.46
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1933775,
+      "ratio": 0.2918,
+      "compress_mbps": 51.93,
+      "decompress_mbps": 538.73
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1858103,
+      "ratio": 0.2804,
+      "compress_mbps": 22.05,
+      "decompress_mbps": 541.6
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1840414,
+      "ratio": 0.2777,
+      "compress_mbps": 15.15,
+      "decompress_mbps": 550.69
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1831679,
+      "ratio": 0.2764,
+      "compress_mbps": 11.76,
+      "decompress_mbps": 543.82
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1827137,
+      "ratio": 0.2757,
+      "compress_mbps": 10.16,
+      "decompress_mbps": 544.36
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 7089759,
+      "ratio": 0.3281,
+      "compress_mbps": 290.79,
+      "decompress_mbps": 557.71
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 5966231,
+      "ratio": 0.2761,
+      "compress_mbps": 174.66,
+      "decompress_mbps": 619.46
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5611838,
+      "ratio": 0.2597,
+      "compress_mbps": 111.67,
+      "decompress_mbps": 648.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5535436,
+      "ratio": 0.2562,
+      "compress_mbps": 105.54,
+      "decompress_mbps": 672.27
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5480971,
+      "ratio": 0.2537,
+      "compress_mbps": 81.52,
+      "decompress_mbps": 680.77
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5437556,
+      "ratio": 0.2517,
+      "compress_mbps": 49.47,
+      "decompress_mbps": 697.31
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5432108,
+      "ratio": 0.2514,
+      "compress_mbps": 40.48,
+      "decompress_mbps": 694.27
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5428571,
+      "ratio": 0.2512,
+      "compress_mbps": 33.62,
+      "decompress_mbps": 700.3
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5425526,
+      "ratio": 0.2511,
+      "compress_mbps": 30.51,
+      "decompress_mbps": 703.33
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5900800,
+      "ratio": 0.8137,
+      "compress_mbps": 188.47,
+      "decompress_mbps": 324.35
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5523611,
+      "ratio": 0.7617,
+      "compress_mbps": 69.45,
+      "decompress_mbps": 340.66
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5393086,
+      "ratio": 0.7437,
+      "compress_mbps": 40.33,
+      "decompress_mbps": 351.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5401582,
+      "ratio": 0.7448,
+      "compress_mbps": 40.72,
+      "decompress_mbps": 367.5
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5371274,
+      "ratio": 0.7407,
+      "compress_mbps": 31.31,
+      "decompress_mbps": 358.37
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5330096,
+      "ratio": 0.735,
+      "compress_mbps": 20.8,
+      "decompress_mbps": 365.39
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5325437,
+      "ratio": 0.7343,
+      "compress_mbps": 18.98,
+      "decompress_mbps": 366.05
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5323934,
+      "ratio": 0.7341,
+      "compress_mbps": 18.05,
+      "decompress_mbps": 364.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323621,
+      "ratio": 0.7341,
+      "compress_mbps": 17.67,
+      "decompress_mbps": 364.02
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 17587173,
+      "ratio": 0.4242,
+      "compress_mbps": 185.73,
+      "decompress_mbps": 379.13
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 14171707,
+      "ratio": 0.3418,
+      "compress_mbps": 149.15,
+      "decompress_mbps": 409.08
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12774851,
+      "ratio": 0.3081,
+      "compress_mbps": 85.71,
+      "decompress_mbps": 440.79
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12612554,
+      "ratio": 0.3042,
+      "compress_mbps": 76.13,
+      "decompress_mbps": 444.75
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12392339,
+      "ratio": 0.2989,
+      "compress_mbps": 58.1,
+      "decompress_mbps": 457.17
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12158314,
+      "ratio": 0.2933,
+      "compress_mbps": 34.41,
+      "decompress_mbps": 463.08
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12107840,
+      "ratio": 0.292,
+      "compress_mbps": 27.64,
+      "decompress_mbps": 466.33
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12081311,
+      "ratio": 0.2914,
+      "compress_mbps": 22.88,
+      "decompress_mbps": 462.63
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12081011,
+      "ratio": 0.2914,
+      "compress_mbps": 22.78,
+      "decompress_mbps": 460.01
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6527324,
+      "ratio": 0.7703,
+      "compress_mbps": 238.95,
+      "decompress_mbps": 330.7
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6051483,
+      "ratio": 0.7141,
+      "compress_mbps": 75.62,
+      "decompress_mbps": 332.39
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6010123,
+      "ratio": 0.7092,
+      "compress_mbps": 52.06,
+      "decompress_mbps": 334.45
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6024815,
+      "ratio": 0.711,
+      "compress_mbps": 44.63,
+      "decompress_mbps": 286.25
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6005181,
+      "ratio": 0.7086,
+      "compress_mbps": 40.44,
+      "decompress_mbps": 293.0
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5997508,
+      "ratio": 0.7077,
+      "compress_mbps": 37.97,
+      "decompress_mbps": 295.42
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 5997403,
+      "ratio": 0.7077,
+      "compress_mbps": 37.87,
+      "decompress_mbps": 295.69
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 5997403,
+      "ratio": 0.7077,
+      "compress_mbps": 37.82,
+      "decompress_mbps": 295.45
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5997403,
+      "ratio": 0.7077,
+      "compress_mbps": 37.76,
+      "decompress_mbps": 292.96
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 1147652,
+      "ratio": 0.2147,
+      "compress_mbps": 388.67,
+      "decompress_mbps": 761.65
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 919639,
+      "ratio": 0.172,
+      "compress_mbps": 262.86,
+      "decompress_mbps": 956.95
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 752341,
+      "ratio": 0.1407,
+      "compress_mbps": 167.46,
+      "decompress_mbps": 1057.51
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 735537,
+      "ratio": 0.1376,
+      "compress_mbps": 161.37,
+      "decompress_mbps": 1037.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 706789,
+      "ratio": 0.1322,
+      "compress_mbps": 123.5,
+      "decompress_mbps": 1129.34
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 676279,
+      "ratio": 0.1265,
+      "compress_mbps": 69.53,
+      "decompress_mbps": 1219.4
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 668772,
+      "ratio": 0.1251,
+      "compress_mbps": 55.97,
+      "decompress_mbps": 1208.21
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 665340,
+      "ratio": 0.1245,
+      "compress_mbps": 47.61,
+      "decompress_mbps": 1208.14
+    },
+    {
+      "compressor": "miniz_oxide",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 664273,
+      "ratio": 0.1243,
+      "compress_mbps": 45.85,
+      "decompress_mbps": 1218.11
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4217525,
+      "ratio": 0.4138,
+      "compress_mbps": 243.85,
+      "decompress_mbps": 801.13
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4053259,
+      "ratio": 0.3977,
+      "compress_mbps": 170.19,
+      "decompress_mbps": 864.66
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3989875,
+      "ratio": 0.3915,
+      "compress_mbps": 140.0,
+      "decompress_mbps": 934.98
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 3972869,
+      "ratio": 0.3898,
+      "compress_mbps": 127.83,
+      "decompress_mbps": 825.71
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3894026,
+      "ratio": 0.3821,
+      "compress_mbps": 99.29,
+      "decompress_mbps": 791.29
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3859436,
+      "ratio": 0.3787,
+      "compress_mbps": 75.65,
+      "decompress_mbps": 819.18
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3837515,
+      "ratio": 0.3765,
+      "compress_mbps": 55.71,
+      "decompress_mbps": 796.16
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3811467,
+      "ratio": 0.374,
+      "compress_mbps": 36.03,
+      "decompress_mbps": 816.32
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3810354,
+      "ratio": 0.3738,
+      "compress_mbps": 32.76,
+      "decompress_mbps": 816.68
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20192961,
+      "ratio": 0.3942,
+      "compress_mbps": 242.16,
+      "decompress_mbps": 676.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 19374226,
+      "ratio": 0.3783,
+      "compress_mbps": 185.69,
+      "decompress_mbps": 710.78
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19234937,
+      "ratio": 0.3755,
+      "compress_mbps": 173.04,
+      "decompress_mbps": 727.76
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19145385,
+      "ratio": 0.3738,
+      "compress_mbps": 162.62,
+      "decompress_mbps": 728.74
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 18878875,
+      "ratio": 0.3686,
+      "compress_mbps": 142.62,
+      "decompress_mbps": 741.83
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 18805391,
+      "ratio": 0.3671,
+      "compress_mbps": 117.71,
+      "decompress_mbps": 750.56
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 18749947,
+      "ratio": 0.3661,
+      "compress_mbps": 87.16,
+      "decompress_mbps": 759.3
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 18718540,
+      "ratio": 0.3655,
+      "compress_mbps": 47.56,
+      "decompress_mbps": 766.6
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 18713659,
+      "ratio": 0.3654,
+      "compress_mbps": 33.49,
+      "decompress_mbps": 676.15
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3740775,
+      "ratio": 0.3752,
+      "compress_mbps": 293.42,
+      "decompress_mbps": 755.42
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3707407,
+      "ratio": 0.3718,
+      "compress_mbps": 217.45,
+      "decompress_mbps": 768.84
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3672389,
+      "ratio": 0.3683,
+      "compress_mbps": 185.43,
+      "decompress_mbps": 809.7
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3660011,
+      "ratio": 0.3671,
+      "compress_mbps": 171.62,
+      "decompress_mbps": 751.11
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3664245,
+      "ratio": 0.3675,
+      "compress_mbps": 141.37,
+      "decompress_mbps": 712.85
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3648644,
+      "ratio": 0.3659,
+      "compress_mbps": 106.84,
+      "decompress_mbps": 739.26
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3635323,
+      "ratio": 0.3646,
+      "compress_mbps": 68.34,
+      "decompress_mbps": 735.43
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3624778,
+      "ratio": 0.3635,
+      "compress_mbps": 43.04,
+      "decompress_mbps": 773.18
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3625176,
+      "ratio": 0.3636,
+      "compress_mbps": 38.87,
+      "decompress_mbps": 757.44
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3837577,
+      "ratio": 0.1144,
+      "compress_mbps": 609.02,
+      "decompress_mbps": 1491.69
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 3714632,
+      "ratio": 0.1107,
+      "compress_mbps": 462.85,
+      "decompress_mbps": 1747.31
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3599455,
+      "ratio": 0.1073,
+      "compress_mbps": 427.07,
+      "decompress_mbps": 1882.3
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3431843,
+      "ratio": 0.1023,
+      "compress_mbps": 388.74,
+      "decompress_mbps": 1763.39
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3268188,
+      "ratio": 0.0974,
+      "compress_mbps": 346.67,
+      "decompress_mbps": 1777.54
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3091741,
+      "ratio": 0.0921,
+      "compress_mbps": 264.16,
+      "decompress_mbps": 1787.13
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3032499,
+      "ratio": 0.0904,
+      "compress_mbps": 186.41,
+      "decompress_mbps": 1846.22
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 2949097,
+      "ratio": 0.0879,
+      "compress_mbps": 97.63,
+      "decompress_mbps": 1789.45
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2925243,
+      "ratio": 0.0872,
+      "compress_mbps": 69.23,
+      "decompress_mbps": 1757.94
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3275124,
+      "ratio": 0.5324,
+      "compress_mbps": 166.26,
+      "decompress_mbps": 462.6
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3150806,
+      "ratio": 0.5121,
+      "compress_mbps": 128.39,
+      "decompress_mbps": 483.21
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3137061,
+      "ratio": 0.5099,
+      "compress_mbps": 120.82,
+      "decompress_mbps": 502.43
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3129676,
+      "ratio": 0.5087,
+      "compress_mbps": 116.89,
+      "decompress_mbps": 518.56
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3079277,
+      "ratio": 0.5005,
+      "compress_mbps": 99.99,
+      "decompress_mbps": 536.74
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3072378,
+      "ratio": 0.4994,
+      "compress_mbps": 88.82,
+      "decompress_mbps": 533.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3068123,
+      "ratio": 0.4987,
+      "compress_mbps": 76.38,
+      "decompress_mbps": 542.11
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3067299,
+      "ratio": 0.4986,
+      "compress_mbps": 55.33,
+      "decompress_mbps": 533.57
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3066968,
+      "ratio": 0.4985,
+      "compress_mbps": 49.23,
+      "decompress_mbps": 507.58
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3868663,
+      "ratio": 0.3836,
+      "compress_mbps": 285.16,
+      "decompress_mbps": 772.78
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3839158,
+      "ratio": 0.3807,
+      "compress_mbps": 213.22,
+      "decompress_mbps": 914.82
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3818964,
+      "ratio": 0.3787,
+      "compress_mbps": 197.74,
+      "decompress_mbps": 936.61
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3789325,
+      "ratio": 0.3757,
+      "compress_mbps": 179.66,
+      "decompress_mbps": 954.8
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3666476,
+      "ratio": 0.3635,
+      "compress_mbps": 157.89,
+      "decompress_mbps": 942.54
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3660266,
+      "ratio": 0.3629,
+      "compress_mbps": 142.43,
+      "decompress_mbps": 987.45
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3659491,
+      "ratio": 0.3628,
+      "compress_mbps": 135.11,
+      "decompress_mbps": 999.79
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3654863,
+      "ratio": 0.3624,
+      "compress_mbps": 114.32,
+      "decompress_mbps": 1009.23
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3654860,
+      "ratio": 0.3624,
+      "compress_mbps": 114.27,
+      "decompress_mbps": 1001.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2197055,
+      "ratio": 0.3315,
+      "compress_mbps": 300.85,
+      "decompress_mbps": 858.37
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2082309,
+      "ratio": 0.3142,
+      "compress_mbps": 214.77,
+      "decompress_mbps": 1130.12
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2021047,
+      "ratio": 0.305,
+      "compress_mbps": 178.67,
+      "decompress_mbps": 1236.6
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 1990952,
+      "ratio": 0.3004,
+      "compress_mbps": 157.4,
+      "decompress_mbps": 1146.54
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1921113,
+      "ratio": 0.2899,
+      "compress_mbps": 127.99,
+      "decompress_mbps": 1093.81
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1876257,
+      "ratio": 0.2831,
+      "compress_mbps": 86.94,
+      "decompress_mbps": 1090.38
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1832695,
+      "ratio": 0.2765,
+      "compress_mbps": 46.02,
+      "decompress_mbps": 1103.5
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1809967,
+      "ratio": 0.2731,
+      "compress_mbps": 24.27,
+      "decompress_mbps": 1063.53
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1806374,
+      "ratio": 0.2726,
+      "compress_mbps": 19.83,
+      "decompress_mbps": 1054.62
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5866517,
+      "ratio": 0.2715,
+      "compress_mbps": 338.52,
+      "decompress_mbps": 979.15
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 5695942,
+      "ratio": 0.2636,
+      "compress_mbps": 258.0,
+      "decompress_mbps": 1031.45
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5605878,
+      "ratio": 0.2595,
+      "compress_mbps": 233.32,
+      "decompress_mbps": 1100.86
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5553432,
+      "ratio": 0.257,
+      "compress_mbps": 216.59,
+      "decompress_mbps": 1079.15
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5416713,
+      "ratio": 0.2507,
+      "compress_mbps": 186.71,
+      "decompress_mbps": 1066.93
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5337149,
+      "ratio": 0.247,
+      "compress_mbps": 142.78,
+      "decompress_mbps": 1079.29
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5310181,
+      "ratio": 0.2458,
+      "compress_mbps": 100.23,
+      "decompress_mbps": 1069.71
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5272761,
+      "ratio": 0.244,
+      "compress_mbps": 62.39,
+      "decompress_mbps": 1089.17
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5270405,
+      "ratio": 0.2439,
+      "compress_mbps": 50.04,
+      "decompress_mbps": 1101.61
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5575128,
+      "ratio": 0.7688,
+      "compress_mbps": 162.23,
+      "decompress_mbps": 485.07
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5417142,
+      "ratio": 0.747,
+      "compress_mbps": 116.65,
+      "decompress_mbps": 518.27
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5397999,
+      "ratio": 0.7444,
+      "compress_mbps": 105.25,
+      "decompress_mbps": 528.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5391125,
+      "ratio": 0.7434,
+      "compress_mbps": 99.31,
+      "decompress_mbps": 542.53
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5352212,
+      "ratio": 0.738,
+      "compress_mbps": 87.58,
+      "decompress_mbps": 513.46
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5335405,
+      "ratio": 0.7357,
+      "compress_mbps": 73.79,
+      "decompress_mbps": 526.1
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5325697,
+      "ratio": 0.7344,
+      "compress_mbps": 63.45,
+      "decompress_mbps": 513.46
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5324004,
+      "ratio": 0.7341,
+      "compress_mbps": 52.34,
+      "decompress_mbps": 522.62
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5323197,
+      "ratio": 0.734,
+      "compress_mbps": 50.85,
+      "decompress_mbps": 511.04
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 13550569,
+      "ratio": 0.3268,
+      "compress_mbps": 266.06,
+      "decompress_mbps": 891.09
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 13130705,
+      "ratio": 0.3167,
+      "compress_mbps": 199.84,
+      "decompress_mbps": 973.65
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12839361,
+      "ratio": 0.3097,
+      "compress_mbps": 176.74,
+      "decompress_mbps": 1015.15
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12601933,
+      "ratio": 0.304,
+      "compress_mbps": 161.98,
+      "decompress_mbps": 899.79
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12310776,
+      "ratio": 0.2969,
+      "compress_mbps": 131.58,
+      "decompress_mbps": 879.58
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12140474,
+      "ratio": 0.2928,
+      "compress_mbps": 104.62,
+      "decompress_mbps": 887.92
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12025296,
+      "ratio": 0.2901,
+      "compress_mbps": 75.01,
+      "decompress_mbps": 892.91
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 11893824,
+      "ratio": 0.2869,
+      "compress_mbps": 45.87,
+      "decompress_mbps": 886.31
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11882496,
+      "ratio": 0.2866,
+      "compress_mbps": 39.46,
+      "decompress_mbps": 930.2
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6293390,
+      "ratio": 0.7426,
+      "compress_mbps": 145.39,
+      "decompress_mbps": 523.59
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6058412,
+      "ratio": 0.7149,
+      "compress_mbps": 120.35,
+      "decompress_mbps": 529.46
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6058381,
+      "ratio": 0.7149,
+      "compress_mbps": 120.3,
+      "decompress_mbps": 539.19
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6058363,
+      "ratio": 0.7149,
+      "compress_mbps": 120.03,
+      "decompress_mbps": 437.57
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 5998400,
+      "ratio": 0.7078,
+      "compress_mbps": 108.52,
+      "decompress_mbps": 459.54
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5998438,
+      "ratio": 0.7078,
+      "compress_mbps": 108.55,
+      "decompress_mbps": 463.75
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 5998439,
+      "ratio": 0.7078,
+      "compress_mbps": 108.18,
+      "decompress_mbps": 462.69
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": 90.15,
+      "decompress_mbps": 462.82
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5986859,
+      "ratio": 0.7065,
+      "compress_mbps": 90.18,
+      "decompress_mbps": 454.72
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 887708,
+      "ratio": 0.1661,
+      "compress_mbps": 492.83,
+      "decompress_mbps": 1270.45
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 843475,
+      "ratio": 0.1578,
+      "compress_mbps": 363.79,
+      "decompress_mbps": 1801.54
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 793388,
+      "ratio": 0.1484,
+      "compress_mbps": 337.16,
+      "decompress_mbps": 1867.27
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 747602,
+      "ratio": 0.1399,
+      "compress_mbps": 304.24,
+      "decompress_mbps": 1819.5
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 718615,
+      "ratio": 0.1344,
+      "compress_mbps": 263.07,
+      "decompress_mbps": 1830.67
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 684405,
+      "ratio": 0.128,
+      "compress_mbps": 206.4,
+      "decompress_mbps": 1920.08
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 664859,
+      "ratio": 0.1244,
+      "compress_mbps": 142.72,
+      "decompress_mbps": 1906.99
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 650835,
+      "ratio": 0.1218,
+      "compress_mbps": 81.56,
+      "decompress_mbps": 1892.16
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 649494,
+      "ratio": 0.1215,
+      "compress_mbps": 68.13,
+      "decompress_mbps": 1902.14
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 65708,
+      "ratio": 0.432,
+      "compress_mbps": 42.56,
+      "decompress_mbps": 61.17
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 60259,
+      "ratio": 0.3962,
+      "compress_mbps": 26.21,
+      "decompress_mbps": 68.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 58544,
+      "ratio": 0.3849,
+      "compress_mbps": 21.92,
+      "decompress_mbps": 69.11
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 56238,
+      "ratio": 0.3698,
+      "compress_mbps": 21.46,
+      "decompress_mbps": 70.96
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 54764,
+      "ratio": 0.3601,
+      "compress_mbps": 16.16,
+      "decompress_mbps": 71.22
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54311,
+      "ratio": 0.3571,
+      "compress_mbps": 10.7,
+      "decompress_mbps": 71.22
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 54262,
+      "ratio": 0.3568,
+      "compress_mbps": 9.8,
+      "decompress_mbps": 72.02
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 54247,
+      "ratio": 0.3567,
+      "compress_mbps": 9.57,
+      "decompress_mbps": 72.02
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 54247,
+      "ratio": 0.3567,
+      "compress_mbps": 9.65,
+      "decompress_mbps": 72.57
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 56882,
+      "ratio": 0.4544,
+      "compress_mbps": 37.25,
+      "decompress_mbps": 55.92
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 52826,
+      "ratio": 0.422,
+      "compress_mbps": 23.05,
+      "decompress_mbps": 62.21
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 51625,
+      "ratio": 0.4124,
+      "compress_mbps": 22.69,
+      "decompress_mbps": 65.27
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 50034,
+      "ratio": 0.3997,
+      "compress_mbps": 22.5,
+      "decompress_mbps": 65.59
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 48912,
+      "ratio": 0.3907,
+      "compress_mbps": 12.62,
+      "decompress_mbps": 65.42
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48738,
+      "ratio": 0.3893,
+      "compress_mbps": 11.77,
+      "decompress_mbps": 65.61
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48719,
+      "ratio": 0.3892,
+      "compress_mbps": 9.97,
+      "decompress_mbps": 65.88
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 48716,
+      "ratio": 0.3892,
+      "compress_mbps": 9.9,
+      "decompress_mbps": 68.31
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 48716,
+      "ratio": 0.3892,
+      "compress_mbps": 12.58,
+      "decompress_mbps": 64.73
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 8988,
+      "ratio": 0.3653,
+      "compress_mbps": 36.94,
+      "decompress_mbps": 103.46
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8564,
+      "ratio": 0.3481,
+      "compress_mbps": 43.51,
+      "decompress_mbps": 102.54
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8390,
+      "ratio": 0.341,
+      "compress_mbps": 28.97,
+      "decompress_mbps": 97.31
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8167,
+      "ratio": 0.332,
+      "compress_mbps": 37.49,
+      "decompress_mbps": 98.37
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 7965,
+      "ratio": 0.3237,
+      "compress_mbps": 28.72,
+      "decompress_mbps": 88.78
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7916,
+      "ratio": 0.3217,
+      "compress_mbps": 22.76,
+      "decompress_mbps": 104.8
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7900,
+      "ratio": 0.3211,
+      "compress_mbps": 21.67,
+      "decompress_mbps": 85.25
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7900,
+      "ratio": 0.3211,
+      "compress_mbps": 20.13,
+      "decompress_mbps": 105.7
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7900,
+      "ratio": 0.3211,
+      "compress_mbps": 27.55,
+      "decompress_mbps": 92.8
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3731,
+      "ratio": 0.3346,
+      "compress_mbps": 18.9,
+      "decompress_mbps": 80.13
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3491,
+      "ratio": 0.3131,
+      "compress_mbps": 23.63,
+      "decompress_mbps": 84.66
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3384,
+      "ratio": 0.3035,
+      "compress_mbps": 22.04,
+      "decompress_mbps": 89.77
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3220,
+      "ratio": 0.2888,
+      "compress_mbps": 21.08,
+      "decompress_mbps": 86.53
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3138,
+      "ratio": 0.2814,
+      "compress_mbps": 17.11,
+      "decompress_mbps": 93.05
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3118,
+      "ratio": 0.2796,
+      "compress_mbps": 15.03,
+      "decompress_mbps": 100.03
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3116,
+      "ratio": 0.2795,
+      "compress_mbps": 14.26,
+      "decompress_mbps": 96.56
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3116,
+      "ratio": 0.2795,
+      "compress_mbps": 14.4,
+      "decompress_mbps": 104.06
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3116,
+      "ratio": 0.2795,
+      "compress_mbps": 15.81,
+      "decompress_mbps": 101.86
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1352,
+      "ratio": 0.3633,
+      "compress_mbps": 8.47,
+      "decompress_mbps": 63.54
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1287,
+      "ratio": 0.3459,
+      "compress_mbps": 11.63,
+      "decompress_mbps": 60.62
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1284,
+      "ratio": 0.3451,
+      "compress_mbps": 11.67,
+      "decompress_mbps": 62.5
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1226,
+      "ratio": 0.3295,
+      "compress_mbps": 11.31,
+      "decompress_mbps": 66.96
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1211,
+      "ratio": 0.3255,
+      "compress_mbps": 9.84,
+      "decompress_mbps": 63.24
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1211,
+      "ratio": 0.3255,
+      "compress_mbps": 10.84,
+      "decompress_mbps": 63.7
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1211,
+      "ratio": 0.3255,
+      "compress_mbps": 10.02,
+      "decompress_mbps": 64.11
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1211,
+      "ratio": 0.3255,
+      "compress_mbps": 10.74,
+      "decompress_mbps": 80.94
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1211,
+      "ratio": 0.3255,
+      "compress_mbps": 11.17,
+      "decompress_mbps": 63.88
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 245423,
+      "ratio": 0.2383,
+      "compress_mbps": 123.71,
+      "decompress_mbps": 127.4
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 229642,
+      "ratio": 0.223,
+      "compress_mbps": 92.84,
+      "decompress_mbps": 151.73
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 225678,
+      "ratio": 0.2192,
+      "compress_mbps": 109.83,
+      "decompress_mbps": 153.59
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 218218,
+      "ratio": 0.2119,
+      "compress_mbps": 99.82,
+      "decompress_mbps": 163.61
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 210550,
+      "ratio": 0.2045,
+      "compress_mbps": 48.7,
+      "decompress_mbps": 154.12
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 207949,
+      "ratio": 0.2019,
+      "compress_mbps": 27.88,
+      "decompress_mbps": 168.6
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 207413,
+      "ratio": 0.2014,
+      "compress_mbps": 18.82,
+      "decompress_mbps": 151.74
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 207478,
+      "ratio": 0.2015,
+      "compress_mbps": 6.77,
+      "decompress_mbps": 153.16
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 207482,
+      "ratio": 0.2015,
+      "compress_mbps": 3.56,
+      "decompress_mbps": 157.49
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 175980,
+      "ratio": 0.4124,
+      "compress_mbps": 43.31,
+      "decompress_mbps": 64.49
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 160455,
+      "ratio": 0.376,
+      "compress_mbps": 70.41,
+      "decompress_mbps": 72.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 156690,
+      "ratio": 0.3672,
+      "compress_mbps": 32.21,
+      "decompress_mbps": 74.1
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 149064,
+      "ratio": 0.3493,
+      "compress_mbps": 36.48,
+      "decompress_mbps": 75.59
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 145616,
+      "ratio": 0.3412,
+      "compress_mbps": 20.01,
+      "decompress_mbps": 76.95
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 144773,
+      "ratio": 0.3392,
+      "compress_mbps": 17.53,
+      "decompress_mbps": 76.34
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 144603,
+      "ratio": 0.3388,
+      "compress_mbps": 19.93,
+      "decompress_mbps": 75.91
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 144573,
+      "ratio": 0.3388,
+      "compress_mbps": 16.49,
+      "decompress_mbps": 80.22
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 144570,
+      "ratio": 0.3388,
+      "compress_mbps": 15.68,
+      "decompress_mbps": 75.93
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 228837,
+      "ratio": 0.4749,
+      "compress_mbps": 35.31,
+      "decompress_mbps": 54.63
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 211248,
+      "ratio": 0.4384,
+      "compress_mbps": 31.57,
+      "decompress_mbps": 61.56
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 205619,
+      "ratio": 0.4267,
+      "compress_mbps": 25.52,
+      "decompress_mbps": 67.59
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 200595,
+      "ratio": 0.4163,
+      "compress_mbps": 34.86,
+      "decompress_mbps": 66.46
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 195418,
+      "ratio": 0.4055,
+      "compress_mbps": 18.88,
+      "decompress_mbps": 65.35
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 194148,
+      "ratio": 0.4029,
+      "compress_mbps": 15.2,
+      "decompress_mbps": 66.36
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 193994,
+      "ratio": 0.4026,
+      "compress_mbps": 16.61,
+      "decompress_mbps": 66.46
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 193991,
+      "ratio": 0.4026,
+      "compress_mbps": 14.97,
+      "decompress_mbps": 65.37
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 193991,
+      "ratio": 0.4026,
+      "compress_mbps": 14.75,
+      "decompress_mbps": 80.17
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 60990,
+      "ratio": 0.1188,
+      "compress_mbps": 240.46,
+      "decompress_mbps": 173.43
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 61650,
+      "ratio": 0.1201,
+      "compress_mbps": 103.12,
+      "decompress_mbps": 188.54
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 60035,
+      "ratio": 0.117,
+      "compress_mbps": 90.48,
+      "decompress_mbps": 205.17
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 57005,
+      "ratio": 0.1111,
+      "compress_mbps": 91.56,
+      "decompress_mbps": 195.56
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 55779,
+      "ratio": 0.1087,
+      "compress_mbps": 81.64,
+      "decompress_mbps": 263.29
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 54970,
+      "ratio": 0.1071,
+      "compress_mbps": 69.16,
+      "decompress_mbps": 204.84
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 53922,
+      "ratio": 0.1051,
+      "compress_mbps": 76.91,
+      "decompress_mbps": 217.15
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 51977,
+      "ratio": 0.1013,
+      "compress_mbps": 17.63,
+      "decompress_mbps": 275.85
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 51474,
+      "ratio": 0.1003,
+      "compress_mbps": 6.71,
+      "decompress_mbps": 239.18
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 14783,
+      "ratio": 0.3866,
+      "compress_mbps": 32.71,
+      "decompress_mbps": 70.98
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 14101,
+      "ratio": 0.3688,
+      "compress_mbps": 33.16,
+      "decompress_mbps": 78.17
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13975,
+      "ratio": 0.3655,
+      "compress_mbps": 28.17,
+      "decompress_mbps": 75.22
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13632,
+      "ratio": 0.3565,
+      "compress_mbps": 30.93,
+      "decompress_mbps": 100.62
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13302,
+      "ratio": 0.3479,
+      "compress_mbps": 25.78,
+      "decompress_mbps": 79.98
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 13279,
+      "ratio": 0.3473,
+      "compress_mbps": 21.9,
+      "decompress_mbps": 77.99
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 13274,
+      "ratio": 0.3471,
+      "compress_mbps": 19.14,
+      "decompress_mbps": 84.74
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 13260,
+      "ratio": 0.3468,
+      "compress_mbps": 7.15,
+      "decompress_mbps": 80.47
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 13260,
+      "ratio": 0.3468,
+      "compress_mbps": 4.57,
+      "decompress_mbps": 79.18
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1862,
+      "ratio": 0.4405,
+      "compress_mbps": 9.05,
+      "decompress_mbps": 61.67
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1803,
+      "ratio": 0.4265,
+      "compress_mbps": 12.61,
+      "decompress_mbps": 58.6
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1791,
+      "ratio": 0.4237,
+      "compress_mbps": 12.87,
+      "decompress_mbps": 60.15
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1746,
+      "ratio": 0.4131,
+      "compress_mbps": 12.23,
+      "decompress_mbps": 60.76
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1725,
+      "ratio": 0.4081,
+      "compress_mbps": 10.95,
+      "decompress_mbps": 59.77
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1725,
+      "ratio": 0.4081,
+      "compress_mbps": 11.32,
+      "decompress_mbps": 59.78
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1725,
+      "ratio": 0.4081,
+      "compress_mbps": 10.98,
+      "decompress_mbps": 65.28
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1725,
+      "ratio": 0.4081,
+      "compress_mbps": 11.09,
+      "decompress_mbps": 61.29
+    },
+    {
+      "compressor": "go",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1725,
+      "ratio": 0.4081,
+      "compress_mbps": 11.55,
+      "decompress_mbps": 61.79
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4623589,
+      "ratio": 0.4536,
+      "compress_mbps": 87.88,
+      "decompress_mbps": 121.47
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4241525,
+      "ratio": 0.4161,
+      "compress_mbps": 59.05,
+      "decompress_mbps": 124.77
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 4123202,
+      "ratio": 0.4045,
+      "compress_mbps": 61.06,
+      "decompress_mbps": 116.15
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 3985937,
+      "ratio": 0.3911,
+      "compress_mbps": 60.91,
+      "decompress_mbps": 204.23
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3883839,
+      "ratio": 0.3811,
+      "compress_mbps": 35.59,
+      "decompress_mbps": 119.76
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3860437,
+      "ratio": 0.3788,
+      "compress_mbps": 27.93,
+      "decompress_mbps": 202.6
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3857076,
+      "ratio": 0.3784,
+      "compress_mbps": 25.13,
+      "decompress_mbps": 126.89
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3856651,
+      "ratio": 0.3784,
+      "compress_mbps": 24.66,
+      "decompress_mbps": 202.36
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3856651,
+      "ratio": 0.3784,
+      "compress_mbps": 24.68,
+      "decompress_mbps": 116.01
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 21508211,
+      "ratio": 0.4199,
+      "compress_mbps": 143.1,
+      "decompress_mbps": 239.36
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 20538783,
+      "ratio": 0.401,
+      "compress_mbps": 103.18,
+      "decompress_mbps": 229.73
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 20334352,
+      "ratio": 0.397,
+      "compress_mbps": 88.51,
+      "decompress_mbps": 208.07
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19886937,
+      "ratio": 0.3883,
+      "compress_mbps": 86.76,
+      "decompress_mbps": 244.41
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19582363,
+      "ratio": 0.3823,
+      "compress_mbps": 65.59,
+      "decompress_mbps": 239.15
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19512479,
+      "ratio": 0.381,
+      "compress_mbps": 43.56,
+      "decompress_mbps": 220.01
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19489160,
+      "ratio": 0.3805,
+      "compress_mbps": 32.93,
+      "decompress_mbps": 227.82
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19475109,
+      "ratio": 0.3802,
+      "compress_mbps": 18.63,
+      "decompress_mbps": 225.38
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19476276,
+      "ratio": 0.3802,
+      "compress_mbps": 10.28,
+      "decompress_mbps": 247.36
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3967718,
+      "ratio": 0.3979,
+      "compress_mbps": 146.76,
+      "decompress_mbps": 172.01
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3773274,
+      "ratio": 0.3784,
+      "compress_mbps": 105.47,
+      "decompress_mbps": 124.64
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3670460,
+      "ratio": 0.3681,
+      "compress_mbps": 77.56,
+      "decompress_mbps": 182.34
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3655100,
+      "ratio": 0.3666,
+      "compress_mbps": 87.36,
+      "decompress_mbps": 107.18
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3620881,
+      "ratio": 0.3632,
+      "compress_mbps": 51.01,
+      "decompress_mbps": 125.34
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3606626,
+      "ratio": 0.3617,
+      "compress_mbps": 33.83,
+      "decompress_mbps": 183.58
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3605405,
+      "ratio": 0.3616,
+      "compress_mbps": 31.23,
+      "decompress_mbps": 130.79
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3601635,
+      "ratio": 0.3612,
+      "compress_mbps": 26.28,
+      "decompress_mbps": 133.31
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3601151,
+      "ratio": 0.3612,
+      "compress_mbps": 19.51,
+      "decompress_mbps": 120.72
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 4501482,
+      "ratio": 0.1342,
+      "compress_mbps": 294.72,
+      "decompress_mbps": 451.24
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 3875891,
+      "ratio": 0.1155,
+      "compress_mbps": 315.51,
+      "decompress_mbps": 356.45
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3731525,
+      "ratio": 0.1112,
+      "compress_mbps": 288.4,
+      "decompress_mbps": 372.55
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3542242,
+      "ratio": 0.1056,
+      "compress_mbps": 236.86,
+      "decompress_mbps": 484.44
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3239184,
+      "ratio": 0.0965,
+      "compress_mbps": 175.14,
+      "decompress_mbps": 539.55
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3113927,
+      "ratio": 0.0928,
+      "compress_mbps": 120.53,
+      "decompress_mbps": 330.65
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3063520,
+      "ratio": 0.0913,
+      "compress_mbps": 84.76,
+      "decompress_mbps": 331.22
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 2961320,
+      "ratio": 0.0883,
+      "compress_mbps": 29.61,
+      "decompress_mbps": 401.64
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2940087,
+      "ratio": 0.0876,
+      "compress_mbps": 20.54,
+      "decompress_mbps": 474.59
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3462708,
+      "ratio": 0.5628,
+      "compress_mbps": 65.77,
+      "decompress_mbps": 109.92
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3327399,
+      "ratio": 0.5408,
+      "compress_mbps": 71.78,
+      "decompress_mbps": 84.48
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3297422,
+      "ratio": 0.536,
+      "compress_mbps": 66.06,
+      "decompress_mbps": 89.69
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3249485,
+      "ratio": 0.5282,
+      "compress_mbps": 64.02,
+      "decompress_mbps": 122.88
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3220046,
+      "ratio": 0.5234,
+      "compress_mbps": 49.81,
+      "decompress_mbps": 90.58
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3213239,
+      "ratio": 0.5223,
+      "compress_mbps": 43.12,
+      "decompress_mbps": 91.3
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3212009,
+      "ratio": 0.5221,
+      "compress_mbps": 39.44,
+      "decompress_mbps": 177.12
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3211575,
+      "ratio": 0.522,
+      "compress_mbps": 27.92,
+      "decompress_mbps": 92.84
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3211561,
+      "ratio": 0.522,
+      "compress_mbps": 29.68,
+      "decompress_mbps": 92.12
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 4334497,
+      "ratio": 0.4298,
+      "compress_mbps": 130.93,
+      "decompress_mbps": 133.29
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3900156,
+      "ratio": 0.3867,
+      "compress_mbps": 131.77,
+      "decompress_mbps": 116.9
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3876099,
+      "ratio": 0.3843,
+      "compress_mbps": 122.94,
+      "decompress_mbps": 133.81
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3782364,
+      "ratio": 0.375,
+      "compress_mbps": 110.84,
+      "decompress_mbps": 135.49
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3679310,
+      "ratio": 0.3648,
+      "compress_mbps": 89.42,
+      "decompress_mbps": 136.59
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3679424,
+      "ratio": 0.3648,
+      "compress_mbps": 87.41,
+      "decompress_mbps": 128.99
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3679163,
+      "ratio": 0.3648,
+      "compress_mbps": 83.39,
+      "decompress_mbps": 141.56
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3679169,
+      "ratio": 0.3648,
+      "compress_mbps": 82.21,
+      "decompress_mbps": 140.66
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3679169,
+      "ratio": 0.3648,
+      "compress_mbps": 81.84,
+      "decompress_mbps": 196.94
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2496363,
+      "ratio": 0.3767,
+      "compress_mbps": 96.93,
+      "decompress_mbps": 111.19
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2202601,
+      "ratio": 0.3324,
+      "compress_mbps": 92.65,
+      "decompress_mbps": 102.3
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2103089,
+      "ratio": 0.3173,
+      "compress_mbps": 49.73,
+      "decompress_mbps": 242.36
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 1999697,
+      "ratio": 0.3017,
+      "compress_mbps": 75.29,
+      "decompress_mbps": 121.18
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1892143,
+      "ratio": 0.2855,
+      "compress_mbps": 37.29,
+      "decompress_mbps": 108.65
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1838372,
+      "ratio": 0.2774,
+      "compress_mbps": 20.3,
+      "decompress_mbps": 108.77
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1828850,
+      "ratio": 0.276,
+      "compress_mbps": 15.87,
+      "decompress_mbps": 115.22
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1823159,
+      "ratio": 0.2751,
+      "compress_mbps": 12.46,
+      "decompress_mbps": 114.31
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1823159,
+      "ratio": 0.2751,
+      "compress_mbps": 12.53,
+      "decompress_mbps": 97.46
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 6447290,
+      "ratio": 0.2984,
+      "compress_mbps": 187.76,
+      "decompress_mbps": 292.5
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 6030257,
+      "ratio": 0.2791,
+      "compress_mbps": 147.85,
+      "decompress_mbps": 241.28
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5928121,
+      "ratio": 0.2744,
+      "compress_mbps": 128.5,
+      "decompress_mbps": 269.87
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5615804,
+      "ratio": 0.2599,
+      "compress_mbps": 121.57,
+      "decompress_mbps": 280.75
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5496738,
+      "ratio": 0.2544,
+      "compress_mbps": 80.22,
+      "decompress_mbps": 336.14
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5464184,
+      "ratio": 0.2529,
+      "compress_mbps": 62.73,
+      "decompress_mbps": 195.35
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5429645,
+      "ratio": 0.2513,
+      "compress_mbps": 47.93,
+      "decompress_mbps": 214.77
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5418135,
+      "ratio": 0.2508,
+      "compress_mbps": 36.65,
+      "decompress_mbps": 241.37
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5416628,
+      "ratio": 0.2507,
+      "compress_mbps": 33.67,
+      "decompress_mbps": 233.28
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5759187,
+      "ratio": 0.7942,
+      "compress_mbps": 91.27,
+      "decompress_mbps": 158.91
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5619390,
+      "ratio": 0.7749,
+      "compress_mbps": 49.54,
+      "decompress_mbps": 94.64
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5560914,
+      "ratio": 0.7668,
+      "compress_mbps": 43.81,
+      "decompress_mbps": 115.78
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5544069,
+      "ratio": 0.7645,
+      "compress_mbps": 44.58,
+      "decompress_mbps": 94.11
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5518257,
+      "ratio": 0.7609,
+      "compress_mbps": 36.73,
+      "decompress_mbps": 163.59
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5508662,
+      "ratio": 0.7596,
+      "compress_mbps": 33.77,
+      "decompress_mbps": 95.01
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5507534,
+      "ratio": 0.7595,
+      "compress_mbps": 35.09,
+      "decompress_mbps": 95.76
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5507183,
+      "ratio": 0.7594,
+      "compress_mbps": 32.41,
+      "decompress_mbps": 94.54
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5507183,
+      "ratio": 0.7594,
+      "compress_mbps": 32.5,
+      "decompress_mbps": 117.56
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 15230651,
+      "ratio": 0.3674,
+      "compress_mbps": 123.36,
+      "decompress_mbps": 184.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 13822040,
+      "ratio": 0.3334,
+      "compress_mbps": 96.36,
+      "decompress_mbps": 194.1
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 13397592,
+      "ratio": 0.3232,
+      "compress_mbps": 83.62,
+      "decompress_mbps": 202.34
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12759940,
+      "ratio": 0.3078,
+      "compress_mbps": 80.4,
+      "decompress_mbps": 223.21
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12274278,
+      "ratio": 0.2961,
+      "compress_mbps": 54.6,
+      "decompress_mbps": 216.16
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12131738,
+      "ratio": 0.2926,
+      "compress_mbps": 40.41,
+      "decompress_mbps": 218.2
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12060450,
+      "ratio": 0.2909,
+      "compress_mbps": 33.43,
+      "decompress_mbps": 203.45
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12036900,
+      "ratio": 0.2903,
+      "compress_mbps": 29.91,
+      "decompress_mbps": 206.04
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12036900,
+      "ratio": 0.2903,
+      "compress_mbps": 30.01,
+      "decompress_mbps": 223.31
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6653052,
+      "ratio": 0.7851,
+      "compress_mbps": 124.38,
+      "decompress_mbps": 152.55
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6305035,
+      "ratio": 0.744,
+      "compress_mbps": 53.84,
+      "decompress_mbps": 154.18
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6302730,
+      "ratio": 0.7438,
+      "compress_mbps": 52.94,
+      "decompress_mbps": 119.64
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6299134,
+      "ratio": 0.7433,
+      "compress_mbps": 52.14,
+      "decompress_mbps": 156.45
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6289022,
+      "ratio": 0.7421,
+      "compress_mbps": 64.63,
+      "decompress_mbps": 159.21
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 6289013,
+      "ratio": 0.7421,
+      "compress_mbps": 50.64,
+      "decompress_mbps": 156.7
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 6289013,
+      "ratio": 0.7421,
+      "compress_mbps": 50.91,
+      "decompress_mbps": 165.38
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 6289012,
+      "ratio": 0.7421,
+      "compress_mbps": 64.4,
+      "decompress_mbps": 157.39
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 6289012,
+      "ratio": 0.7421,
+      "compress_mbps": 64.37,
+      "decompress_mbps": 98.54
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 989456,
+      "ratio": 0.1851,
+      "compress_mbps": 243.16,
+      "decompress_mbps": 153.25
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 839766,
+      "ratio": 0.1571,
+      "compress_mbps": 178.46,
+      "decompress_mbps": 169.75
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 800619,
+      "ratio": 0.1498,
+      "compress_mbps": 181.16,
+      "decompress_mbps": 178.28
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 776397,
+      "ratio": 0.1452,
+      "compress_mbps": 149.67,
+      "decompress_mbps": 185.03
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 712679,
+      "ratio": 0.1333,
+      "compress_mbps": 103.54,
+      "decompress_mbps": 199.06
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 683707,
+      "ratio": 0.1279,
+      "compress_mbps": 93.5,
+      "decompress_mbps": 512.66
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 668601,
+      "ratio": 0.1251,
+      "compress_mbps": 70.7,
+      "decompress_mbps": 209.33
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 659106,
+      "ratio": 0.1233,
+      "compress_mbps": 42.04,
+      "decompress_mbps": 216.57
+    },
+    {
+      "compressor": "go",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 658920,
+      "ratio": 0.1233,
+      "compress_mbps": 42.13,
+      "decompress_mbps": 256.07
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 62797,
+      "ratio": 0.4129,
+      "compress_mbps": 75.96,
+      "decompress_mbps": 132.29
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 59605,
+      "ratio": 0.3919,
+      "compress_mbps": 62.87,
+      "decompress_mbps": 131.77
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 57675,
+      "ratio": 0.3792,
+      "compress_mbps": 53.89,
+      "decompress_mbps": 124.29
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 56500,
+      "ratio": 0.3715,
+      "compress_mbps": 38.93,
+      "decompress_mbps": 131.16
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 56440,
+      "ratio": 0.3711,
+      "compress_mbps": 38.82,
+      "decompress_mbps": 130.65
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 55443,
+      "ratio": 0.3645,
+      "compress_mbps": 32.14,
+      "decompress_mbps": 146.84
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 55373,
+      "ratio": 0.3641,
+      "compress_mbps": 31.65,
+      "decompress_mbps": 130.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 55352,
+      "ratio": 0.3639,
+      "compress_mbps": 31.32,
+      "decompress_mbps": 136.96
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 55352,
+      "ratio": 0.3639,
+      "compress_mbps": 31.37,
+      "decompress_mbps": 135.72
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 55063,
+      "ratio": 0.4399,
+      "compress_mbps": 74.97,
+      "decompress_mbps": 117.68
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 52932,
+      "ratio": 0.4229,
+      "compress_mbps": 60.75,
+      "decompress_mbps": 116.27
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 51597,
+      "ratio": 0.4122,
+      "compress_mbps": 44.1,
+      "decompress_mbps": 116.24
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 50780,
+      "ratio": 0.4057,
+      "compress_mbps": 43.18,
+      "decompress_mbps": 120.67
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 50767,
+      "ratio": 0.4056,
+      "compress_mbps": 42.85,
+      "decompress_mbps": 122.05
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 50160,
+      "ratio": 0.4007,
+      "compress_mbps": 33.03,
+      "decompress_mbps": 128.52
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 50138,
+      "ratio": 0.4005,
+      "compress_mbps": 31.52,
+      "decompress_mbps": 124.51
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 50138,
+      "ratio": 0.4005,
+      "compress_mbps": 32.14,
+      "decompress_mbps": 125.83
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 50138,
+      "ratio": 0.4005,
+      "compress_mbps": 35.79,
+      "decompress_mbps": 124.35
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 8730,
+      "ratio": 0.3548,
+      "compress_mbps": 46.94,
+      "decompress_mbps": 123.4
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8457,
+      "ratio": 0.3437,
+      "compress_mbps": 43.65,
+      "decompress_mbps": 119.12
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8353,
+      "ratio": 0.3395,
+      "compress_mbps": 64.98,
+      "decompress_mbps": 109.7
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8301,
+      "ratio": 0.3374,
+      "compress_mbps": 42.45,
+      "decompress_mbps": 124.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 8212,
+      "ratio": 0.3338,
+      "compress_mbps": 58.84,
+      "decompress_mbps": 103.81
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 8172,
+      "ratio": 0.3322,
+      "compress_mbps": 48.55,
+      "decompress_mbps": 108.53
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 8171,
+      "ratio": 0.3321,
+      "compress_mbps": 50.28,
+      "decompress_mbps": 109.3
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 8171,
+      "ratio": 0.3321,
+      "compress_mbps": 49.23,
+      "decompress_mbps": 109.09
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 8171,
+      "ratio": 0.3321,
+      "compress_mbps": 53.75,
+      "decompress_mbps": 109.08
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3475,
+      "ratio": 0.3117,
+      "compress_mbps": 109.11,
+      "decompress_mbps": 96.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3305,
+      "ratio": 0.2964,
+      "compress_mbps": 102.67,
+      "decompress_mbps": 101.78
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3225,
+      "ratio": 0.2892,
+      "compress_mbps": 91.21,
+      "decompress_mbps": 104.25
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3192,
+      "ratio": 0.2863,
+      "compress_mbps": 100.3,
+      "decompress_mbps": 104.85
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3180,
+      "ratio": 0.2852,
+      "compress_mbps": 100.47,
+      "decompress_mbps": 98.18
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3168,
+      "ratio": 0.2841,
+      "compress_mbps": 94.55,
+      "decompress_mbps": 99.39
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3168,
+      "ratio": 0.2841,
+      "compress_mbps": 95.62,
+      "decompress_mbps": 95.6
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3168,
+      "ratio": 0.2841,
+      "compress_mbps": 91.52,
+      "decompress_mbps": 121.63
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3168,
+      "ratio": 0.2841,
+      "compress_mbps": 83.09,
+      "decompress_mbps": 95.05
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1275,
+      "ratio": 0.3426,
+      "compress_mbps": 59.58,
+      "decompress_mbps": 44.37
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1247,
+      "ratio": 0.3351,
+      "compress_mbps": 59.47,
+      "decompress_mbps": 52.13
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1239,
+      "ratio": 0.333,
+      "compress_mbps": 56.69,
+      "decompress_mbps": 51.11
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1238,
+      "ratio": 0.3327,
+      "compress_mbps": 58.55,
+      "decompress_mbps": 50.63
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1239,
+      "ratio": 0.333,
+      "compress_mbps": 48.99,
+      "decompress_mbps": 51.01
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1237,
+      "ratio": 0.3324,
+      "compress_mbps": 56.51,
+      "decompress_mbps": 50.1
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1237,
+      "ratio": 0.3324,
+      "compress_mbps": 55.71,
+      "decompress_mbps": 51.27
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1237,
+      "ratio": 0.3324,
+      "compress_mbps": 50.22,
+      "decompress_mbps": 48.37
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1237,
+      "ratio": 0.3324,
+      "compress_mbps": 55.39,
+      "decompress_mbps": 48.56
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 226284,
+      "ratio": 0.2197,
+      "compress_mbps": 113.28,
+      "decompress_mbps": 183.05
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 221369,
+      "ratio": 0.215,
+      "compress_mbps": 90.24,
+      "decompress_mbps": 255.24
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 218607,
+      "ratio": 0.2123,
+      "compress_mbps": 78.67,
+      "decompress_mbps": 187.61
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 217919,
+      "ratio": 0.2116,
+      "compress_mbps": 69.94,
+      "decompress_mbps": 195.29
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 217919,
+      "ratio": 0.2116,
+      "compress_mbps": 70.92,
+      "decompress_mbps": 195.59
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 217312,
+      "ratio": 0.211,
+      "compress_mbps": 44.09,
+      "decompress_mbps": 191.18
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 215966,
+      "ratio": 0.2097,
+      "compress_mbps": 31.15,
+      "decompress_mbps": 191.54
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 215930,
+      "ratio": 0.2097,
+      "compress_mbps": 14.32,
+      "decompress_mbps": 194.26
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 215912,
+      "ratio": 0.2097,
+      "compress_mbps": 11.1,
+      "decompress_mbps": 210.59
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 167622,
+      "ratio": 0.3928,
+      "compress_mbps": 64.39,
+      "decompress_mbps": 116.3
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 158003,
+      "ratio": 0.3702,
+      "compress_mbps": 64.34,
+      "decompress_mbps": 139.36
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 152928,
+      "ratio": 0.3584,
+      "compress_mbps": 46.67,
+      "decompress_mbps": 141.08
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 149886,
+      "ratio": 0.3512,
+      "compress_mbps": 33.71,
+      "decompress_mbps": 136.65
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 149767,
+      "ratio": 0.3509,
+      "compress_mbps": 39.31,
+      "decompress_mbps": 138
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 147818,
+      "ratio": 0.3464,
+      "compress_mbps": 33.18,
+      "decompress_mbps": 150.78
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 147733,
+      "ratio": 0.3462,
+      "compress_mbps": 32.42,
+      "decompress_mbps": 154.24
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 147709,
+      "ratio": 0.3461,
+      "compress_mbps": 32.15,
+      "decompress_mbps": 151.45
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 147705,
+      "ratio": 0.3461,
+      "compress_mbps": 32.65,
+      "decompress_mbps": 138.19
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 222866,
+      "ratio": 0.4625,
+      "compress_mbps": 58.92,
+      "decompress_mbps": 105.16
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 212925,
+      "ratio": 0.4419,
+      "compress_mbps": 49.52,
+      "decompress_mbps": 118.08
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 206913,
+      "ratio": 0.4294,
+      "compress_mbps": 40.5,
+      "decompress_mbps": 116.88
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 202875,
+      "ratio": 0.421,
+      "compress_mbps": 33.54,
+      "decompress_mbps": 111.31
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 202867,
+      "ratio": 0.421,
+      "compress_mbps": 33.57,
+      "decompress_mbps": 117.4
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 199818,
+      "ratio": 0.4147,
+      "compress_mbps": 28.4,
+      "decompress_mbps": 114.8
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 199664,
+      "ratio": 0.4144,
+      "compress_mbps": 27.76,
+      "decompress_mbps": 105.02
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 199634,
+      "ratio": 0.4143,
+      "compress_mbps": 28.19,
+      "decompress_mbps": 106.5
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 199634,
+      "ratio": 0.4143,
+      "compress_mbps": 27.99,
+      "decompress_mbps": 121
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 60580,
+      "ratio": 0.118,
+      "compress_mbps": 118.15,
+      "decompress_mbps": 253.84
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 59663,
+      "ratio": 0.1163,
+      "compress_mbps": 131.11,
+      "decompress_mbps": 295.73
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 59465,
+      "ratio": 0.1159,
+      "compress_mbps": 100.74,
+      "decompress_mbps": 295.91
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 59353,
+      "ratio": 0.1156,
+      "compress_mbps": 95.09,
+      "decompress_mbps": 302.88
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 58830,
+      "ratio": 0.1146,
+      "compress_mbps": 107.76,
+      "decompress_mbps": 221.47
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 57884,
+      "ratio": 0.1128,
+      "compress_mbps": 56.85,
+      "decompress_mbps": 285.29
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 57206,
+      "ratio": 0.1115,
+      "compress_mbps": 46.17,
+      "decompress_mbps": 299.77
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 56545,
+      "ratio": 0.1102,
+      "compress_mbps": 23.09,
+      "decompress_mbps": 280.1
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 56454,
+      "ratio": 0.11,
+      "compress_mbps": 9.11,
+      "decompress_mbps": 300.36
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 14194,
+      "ratio": 0.3712,
+      "compress_mbps": 83.27,
+      "decompress_mbps": 134.84
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 13770,
+      "ratio": 0.3601,
+      "compress_mbps": 74.14,
+      "decompress_mbps": 116.53
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13611,
+      "ratio": 0.3559,
+      "compress_mbps": 66.24,
+      "decompress_mbps": 115.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13534,
+      "ratio": 0.3539,
+      "compress_mbps": 61.31,
+      "decompress_mbps": 117.96
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13527,
+      "ratio": 0.3537,
+      "compress_mbps": 61.97,
+      "decompress_mbps": 148.27
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 13438,
+      "ratio": 0.3514,
+      "compress_mbps": 51.17,
+      "decompress_mbps": 142.65
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 13419,
+      "ratio": 0.3509,
+      "compress_mbps": 47.83,
+      "decompress_mbps": 125.84
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 13404,
+      "ratio": 0.3505,
+      "compress_mbps": 41.2,
+      "decompress_mbps": 118.77
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 13390,
+      "ratio": 0.3502,
+      "compress_mbps": 35.78,
+      "decompress_mbps": 116.99
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1832,
+      "ratio": 0.4334,
+      "compress_mbps": 41.01,
+      "decompress_mbps": 45
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1776,
+      "ratio": 0.4202,
+      "compress_mbps": 58.71,
+      "decompress_mbps": 64.9
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1764,
+      "ratio": 0.4173,
+      "compress_mbps": 57.37,
+      "decompress_mbps": 62.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1763,
+      "ratio": 0.4171,
+      "compress_mbps": 56.88,
+      "decompress_mbps": 53.28
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 59.36,
+      "decompress_mbps": 48.79
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 40.25,
+      "decompress_mbps": 47.27
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 57.06,
+      "decompress_mbps": 48.39
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 58.67,
+      "decompress_mbps": 52.39
+    },
+    {
+      "compressor": "js",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1760,
+      "ratio": 0.4164,
+      "compress_mbps": 58.3,
+      "decompress_mbps": 62.91
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 4462632,
+      "ratio": 0.4378,
+      "compress_mbps": 61.62,
+      "decompress_mbps": 170.85
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4244833,
+      "ratio": 0.4165,
+      "compress_mbps": 50.24,
+      "decompress_mbps": 201.42
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 4112285,
+      "ratio": 0.4035,
+      "compress_mbps": 42.04,
+      "decompress_mbps": 178.21
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 4020435,
+      "ratio": 0.3945,
+      "compress_mbps": 35.5,
+      "decompress_mbps": 142.52
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 4019177,
+      "ratio": 0.3943,
+      "compress_mbps": 35.31,
+      "decompress_mbps": 170.54
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3956464,
+      "ratio": 0.3882,
+      "compress_mbps": 28.75,
+      "decompress_mbps": 164.24
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3953310,
+      "ratio": 0.3879,
+      "compress_mbps": 28.47,
+      "decompress_mbps": 198.87
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3952872,
+      "ratio": 0.3878,
+      "compress_mbps": 29.08,
+      "decompress_mbps": 220.53
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3952872,
+      "ratio": 0.3878,
+      "compress_mbps": 29.21,
+      "decompress_mbps": 218.12
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 20177423,
+      "ratio": 0.3939,
+      "compress_mbps": 72.68,
+      "decompress_mbps": 209.54
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 19759467,
+      "ratio": 0.3858,
+      "compress_mbps": 63.85,
+      "decompress_mbps": 193.45
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19583171,
+      "ratio": 0.3823,
+      "compress_mbps": 57.14,
+      "decompress_mbps": 206.47
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19479125,
+      "ratio": 0.3803,
+      "compress_mbps": 51.03,
+      "decompress_mbps": 205.14
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19423693,
+      "ratio": 0.3792,
+      "compress_mbps": 49.13,
+      "decompress_mbps": 200.07
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19337683,
+      "ratio": 0.3775,
+      "compress_mbps": 36.05,
+      "decompress_mbps": 188.48
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19323922,
+      "ratio": 0.3773,
+      "compress_mbps": 29.08,
+      "decompress_mbps": 193.94
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19314797,
+      "ratio": 0.3771,
+      "compress_mbps": 19.5,
+      "decompress_mbps": 225.36
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19312663,
+      "ratio": 0.377,
+      "compress_mbps": 11.12,
+      "decompress_mbps": 219.23
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3762978,
+      "ratio": 0.3774,
+      "compress_mbps": 78.68,
+      "decompress_mbps": 163.86
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3711615,
+      "ratio": 0.3723,
+      "compress_mbps": 68.1,
+      "decompress_mbps": 196.85
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3663131,
+      "ratio": 0.3674,
+      "compress_mbps": 57.01,
+      "decompress_mbps": 241.11
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3631512,
+      "ratio": 0.3642,
+      "compress_mbps": 49.21,
+      "decompress_mbps": 221.03
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3630867,
+      "ratio": 0.3642,
+      "compress_mbps": 48.78,
+      "decompress_mbps": 216.62
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3615953,
+      "ratio": 0.3627,
+      "compress_mbps": 37.72,
+      "decompress_mbps": 247.65
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3615518,
+      "ratio": 0.3626,
+      "compress_mbps": 35.3,
+      "decompress_mbps": 189.82
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3613845,
+      "ratio": 0.3625,
+      "compress_mbps": 30.03,
+      "decompress_mbps": 255.34
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3614283,
+      "ratio": 0.3625,
+      "compress_mbps": 26.24,
+      "decompress_mbps": 222.16
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 4418800,
+      "ratio": 0.1317,
+      "compress_mbps": 133,
+      "decompress_mbps": 338.57
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 4026774,
+      "ratio": 0.12,
+      "compress_mbps": 123.44,
+      "decompress_mbps": 339.7
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3837798,
+      "ratio": 0.1144,
+      "compress_mbps": 116.34,
+      "decompress_mbps": 370.54
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3751023,
+      "ratio": 0.1118,
+      "compress_mbps": 110.1,
+      "decompress_mbps": 361.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3643468,
+      "ratio": 0.1086,
+      "compress_mbps": 101.98,
+      "decompress_mbps": 371.36
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3379481,
+      "ratio": 0.1007,
+      "compress_mbps": 68.99,
+      "decompress_mbps": 366.05
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3354082,
+      "ratio": 0.1,
+      "compress_mbps": 61.49,
+      "decompress_mbps": 366.51
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 3330028,
+      "ratio": 0.0992,
+      "compress_mbps": 49.65,
+      "decompress_mbps": 396.52
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 3327482,
+      "ratio": 0.0992,
+      "compress_mbps": 37.41,
+      "decompress_mbps": 367.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3233790,
+      "ratio": 0.5256,
+      "compress_mbps": 52.65,
+      "decompress_mbps": 141.02
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3184644,
+      "ratio": 0.5176,
+      "compress_mbps": 48.35,
+      "decompress_mbps": 141.34
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3160521,
+      "ratio": 0.5137,
+      "compress_mbps": 44.16,
+      "decompress_mbps": 134.37
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3141929,
+      "ratio": 0.5107,
+      "compress_mbps": 40.04,
+      "decompress_mbps": 150.29
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3138514,
+      "ratio": 0.5101,
+      "compress_mbps": 39.11,
+      "decompress_mbps": 134.68
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3126843,
+      "ratio": 0.5082,
+      "compress_mbps": 32.81,
+      "decompress_mbps": 149.93
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3126796,
+      "ratio": 0.5082,
+      "compress_mbps": 30.63,
+      "decompress_mbps": 145.05
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3126322,
+      "ratio": 0.5082,
+      "compress_mbps": 27.28,
+      "decompress_mbps": 153.07
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3126286,
+      "ratio": 0.5082,
+      "compress_mbps": 23.43,
+      "decompress_mbps": 154.77
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 4076349,
+      "ratio": 0.4042,
+      "compress_mbps": 79.56,
+      "decompress_mbps": 217.72
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3914739,
+      "ratio": 0.3881,
+      "compress_mbps": 72.11,
+      "decompress_mbps": 235.6
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3845160,
+      "ratio": 0.3812,
+      "compress_mbps": 68.92,
+      "decompress_mbps": 265.95
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3822047,
+      "ratio": 0.379,
+      "compress_mbps": 65.9,
+      "decompress_mbps": 249.1
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3799472,
+      "ratio": 0.3767,
+      "compress_mbps": 60.47,
+      "decompress_mbps": 196.63
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3783861,
+      "ratio": 0.3752,
+      "compress_mbps": 59.24,
+      "decompress_mbps": 206.2
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3783432,
+      "ratio": 0.3751,
+      "compress_mbps": 57.5,
+      "decompress_mbps": 276.55
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3783342,
+      "ratio": 0.3751,
+      "compress_mbps": 57.79,
+      "decompress_mbps": 278.67
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3783342,
+      "ratio": 0.3751,
+      "compress_mbps": 57.86,
+      "decompress_mbps": 279.64
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2261112,
+      "ratio": 0.3412,
+      "compress_mbps": 71.4,
+      "decompress_mbps": 216.97
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2128691,
+      "ratio": 0.3212,
+      "compress_mbps": 58.57,
+      "decompress_mbps": 197.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2049023,
+      "ratio": 0.3092,
+      "compress_mbps": 48.53,
+      "decompress_mbps": 209.61
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 1990249,
+      "ratio": 0.3003,
+      "compress_mbps": 41.12,
+      "decompress_mbps": 207.91
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1975224,
+      "ratio": 0.298,
+      "compress_mbps": 39.61,
+      "decompress_mbps": 151.52
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1910262,
+      "ratio": 0.2882,
+      "compress_mbps": 28.21,
+      "decompress_mbps": 164.32
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1902923,
+      "ratio": 0.2871,
+      "compress_mbps": 25.04,
+      "decompress_mbps": 221.63
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1900964,
+      "ratio": 0.2868,
+      "compress_mbps": 23.45,
+      "decompress_mbps": 227.66
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1900958,
+      "ratio": 0.2868,
+      "compress_mbps": 24.4,
+      "decompress_mbps": 207.65
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 6016919,
+      "ratio": 0.2785,
+      "compress_mbps": 92.31,
+      "decompress_mbps": 250.38
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 5767272,
+      "ratio": 0.2669,
+      "compress_mbps": 81.02,
+      "decompress_mbps": 287.18
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5669548,
+      "ratio": 0.2624,
+      "compress_mbps": 75.87,
+      "decompress_mbps": 211.21
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5619947,
+      "ratio": 0.2601,
+      "compress_mbps": 68.8,
+      "decompress_mbps": 271.25
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5586034,
+      "ratio": 0.2585,
+      "compress_mbps": 64.77,
+      "decompress_mbps": 270.13
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5540130,
+      "ratio": 0.2564,
+      "compress_mbps": 50.72,
+      "decompress_mbps": 269.04
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5537271,
+      "ratio": 0.2563,
+      "compress_mbps": 45.58,
+      "decompress_mbps": 209.67
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5530686,
+      "ratio": 0.256,
+      "compress_mbps": 35.75,
+      "decompress_mbps": 303.18
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5529823,
+      "ratio": 0.2559,
+      "compress_mbps": 31.59,
+      "decompress_mbps": 227.31
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5602819,
+      "ratio": 0.7726,
+      "compress_mbps": 47.72,
+      "decompress_mbps": 166.89
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5504019,
+      "ratio": 0.759,
+      "compress_mbps": 42.76,
+      "decompress_mbps": 153.39
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5452816,
+      "ratio": 0.7519,
+      "compress_mbps": 38.01,
+      "decompress_mbps": 153.91
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5425752,
+      "ratio": 0.7482,
+      "compress_mbps": 35.6,
+      "decompress_mbps": 177.63
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5425752,
+      "ratio": 0.7482,
+      "compress_mbps": 36.17,
+      "decompress_mbps": 176.78
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5407602,
+      "ratio": 0.7457,
+      "compress_mbps": 30.72,
+      "decompress_mbps": 153.42
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5406417,
+      "ratio": 0.7455,
+      "compress_mbps": 30.08,
+      "decompress_mbps": 155.44
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5406380,
+      "ratio": 0.7455,
+      "compress_mbps": 30.76,
+      "decompress_mbps": 154.32
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5406380,
+      "ratio": 0.7455,
+      "compress_mbps": 30.68,
+      "decompress_mbps": 117.26
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 14342407,
+      "ratio": 0.3459,
+      "compress_mbps": 73.52,
+      "decompress_mbps": 197.71
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 13424966,
+      "ratio": 0.3238,
+      "compress_mbps": 63.27,
+      "decompress_mbps": 213.25
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 13061399,
+      "ratio": 0.315,
+      "compress_mbps": 56.27,
+      "decompress_mbps": 222.06
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12877207,
+      "ratio": 0.3106,
+      "compress_mbps": 49.84,
+      "decompress_mbps": 208.96
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12671090,
+      "ratio": 0.3056,
+      "compress_mbps": 47.71,
+      "decompress_mbps": 209.63
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12511088,
+      "ratio": 0.3018,
+      "compress_mbps": 40.67,
+      "decompress_mbps": 235.26
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12503313,
+      "ratio": 0.3016,
+      "compress_mbps": 39.02,
+      "decompress_mbps": 224.89
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12502263,
+      "ratio": 0.3016,
+      "compress_mbps": 39.56,
+      "decompress_mbps": 227.39
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12502263,
+      "ratio": 0.3016,
+      "compress_mbps": 39.56,
+      "decompress_mbps": 225.48
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6022390,
+      "ratio": 0.7107,
+      "compress_mbps": 54.31,
+      "decompress_mbps": 145.97
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 5997124,
+      "ratio": 0.7077,
+      "compress_mbps": 48.84,
+      "decompress_mbps": 145.24
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 5979254,
+      "ratio": 0.7056,
+      "compress_mbps": 43.2,
+      "decompress_mbps": 149.3
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 5967955,
+      "ratio": 0.7042,
+      "compress_mbps": 42.03,
+      "decompress_mbps": 178.27
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 5967953,
+      "ratio": 0.7042,
+      "compress_mbps": 42.1,
+      "decompress_mbps": 155.23
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 5965386,
+      "ratio": 0.7039,
+      "compress_mbps": 41.26,
+      "decompress_mbps": 150.17
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 5965383,
+      "ratio": 0.7039,
+      "compress_mbps": 41,
+      "decompress_mbps": 152.03
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 5965383,
+      "ratio": 0.7039,
+      "compress_mbps": 40.8,
+      "decompress_mbps": 151.14
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 5965383,
+      "ratio": 0.7039,
+      "compress_mbps": 41.86,
+      "decompress_mbps": 155
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 985606,
+      "ratio": 0.1844,
+      "compress_mbps": 111.12,
+      "decompress_mbps": 305.94
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 852636,
+      "ratio": 0.1595,
+      "compress_mbps": 102.74,
+      "decompress_mbps": 250.95
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 814293,
+      "ratio": 0.1523,
+      "compress_mbps": 96.19,
+      "decompress_mbps": 221.84
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 788388,
+      "ratio": 0.1475,
+      "compress_mbps": 89.39,
+      "decompress_mbps": 250.71
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 749390,
+      "ratio": 0.1402,
+      "compress_mbps": 83.47,
+      "decompress_mbps": 304.92
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 706892,
+      "ratio": 0.1322,
+      "compress_mbps": 64.12,
+      "decompress_mbps": 266.99
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 705695,
+      "ratio": 0.132,
+      "compress_mbps": 64.27,
+      "decompress_mbps": 329.56
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 703904,
+      "ratio": 0.1317,
+      "compress_mbps": 61.16,
+      "decompress_mbps": 268.63
+    },
+    {
+      "compressor": "js",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 703900,
+      "ratio": 0.1317,
+      "compress_mbps": 60.89,
+      "decompress_mbps": 396.78
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 56099,
+      "ratio": 0.3689,
+      "compress_mbps": 88.44,
+      "decompress_mbps": 310.31
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 56099,
+      "ratio": 0.3689,
+      "compress_mbps": 87.92,
+      "decompress_mbps": 310.59
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 56099,
+      "ratio": 0.3689,
+      "compress_mbps": 88.84,
+      "decompress_mbps": 310.08
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 56099,
+      "ratio": 0.3689,
+      "compress_mbps": 88.64,
+      "decompress_mbps": 314.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 54531,
+      "ratio": 0.3585,
+      "compress_mbps": 55.46,
+      "decompress_mbps": 303.62
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 54068,
+      "ratio": 0.3555,
+      "compress_mbps": 42.11,
+      "decompress_mbps": 310.13
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 54003,
+      "ratio": 0.3551,
+      "compress_mbps": 37.45,
+      "decompress_mbps": 307.64
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 53974,
+      "ratio": 0.3549,
+      "compress_mbps": 33.15,
+      "decompress_mbps": 306.21
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 53974,
+      "ratio": 0.3549,
+      "compress_mbps": 33.03,
+      "decompress_mbps": 307.58
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 50031,
+      "ratio": 0.3997,
+      "compress_mbps": 82.91,
+      "decompress_mbps": 273.52
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 50031,
+      "ratio": 0.3997,
+      "compress_mbps": 83.46,
+      "decompress_mbps": 272.35
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 50031,
+      "ratio": 0.3997,
+      "compress_mbps": 84.13,
+      "decompress_mbps": 272.98
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 50031,
+      "ratio": 0.3997,
+      "compress_mbps": 83.95,
+      "decompress_mbps": 268.75
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 48753,
+      "ratio": 0.3895,
+      "compress_mbps": 50.79,
+      "decompress_mbps": 277.44
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 48557,
+      "ratio": 0.3879,
+      "compress_mbps": 40.8,
+      "decompress_mbps": 274.84
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 48523,
+      "ratio": 0.3876,
+      "compress_mbps": 38.65,
+      "decompress_mbps": 273.33
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 48522,
+      "ratio": 0.3876,
+      "compress_mbps": 37.86,
+      "decompress_mbps": 276.85
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 48522,
+      "ratio": 0.3876,
+      "compress_mbps": 37.9,
+      "decompress_mbps": 276.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 8182,
+      "ratio": 0.3326,
+      "compress_mbps": 164.27,
+      "decompress_mbps": 279.42
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 8182,
+      "ratio": 0.3326,
+      "compress_mbps": 172.17,
+      "decompress_mbps": 279.97
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 8182,
+      "ratio": 0.3326,
+      "compress_mbps": 171.79,
+      "decompress_mbps": 279.43
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8182,
+      "ratio": 0.3326,
+      "compress_mbps": 170.54,
+      "decompress_mbps": 279.22
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 7965,
+      "ratio": 0.3237,
+      "compress_mbps": 110.55,
+      "decompress_mbps": 288.06
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 7914,
+      "ratio": 0.3217,
+      "compress_mbps": 87.16,
+      "decompress_mbps": 290.85
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 7895,
+      "ratio": 0.3209,
+      "compress_mbps": 80.21,
+      "decompress_mbps": 290.06
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 7896,
+      "ratio": 0.3209,
+      "compress_mbps": 73.83,
+      "decompress_mbps": 287.97
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 7896,
+      "ratio": 0.3209,
+      "compress_mbps": 74.8,
+      "decompress_mbps": 285.58
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 3218,
+      "ratio": 0.2886,
+      "compress_mbps": 167.43,
+      "decompress_mbps": 252.93
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 3218,
+      "ratio": 0.2886,
+      "compress_mbps": 171.07,
+      "decompress_mbps": 257.31
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 3218,
+      "ratio": 0.2886,
+      "compress_mbps": 171.82,
+      "decompress_mbps": 258.29
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3218,
+      "ratio": 0.2886,
+      "compress_mbps": 166.85,
+      "decompress_mbps": 256.2
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3136,
+      "ratio": 0.2813,
+      "compress_mbps": 143.33,
+      "decompress_mbps": 259.73
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3115,
+      "ratio": 0.2794,
+      "compress_mbps": 126.88,
+      "decompress_mbps": 263.65
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 116.0,
+      "decompress_mbps": 266.62
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 105.81,
+      "decompress_mbps": 262.03
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3112,
+      "ratio": 0.2791,
+      "compress_mbps": 108.16,
+      "decompress_mbps": 263.41
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1221,
+      "ratio": 0.3281,
+      "compress_mbps": 119.04,
+      "decompress_mbps": 119.21
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1221,
+      "ratio": 0.3281,
+      "compress_mbps": 114.29,
+      "decompress_mbps": 121.57
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1221,
+      "ratio": 0.3281,
+      "compress_mbps": 111.93,
+      "decompress_mbps": 114.91
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1221,
+      "ratio": 0.3281,
+      "compress_mbps": 113.37,
+      "decompress_mbps": 116.95
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 104.47,
+      "decompress_mbps": 117.21
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 101.17,
+      "decompress_mbps": 116.13
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 99.01,
+      "decompress_mbps": 115.26
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 100.66,
+      "decompress_mbps": 116.17
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1207,
+      "ratio": 0.3244,
+      "compress_mbps": 100.75,
+      "decompress_mbps": 117.41
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 227063,
+      "ratio": 0.2205,
+      "compress_mbps": 226.33,
+      "decompress_mbps": 462.07
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 227063,
+      "ratio": 0.2205,
+      "compress_mbps": 232.22,
+      "decompress_mbps": 461.76
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 227063,
+      "ratio": 0.2205,
+      "compress_mbps": 226.95,
+      "decompress_mbps": 462.59
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 227063,
+      "ratio": 0.2205,
+      "compress_mbps": 231.82,
+      "decompress_mbps": 462.46
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 218313,
+      "ratio": 0.212,
+      "compress_mbps": 163.75,
+      "decompress_mbps": 447.06
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 215095,
+      "ratio": 0.2089,
+      "compress_mbps": 107.22,
+      "decompress_mbps": 448.7
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 213213,
+      "ratio": 0.2071,
+      "compress_mbps": 73.07,
+      "decompress_mbps": 450.65
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 210955,
+      "ratio": 0.2049,
+      "compress_mbps": 9.42,
+      "decompress_mbps": 452.49
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 210981,
+      "ratio": 0.2049,
+      "compress_mbps": 4.64,
+      "decompress_mbps": 454.09
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 148927,
+      "ratio": 0.349,
+      "compress_mbps": 92.55,
+      "decompress_mbps": 304.95
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 148927,
+      "ratio": 0.349,
+      "compress_mbps": 92.89,
+      "decompress_mbps": 306.86
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 148927,
+      "ratio": 0.349,
+      "compress_mbps": 92.22,
+      "decompress_mbps": 306.2
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 148927,
+      "ratio": 0.349,
+      "compress_mbps": 92.33,
+      "decompress_mbps": 304.41
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 145024,
+      "ratio": 0.3398,
+      "compress_mbps": 57.83,
+      "decompress_mbps": 305.53
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 144159,
+      "ratio": 0.3378,
+      "compress_mbps": 44.56,
+      "decompress_mbps": 304.1
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 143991,
+      "ratio": 0.3374,
+      "compress_mbps": 40.14,
+      "decompress_mbps": 306.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 143941,
+      "ratio": 0.3373,
+      "compress_mbps": 36.87,
+      "decompress_mbps": 306.13
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 143939,
+      "ratio": 0.3373,
+      "compress_mbps": 37.03,
+      "decompress_mbps": 305.69
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 200074,
+      "ratio": 0.4152,
+      "compress_mbps": 81.26,
+      "decompress_mbps": 255.97
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 200074,
+      "ratio": 0.4152,
+      "compress_mbps": 80.9,
+      "decompress_mbps": 255.49
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 200074,
+      "ratio": 0.4152,
+      "compress_mbps": 81.21,
+      "decompress_mbps": 255.67
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 200074,
+      "ratio": 0.4152,
+      "compress_mbps": 81.07,
+      "decompress_mbps": 256.32
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 194496,
+      "ratio": 0.4036,
+      "compress_mbps": 46.0,
+      "decompress_mbps": 247.64
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 193176,
+      "ratio": 0.4009,
+      "compress_mbps": 34.56,
+      "decompress_mbps": 253.55
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 192991,
+      "ratio": 0.4005,
+      "compress_mbps": 31.43,
+      "decompress_mbps": 250.63
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 192980,
+      "ratio": 0.4005,
+      "compress_mbps": 29.91,
+      "decompress_mbps": 251.77
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 192980,
+      "ratio": 0.4005,
+      "compress_mbps": 29.82,
+      "decompress_mbps": 253.98
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 57484,
+      "ratio": 0.112,
+      "compress_mbps": 294.39,
+      "decompress_mbps": 724.52
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 57484,
+      "ratio": 0.112,
+      "compress_mbps": 294.6,
+      "decompress_mbps": 721.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 57484,
+      "ratio": 0.112,
+      "compress_mbps": 294.93,
+      "decompress_mbps": 721.32
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 57484,
+      "ratio": 0.112,
+      "compress_mbps": 295.58,
+      "decompress_mbps": 727.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 56050,
+      "ratio": 0.1092,
+      "compress_mbps": 229.82,
+      "decompress_mbps": 759.78
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 55292,
+      "ratio": 0.1077,
+      "compress_mbps": 153.4,
+      "decompress_mbps": 778.62
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 54651,
+      "ratio": 0.1065,
+      "compress_mbps": 124.47,
+      "decompress_mbps": 790.77
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 52583,
+      "ratio": 0.1025,
+      "compress_mbps": 46.92,
+      "decompress_mbps": 823.54
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 51816,
+      "ratio": 0.101,
+      "compress_mbps": 15.63,
+      "decompress_mbps": 833.02
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 13765,
+      "ratio": 0.36,
+      "compress_mbps": 119.63,
+      "decompress_mbps": 301.35
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 13765,
+      "ratio": 0.36,
+      "compress_mbps": 118.87,
+      "decompress_mbps": 304.63
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 13765,
+      "ratio": 0.36,
+      "compress_mbps": 120.64,
+      "decompress_mbps": 303.05
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13765,
+      "ratio": 0.36,
+      "compress_mbps": 118.25,
+      "decompress_mbps": 303.27
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13290,
+      "ratio": 0.3475,
+      "compress_mbps": 89.99,
+      "decompress_mbps": 316.05
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 13258,
+      "ratio": 0.3467,
+      "compress_mbps": 68.72,
+      "decompress_mbps": 317.08
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 13246,
+      "ratio": 0.3464,
+      "compress_mbps": 57.01,
+      "decompress_mbps": 319.69
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 13236,
+      "ratio": 0.3461,
+      "compress_mbps": 25.4,
+      "decompress_mbps": 320.24
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 13233,
+      "ratio": 0.3461,
+      "compress_mbps": 16.12,
+      "decompress_mbps": 322.36
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 1742,
+      "ratio": 0.4121,
+      "compress_mbps": 95.7,
+      "decompress_mbps": 132.85
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 1742,
+      "ratio": 0.4121,
+      "compress_mbps": 98.31,
+      "decompress_mbps": 133.01
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 1742,
+      "ratio": 0.4121,
+      "compress_mbps": 97.54,
+      "decompress_mbps": 132.07
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 1742,
+      "ratio": 0.4121,
+      "compress_mbps": 100.39,
+      "decompress_mbps": 132.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 95.29,
+      "decompress_mbps": 132.31
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 95.54,
+      "decompress_mbps": 134.31
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 93.18,
+      "decompress_mbps": 133.95
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 95.09,
+      "decompress_mbps": 134.19
+    },
+    {
+      "compressor": "zig",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 1720,
+      "ratio": 0.4069,
+      "compress_mbps": 92.21,
+      "decompress_mbps": 134.59
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 3974126,
+      "ratio": 0.3899,
+      "compress_mbps": 84.07,
+      "decompress_mbps": 273.96
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 3974126,
+      "ratio": 0.3899,
+      "compress_mbps": 84.3,
+      "decompress_mbps": 273.56
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 3974126,
+      "ratio": 0.3899,
+      "compress_mbps": 83.99,
+      "decompress_mbps": 274.36
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 3974126,
+      "ratio": 0.3899,
+      "compress_mbps": 84.24,
+      "decompress_mbps": 272.3
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 3863846,
+      "ratio": 0.3791,
+      "compress_mbps": 49.03,
+      "decompress_mbps": 267.64
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3838854,
+      "ratio": 0.3766,
+      "compress_mbps": 37.71,
+      "decompress_mbps": 272.4
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3835182,
+      "ratio": 0.3763,
+      "compress_mbps": 33.64,
+      "decompress_mbps": 271.15
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3834518,
+      "ratio": 0.3762,
+      "compress_mbps": 31.63,
+      "decompress_mbps": 269.9
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3834518,
+      "ratio": 0.3762,
+      "compress_mbps": 31.46,
+      "decompress_mbps": 270.85
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 19877952,
+      "ratio": 0.3881,
+      "compress_mbps": 103.55,
+      "decompress_mbps": 250.87
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 19877952,
+      "ratio": 0.3881,
+      "compress_mbps": 103.76,
+      "decompress_mbps": 251.19
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 19877952,
+      "ratio": 0.3881,
+      "compress_mbps": 103.86,
+      "decompress_mbps": 251.37
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 19877952,
+      "ratio": 0.3881,
+      "compress_mbps": 103.63,
+      "decompress_mbps": 251.14
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 19578840,
+      "ratio": 0.3822,
+      "compress_mbps": 78.52,
+      "decompress_mbps": 258.92
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 19492445,
+      "ratio": 0.3806,
+      "compress_mbps": 58.0,
+      "decompress_mbps": 261.52
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 19463481,
+      "ratio": 0.38,
+      "compress_mbps": 46.5,
+      "decompress_mbps": 263.14
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 19444704,
+      "ratio": 0.3796,
+      "compress_mbps": 22.81,
+      "decompress_mbps": 262.15
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 19440748,
+      "ratio": 0.3796,
+      "compress_mbps": 13.07,
+      "decompress_mbps": 263.2
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3662279,
+      "ratio": 0.3673,
+      "compress_mbps": 112.24,
+      "decompress_mbps": 259.97
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3662279,
+      "ratio": 0.3673,
+      "compress_mbps": 112.65,
+      "decompress_mbps": 260.85
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3662279,
+      "ratio": 0.3673,
+      "compress_mbps": 111.43,
+      "decompress_mbps": 257.26
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3662279,
+      "ratio": 0.3673,
+      "compress_mbps": 112.43,
+      "decompress_mbps": 258.95
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3637736,
+      "ratio": 0.3648,
+      "compress_mbps": 65.79,
+      "decompress_mbps": 267.17
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3621530,
+      "ratio": 0.3632,
+      "compress_mbps": 46.42,
+      "decompress_mbps": 268.5
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3623924,
+      "ratio": 0.3635,
+      "compress_mbps": 42.48,
+      "decompress_mbps": 270.13
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3623112,
+      "ratio": 0.3634,
+      "compress_mbps": 33.07,
+      "decompress_mbps": 270.31
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3623382,
+      "ratio": 0.3634,
+      "compress_mbps": 24.87,
+      "decompress_mbps": 268.67
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 3580057,
+      "ratio": 0.1067,
+      "compress_mbps": 306.93,
+      "decompress_mbps": 882.12
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 3580057,
+      "ratio": 0.1067,
+      "compress_mbps": 309.49,
+      "decompress_mbps": 879.51
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 3580057,
+      "ratio": 0.1067,
+      "compress_mbps": 306.65,
+      "decompress_mbps": 865.76
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3580057,
+      "ratio": 0.1067,
+      "compress_mbps": 309.44,
+      "decompress_mbps": 876.41
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3268887,
+      "ratio": 0.0974,
+      "compress_mbps": 229.13,
+      "decompress_mbps": 923.49
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3131445,
+      "ratio": 0.0933,
+      "compress_mbps": 163.5,
+      "decompress_mbps": 955.29
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3080217,
+      "ratio": 0.0918,
+      "compress_mbps": 129.46,
+      "decompress_mbps": 960.33
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 2978354,
+      "ratio": 0.0888,
+      "compress_mbps": 57.16,
+      "decompress_mbps": 973.32
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 2947971,
+      "ratio": 0.0879,
+      "compress_mbps": 34.51,
+      "decompress_mbps": 973.37
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 3221973,
+      "ratio": 0.5237,
+      "compress_mbps": 72.44,
+      "decompress_mbps": 182.53
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3221973,
+      "ratio": 0.5237,
+      "compress_mbps": 72.2,
+      "decompress_mbps": 182.46
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3221973,
+      "ratio": 0.5237,
+      "compress_mbps": 72.32,
+      "decompress_mbps": 182.97
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3221973,
+      "ratio": 0.5237,
+      "compress_mbps": 72.36,
+      "decompress_mbps": 183.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3178914,
+      "ratio": 0.5167,
+      "compress_mbps": 55.82,
+      "decompress_mbps": 189.9
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3174170,
+      "ratio": 0.5159,
+      "compress_mbps": 49.39,
+      "decompress_mbps": 191.24
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3172734,
+      "ratio": 0.5157,
+      "compress_mbps": 45.82,
+      "decompress_mbps": 191.56
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3171353,
+      "ratio": 0.5155,
+      "compress_mbps": 38.64,
+      "decompress_mbps": 191.37
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3171299,
+      "ratio": 0.5155,
+      "compress_mbps": 34.82,
+      "decompress_mbps": 191.12
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 3791952,
+      "ratio": 0.376,
+      "compress_mbps": 123.34,
+      "decompress_mbps": 273.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 3791952,
+      "ratio": 0.376,
+      "compress_mbps": 122.2,
+      "decompress_mbps": 272.47
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 3791952,
+      "ratio": 0.376,
+      "compress_mbps": 121.33,
+      "decompress_mbps": 269.13
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3791952,
+      "ratio": 0.376,
+      "compress_mbps": 122.45,
+      "decompress_mbps": 274.58
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3654027,
+      "ratio": 0.3623,
+      "compress_mbps": 95.52,
+      "decompress_mbps": 276.5
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3652732,
+      "ratio": 0.3622,
+      "compress_mbps": 91.8,
+      "decompress_mbps": 276.29
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3652496,
+      "ratio": 0.3621,
+      "compress_mbps": 87.07,
+      "decompress_mbps": 275.95
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3652505,
+      "ratio": 0.3621,
+      "compress_mbps": 87.05,
+      "decompress_mbps": 277.5
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3652505,
+      "ratio": 0.3621,
+      "compress_mbps": 87.07,
+      "decompress_mbps": 276.53
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2009824,
+      "ratio": 0.3033,
+      "compress_mbps": 100.62,
+      "decompress_mbps": 354.06
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2009824,
+      "ratio": 0.3033,
+      "compress_mbps": 100.0,
+      "decompress_mbps": 353.82
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2009824,
+      "ratio": 0.3033,
+      "compress_mbps": 99.59,
+      "decompress_mbps": 351.77
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 2009824,
+      "ratio": 0.3033,
+      "compress_mbps": 99.81,
+      "decompress_mbps": 354.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1892183,
+      "ratio": 0.2855,
+      "compress_mbps": 53.63,
+      "decompress_mbps": 353.52
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1837957,
+      "ratio": 0.2773,
+      "compress_mbps": 30.64,
+      "decompress_mbps": 360.81
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1826603,
+      "ratio": 0.2756,
+      "compress_mbps": 24.41,
+      "decompress_mbps": 362.4
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1818702,
+      "ratio": 0.2744,
+      "compress_mbps": 16.09,
+      "decompress_mbps": 362.85
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1818702,
+      "ratio": 0.2744,
+      "compress_mbps": 15.95,
+      "decompress_mbps": 359.54
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 5633558,
+      "ratio": 0.2607,
+      "compress_mbps": 146.11,
+      "decompress_mbps": 399.24
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 5633558,
+      "ratio": 0.2607,
+      "compress_mbps": 145.88,
+      "decompress_mbps": 400.49
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 5633558,
+      "ratio": 0.2607,
+      "compress_mbps": 146.06,
+      "decompress_mbps": 396.62
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 5633558,
+      "ratio": 0.2607,
+      "compress_mbps": 144.39,
+      "decompress_mbps": 379.0
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 5501344,
+      "ratio": 0.2546,
+      "compress_mbps": 103.33,
+      "decompress_mbps": 402.09
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5464646,
+      "ratio": 0.2529,
+      "compress_mbps": 79.54,
+      "decompress_mbps": 407.14
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5429975,
+      "ratio": 0.2513,
+      "compress_mbps": 66.81,
+      "decompress_mbps": 408.73
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5419566,
+      "ratio": 0.2508,
+      "compress_mbps": 49.41,
+      "decompress_mbps": 410.08
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5417952,
+      "ratio": 0.2508,
+      "compress_mbps": 45.54,
+      "decompress_mbps": 407.63
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 5481930,
+      "ratio": 0.7559,
+      "compress_mbps": 60.47,
+      "decompress_mbps": 161.38
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 5481930,
+      "ratio": 0.7559,
+      "compress_mbps": 60.25,
+      "decompress_mbps": 161.25
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 5481930,
+      "ratio": 0.7559,
+      "compress_mbps": 60.34,
+      "decompress_mbps": 161.47
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5481930,
+      "ratio": 0.7559,
+      "compress_mbps": 60.28,
+      "decompress_mbps": 159.84
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5450496,
+      "ratio": 0.7516,
+      "compress_mbps": 46.56,
+      "decompress_mbps": 163.89
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5440281,
+      "ratio": 0.7502,
+      "compress_mbps": 42.07,
+      "decompress_mbps": 164.58
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5439077,
+      "ratio": 0.75,
+      "compress_mbps": 40.6,
+      "decompress_mbps": 164.64
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5438787,
+      "ratio": 0.75,
+      "compress_mbps": 39.98,
+      "decompress_mbps": 163.79
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5438787,
+      "ratio": 0.75,
+      "compress_mbps": 39.92,
+      "decompress_mbps": 165.07
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 12756531,
+      "ratio": 0.3077,
+      "compress_mbps": 108.43,
+      "decompress_mbps": 313.19
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 12756531,
+      "ratio": 0.3077,
+      "compress_mbps": 108.96,
+      "decompress_mbps": 316.83
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 12756531,
+      "ratio": 0.3077,
+      "compress_mbps": 108.45,
+      "decompress_mbps": 312.18
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 12756531,
+      "ratio": 0.3077,
+      "compress_mbps": 108.89,
+      "decompress_mbps": 315.83
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12238874,
+      "ratio": 0.2952,
+      "compress_mbps": 72.34,
+      "decompress_mbps": 317.65
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12086531,
+      "ratio": 0.2915,
+      "compress_mbps": 53.58,
+      "decompress_mbps": 323.18
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12020742,
+      "ratio": 0.2899,
+      "compress_mbps": 46.37,
+      "decompress_mbps": 319.97
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 11987253,
+      "ratio": 0.2891,
+      "compress_mbps": 38.17,
+      "decompress_mbps": 322.52
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 11987245,
+      "ratio": 0.2891,
+      "compress_mbps": 38.15,
+      "decompress_mbps": 319.56
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6273039,
+      "ratio": 0.7402,
+      "compress_mbps": 60.53,
+      "decompress_mbps": 146.13
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6273039,
+      "ratio": 0.7402,
+      "compress_mbps": 60.39,
+      "decompress_mbps": 146.09
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6273039,
+      "ratio": 0.7402,
+      "compress_mbps": 60.11,
+      "decompress_mbps": 146.99
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6273039,
+      "ratio": 0.7402,
+      "compress_mbps": 60.42,
+      "decompress_mbps": 146.5
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6244483,
+      "ratio": 0.7369,
+      "compress_mbps": 55.4,
+      "decompress_mbps": 148.54
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 6244482,
+      "ratio": 0.7369,
+      "compress_mbps": 55.47,
+      "decompress_mbps": 148.16
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 6244482,
+      "ratio": 0.7369,
+      "compress_mbps": 55.08,
+      "decompress_mbps": 147.42
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 6244480,
+      "ratio": 0.7369,
+      "compress_mbps": 55.49,
+      "decompress_mbps": 148.22
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 6244480,
+      "ratio": 0.7369,
+      "compress_mbps": 55.43,
+      "decompress_mbps": 147.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 785041,
+      "ratio": 0.1469,
+      "compress_mbps": 230.66,
+      "decompress_mbps": 673.8
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 785041,
+      "ratio": 0.1469,
+      "compress_mbps": 230.52,
+      "decompress_mbps": 670.21
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 785041,
+      "ratio": 0.1469,
+      "compress_mbps": 231.93,
+      "decompress_mbps": 669.9
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 785041,
+      "ratio": 0.1469,
+      "compress_mbps": 230.28,
+      "decompress_mbps": 671.23
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 716461,
+      "ratio": 0.134,
+      "compress_mbps": 166.09,
+      "decompress_mbps": 710.38
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 687053,
+      "ratio": 0.1285,
+      "compress_mbps": 124.29,
+      "decompress_mbps": 733.86
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 673597,
+      "ratio": 0.126,
+      "compress_mbps": 100.95,
+      "decompress_mbps": 744.02
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 662156,
+      "ratio": 0.1239,
+      "compress_mbps": 65.08,
+      "decompress_mbps": 750.21
+    },
+    {
+      "compressor": "zig",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 661610,
+      "ratio": 0.1238,
+      "compress_mbps": 61.06,
+      "decompress_mbps": 754.5
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 1,
+      "out_size": 73589,
+      "ratio": 0.4839,
+      "compress_mbps": 33.76,
+      "decompress_mbps": 57.05
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 2,
+      "out_size": 69878,
+      "ratio": 0.4595,
+      "compress_mbps": 32.08,
+      "decompress_mbps": 58.09
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 3,
+      "out_size": 66917,
+      "ratio": 0.44,
+      "compress_mbps": 26.68,
+      "decompress_mbps": 66.6
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 4,
+      "out_size": 59388,
+      "ratio": 0.3905,
+      "compress_mbps": 31.26,
+      "decompress_mbps": 80.36
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 5,
+      "out_size": 57062,
+      "ratio": 0.3752,
+      "compress_mbps": 22.77,
+      "decompress_mbps": 80.1
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 6,
+      "out_size": 55472,
+      "ratio": 0.3647,
+      "compress_mbps": 16.23,
+      "decompress_mbps": 79.12
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 7,
+      "out_size": 55265,
+      "ratio": 0.3634,
+      "compress_mbps": 14.29,
+      "decompress_mbps": 79.84
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 8,
+      "out_size": 55168,
+      "ratio": 0.3627,
+      "compress_mbps": 11.91,
+      "decompress_mbps": 78.92
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 9,
+      "out_size": 55168,
+      "ratio": 0.3627,
+      "compress_mbps": 11.93,
+      "decompress_mbps": 78.52
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 1,
+      "out_size": 64551,
+      "ratio": 0.5157,
+      "compress_mbps": 31.89,
+      "decompress_mbps": 53.82
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 2,
+      "out_size": 62089,
+      "ratio": 0.496,
+      "compress_mbps": 30.15,
+      "decompress_mbps": 57.83
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 3,
+      "out_size": 58690,
+      "ratio": 0.4688,
+      "compress_mbps": 24.34,
+      "decompress_mbps": 59.96
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 4,
+      "out_size": 53521,
+      "ratio": 0.4276,
+      "compress_mbps": 30.1,
+      "decompress_mbps": 79.96
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 5,
+      "out_size": 51677,
+      "ratio": 0.4128,
+      "compress_mbps": 20.89,
+      "decompress_mbps": 78.97
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 6,
+      "out_size": 50638,
+      "ratio": 0.4045,
+      "compress_mbps": 14.85,
+      "decompress_mbps": 82.68
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 7,
+      "out_size": 50501,
+      "ratio": 0.4034,
+      "compress_mbps": 13.53,
+      "decompress_mbps": 79.57
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 8,
+      "out_size": 50452,
+      "ratio": 0.403,
+      "compress_mbps": 12.59,
+      "decompress_mbps": 81.82
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 9,
+      "out_size": 50452,
+      "ratio": 0.403,
+      "compress_mbps": 12.59,
+      "decompress_mbps": 81.99
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 1,
+      "out_size": 9859,
+      "ratio": 0.4007,
+      "compress_mbps": 43.03,
+      "decompress_mbps": 111.15
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 2,
+      "out_size": 10473,
+      "ratio": 0.4257,
+      "compress_mbps": 47.23,
+      "decompress_mbps": 149.93
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 3,
+      "out_size": 10172,
+      "ratio": 0.4134,
+      "compress_mbps": 42.85,
+      "decompress_mbps": 148.23
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 4,
+      "out_size": 8692,
+      "ratio": 0.3533,
+      "compress_mbps": 40.47,
+      "decompress_mbps": 152.86
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 5,
+      "out_size": 8440,
+      "ratio": 0.343,
+      "compress_mbps": 36.18,
+      "decompress_mbps": 157.16
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 6,
+      "out_size": 8385,
+      "ratio": 0.3408,
+      "compress_mbps": 31.88,
+      "decompress_mbps": 158.84
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 7,
+      "out_size": 8366,
+      "ratio": 0.34,
+      "compress_mbps": 29.95,
+      "decompress_mbps": 158.95
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 8,
+      "out_size": 8367,
+      "ratio": 0.3401,
+      "compress_mbps": 28.71,
+      "decompress_mbps": 157.48
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 9,
+      "out_size": 8367,
+      "ratio": 0.3401,
+      "compress_mbps": 28.72,
+      "decompress_mbps": 156.54
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 1,
+      "out_size": 4822,
+      "ratio": 0.4325,
+      "compress_mbps": 54.35,
+      "decompress_mbps": 187.68
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 2,
+      "out_size": 4593,
+      "ratio": 0.4119,
+      "compress_mbps": 52.8,
+      "decompress_mbps": 193.41
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 3,
+      "out_size": 4381,
+      "ratio": 0.3929,
+      "compress_mbps": 49.8,
+      "decompress_mbps": 200.8
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 4,
+      "out_size": 3725,
+      "ratio": 0.3341,
+      "compress_mbps": 51.8,
+      "decompress_mbps": 202.76
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 5,
+      "out_size": 3614,
+      "ratio": 0.3241,
+      "compress_mbps": 43.83,
+      "decompress_mbps": 208.48
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 6,
+      "out_size": 3578,
+      "ratio": 0.3209,
+      "compress_mbps": 39.35,
+      "decompress_mbps": 209.91
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 7,
+      "out_size": 3572,
+      "ratio": 0.3204,
+      "compress_mbps": 36.83,
+      "decompress_mbps": 210.72
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 8,
+      "out_size": 3568,
+      "ratio": 0.32,
+      "compress_mbps": 34.7,
+      "decompress_mbps": 208.41
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 9,
+      "out_size": 3568,
+      "ratio": 0.32,
+      "compress_mbps": 33.66,
+      "decompress_mbps": 206.14
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 1,
+      "out_size": 1738,
+      "ratio": 0.4671,
+      "compress_mbps": 30.09,
+      "decompress_mbps": 176.72
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 2,
+      "out_size": 1709,
+      "ratio": 0.4593,
+      "compress_mbps": 30.1,
+      "decompress_mbps": 174.49
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 3,
+      "out_size": 1694,
+      "ratio": 0.4553,
+      "compress_mbps": 31.7,
+      "decompress_mbps": 180.35
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 4,
+      "out_size": 1458,
+      "ratio": 0.3918,
+      "compress_mbps": 29.73,
+      "decompress_mbps": 187.58
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 5,
+      "out_size": 1441,
+      "ratio": 0.3873,
+      "compress_mbps": 28.44,
+      "decompress_mbps": 189.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 6,
+      "out_size": 1440,
+      "ratio": 0.387,
+      "compress_mbps": 27.18,
+      "decompress_mbps": 189.99
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 7,
+      "out_size": 1440,
+      "ratio": 0.387,
+      "compress_mbps": 27.68,
+      "decompress_mbps": 190.15
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 8,
+      "out_size": 1440,
+      "ratio": 0.387,
+      "compress_mbps": 26.12,
+      "decompress_mbps": 189.99
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 9,
+      "out_size": 1440,
+      "ratio": 0.387,
+      "compress_mbps": 27.78,
+      "decompress_mbps": 191.2
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 1,
+      "out_size": 260073,
+      "ratio": 0.2526,
+      "compress_mbps": 52.45,
+      "decompress_mbps": 56.85
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 2,
+      "out_size": 296764,
+      "ratio": 0.2882,
+      "compress_mbps": 48.94,
+      "decompress_mbps": 76.97
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 3,
+      "out_size": 288989,
+      "ratio": 0.2806,
+      "compress_mbps": 37.59,
+      "decompress_mbps": 77.33
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 4,
+      "out_size": 246442,
+      "ratio": 0.2393,
+      "compress_mbps": 54.71,
+      "decompress_mbps": 83.32
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 5,
+      "out_size": 218888,
+      "ratio": 0.2126,
+      "compress_mbps": 40.79,
+      "decompress_mbps": 76.86
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 6,
+      "out_size": 217830,
+      "ratio": 0.2115,
+      "compress_mbps": 24.16,
+      "decompress_mbps": 88.24
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 7,
+      "out_size": 221437,
+      "ratio": 0.215,
+      "compress_mbps": 19.26,
+      "decompress_mbps": 86.6
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 8,
+      "out_size": 219666,
+      "ratio": 0.2133,
+      "compress_mbps": 5.49,
+      "decompress_mbps": 86.51
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 9,
+      "out_size": 219921,
+      "ratio": 0.2136,
+      "compress_mbps": 2.77,
+      "decompress_mbps": 85.35
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 1,
+      "out_size": 194588,
+      "ratio": 0.456,
+      "compress_mbps": 34.47,
+      "decompress_mbps": 51.9
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 2,
+      "out_size": 185757,
+      "ratio": 0.4353,
+      "compress_mbps": 32.92,
+      "decompress_mbps": 49.65
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 3,
+      "out_size": 175850,
+      "ratio": 0.4121,
+      "compress_mbps": 27.11,
+      "decompress_mbps": 59.21
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 4,
+      "out_size": 155951,
+      "ratio": 0.3654,
+      "compress_mbps": 31.95,
+      "decompress_mbps": 73.02
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 5,
+      "out_size": 150274,
+      "ratio": 0.3521,
+      "compress_mbps": 23.12,
+      "decompress_mbps": 71.4
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 6,
+      "out_size": 147958,
+      "ratio": 0.3467,
+      "compress_mbps": 16.73,
+      "decompress_mbps": 72.74
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 7,
+      "out_size": 147522,
+      "ratio": 0.3457,
+      "compress_mbps": 14.93,
+      "decompress_mbps": 70.21
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 8,
+      "out_size": 147331,
+      "ratio": 0.3452,
+      "compress_mbps": 13.5,
+      "decompress_mbps": 68.78
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 9,
+      "out_size": 147328,
+      "ratio": 0.3452,
+      "compress_mbps": 13.48,
+      "decompress_mbps": 70.75
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 1,
+      "out_size": 256904,
+      "ratio": 0.5331,
+      "compress_mbps": 29.73,
+      "decompress_mbps": 46.55
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 2,
+      "out_size": 245675,
+      "ratio": 0.5098,
+      "compress_mbps": 28.42,
+      "decompress_mbps": 50.05
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 3,
+      "out_size": 231519,
+      "ratio": 0.4805,
+      "compress_mbps": 22.58,
+      "decompress_mbps": 56.23
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 4,
+      "out_size": 210028,
+      "ratio": 0.4359,
+      "compress_mbps": 27.54,
+      "decompress_mbps": 64.61
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 5,
+      "out_size": 203312,
+      "ratio": 0.4219,
+      "compress_mbps": 18.52,
+      "decompress_mbps": 61.6
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 6,
+      "out_size": 199287,
+      "ratio": 0.4136,
+      "compress_mbps": 12.88,
+      "decompress_mbps": 65.73
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 7,
+      "out_size": 198474,
+      "ratio": 0.4119,
+      "compress_mbps": 11.21,
+      "decompress_mbps": 66.4
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 8,
+      "out_size": 198080,
+      "ratio": 0.4111,
+      "compress_mbps": 8.88,
+      "decompress_mbps": 65.36
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 9,
+      "out_size": 198080,
+      "ratio": 0.4111,
+      "compress_mbps": 8.84,
+      "decompress_mbps": 65.03
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 1,
+      "out_size": 71229,
+      "ratio": 0.1388,
+      "compress_mbps": 82.96,
+      "decompress_mbps": 136.59
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 2,
+      "out_size": 69946,
+      "ratio": 0.1363,
+      "compress_mbps": 78.92,
+      "decompress_mbps": 137.96
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 3,
+      "out_size": 68538,
+      "ratio": 0.1335,
+      "compress_mbps": 69.23,
+      "decompress_mbps": 151.76
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 4,
+      "out_size": 61320,
+      "ratio": 0.1195,
+      "compress_mbps": 65.87,
+      "decompress_mbps": 164.26
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 5,
+      "out_size": 59993,
+      "ratio": 0.1169,
+      "compress_mbps": 57.15,
+      "decompress_mbps": 169.1
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 6,
+      "out_size": 58637,
+      "ratio": 0.1143,
+      "compress_mbps": 41.42,
+      "decompress_mbps": 166.25
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 7,
+      "out_size": 58209,
+      "ratio": 0.1134,
+      "compress_mbps": 35.38,
+      "decompress_mbps": 173.09
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 8,
+      "out_size": 55749,
+      "ratio": 0.1086,
+      "compress_mbps": 19.35,
+      "decompress_mbps": 176.71
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 9,
+      "out_size": 54927,
+      "ratio": 0.107,
+      "compress_mbps": 7.52,
+      "decompress_mbps": 176.17
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 1,
+      "out_size": 16399,
+      "ratio": 0.4288,
+      "compress_mbps": 36.37,
+      "decompress_mbps": 86.67
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 2,
+      "out_size": 15933,
+      "ratio": 0.4167,
+      "compress_mbps": 33.72,
+      "decompress_mbps": 88.83
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 3,
+      "out_size": 15739,
+      "ratio": 0.4116,
+      "compress_mbps": 28.05,
+      "decompress_mbps": 87.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 4,
+      "out_size": 13834,
+      "ratio": 0.3618,
+      "compress_mbps": 31.73,
+      "decompress_mbps": 108.86
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 5,
+      "out_size": 13463,
+      "ratio": 0.3521,
+      "compress_mbps": 25.96,
+      "decompress_mbps": 111.56
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 6,
+      "out_size": 13353,
+      "ratio": 0.3492,
+      "compress_mbps": 18.86,
+      "decompress_mbps": 111.15
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 7,
+      "out_size": 13317,
+      "ratio": 0.3482,
+      "compress_mbps": 15.93,
+      "decompress_mbps": 113.26
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 8,
+      "out_size": 13255,
+      "ratio": 0.3466,
+      "compress_mbps": 8.38,
+      "decompress_mbps": 110.11
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 9,
+      "out_size": 13171,
+      "ratio": 0.3444,
+      "compress_mbps": 4.16,
+      "decompress_mbps": 114.39
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 1,
+      "out_size": 2512,
+      "ratio": 0.5943,
+      "compress_mbps": 29.63,
+      "decompress_mbps": 155.88
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 2,
+      "out_size": 2477,
+      "ratio": 0.586,
+      "compress_mbps": 29.51,
+      "decompress_mbps": 158.96
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 3,
+      "out_size": 2452,
+      "ratio": 0.5801,
+      "compress_mbps": 30.37,
+      "decompress_mbps": 157.34
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 4,
+      "out_size": 2110,
+      "ratio": 0.4992,
+      "compress_mbps": 29.99,
+      "decompress_mbps": 162.81
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 5,
+      "out_size": 2086,
+      "ratio": 0.4935,
+      "compress_mbps": 28.87,
+      "decompress_mbps": 169.5
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 6,
+      "out_size": 2086,
+      "ratio": 0.4935,
+      "compress_mbps": 28.86,
+      "decompress_mbps": 167.98
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 7,
+      "out_size": 2086,
+      "ratio": 0.4935,
+      "compress_mbps": 28.5,
+      "decompress_mbps": 169.54
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 8,
+      "out_size": 2086,
+      "ratio": 0.4935,
+      "compress_mbps": 27.54,
+      "decompress_mbps": 169.65
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 9,
+      "out_size": 2086,
+      "ratio": 0.4935,
+      "compress_mbps": 28.63,
+      "decompress_mbps": 169.5
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 1,
+      "out_size": 5183792,
+      "ratio": 0.5086,
+      "compress_mbps": 31.31,
+      "decompress_mbps": 40.47
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 2,
+      "out_size": 4956750,
+      "ratio": 0.4863,
+      "compress_mbps": 29.97,
+      "decompress_mbps": 43.45
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 3,
+      "out_size": 4644095,
+      "ratio": 0.4556,
+      "compress_mbps": 24.06,
+      "decompress_mbps": 47.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 4,
+      "out_size": 4178564,
+      "ratio": 0.41,
+      "compress_mbps": 29.06,
+      "decompress_mbps": 61.99
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 5,
+      "out_size": 4034632,
+      "ratio": 0.3958,
+      "compress_mbps": 19.92,
+      "decompress_mbps": 61.3
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 6,
+      "out_size": 3952244,
+      "ratio": 0.3878,
+      "compress_mbps": 13.83,
+      "decompress_mbps": 61.12
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 7,
+      "out_size": 3938822,
+      "ratio": 0.3864,
+      "compress_mbps": 12.23,
+      "decompress_mbps": 62.83
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 8,
+      "out_size": 3935171,
+      "ratio": 0.3861,
+      "compress_mbps": 10.76,
+      "decompress_mbps": 60.2
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 9,
+      "out_size": 3935171,
+      "ratio": 0.3861,
+      "compress_mbps": 10.72,
+      "decompress_mbps": 60.89
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 1,
+      "out_size": 25320013,
+      "ratio": 0.4943,
+      "compress_mbps": 31.71,
+      "decompress_mbps": 34.88
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 2,
+      "out_size": 24804084,
+      "ratio": 0.4843,
+      "compress_mbps": 30.3,
+      "decompress_mbps": 36.64
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 3,
+      "out_size": 24241121,
+      "ratio": 0.4733,
+      "compress_mbps": 25.73,
+      "decompress_mbps": 37.97
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 4,
+      "out_size": 20950547,
+      "ratio": 0.409,
+      "compress_mbps": 28.84,
+      "decompress_mbps": 44.03
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 5,
+      "out_size": 20592289,
+      "ratio": 0.402,
+      "compress_mbps": 24.29,
+      "decompress_mbps": 46.14
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 6,
+      "out_size": 20445232,
+      "ratio": 0.3992,
+      "compress_mbps": 18.69,
+      "decompress_mbps": 46.11
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 7,
+      "out_size": 20407676,
+      "ratio": 0.3984,
+      "compress_mbps": 15.95,
+      "decompress_mbps": 46.63
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 8,
+      "out_size": 20389473,
+      "ratio": 0.3981,
+      "compress_mbps": 10.13,
+      "decompress_mbps": 45.4
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 9,
+      "out_size": 20386824,
+      "ratio": 0.398,
+      "compress_mbps": 6.82,
+      "decompress_mbps": 46.45
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 1,
+      "out_size": 3964698,
+      "ratio": 0.3976,
+      "compress_mbps": 37.98,
+      "decompress_mbps": 48.02
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 2,
+      "out_size": 3936391,
+      "ratio": 0.3948,
+      "compress_mbps": 35.52,
+      "decompress_mbps": 47.93
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 3,
+      "out_size": 3823540,
+      "ratio": 0.3835,
+      "compress_mbps": 27.78,
+      "decompress_mbps": 51.72
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 4,
+      "out_size": 3799601,
+      "ratio": 0.3811,
+      "compress_mbps": 33.02,
+      "decompress_mbps": 63.69
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 5,
+      "out_size": 3830938,
+      "ratio": 0.3842,
+      "compress_mbps": 22.58,
+      "decompress_mbps": 58.61
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 6,
+      "out_size": 3808303,
+      "ratio": 0.382,
+      "compress_mbps": 14.79,
+      "decompress_mbps": 57.61
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 7,
+      "out_size": 3802814,
+      "ratio": 0.3814,
+      "compress_mbps": 12.14,
+      "decompress_mbps": 57.87
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 8,
+      "out_size": 3800355,
+      "ratio": 0.3812,
+      "compress_mbps": 6.76,
+      "decompress_mbps": 59.01
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 9,
+      "out_size": 3799676,
+      "ratio": 0.3811,
+      "compress_mbps": 6.05,
+      "decompress_mbps": 59.07
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 1,
+      "out_size": 4899547,
+      "ratio": 0.146,
+      "compress_mbps": 95.3,
+      "decompress_mbps": 131.63
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 2,
+      "out_size": 4587004,
+      "ratio": 0.1367,
+      "compress_mbps": 94.92,
+      "decompress_mbps": 142.96
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 3,
+      "out_size": 4229035,
+      "ratio": 0.126,
+      "compress_mbps": 90.43,
+      "decompress_mbps": 152.33
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 4,
+      "out_size": 3791322,
+      "ratio": 0.113,
+      "compress_mbps": 81.61,
+      "decompress_mbps": 160.66
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 5,
+      "out_size": 3449193,
+      "ratio": 0.1028,
+      "compress_mbps": 72.81,
+      "decompress_mbps": 168.1
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 6,
+      "out_size": 3269452,
+      "ratio": 0.0974,
+      "compress_mbps": 58.66,
+      "decompress_mbps": 173.37
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 7,
+      "out_size": 3211286,
+      "ratio": 0.0957,
+      "compress_mbps": 50.59,
+      "decompress_mbps": 173.62
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 8,
+      "out_size": 3101534,
+      "ratio": 0.0924,
+      "compress_mbps": 27.5,
+      "decompress_mbps": 174.42
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 9,
+      "out_size": 3058177,
+      "ratio": 0.0911,
+      "compress_mbps": 16.6,
+      "decompress_mbps": 177.54
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 1,
+      "out_size": 4024327,
+      "ratio": 0.6541,
+      "compress_mbps": 22.81,
+      "decompress_mbps": 29.95
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 2,
+      "out_size": 3953722,
+      "ratio": 0.6427,
+      "compress_mbps": 21.66,
+      "decompress_mbps": 30.5
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 3,
+      "out_size": 3887921,
+      "ratio": 0.632,
+      "compress_mbps": 18.47,
+      "decompress_mbps": 31.15
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 4,
+      "out_size": 3320440,
+      "ratio": 0.5397,
+      "compress_mbps": 21.3,
+      "decompress_mbps": 37.41
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 5,
+      "out_size": 3279338,
+      "ratio": 0.533,
+      "compress_mbps": 17.83,
+      "decompress_mbps": 38.07
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 6,
+      "out_size": 3254309,
+      "ratio": 0.529,
+      "compress_mbps": 14.0,
+      "decompress_mbps": 37.9
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 7,
+      "out_size": 3250139,
+      "ratio": 0.5283,
+      "compress_mbps": 12.22,
+      "decompress_mbps": 38.09
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 8,
+      "out_size": 3247018,
+      "ratio": 0.5278,
+      "compress_mbps": 10.17,
+      "decompress_mbps": 38.03
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 9,
+      "out_size": 3246865,
+      "ratio": 0.5278,
+      "compress_mbps": 9.51,
+      "decompress_mbps": 38.0
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 1,
+      "out_size": 4471091,
+      "ratio": 0.4433,
+      "compress_mbps": 34.91,
+      "decompress_mbps": 69.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 2,
+      "out_size": 4372105,
+      "ratio": 0.4335,
+      "compress_mbps": 33.82,
+      "decompress_mbps": 71.85
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 3,
+      "out_size": 4305270,
+      "ratio": 0.4269,
+      "compress_mbps": 30.7,
+      "decompress_mbps": 73.16
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 4,
+      "out_size": 3920495,
+      "ratio": 0.3887,
+      "compress_mbps": 30.3,
+      "decompress_mbps": 64.84
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 5,
+      "out_size": 3853177,
+      "ratio": 0.382,
+      "compress_mbps": 26.63,
+      "decompress_mbps": 63.95
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 6,
+      "out_size": 3780878,
+      "ratio": 0.3749,
+      "compress_mbps": 23.38,
+      "decompress_mbps": 64.31
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 7,
+      "out_size": 3763880,
+      "ratio": 0.3732,
+      "compress_mbps": 20.2,
+      "decompress_mbps": 72.93
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 8,
+      "out_size": 3757719,
+      "ratio": 0.3726,
+      "compress_mbps": 18.3,
+      "decompress_mbps": 73.42
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 9,
+      "out_size": 3757719,
+      "ratio": 0.3726,
+      "compress_mbps": 18.25,
+      "decompress_mbps": 72.55
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 1,
+      "out_size": 2722387,
+      "ratio": 0.4108,
+      "compress_mbps": 38.01,
+      "decompress_mbps": 64.73
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 2,
+      "out_size": 2572544,
+      "ratio": 0.3882,
+      "compress_mbps": 36.87,
+      "decompress_mbps": 70.55
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 3,
+      "out_size": 2384328,
+      "ratio": 0.3598,
+      "compress_mbps": 29.15,
+      "decompress_mbps": 78.64
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 4,
+      "out_size": 2112060,
+      "ratio": 0.3187,
+      "compress_mbps": 36.42,
+      "decompress_mbps": 85.62
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 5,
+      "out_size": 1991581,
+      "ratio": 0.3005,
+      "compress_mbps": 25.34,
+      "decompress_mbps": 91.01
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 6,
+      "out_size": 1917866,
+      "ratio": 0.2894,
+      "compress_mbps": 15.03,
+      "decompress_mbps": 90.85
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 7,
+      "out_size": 1895353,
+      "ratio": 0.286,
+      "compress_mbps": 11.08,
+      "decompress_mbps": 90.48
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 8,
+      "out_size": 1880740,
+      "ratio": 0.2838,
+      "compress_mbps": 5.59,
+      "decompress_mbps": 90.95
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 9,
+      "out_size": 1880711,
+      "ratio": 0.2838,
+      "compress_mbps": 5.56,
+      "decompress_mbps": 92.3
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 1,
+      "out_size": 7441483,
+      "ratio": 0.3444,
+      "compress_mbps": 43.78,
+      "decompress_mbps": 66.88
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 2,
+      "out_size": 7229248,
+      "ratio": 0.3346,
+      "compress_mbps": 43.14,
+      "decompress_mbps": 69.03
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 3,
+      "out_size": 7083451,
+      "ratio": 0.3278,
+      "compress_mbps": 38.92,
+      "decompress_mbps": 71.31
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 4,
+      "out_size": 6189639,
+      "ratio": 0.2865,
+      "compress_mbps": 42.2,
+      "decompress_mbps": 92.76
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 5,
+      "out_size": 6053058,
+      "ratio": 0.2802,
+      "compress_mbps": 35.08,
+      "decompress_mbps": 96.18
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 6,
+      "out_size": 5988137,
+      "ratio": 0.2771,
+      "compress_mbps": 28.51,
+      "decompress_mbps": 101.1
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 7,
+      "out_size": 5949908,
+      "ratio": 0.2754,
+      "compress_mbps": 25.19,
+      "decompress_mbps": 103.3
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 8,
+      "out_size": 5936656,
+      "ratio": 0.2748,
+      "compress_mbps": 19.22,
+      "decompress_mbps": 106.46
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 9,
+      "out_size": 5934701,
+      "ratio": 0.2747,
+      "compress_mbps": 17.98,
+      "decompress_mbps": 105.25
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 1,
+      "out_size": 6335542,
+      "ratio": 0.8736,
+      "compress_mbps": 18.44,
+      "decompress_mbps": 31.75
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 2,
+      "out_size": 6247260,
+      "ratio": 0.8615,
+      "compress_mbps": 17.59,
+      "decompress_mbps": 48.2
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 3,
+      "out_size": 6064713,
+      "ratio": 0.8363,
+      "compress_mbps": 15.15,
+      "decompress_mbps": 56.49
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 4,
+      "out_size": 5568111,
+      "ratio": 0.7678,
+      "compress_mbps": 17.55,
+      "decompress_mbps": 58.99
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 5,
+      "out_size": 5544524,
+      "ratio": 0.7646,
+      "compress_mbps": 14.42,
+      "decompress_mbps": 64.88
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 6,
+      "out_size": 5513056,
+      "ratio": 0.7602,
+      "compress_mbps": 11.94,
+      "decompress_mbps": 62.87
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 7,
+      "out_size": 5508915,
+      "ratio": 0.7596,
+      "compress_mbps": 11.32,
+      "decompress_mbps": 64.42
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 8,
+      "out_size": 5508365,
+      "ratio": 0.7596,
+      "compress_mbps": 10.52,
+      "decompress_mbps": 65.26
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 9,
+      "out_size": 5508365,
+      "ratio": 0.7596,
+      "compress_mbps": 10.57,
+      "decompress_mbps": 64.3
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 1,
+      "out_size": 16776095,
+      "ratio": 0.4046,
+      "compress_mbps": 37.73,
+      "decompress_mbps": 50.93
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 2,
+      "out_size": 16032651,
+      "ratio": 0.3867,
+      "compress_mbps": 36.24,
+      "decompress_mbps": 54.65
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 3,
+      "out_size": 15180334,
+      "ratio": 0.3662,
+      "compress_mbps": 31.28,
+      "decompress_mbps": 51.85
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 4,
+      "out_size": 13261924,
+      "ratio": 0.3199,
+      "compress_mbps": 35.24,
+      "decompress_mbps": 68.67
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 5,
+      "out_size": 12706028,
+      "ratio": 0.3065,
+      "compress_mbps": 27.63,
+      "decompress_mbps": 70.4
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 6,
+      "out_size": 12464158,
+      "ratio": 0.3006,
+      "compress_mbps": 21.0,
+      "decompress_mbps": 70.64
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 7,
+      "out_size": 12375954,
+      "ratio": 0.2985,
+      "compress_mbps": 18.31,
+      "decompress_mbps": 73.55
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 8,
+      "out_size": 12321552,
+      "ratio": 0.2972,
+      "compress_mbps": 14.45,
+      "decompress_mbps": 70.76
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 9,
+      "out_size": 12320276,
+      "ratio": 0.2972,
+      "compress_mbps": 14.41,
+      "decompress_mbps": 70.34
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 1,
+      "out_size": 6799201,
+      "ratio": 0.8023,
+      "compress_mbps": 18.34,
+      "decompress_mbps": 18.29
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 2,
+      "out_size": 6800500,
+      "ratio": 0.8025,
+      "compress_mbps": 16.95,
+      "decompress_mbps": 18.49
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 3,
+      "out_size": 6803212,
+      "ratio": 0.8028,
+      "compress_mbps": 14.91,
+      "decompress_mbps": 18.44
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 4,
+      "out_size": 6264611,
+      "ratio": 0.7393,
+      "compress_mbps": 17.32,
+      "decompress_mbps": 24.91
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 5,
+      "out_size": 6217901,
+      "ratio": 0.7337,
+      "compress_mbps": 15.76,
+      "decompress_mbps": 25.36
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 6,
+      "out_size": 6201999,
+      "ratio": 0.7319,
+      "compress_mbps": 15.32,
+      "decompress_mbps": 25.35
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 7,
+      "out_size": 6201883,
+      "ratio": 0.7319,
+      "compress_mbps": 15.24,
+      "decompress_mbps": 25.06
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 8,
+      "out_size": 6201887,
+      "ratio": 0.7319,
+      "compress_mbps": 15.22,
+      "decompress_mbps": 24.94
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 9,
+      "out_size": 6201887,
+      "ratio": 0.7319,
+      "compress_mbps": 15.3,
+      "decompress_mbps": 24.93
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 1,
+      "out_size": 1081679,
+      "ratio": 0.2024,
+      "compress_mbps": 74.26,
+      "decompress_mbps": 106.26
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 2,
+      "out_size": 1001890,
+      "ratio": 0.1874,
+      "compress_mbps": 74.05,
+      "decompress_mbps": 118.21
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 3,
+      "out_size": 921722,
+      "ratio": 0.1724,
+      "compress_mbps": 67.22,
+      "decompress_mbps": 127.75
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 4,
+      "out_size": 849263,
+      "ratio": 0.1589,
+      "compress_mbps": 64.23,
+      "decompress_mbps": 142.53
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 5,
+      "out_size": 771964,
+      "ratio": 0.1444,
+      "compress_mbps": 54.81,
+      "decompress_mbps": 144.22
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 6,
+      "out_size": 728098,
+      "ratio": 0.1362,
+      "compress_mbps": 43.49,
+      "decompress_mbps": 150.41
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 7,
+      "out_size": 713635,
+      "ratio": 0.1335,
+      "compress_mbps": 37.23,
+      "decompress_mbps": 154.84
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 8,
+      "out_size": 699093,
+      "ratio": 0.1308,
+      "compress_mbps": 27.08,
+      "decompress_mbps": 146.56
+    },
+    {
+      "compressor": "ocaml",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 9,
+      "out_size": 698459,
+      "ratio": 0.1307,
+      "compress_mbps": 25.17,
+      "decompress_mbps": 148.81
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 10,
+      "out_size": 51721,
+      "ratio": 0.3401,
+      "compress_mbps": 12.25,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 11,
+      "out_size": 51662,
+      "ratio": 0.3397,
+      "compress_mbps": 8.43,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 12,
+      "out_size": 51662,
+      "ratio": 0.3397,
+      "compress_mbps": 5.17,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 10,
+      "out_size": 46657,
+      "ratio": 0.3727,
+      "compress_mbps": 13.72,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 11,
+      "out_size": 46515,
+      "ratio": 0.3716,
+      "compress_mbps": 9.35,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 12,
+      "out_size": 46469,
+      "ratio": 0.3712,
+      "compress_mbps": 7.14,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 10,
+      "out_size": 7725,
+      "ratio": 0.314,
+      "compress_mbps": 15.97,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 11,
+      "out_size": 7727,
+      "ratio": 0.3141,
+      "compress_mbps": 10.79,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 12,
+      "out_size": 7723,
+      "ratio": 0.3139,
+      "compress_mbps": 7.17,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 10,
+      "out_size": 3026,
+      "ratio": 0.2714,
+      "compress_mbps": 17.74,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 11,
+      "out_size": 3024,
+      "ratio": 0.2712,
+      "compress_mbps": 14.13,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 12,
+      "out_size": 3024,
+      "ratio": 0.2712,
+      "compress_mbps": 10.64,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 10,
+      "out_size": 1186,
+      "ratio": 0.3187,
+      "compress_mbps": 41.49,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 11,
+      "out_size": 1186,
+      "ratio": 0.3187,
+      "compress_mbps": 33.55,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 12,
+      "out_size": 1186,
+      "ratio": 0.3187,
+      "compress_mbps": 24.35,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 10,
+      "out_size": 179347,
+      "ratio": 0.1742,
+      "compress_mbps": 30.91,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 11,
+      "out_size": 179096,
+      "ratio": 0.1739,
+      "compress_mbps": 20.04,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 12,
+      "out_size": 179049,
+      "ratio": 0.1739,
+      "compress_mbps": 15.47,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 10,
+      "out_size": 138116,
+      "ratio": 0.3236,
+      "compress_mbps": 12.77,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 11,
+      "out_size": 137923,
+      "ratio": 0.3232,
+      "compress_mbps": 8.78,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 12,
+      "out_size": 137921,
+      "ratio": 0.3232,
+      "compress_mbps": 7.43,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 10,
+      "out_size": 185328,
+      "ratio": 0.3846,
+      "compress_mbps": 12.88,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 11,
+      "out_size": 184440,
+      "ratio": 0.3828,
+      "compress_mbps": 9.1,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 12,
+      "out_size": 184371,
+      "ratio": 0.3826,
+      "compress_mbps": 5.56,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 10,
+      "out_size": 51319,
+      "ratio": 0.1,
+      "compress_mbps": 12.87,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 11,
+      "out_size": 49675,
+      "ratio": 0.0968,
+      "compress_mbps": 6.13,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 12,
+      "out_size": 49194,
+      "ratio": 0.0959,
+      "compress_mbps": 3.65,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 10,
+      "out_size": 11975,
+      "ratio": 0.3132,
+      "compress_mbps": 20.05,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 11,
+      "out_size": 11966,
+      "ratio": 0.3129,
+      "compress_mbps": 13.4,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 12,
+      "out_size": 11965,
+      "ratio": 0.3129,
+      "compress_mbps": 10.77,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 10,
+      "out_size": 1692,
+      "ratio": 0.4003,
+      "compress_mbps": 54.22,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 11,
+      "out_size": 1690,
+      "ratio": 0.3998,
+      "compress_mbps": 45.3,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 12,
+      "out_size": 1690,
+      "ratio": 0.3998,
+      "compress_mbps": 29.74,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 10,
+      "out_size": 3681797,
+      "ratio": 0.3612,
+      "compress_mbps": 12.62,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 11,
+      "out_size": 3679289,
+      "ratio": 0.361,
+      "compress_mbps": 9.26,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 12,
+      "out_size": 3679105,
+      "ratio": 0.361,
+      "compress_mbps": 7.67,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 10,
+      "out_size": 18268811,
+      "ratio": 0.3567,
+      "compress_mbps": 16.35,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 11,
+      "out_size": 18245674,
+      "ratio": 0.3562,
+      "compress_mbps": 11.71,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 12,
+      "out_size": 18241312,
+      "ratio": 0.3561,
+      "compress_mbps": 9.35,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 10,
+      "out_size": 3461494,
+      "ratio": 0.3472,
+      "compress_mbps": 18.28,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 11,
+      "out_size": 3446053,
+      "ratio": 0.3456,
+      "compress_mbps": 10.54,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 12,
+      "out_size": 3447985,
+      "ratio": 0.3458,
+      "compress_mbps": 5.38,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 10,
+      "out_size": 2782465,
+      "ratio": 0.0829,
+      "compress_mbps": 8.49,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 11,
+      "out_size": 2751857,
+      "ratio": 0.082,
+      "compress_mbps": 5.54,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 12,
+      "out_size": 2748273,
+      "ratio": 0.0819,
+      "compress_mbps": 4.07,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 10,
+      "out_size": 2995902,
+      "ratio": 0.487,
+      "compress_mbps": 19.22,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 11,
+      "out_size": 2994386,
+      "ratio": 0.4867,
+      "compress_mbps": 14.58,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 12,
+      "out_size": 2994086,
+      "ratio": 0.4867,
+      "compress_mbps": 12.48,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 10,
+      "out_size": 3608746,
+      "ratio": 0.3578,
+      "compress_mbps": 19.08,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 11,
+      "out_size": 3608161,
+      "ratio": 0.3578,
+      "compress_mbps": 14.81,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 12,
+      "out_size": 3608138,
+      "ratio": 0.3577,
+      "compress_mbps": 13.22,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 10,
+      "out_size": 1697693,
+      "ratio": 0.2562,
+      "compress_mbps": 8.9,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 11,
+      "out_size": 1696742,
+      "ratio": 0.256,
+      "compress_mbps": 6.68,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 12,
+      "out_size": 1696488,
+      "ratio": 0.256,
+      "compress_mbps": 5.74,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 10,
+      "out_size": 5137640,
+      "ratio": 0.2378,
+      "compress_mbps": 16.05,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 11,
+      "out_size": 5122694,
+      "ratio": 0.2371,
+      "compress_mbps": 9.68,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 12,
+      "out_size": 5118130,
+      "ratio": 0.2369,
+      "compress_mbps": 7.0,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 10,
+      "out_size": 5250862,
+      "ratio": 0.7241,
+      "compress_mbps": 25.53,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 11,
+      "out_size": 5250747,
+      "ratio": 0.724,
+      "compress_mbps": 20.83,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 12,
+      "out_size": 5250745,
+      "ratio": 0.724,
+      "compress_mbps": 19.39,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 10,
+      "out_size": 11526846,
+      "ratio": 0.278,
+      "compress_mbps": 10.51,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 11,
+      "out_size": 11520969,
+      "ratio": 0.2779,
+      "compress_mbps": 7.08,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 12,
+      "out_size": 11520871,
+      "ratio": 0.2779,
+      "compress_mbps": 6.12,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 10,
+      "out_size": 5748096,
+      "ratio": 0.6783,
+      "compress_mbps": 38.25,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 11,
+      "out_size": 5747172,
+      "ratio": 0.6782,
+      "compress_mbps": 29.45,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 12,
+      "out_size": 5747146,
+      "ratio": 0.6782,
+      "compress_mbps": 26.58,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 10,
+      "out_size": 637425,
+      "ratio": 0.1193,
+      "compress_mbps": 12.15,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 11,
+      "out_size": 630827,
+      "ratio": 0.118,
+      "compress_mbps": 7.32,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "libdeflate",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 12,
+      "out_size": 629349,
+      "ratio": 0.1177,
+      "compress_mbps": 4.73,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/alice29.txt",
+      "size": 152089,
+      "level": 10,
+      "out_size": 52115,
+      "ratio": 0.3427,
+      "compress_mbps": 1.82,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/asyoulik.txt",
+      "size": 125179,
+      "level": 10,
+      "out_size": 46881,
+      "ratio": 0.3745,
+      "compress_mbps": 2.08,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/cp.html",
+      "size": 24603,
+      "level": 10,
+      "out_size": 7730,
+      "ratio": 0.3142,
+      "compress_mbps": 2.53,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/fields.c",
+      "size": 11150,
+      "level": 10,
+      "out_size": 3030,
+      "ratio": 0.2717,
+      "compress_mbps": 2.44,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/grammar.lsp",
+      "size": 3721,
+      "level": 10,
+      "out_size": 1191,
+      "ratio": 0.3201,
+      "compress_mbps": 2.14,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/kennedy.xls",
+      "size": 1029744,
+      "level": 10,
+      "out_size": 178311,
+      "ratio": 0.1732,
+      "compress_mbps": 1.17,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/lcet10.txt",
+      "size": 426754,
+      "level": 10,
+      "out_size": 138684,
+      "ratio": 0.325,
+      "compress_mbps": 1.93,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/plrabn12.txt",
+      "size": 481861,
+      "level": 10,
+      "out_size": 186472,
+      "ratio": 0.387,
+      "compress_mbps": 1.79,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/ptt5",
+      "size": 513216,
+      "level": 10,
+      "out_size": 52368,
+      "ratio": 0.102,
+      "compress_mbps": 3.12,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/sum",
+      "size": 38240,
+      "level": 10,
+      "out_size": 12277,
+      "ratio": 0.3211,
+      "compress_mbps": 2.16,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "canterbury/xargs.1",
+      "size": 4227,
+      "level": 10,
+      "out_size": 1696,
+      "ratio": 0.4012,
+      "compress_mbps": 2.47,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/dickens",
+      "size": 10192446,
+      "level": 10,
+      "out_size": 3712353,
+      "ratio": 0.3642,
+      "compress_mbps": 1.8,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mozilla",
+      "size": 51220480,
+      "level": 10,
+      "out_size": 18524576,
+      "ratio": 0.3617,
+      "compress_mbps": 1.77,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/mr",
+      "size": 9970564,
+      "level": 10,
+      "out_size": 3523172,
+      "ratio": 0.3534,
+      "compress_mbps": 1.86,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/nci",
+      "size": 33553445,
+      "level": 10,
+      "out_size": 2930422,
+      "ratio": 0.0873,
+      "compress_mbps": 1.68,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/ooffice",
+      "size": 6152192,
+      "level": 10,
+      "out_size": 3017814,
+      "ratio": 0.4905,
+      "compress_mbps": 2.36,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/osdb",
+      "size": 10085684,
+      "level": 10,
+      "out_size": 3647718,
+      "ratio": 0.3617,
+      "compress_mbps": 2.77,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/reymont",
+      "size": 6627202,
+      "level": 10,
+      "out_size": 1724649,
+      "ratio": 0.2602,
+      "compress_mbps": 1.18,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/samba",
+      "size": 21606400,
+      "level": 10,
+      "out_size": 5179097,
+      "ratio": 0.2397,
+      "compress_mbps": 2.22,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/sao",
+      "size": 7251944,
+      "level": 10,
+      "out_size": 5261135,
+      "ratio": 0.7255,
+      "compress_mbps": 2.52,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/webster",
+      "size": 41458703,
+      "level": 10,
+      "out_size": 11640134,
+      "ratio": 0.2808,
+      "compress_mbps": 1.62,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/x-ray",
+      "size": 8474240,
+      "level": 10,
+      "out_size": 5825680,
+      "ratio": 0.6875,
+      "compress_mbps": 3.31,
+      "decompress_mbps": null
+    },
+    {
+      "compressor": "native",
+      "pattern": "silesia/xml",
+      "size": 5345280,
+      "level": 10,
+      "out_size": 643958,
+      "ratio": 0.1205,
+      "compress_mbps": 2.56,
+      "decompress_mbps": null
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds libdeflate's nice-length skip-ahead to the near-optimal parser's candidate-cache build (closes #2740): once the deepest match the chain walk finds at a position reaches a per-tier threshold, the match interior — the next `bestLen - 1` positions, clamped to the region end — is only hash-inserted into the chains (`insertChainRange`), never searched or cached, and the search resumes past it. A long repeated region then costs one chain walk instead of one per byte, and the match finder was ~70% of the L9/L10 cost.

The chain walk already threads its running best match length, so it now returns that as a third tuple component (`chainWalkAll`/`chainWalkAllFast`/`chainWalkAllGuarded` return `Array Nat × Array Nat × Nat`) and the skip decision costs nothing beyond the walk itself — no per-position rescan of the cache slots, which would otherwise tax every position and lose the win on inputs with few long matches (measured: rescanning turned a small win into a net slowdown on binary corpora).

The thresholds are swept per tier, since the L9-fast matcher is shallower (`fastChainDepth = 64`, single round) and gains less from skipping while costing proportionally more ratio: `optNiceSkip = 64` for the L10 exact DP, `fastNiceSkip = 128` for L9-fast. On the Silesia geomean, L10 gains ~2.5x on xml and ~1.8x on nci for +0.3% geomean ratio; L9 gains ~1.5x on xml for +0.45% geomean, both neutral on low-match text/binary members.

The choice arrays stay untrusted heuristics that `optimalEmit` re-verifies with `countMatch` (falling back to a literal), and the `ValidDecomp`/encodability proofs quantify over arbitrary choice arrays, so this is ratio-risk only with zero correctness risk — the roundtrip proofs are unchanged. A second opinion (Codex) confirmed the chain-insertion, DP-validity, termination, and best-length-threading all hold.

🤖 Prepared with Claude Code