### PR TITLE
perf: size-arbitrate the L6-L8 split candidates, emit only the winner

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -463,6 +463,18 @@ open Zip.Spec.DeflateStoredCorrect (deflateStoredPure storedBlockBytes storedBlo
 def pickSmaller (a b : ByteArray) : ByteArray :=
   if a.size < b.size then a else b
 
+/-- Lazy `pickSmaller` keyed on precomputed byte sizes: forces (emits) only the
+    winning candidate. When `sa = (a ()).size` and `sb = (b ()).size` this equals
+    `pickSmaller (a ()) (b ())` byte-for-byte (`a` wins iff strictly smaller, ties
+    keep `b`), but the losing candidate is never emitted — the whole point of
+    sizing every candidate before emitting any. Correctness of the byte-identity
+    (that `sa`/`sb` are the true emitted sizes) is pinned by the `SizeHelpers`
+    conformance tests, exactly as the single-block `fixedBlockBytes`/`dynBlockBytes`
+    dispatch is; the roundtrip theorems only need each candidate to decode. -/
+@[inline] def emitSmallerBy (sa : Nat) (a : Unit → ByteArray)
+    (sb : Nat) (b : Unit → ByteArray) : ByteArray :=
+  if sa < sb then a () else b ()
+
 /-! ## Sizing a block without emitting it
 
 A DEFLATE block's body is a *dot product* of symbol frequencies and code
@@ -1243,6 +1255,71 @@ def deflateDynamicBlocksSharedAtP (data : ByteArray) (toks : Array UInt32)
   else
     (emitSharedBlocksAtP data toks cuts 0 BitWriter.empty).flush
 
+/-- Packed twin of `sharedPartitionSized` (Wave 5, #2552): the exact unflushed
+    bit size of the shared-window partition **together with** each block's sized
+    trees, so the winning candidate's emission reuses them instead of rebuilding
+    `tokenFreqsP` + `dynamicCodeLengths` per block. Each group's frequencies come
+    from `tokenFreqsP` (dense packed tables); component 1 is the same
+    `3 + header + freq·codeLen` sum the packed emitter (`emitSharedBlocksAtP`)
+    flushes as `⌈bits/8⌉`, and component 2's entries are definitionally
+    `dynamicCodeLengths (tokenFreqsP group)` — exactly what `emitSharedBlockP`
+    would recompute (`emitSharedBlocksAtSizedP_eq`). This is what makes the
+    size-arbitrated dispatch (#2753) a net win: the per-block trees are built
+    **once**, during sizing, and the emit pass reuses them. -/
+def sharedPartitionSizedP (toks : Array UInt32) (cuts : List Nat) (pos : Nat) :
+    Nat × List SizedTrees :=
+  let j := min (max (cuts.headD toks.size) (pos + 1)) toks.size
+  let f := tokenFreqsP (toks.extract pos j)
+  let t := sizedTrees f.1 f.2
+  let blockBits := 3 + (writeDynamicHeader BitWriter.empty t.val.1 t.val.2).bitLength
+    + symbolBitCount f.1 f.2 t.val.1.toArray t.val.2.toArray
+  if j ≥ toks.size then (blockBits, [t])
+  else
+    let rest := sharedPartitionSizedP toks cuts.tail j
+    (blockBits + rest.1, t :: rest.2)
+termination_by toks.size - pos
+decreasing_by
+  rename_i h
+  simp only [Nat.not_le] at h
+  omega
+
+/-- Tree-taking twin of `emitSharedBlocksAtP`: same clamped cut points, but each
+    block's `(litLens, distLens)` come from the `trees` list (in lockstep with
+    `cuts`) instead of being recomputed from the group via `tokenFreqsP` +
+    `dynamicCodeLengths`. Byte-identical to `emitSharedBlocksAtP` when `trees` is
+    `sharedPartitionSizedP`'s output (`emitSharedBlocksAtSizedP_eq`). -/
+def emitSharedBlocksAtSizedP (data : ByteArray) (toks : Array UInt32) (cuts : List Nat)
+    (trees : List SizedTrees) (pos : Nat) (bw : BitWriter) : BitWriter :=
+  let j := min (max (cuts.headD toks.size) (pos + 1)) toks.size
+  let t := trees.headD emptySizedTrees
+  let bw := emitDynBlockP bw data (toks.extract pos j) t.val.1 t.val.2
+    t.property.1 t.property.2 (decide (j ≥ toks.size))
+  if j ≥ toks.size then bw
+  else emitSharedBlocksAtSizedP data toks cuts.tail trees.tail j bw
+termination_by toks.size - pos
+decreasing_by
+  rename_i h
+  simp only [Nat.not_le] at h
+  omega
+
+/-- The packed sized-tree split candidate: the flushed byte size of
+    `deflateDynamicBlocksSharedAtP data toks cuts` **paired with** a thunk that
+    emits it, reusing the per-block trees built during sizing (no second
+    frequency/Huffman pass). The emit thunk is byte-identical to the reference
+    `deflateDynamicBlocksSharedAtP` (`deflateDynamicBlocksSharedAtSizedP_emit`),
+    so its roundtrip transfers for **any** cut list; component 1 equals that
+    output's `.size` (`SizeHelpers` conformance). `deflateRaw` sizes every split
+    candidate this way and forces only the winner's thunk. -/
+def deflateDynamicBlocksSharedAtSizedP (data : ByteArray) (toks : Array UInt32)
+    (cuts : List Nat) : Nat × (Unit → ByteArray) :=
+  if data.size == 0 then
+    let out := deflateDynamicBlocksSharedAtP data toks cuts
+    (out.size, fun _ => out)
+  else
+    let sp := sharedPartitionSizedP toks cuts 0
+    ((sp.1 + 7) / 8,
+      fun _ => (emitSharedBlocksAtSizedP data toks cuts sp.2 0 BitWriter.empty).flush)
+
 /-- The compressed-block dispatch (no stored fallback). Every level ≥ 1 uses the
     hash-chain matcher with the level's search depth (`chainDepth`) and interior
     insertion cap (`insertCap`): low levels defer insertion + search shallowly
@@ -1307,6 +1384,36 @@ def deflateRawBaseP (data : ByteArray) (ptokens : Array UInt32) : ByteArray :=
   else if fixedBytes < dynBytes then deflateFixedBlockP data ptokens
   else deflateDynamicBlockCorePWith data ptokens lens.1 lens.2 plan hcl
     (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2
+
+/-- The base candidate *sized and prepared* from one shared token pass: the
+    winner's flushed byte size (the same stored / fixed / dynamic comparison
+    `deflateRawBaseP` makes internally) **paired with** a thunk that emits it. The
+    frequencies, code lengths, and dynamic-tree plan are computed once and shared
+    between the size and the emit — so when the base wins, forcing the thunk pays
+    no second sizing pass. The thunk is definitionally `deflateRawBaseP data
+    ptokens` (`deflateRawBasePPrep_emit`) and component 1 equals its `.size`
+    (`SizeHelpers` conformance), so byte-identity to the emit-then-`pickSmaller`
+    dispatch is preserved. -/
+def deflateRawBasePPrep (data : ByteArray) (ptokens : Array UInt32) : Nat × (Unit → ByteArray) :=
+  let f := tokenFreqsP ptokens
+  let lens := dynamicCodeLengths f.1 f.2
+  let plan := dynHeaderCodes lens.1 lens.2
+  have hcl : plan.clCodes.size ≥ 19 :=
+    Nat.le_of_eq (dynHeaderCodes_clCodes_size lens.1 lens.2).symm
+  let fixedBytes := fixedBlockBytes f.1 f.2
+  let dynBytes := dynBlockBytesWith f.1 f.2 lens.1 lens.2 plan hcl
+  let storedBytes := storedBlockBytes data
+  ((if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then storedBytes
+    else if fixedBytes < dynBytes then fixedBytes else dynBytes),
+   fun _ =>
+    if storedBytes < (if fixedBytes < dynBytes then fixedBytes else dynBytes) then deflateStoredPure data
+    else if fixedBytes < dynBytes then deflateFixedBlockP data ptokens
+    else deflateDynamicBlockCorePWith data ptokens lens.1 lens.2 plan hcl
+      (dynamicCodeLengths_length f.1 f.2).1 (dynamicCodeLengths_length f.1 f.2).2)
+
+/-- The prep's emit thunk is exactly `deflateRawBaseP` (same shared plan). -/
+theorem deflateRawBasePPrep_emit (data : ByteArray) (ptokens : Array UInt32) :
+    (deflateRawBasePPrep data ptokens).2 () = deflateRawBaseP data ptokens := rfl
 
 /-- `deflateRawBaseP` over this level's *packed* `lzMatchP` stream
     (definitional wrapper, `deflateRawBaseP_def`). Equal to the boxed
@@ -1595,12 +1702,14 @@ def incompressiblePrescan (data : ByteArray) : Bool := Id.run do
     The split tier starts at level 6 (#2737; previously level ≥ 8, and before
     that ≥ 7 — see #2698 for that history): with the boundaries chosen by the
     cheap streaming heuristic and the whole split pipeline on packed tokens,
-    the split candidate's cost is one extra emit-speed pass over the token
-    stream (no sizing passes, no boxed tokens). Levels 4–5 stay single-block
-    on purpose — they carry the old mid-band's high-speed points (the split's
-    extra emit pass would push them off that territory), while levels 6–8
-    spend the same cycles on per-block trees instead of deeper chains.
-    Levels 1–3 (`deflate_fast`, emit-bound) stay single-block greedy.
+    the candidates are **sized with their per-block trees captured**
+    (`deflateRawBasePPrep` / `deflateDynamicBlocksSharedAtSizedP`) and only the
+    winner is emitted (#2753), reusing the trees the sizing pass already built —
+    so exactly one emit pass runs instead of two (three at L8). Levels 4–5 stay
+    single-block on purpose — they carry the old mid-band's high-speed points
+    (even a size-only split pass would push them off that territory), while
+    levels 6–8 spend the same cycles on per-block trees instead of deeper
+    chains. Levels 1–3 (`deflate_fast`, emit-bound) stay single-block greedy.
 
     Before any of that, an `incompressiblePrescan` reads a bounded sample (≤128 KiB,
     short-circuited on the first compressible region) and, on unambiguously
@@ -1637,31 +1746,48 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
         (deflateDynamicBlocksOptimal data sharedTokChunk)
     else
       -- Levels 6–8 (and level 9/10 above the memory gate): base vs cross-block
-      -- shared-window split at the observation-divergence boundaries (#2737).
-      -- No cuts ⇒ the split would be a single dynamic block the base already
-      -- sizes, so skip the second emit entirely (every input under
-      -- ~2·splitMinBlockBytes takes this path).
-      let base := deflateRawBaseP data ptokens
+      -- shared-window split at the observation-divergence boundaries (#2737),
+      -- **size-arbitrated** (#2753). Every candidate is *prepared* — sized to its
+      -- flushed byte count with its per-block trees captured (`deflateRawBasePPrep`
+      -- for the base, `deflateDynamicBlocksSharedAtSizedP` for each cut list) — and
+      -- only the winner is emitted, reusing the trees the sizing pass already
+      -- built, instead of emitting every candidate and discarding all but the
+      -- smallest via `pickSmaller`. `emitSmallerBy` selects by the same ⌈bits/8⌉
+      -- byte counts the emitted blocks flush (pinned by the `SizeHelpers`
+      -- conformance tests), so the winner and its bytes are identical to the
+      -- retired two/three-emit dispatch. The tree capture is what makes this a net
+      -- win: sizing a dynamic block otherwise costs a full frequency + Huffman
+      -- pass, so without reuse "size all + emit winner" would not beat "emit all"
+      -- (measured — Silesia L6-L7 +5-12% with reuse). No cuts ⇒ the split would be
+      -- a single dynamic block the base already sizes, so skip it entirely (every
+      -- input under ~2·splitMinBlockBytes takes this path).
+      let basePrep := deflateRawBasePPrep data ptokens
       let cuts := chooseSplitsHeuristicP ptokens
-      let withObs :=
-        if cuts.isEmpty then base
-        else pickSmaller base (deflateDynamicBlocksSharedAtP data ptokens cuts)
+      -- `withObs`: the base, or the size-arbitrated smaller of base and the
+      -- obs-divergence split — selected *eagerly* (the winning prep pair, tie →
+      -- the split, matching `pickSmaller`), so the loser's captured per-block
+      -- trees are dropped now rather than held live through the L8 sizing below.
+      -- The winner's emit thunk stays unforced until the final selection.
+      let withObs : Nat × (Unit → ByteArray) :=
+        if cuts.isEmpty then basePrep
+        else
+          let obsPrep := deflateDynamicBlocksSharedAtSizedP data ptokens cuts
+          if basePrep.1 < obsPrep.1 then basePrep else obsPrep
       if 8 ≤ level then
-        -- Max-ratio split tier: also *emit* the fixed-cadence partition and keep
-        -- the smallest. The old L8 arbitration picked between the heuristic and
-        -- cadence partitions by exact bit sizing; taking the min over the two
-        -- *emitted* candidates decides by the same quantity (⌈bits/8⌉), so this
-        -- is never worse than the retired sizing pass on any input — at the cost
-        -- of one extra packed emit pass instead of two boxed sizing walks.
+        -- Max-ratio split tier: also arbitrate the fixed-cadence partition. The
+        -- old L8 arbitration picked between the heuristic and cadence partitions
+        -- by exact bit sizing; deciding by the sized ⌈bits/8⌉ of the two split
+        -- candidates plus the base is that same quantity — never worse than the
+        -- retired sizing pass on any input, now at *one* emit instead of three.
         -- Measured (Silesia): the divergence cuts alone lose only on sao
         -- (+0.6pp, a statistically uniform star catalog the cadence handles
         -- better); this candidate closes exactly that hole. L4–L7 skip it: they
         -- had no split tier before, so there is nothing to not-regress, and the
-        -- divergence cuts already capture the mid-band win at one extra emit.
-        pickSmaller withObs
-          (deflateDynamicBlocksSharedAtP data ptokens
-            (fixedCadenceCuts sharedTokChunk ptokens.size))
-      else withObs
+        -- divergence cuts already capture the mid-band win.
+        let fixedPrep := deflateDynamicBlocksSharedAtSizedP data ptokens
+          (fixedCadenceCuts sharedTokChunk ptokens.size)
+        emitSmallerBy withObs.1 withObs.2 fixedPrep.1 fixedPrep.2
+      else withObs.2 ()
   else deflateRawBase data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -69,6 +69,22 @@ theorem pickSmaller_bytesToBits {P : List Bool → Prop} (a b : ByteArray)
     P (Deflate.Spec.bytesToBits (pickSmaller a b)) := by
   unfold pickSmaller; split <;> assumption
 
+set_option maxRecDepth 8000 in
+/-- `emitSmallerBy` (the size-arbitrated, emit-only-the-winner selector, #2753)
+    of two candidates that both roundtrip also roundtrips — whichever the size
+    comparison forces is emitted, and both decode to `dataOut`. -/
+theorem inflate_emitSmallerBy (sa sb : Nat) (a b : Unit → ByteArray) (dataOut : ByteArray) (m : Nat)
+    (ha : Zip.Native.Inflate.inflateReference (a ()) m = .ok dataOut)
+    (hb : Zip.Native.Inflate.inflateReference (b ()) m = .ok dataOut) :
+    Zip.Native.Inflate.inflateReference (emitSmallerBy sa a sb b) m = .ok dataOut := by
+  unfold emitSmallerBy; split <;> assumption
+
+/-- `emitSmallerBy` preserves any predicate on the bit stream both candidates meet. -/
+theorem emitSmallerBy_bytesToBits {P : List Bool → Prop} (sa sb : Nat) (a b : Unit → ByteArray)
+    (ha : P (Deflate.Spec.bytesToBits (a ()))) (hb : P (Deflate.Spec.bytesToBits (b ()))) :
+    P (Deflate.Spec.bytesToBits (emitSmallerBy sa a sb b)) := by
+  unfold emitSmallerBy; split <;> assumption
+
 /-- Roundtrip for the compressed-block dispatch (`deflateCompressed`), i.e. the
     `deflateRaw` cases without the stored-block fallback. -/
 theorem inflate_deflateCompressed (data : ByteArray) (level : UInt8)
@@ -106,36 +122,53 @@ theorem inflate_deflateRawBase (data : ByteArray) (level : UInt8)
       (lzMatch data level)
       (cEnc data level) (fun hz => cEmpty data level hz) (cRes data level) _ hsize
 
+set_option maxRecDepth 8000 in
 /-- Unified DEFLATE roundtrip: inflate ∘ deflateRaw = identity.
     This is the Phase B4 capstone theorem from PLAN.md. Generalized to any
     `maxOutputSize` large enough to hold the input. The incompressible pre-scan
     and the level-0 path both dispatch to `deflateStoredPure` directly; the
     cost-model stored fallback is covered by `deflateRawBase`; the level-6–8
-    split and level-9/10 optimal candidates are covered by the `pickSmaller`
-    cases. -/
+    size-arbitrated split (`emitSmallerBy`, #2753) and level-9/10 optimal
+    candidates each emit one of concretely-roundtripping blocks. -/
 theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     (maxOutputSize : Nat) (hsize : data.size ≤ maxOutputSize) :
     Zip.Native.Inflate.inflateReference (deflateRaw data level) maxOutputSize = .ok data := by
   unfold deflateRaw
   dsimp only []
-  simp only [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
-    deflateDynamicBlocksSharedAt_def]
-  -- The obs-divergence candidate (`withObs`): base when the heuristic proposes
-  -- no cuts, else pickSmaller of base and the cut-list split (#2737). The
-  -- roundtrip holds for any cut selector.
-  have hobs : Zip.Native.Inflate.inflateReference
-      (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
-        deflateRawBase data level
-      else
-        pickSmaller (deflateRawBase data level)
-          (deflateDynamicBlocksSharedAt data
-            (fun _ => chooseSplitsHeuristicP (lzMatchP data level)) level))
+  simp only [deflateRawBaseP_def]
+  -- The base and split candidates are *prepared* (sized-with-trees), and only the
+  -- winner's emit thunk is forced. Each thunk decodes: the base thunk is
+  -- `deflateRawBaseP` (`deflateRawBasePPrep_emit`), each split thunk is
+  -- `deflateDynamicBlocksSharedAtP` (`deflateDynamicBlocksSharedAtSizedP_emit`);
+  -- both transfer to the already-proven roundtrips.
+  have hbase : Zip.Native.Inflate.inflateReference
+      ((deflateRawBasePPrep data (lzMatchP data level)).2 ()) maxOutputSize = .ok data := by
+    rw [deflateRawBasePPrep_emit, deflateRawBaseP_def]
+    exact inflate_deflateRawBase data level _ hsize
+  have hsplit : ∀ cuts, Zip.Native.Inflate.inflateReference
+      ((deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level) cuts).2 ())
       maxOutputSize = .ok data := by
+    intro cuts
+    rw [deflateDynamicBlocksSharedAtSizedP_emit, deflateDynamicBlocksSharedAtP_eq,
+      lzMatchP_map, deflateDynamicBlocksSharedAt_def]
+    exact inflate_deflateDynamicBlocksSharedAt data _ level _ hsize
+  -- `withObs`: base, or the eagerly-selected smaller of base and the obs-split.
+  have hwithObs : ∀ p : Nat × (Unit → ByteArray),
+      p = (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
+            deflateRawBasePPrep data (lzMatchP data level)
+          else
+            let obsPrep := deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level)
+              (chooseSplitsHeuristicP (lzMatchP data level))
+            if (deflateRawBasePPrep data (lzMatchP data level)).1 < obsPrep.1 then
+              deflateRawBasePPrep data (lzMatchP data level) else obsPrep) →
+      Zip.Native.Inflate.inflateReference (p.2 ()) maxOutputSize = .ok data := by
+    intro p hp; subst hp
     split
-    · exact inflate_deflateRawBase data level _ hsize
-    · exact inflate_pickSmaller _ _ data maxOutputSize
-        (inflate_deflateRawBase data level _ hsize)
-        (inflate_deflateDynamicBlocksSharedAt data _ level _ hsize)
+    · exact hbase
+    · dsimp only []
+      split
+      · exact hbase
+      · exact hsplit _
   split
   · exact inflate_deflateStoredPure data _ (by omega)
   -- The incompressible pre-scan routes straight to the same stored block.
@@ -153,11 +186,11 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
               (inflate_deflateRawBase data level _ hsize)
               (inflate_deflateDynamicBlocksOptimal data sharedTokChunk _ hsize)
           · split
-            · -- level 8: obs candidate vs the emitted fixed-cadence partition
-              exact inflate_pickSmaller _ _ data maxOutputSize hobs
-                (inflate_deflateDynamicBlocksSharedAt data _ level _ hsize)
+            · -- level 8: withObs vs the sized fixed-cadence partition
+              exact inflate_emitSmallerBy _ _ _ _ data maxOutputSize (hwithObs _ rfl)
+                (hsplit _)
             · -- levels 6–7 (and 9/10 above the optimal-size gate)
-              exact hobs
+              exact hwithObs _ rfl
       · exact inflate_deflateRawBase data level _ hsize
 
 /-- Padding decomposition for the compressed-block dispatch. -/
@@ -229,31 +262,45 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
       padding.length < 8 := by
   unfold deflateRaw
   dsimp only []
-  simp only [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
-    deflateDynamicBlocksSharedAt_def]
+  simp only [deflateRawBaseP_def]
   have hstored : ∃ (contentBits padding : List Bool),
       Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data)
         = contentBits ++ padding ∧ padding.length < 8 :=
     ⟨Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data),
       [], by simp only [List.append_nil], by decide⟩
-  -- The obs-divergence candidate (`withObs`, #2737): base or pickSmaller of
-  -- base and the cut-list split.
-  have hobs : ∃ (contentBits padding : List Bool),
-      Deflate.Spec.bytesToBits
-        (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
-          deflateRawBase data level
-        else
-          pickSmaller (deflateRawBase data level)
-            (deflateDynamicBlocksSharedAt data
-              (fun _ => chooseSplitsHeuristicP (lzMatchP data level)) level))
+  -- The prepared base and split thunks each pad shortly: the base thunk is
+  -- `deflateRawBaseP` (`deflateRawBasePPrep_emit`), each split thunk is
+  -- `deflateDynamicBlocksSharedAtP` (`deflateDynamicBlocksSharedAtSizedP_emit`).
+  have hbase : ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits ((deflateRawBasePPrep data (lzMatchP data level)).2 ())
         = contentBits ++ padding ∧ padding.length < 8 := by
+    rw [deflateRawBasePPrep_emit, deflateRawBaseP_def]; exact deflateRawBase_pad data level
+  have hsplit : ∀ cuts, ∃ (contentBits padding : List Bool),
+      Deflate.Spec.bytesToBits
+        ((deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level) cuts).2 ())
+        = contentBits ++ padding ∧ padding.length < 8 := by
+    intro cuts
+    rw [deflateDynamicBlocksSharedAtSizedP_emit, deflateDynamicBlocksSharedAtP_eq,
+      lzMatchP_map, deflateDynamicBlocksSharedAt_def]
+    exact deflateDynamicBlocksSharedAt_pad data _ level
+  -- `withObs`: base, or the eagerly-selected smaller of base and the obs-split.
+  have hwithObs : ∀ p : Nat × (Unit → ByteArray),
+      p = (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
+            deflateRawBasePPrep data (lzMatchP data level)
+          else
+            let obsPrep := deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level)
+              (chooseSplitsHeuristicP (lzMatchP data level))
+            if (deflateRawBasePPrep data (lzMatchP data level)).1 < obsPrep.1 then
+              deflateRawBasePPrep data (lzMatchP data level) else obsPrep) →
+      ∃ (contentBits padding : List Bool),
+        Deflate.Spec.bytesToBits (p.2 ()) = contentBits ++ padding ∧ padding.length < 8 := by
+    intro p hp; subst hp
     split
-    · exact deflateRawBase_pad data level
-    · exact pickSmaller_bytesToBits
-        (P := fun bits => ∃ (contentBits padding : List Bool),
-          bits = contentBits ++ padding ∧ padding.length < 8)
-        _ _ (deflateRawBase_pad data level)
-        (deflateDynamicBlocksSharedAt_pad data _ level)
+    · exact hbase
+    · dsimp only []
+      split
+      · exact hbase
+      · exact hsplit _
   split
   · -- Level 0: stored blocks — all byte-aligned, padding = []
     exact hstored
@@ -276,13 +323,13 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
               _ _ (deflateRawBase_pad data level)
               (deflateDynamicBlocksOptimal_pad data sharedTokChunk)
           · split
-            · -- level 8: obs candidate vs the emitted fixed-cadence partition
-              exact pickSmaller_bytesToBits
+            · -- level 8: withObs vs the sized fixed-cadence partition
+              exact emitSmallerBy_bytesToBits
                 (P := fun bits => ∃ (contentBits padding : List Bool),
                   bits = contentBits ++ padding ∧ padding.length < 8)
-                _ _ hobs (deflateDynamicBlocksSharedAt_pad data _ level)
+                _ _ _ _ (hwithObs _ rfl) (hsplit _)
             · -- levels 6–7 (and 9/10 above the optimal-size gate)
-              exact hobs
+              exact hwithObs _ rfl
       · exact deflateRawBase_pad data level
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
@@ -426,33 +473,48 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
         = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
   unfold deflateRaw
   dsimp only []
-  simp only [deflateRawBaseP_def, deflateDynamicBlocksSharedAtP_eq, lzMatchP_map,
-    deflateDynamicBlocksSharedAt_def]
+  simp only [deflateRawBaseP_def]
   have hstored : ∃ remaining,
       Deflate.Spec.decode.goR
           (Deflate.Spec.bytesToBits (Zip.Spec.DeflateStoredCorrect.deflateStoredPure data)) []
         = some (data.data.toList, remaining) ∧ remaining.length < 8 :=
     ⟨[], Deflate.Spec.deflateStoredPure_goR data, by decide⟩
-  -- The obs-divergence candidate (`withObs`, #2737): base or pickSmaller of
-  -- base and the cut-list split.
-  have hobs : ∃ remaining,
+  -- The prepared base and split thunks each leave a short remaining: the base
+  -- thunk is `deflateRawBaseP` (`deflateRawBasePPrep_emit`), each split thunk is
+  -- `deflateDynamicBlocksSharedAtP` (`deflateDynamicBlocksSharedAtSizedP_emit`).
+  have hbase : ∃ remaining,
       Deflate.Spec.decode.goR
-          (Deflate.Spec.bytesToBits
-            (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
-              deflateRawBase data level
-            else
-              pickSmaller (deflateRawBase data level)
-                (deflateDynamicBlocksSharedAt data
-                  (fun _ => chooseSplitsHeuristicP (lzMatchP data level)) level))) []
+        (Deflate.Spec.bytesToBits ((deflateRawBasePPrep data (lzMatchP data level)).2 ())) []
         = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+    rw [deflateRawBasePPrep_emit, deflateRawBaseP_def]; exact deflateRawBase_goR_pad data level
+  have hsplit : ∀ cuts, ∃ remaining,
+      Deflate.Spec.decode.goR
+        (Deflate.Spec.bytesToBits
+          ((deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level) cuts).2 ())) []
+        = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+    intro cuts
+    rw [deflateDynamicBlocksSharedAtSizedP_emit, deflateDynamicBlocksSharedAtP_eq,
+      lzMatchP_map, deflateDynamicBlocksSharedAt_def]
+    exact deflateDynamicBlocksSharedAt_goR_pad data _ level
+  -- `withObs`: base, or the eagerly-selected smaller of base and the obs-split.
+  have hwithObs : ∀ p : Nat × (Unit → ByteArray),
+      p = (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
+            deflateRawBasePPrep data (lzMatchP data level)
+          else
+            let obsPrep := deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level)
+              (chooseSplitsHeuristicP (lzMatchP data level))
+            if (deflateRawBasePPrep data (lzMatchP data level)).1 < obsPrep.1 then
+              deflateRawBasePPrep data (lzMatchP data level) else obsPrep) →
+      ∃ remaining,
+        Deflate.Spec.decode.goR (Deflate.Spec.bytesToBits (p.2 ())) []
+          = some (data.data.toList, remaining) ∧ remaining.length < 8 := by
+    intro p hp; subst hp
     split
-    · exact deflateRawBase_goR_pad data level
-    · exact pickSmaller_bytesToBits
-        (P := fun bits => ∃ remaining,
-          Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
-            remaining.length < 8)
-        _ _ (deflateRawBase_goR_pad data level)
-        (deflateDynamicBlocksSharedAt_goR_pad data _ level)
+    · exact hbase
+    · dsimp only []
+      split
+      · exact hbase
+      · exact hsplit _
   split
   · -- Level 0: stored blocks — byte-aligned, remaining = []
     exact hstored
@@ -477,14 +539,14 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
               _ _ (deflateRawBase_goR_pad data level)
               (deflateDynamicBlocksOptimal_goR_pad data sharedTokChunk)
           · split
-            · -- level 8: obs candidate vs the emitted fixed-cadence partition
-              exact pickSmaller_bytesToBits
+            · -- level 8: withObs vs the sized fixed-cadence partition
+              exact emitSmallerBy_bytesToBits
                 (P := fun bits => ∃ remaining,
                   Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
                     remaining.length < 8)
-                _ _ hobs (deflateDynamicBlocksSharedAt_goR_pad data _ level)
+                _ _ _ _ (hwithObs _ rfl) (hsplit _)
             · -- levels 6–7 (and 9/10 above the optimal-size gate)
-              exact hobs
+              exact hwithObs _ rfl
       · exact deflateRawBase_goR_pad data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -300,4 +300,76 @@ theorem deflateDynamicBlocksSharedAtP_eq (data : ByteArray) (ws : Array UInt32)
   · rfl
   · rw [emitSharedBlocksAtP_eq]
 
+/-! ## The packed sized-tree split candidate reuses trees (Wave 5 → #2753)
+
+`emitSharedBlocksAtSizedP`, fed the trees `sharedPartitionSizedP` builds while
+sizing, emits byte-for-byte what `emitSharedBlocksAtP` emits recomputing them —
+the packed twin of `emitSharedBlocksAtSized_eq`. Each block's trees are
+`sizedTrees (tokenFreqsP group) = dynamicCodeLengths (tokenFreqsP group)`, which
+is exactly what `emitSharedBlockP` recomputes; the `emitDynBlockP` calls then
+coincide (the alphabet-size proofs are proof-irrelevant). -/
+
+/-- Fed the sizing pass's trees, the tree-taking packed emitter equals the
+    reference packed emitter (fuel-quantified form for the induction). -/
+private theorem emitSharedBlocksAtSizedP_eq_fuel (data : ByteArray) (ws : Array UInt32) :
+    ∀ (fuel pos : Nat), ws.size - pos < fuel → ∀ (cuts : List Nat) (bw : BitWriter),
+      emitSharedBlocksAtSizedP data ws cuts (sharedPartitionSizedP ws cuts pos).2 pos bw
+        = emitSharedBlocksAtP data ws cuts pos bw := by
+  intro fuel
+  induction fuel with
+  | zero => intro pos hf; omega
+  | succ fuel ih =>
+    intro pos hf cuts bw
+    by_cases hend : min (max (cuts.headD ws.size) (pos + 1)) ws.size ≥ ws.size
+    · have hsnd : (sharedPartitionSizedP ws cuts pos).2 =
+          [sizedTrees (tokenFreqsP (ws.extract pos
+            (min (max (cuts.headD ws.size) (pos + 1)) ws.size))).1
+            (tokenFreqsP (ws.extract pos
+            (min (max (cuts.headD ws.size) (pos + 1)) ws.size))).2] := by
+        conv => lhs; unfold sharedPartitionSizedP
+        simp only [if_pos hend]
+      rw [hsnd]
+      conv => lhs; unfold emitSharedBlocksAtSizedP
+      conv => rhs; unfold emitSharedBlocksAtP
+      simp only [if_pos hend, List.headD_cons, emitSharedBlockP, sizedTrees]
+    · have hsnd : (sharedPartitionSizedP ws cuts pos).2 =
+          sizedTrees (tokenFreqsP (ws.extract pos
+            (min (max (cuts.headD ws.size) (pos + 1)) ws.size))).1
+            (tokenFreqsP (ws.extract pos
+            (min (max (cuts.headD ws.size) (pos + 1)) ws.size))).2 ::
+          (sharedPartitionSizedP ws cuts.tail
+            (min (max (cuts.headD ws.size) (pos + 1)) ws.size)).2 := by
+        conv => lhs; unfold sharedPartitionSizedP
+        simp only [if_neg hend]
+      rw [hsnd]
+      conv => lhs; unfold emitSharedBlocksAtSizedP
+      conv => rhs; unfold emitSharedBlocksAtP
+      simp only [if_neg hend, List.headD_cons, List.tail_cons, emitSharedBlockP, sizedTrees]
+      exact ih (min (max (cuts.headD ws.size) (pos + 1)) ws.size) (by omega) cuts.tail _
+
+/-- Fed the sizing pass's trees, the tree-taking packed emitter equals the
+    reference packed emitter, for any cut list and start position. -/
+theorem emitSharedBlocksAtSizedP_eq (data : ByteArray) (ws : Array UInt32)
+    (cuts : List Nat) (pos : Nat) (bw : BitWriter) :
+    emitSharedBlocksAtSizedP data ws cuts (sharedPartitionSizedP ws cuts pos).2 pos bw
+      = emitSharedBlocksAtP data ws cuts pos bw :=
+  emitSharedBlocksAtSizedP_eq_fuel data ws (ws.size - pos + 1) pos (by omega) cuts bw
+
+/-- The packed sized-tree split candidate's emit thunk is byte-identical to the
+    reference `deflateDynamicBlocksSharedAtP`: the roundtrip and padding theorems
+    transfer through this, exactly as for the un-sized packed candidate. -/
+theorem deflateDynamicBlocksSharedAtSizedP_emit (data : ByteArray) (ws : Array UInt32)
+    (cuts : List Nat) :
+    (deflateDynamicBlocksSharedAtSizedP data ws cuts).2 () =
+      deflateDynamicBlocksSharedAtP data ws cuts := by
+  unfold deflateDynamicBlocksSharedAtSizedP
+  split
+  · rfl
+  · rename_i h
+    show (emitSharedBlocksAtSizedP data ws cuts (sharedPartitionSizedP ws cuts 0).2 0
+      BitWriter.empty).flush = deflateDynamicBlocksSharedAtP data ws cuts
+    rw [emitSharedBlocksAtSizedP_eq]
+    unfold deflateDynamicBlocksSharedAtP
+    rw [if_neg h]
+
 end Zip.Native.Deflate

--- a/ZipTest.lean
+++ b/ZipTest.lean
@@ -30,6 +30,7 @@ import ZipTest.BoundedReadTest
 import ZipTest.InflateTable
 import ZipTest.OptimalParse
 import ZipTest.PackedTokens
+import ZipTest.SizeHelpers
 
 def main : IO Unit := do
   unless ← System.FilePath.pathExists "testdata" do
@@ -60,6 +61,7 @@ def main : IO Unit := do
   ZipTest.NativeDeflate.tests
   ZipTest.OptimalParse.tests
   ZipTest.PackedTokens.tests
+  ZipTest.SizeHelpers.tests
   ZipTest.NativeCompressBench.tests
   ZipTest.Benchmark.tests
   ZipTest.FuzzInflate.tests

--- a/ZipTest/SizeHelpers.lean
+++ b/ZipTest/SizeHelpers.lean
@@ -154,6 +154,61 @@ def tests : IO Unit := do
     let arbCuts := chooseSplitsArbitrated toks9
     unless (sharedPartitionSized toks9 arbCuts 0).1 == sharedPartitionBits toks9 arbCuts 0 do
       throw (IO.userError s!"sharedPartitionSized bits mismatch on {name}")
+
+  -- 7. Size-arbitrated split dispatch with sized-tree reuse (#2753): each
+  -- candidate is *prepared* — the winner's flushed byte size paired with an
+  -- emit thunk that reuses the trees built during sizing. The prepared sizes
+  -- must equal the emitted `.size` (so the arbitration decides by the true
+  -- flushed byte counts), the emit thunks must be byte-identical to the
+  -- reference emitters (`deflateRawBaseP` / `deflateDynamicBlocksSharedAtP`,
+  -- proven — this pins the compiled code), and the new emit-only-the-winner
+  -- `deflateRaw` at levels 6/7/8 must be byte-identical to the retired
+  -- emit-every-candidate dispatch.
+  for (name, data) in samples do
+    for level in [(6 : UInt8), 7, 8] do
+      let ptokens := lzMatchP data level
+      -- 7a. base prep: size == emitted size, thunk == reference emit
+      let basePrep := deflateRawBasePPrep data ptokens
+      let baseEmit := deflateRawBaseP data ptokens
+      unless basePrep.1 == baseEmit.size do
+        throw (IO.userError
+          s!"deflateRawBasePPrep size mismatch on {name}@L{level}: model={basePrep.1} emit={baseEmit.size}")
+      unless (basePrep.2 ()).beq baseEmit do
+        throw (IO.userError s!"deflateRawBasePPrep emit not byte-identical on {name}@L{level}")
+      -- 7b. split prep: size == emitted size and thunk == reference emit, over
+      -- diverse cut lists (the tree-reuse emit must match the recompute emit)
+      if data.size > 0 then
+        let cutsLists : List (String × List Nat) :=
+          [ ("heuristic", chooseSplitsHeuristicP ptokens),
+            ("fixed", fixedCadenceCuts sharedTokChunk ptokens.size),
+            ("empty", []),
+            ("nonmonotone", [5, 3, 7]),
+            ("huge", [1000000000]) ]
+        for (cname, cuts) in cutsLists do
+          let splitPrep := deflateDynamicBlocksSharedAtSizedP data ptokens cuts
+          let splitEmit := deflateDynamicBlocksSharedAtP data ptokens cuts
+          unless splitPrep.1 == splitEmit.size do
+            throw (IO.userError
+              s!"deflateDynamicBlocksSharedAtSizedP size mismatch on {name}@L{level}/{cname}: \
+                 model={splitPrep.1} emit={splitEmit.size}")
+          unless (splitPrep.2 ()).beq splitEmit do
+            throw (IO.userError
+              s!"deflateDynamicBlocksSharedAtSizedP emit not byte-identical on {name}@L{level}/{cname}")
+      -- 7c. the size-arbitrated dispatch is byte-identical to the old
+      -- emit-every-candidate one (`pickSmaller` over emitted blocks).
+      let base := deflateRawBaseP data ptokens
+      let cuts := chooseSplitsHeuristicP ptokens
+      let withObs := if cuts.isEmpty then base
+        else pickSmaller base (deflateDynamicBlocksSharedAtP data ptokens cuts)
+      let refOut := if 8 ≤ level then
+          pickSmaller withObs (deflateDynamicBlocksSharedAtP data ptokens
+            (fixedCadenceCuts sharedTokChunk ptokens.size))
+        else withObs
+      let newOut := deflateRaw data level
+      unless newOut.beq refOut do
+        throw (IO.userError
+          s!"deflateRaw(L{level}) not byte-identical to emit-all reference on {name}: \
+             new.size={newOut.size} ref.size={refOut.size}")
   IO.println "  SizeHelpers tests passed."
 
 end ZipTest.SizeHelpers

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p4b86b30721)">
+   <g clip-path="url(#p93a7c51671)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEUlEQVR4nO3YQYrkZx2H8a6emmEYmsEEJomDiAR05T6LnCGbHMQTeAtPIASyylZEl+48gqhIIGMwnelk0tPT6ampvzv3geflZ4rP5wTfopq3nv7tjt9+up3x43J7Pb1gndsX0wuW2F7fTU9YZvf4nekJa9x/OL1gnfPz6QVrvL6dXrDO7jS/s+3q2fSEZU7zGwMAGCSwAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+3+dXU5vWOL18XZ6wjI//cn70xOWudjem56wxO7l8+kJy/zl1d+mJyzxswfvTE9Y5nC8m56wxPWb0333746H6QlLfPD459MTlnHBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNjuxfefbdMjVnh1uJ6esMyT46PpCesc7qYXrHF9Ob1gnXd/Nb1gievtZnrCMqf6Pj7ZLqYnLPPs7Pn0hCWeXn4zPWEZFywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCI7S+uLqc3LHGxfzA9YZ3bL6cXLLNdfzs9YY3jcXrBMrtH/5mesMQpvyEX+8fTE9Z48HB6wTJPX91NT1hiu/n39IRlXLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL77fLL6Q38UMfj9AL4n+2Lf05PWOPc/58/Ot5G/o94QQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/81Xn09vWOLq9s30hGX++uzF9IRl/vDxh9MTlnjv0S+mJyzz699/Mj1hiY9++fb0hGX+cXU7PYEf6I9/+vv0hCVufvfb6QnLuGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbHc4/nmbHrHCm+NhesIy57vT7eJ7tzfTE9a4t59esM7L59MLlji+9XR6wjLbdpyesMS9E74ZvN5O8zft/uE0P9fZmQsWAEBOYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxPbnNy+mNyxxfm8/PWGdrz+fXrDMdvPd9IQ1DofpBcvs3noyPWGJ81fX0xPWuf9wesEaV6f7Nt7//jT/HrfrE33zz1ywAAByAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIPZfJx+Mwj7c4WwAAAAASUVORK5CYII=" id="image84bbf97799" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3YwarcZx2H8TMnk1DCIbRC2hpEilBX7l14DW68EK/Au/AKhIIrtyK6dOclSFuK0LSYQ2Lj6cnkZDL/7twXnpefHT6fK/gOA+8889udvvnjdsEPy+FmesE6h5fTC5bY3txNT1hm9+j96Qlr3H9nesE6l5fTC9Z4c5hesM7uPL+z7cXT6QnLnOc3BgAwSGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT2X1xcT29Y4s3pMD1hmR+/+7PpCctcbR9OT1hi9+3z6QnL/P3VP6cnLPGTB+9PT1jmeLqbnrDEzdvzfffvTsfpCUv88tFPpycs44IFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsd3L13/apkes8Op4Mz1hmcenh9MT1jneTS9Y4+Z6esE6H/x8esESN9vt9IRlzvV9fLxdTU9Y5unF8+kJSzy5/s/0hGVcsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2v3pxPb1hiav9g+kJ6xy+nl6wzHbzzfSENU6n6QXL7B7+e3rCEuf8hlztH01PWOPBO9MLlnny6m56whLb7VfTE5ZxwQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiO2366+nN/B9nU7TC+B/ti8/n56wxqX/nz843kb+j3hBAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILb/7bN/TW9Y4sXh7fSEZf7x9OX0hGX+/JtfTU9Y4sOHH01PWOYXf/hkesISv/74R9MTlvnsxWF6At/TX/766fSEJW5//7vpCcu4YAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBsdzz9bZsescLb03F6wjKXu/Pt4nuH2+kJa9zbTy9Y59vn0wuWOL33ZHrCMtt2mp6wxL0zvhm82c7zN+3+8Tw/18WFCxYAQE5gAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE9pevb6c3LHF5uZ+esM6zT6cXLLPd/nd6whrH4/SCZXbvPZ6esMTl3WF6wjoPHk4vWOPZ59MLlrn/+mZ6whLbzZm++RcuWAAAOYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABD7DjZrjMJlrDqzAAAAAElFTkSuQmCC" id="image44679fc0e8" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m121a652c0e" d="M 0 0 
+       <path id="me203e183aa" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m121a652c0e" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m121a652c0e" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m121a652c0e" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m121a652c0e" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m121a652c0e" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m121a652c0e" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m121a652c0e" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m121a652c0e" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m121a652c0e" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m121a652c0e" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m121a652c0e" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me203e183aa" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mb68207033b" d="M 0 0 
+       <path id="m09e1d7bef1" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb68207033b" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09e1d7bef1" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mb68207033b" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09e1d7bef1" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb68207033b" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09e1d7bef1" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mb68207033b" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09e1d7bef1" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mb68207033b" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09e1d7bef1" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mb68207033b" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09e1d7bef1" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb68207033b" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09e1d7bef1" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mb68207033b" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09e1d7bef1" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,19 +1303,40 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -25 -->
+    <!-- -20 -->
     <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- -21 -->
+    <!-- -14 -->
     <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1420,27 +1441,6 @@ z
    <g id="text_24">
     <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
@@ -1455,8 +1455,23 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- -23 -->
+    <!-- -17 -->
     <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -2 -->
+    <g transform="translate(386.816887 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -53 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1491,22 +1506,6 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -10 -->
-    <g transform="translate(384.749074 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -53 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
@@ -2183,18 +2182,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image55a40524ed" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image1ea8fc0ac2" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mae3858eed5" d="M 0 0 
+       <path id="mda747980dc" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mae3858eed5" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda747980dc" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2217,7 +2216,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mae3858eed5" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda747980dc" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2231,7 +2230,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mae3858eed5" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda747980dc" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2245,7 +2244,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mae3858eed5" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda747980dc" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2258,7 +2257,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mae3858eed5" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda747980dc" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2271,7 +2270,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mae3858eed5" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda747980dc" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2284,7 +2283,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mae3858eed5" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mda747980dc" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2945,8 +2944,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.606953 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.904453 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3016,12 +3015,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3061,109 +3060,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p4b86b30721">
+  <clipPath id="p93a7c51671">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="ma97dbfdbae" d="M 0 0 
+       <path id="m8f378e7576" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma97dbfdbae" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f378e7576" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma97dbfdbae" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f378e7576" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma97dbfdbae" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f378e7576" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma97dbfdbae" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f378e7576" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma97dbfdbae" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f378e7576" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma97dbfdbae" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f378e7576" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma97dbfdbae" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8f378e7576" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m7af9cf99de" d="M 0 0 
+       <path id="m33de64ba0f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7af9cf99de" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m33de64ba0f" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m7af9cf99de" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m33de64ba0f" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7af9cf99de" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m33de64ba0f" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m3b1fe93d45" d="M 0 0 
+       <path id="m6a4ae2333b" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m3b1fe93d45" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6a4ae2333b" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 165.254203) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 165.450093) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(105.541635 307.810372) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(105.541635 307.648072) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m52d038e996" d="M -2.5 2.5 
+     <path id="m0d6ccb6e77" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p300c156ebd)">
-     <use xlink:href="#m52d038e996" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d038e996" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d038e996" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d038e996" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d038e996" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d038e996" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d038e996" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d038e996" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m52d038e996" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p77ecb5723f)">
+     <use xlink:href="#m0d6ccb6e77" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d6ccb6e77" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d6ccb6e77" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d6ccb6e77" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d6ccb6e77" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d6ccb6e77" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d6ccb6e77" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d6ccb6e77" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0d6ccb6e77" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.211803
 L 310.240844 102.355284 
 L 309.257387 102.498333 
 L 308.273931 102.64095 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.64095 
@@ -1853,7 +1853,7 @@ L 273.545396 115.495372
 L 272.773651 115.744903 
 L 272.001906 115.993127 
 L 271.230161 116.240058 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.240058 
@@ -1905,7 +1905,7 @@ L 221.171803 119.753456
 L 220.059395 119.828647 
 L 218.946988 119.90372 
 L 217.83458 119.978674 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 119.978674 
@@ -1957,7 +1957,7 @@ L 179.624997 137.397353
 L 178.775895 137.720164 
 L 177.926794 138.04079 
 L 177.077692 138.359262 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.359262 
@@ -2009,7 +2009,7 @@ L 163.767861 156.658214
 L 163.472087 156.994351 
 L 163.176313 157.328121 
 L 162.880539 157.659557 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.659557 
@@ -2061,7 +2061,7 @@ L 160.875139 164.650114
 L 160.830574 164.794326 
 L 160.78601 164.9381 
 L 160.741445 165.081439 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.081439 
@@ -2113,7 +2113,7 @@ L 154.390101 182.353217
 L 154.24896 182.673779 
 L 154.107819 182.992187 
 L 153.966678 183.30847 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.30847 
@@ -2165,26 +2165,26 @@ L 151.73818 193.734619
 L 151.688658 193.942139 
 L 151.639136 194.148754 
 L 151.589614 194.354473 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m21ac5b7896" d="M 0 -2.5 
+     <path id="ma8ea8d25c2" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p300c156ebd)">
-     <use xlink:href="#m21ac5b7896" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21ac5b7896" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21ac5b7896" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21ac5b7896" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21ac5b7896" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21ac5b7896" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21ac5b7896" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21ac5b7896" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21ac5b7896" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p77ecb5723f)">
+     <use xlink:href="#ma8ea8d25c2" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8ea8d25c2" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8ea8d25c2" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8ea8d25c2" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8ea8d25c2" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8ea8d25c2" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8ea8d25c2" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8ea8d25c2" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8ea8d25c2" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.610561
 L 294.051648 97.995945 
 L 288.886486 98.37822 
 L 283.721324 98.757435 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 98.757435 
@@ -2289,7 +2289,7 @@ L 222.934499 119.784103
 L 221.583681 120.159977 
 L 220.232863 120.532893 
 L 218.882044 120.902897 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 120.902897 
@@ -2341,7 +2341,7 @@ L 189.411904 126.368029
 L 188.757012 126.482596 
 L 188.10212 126.596887 
 L 187.447228 126.710903 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 126.710903 
@@ -2393,7 +2393,7 @@ L 177.036521 137.569875
 L 176.805172 137.785045 
 L 176.573823 137.999242 
 L 176.342474 138.212475 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.212475 
@@ -2445,7 +2445,7 @@ L 163.884824 160.054818
 L 163.607987 160.442131 
 L 163.33115 160.826303 
 L 163.054314 161.207386 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.207386 
@@ -2497,7 +2497,7 @@ L 162.263275 168.244909
 L 162.245696 168.390018 
 L 162.228118 168.534683 
 L 162.210539 168.678909 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.678909 
@@ -2549,7 +2549,7 @@ L 159.485481 175.228819
 L 159.424925 175.364567 
 L 159.364368 175.499927 
 L 159.303811 175.634901 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.634901 
@@ -2601,30 +2601,30 @@ L 157.888296 179.180942
 L 157.85684 179.256806 
 L 157.825384 179.332549 
 L 157.793928 179.408171 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m47dc2085cd" d="M -0 3.535534 
+     <path id="mb185433dcf" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p300c156ebd)">
-     <use xlink:href="#m47dc2085cd" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47dc2085cd" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p77ecb5723f)">
+     <use xlink:href="#mb185433dcf" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb185433dcf" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.99106
 L 205.766837 81.29344 
 L 204.771342 81.593904 
 L 203.775848 81.892474 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.892474 
@@ -2729,7 +2729,7 @@ L 188.032264 88.395253
 L 187.682406 88.530091 
 L 187.332549 88.664546 
 L 186.982691 88.798621 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.798621 
@@ -2781,7 +2781,7 @@ L 180.229518 90.954599
 L 180.079447 91.001413 
 L 179.929376 91.048181 
 L 179.779306 91.094902 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.094902 
@@ -2833,7 +2833,7 @@ L 158.995974 98.861987
 L 158.534122 99.02092 
 L 158.07227 99.179321 
 L 157.610419 99.337194 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.337194 
@@ -2885,7 +2885,7 @@ L 149.27802 107.306615
 L 149.092855 107.469343 
 L 148.907691 107.631514 
 L 148.722526 107.793132 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.793132 
@@ -2937,7 +2937,7 @@ L 144.65906 120.462338
 L 144.568761 120.708742 
 L 144.478462 120.95387 
 L 144.388162 121.197738 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.197738 
@@ -2989,7 +2989,7 @@ L 128.153555 143.293159
 L 127.792786 143.68398 
 L 127.432016 144.071604 
 L 127.071247 144.456083 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.456083 
@@ -3041,7 +3041,7 @@ L 124.653192 151.618794
 L 124.599457 151.76629 
 L 124.545723 151.913329 
 L 124.491988 152.059912 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.059912 
@@ -3093,7 +3093,7 @@ L 94.606058 205.368437
 L 93.941926 206.074323 
 L 93.277794 206.769849 
 L 92.613662 207.455314 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.455314 
@@ -3145,7 +3145,7 @@ L 87.677774 224.060225
 L 87.568088 224.37049 
 L 87.458402 224.678737 
 L 87.348715 224.984992 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 224.984992 
@@ -3197,23 +3197,23 @@ L 86.134388 240.678828
 L 86.107403 240.974786 
 L 86.080418 241.268907 
 L 86.053433 241.561213 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m0678f05679" d="M -0 2.5 
+     <path id="md806be60ef" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p300c156ebd)">
-     <use xlink:href="#m0678f05679" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p77ecb5723f)">
+     <use xlink:href="#md806be60ef" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m5643790a8c" d="M -0.833333 2.5 
+     <path id="m6349dbad88" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p300c156ebd)">
-     <use xlink:href="#m5643790a8c" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5643790a8c" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5643790a8c" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5643790a8c" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5643790a8c" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5643790a8c" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5643790a8c" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5643790a8c" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5643790a8c" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p77ecb5723f)">
+     <use xlink:href="#m6349dbad88" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6349dbad88" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6349dbad88" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6349dbad88" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6349dbad88" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6349dbad88" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6349dbad88" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6349dbad88" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6349dbad88" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 180.888961
 L 282.301002 180.947904 
 L 280.549589 181.006774 
 L 278.798176 181.06557 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 181.06557 
@@ -3342,7 +3342,7 @@ L 252.902686 188.238912
 L 252.327231 188.386611 
 L 251.751776 188.53385 
 L 251.17632 188.680634 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 188.680634 
@@ -3394,7 +3394,7 @@ L 203.954921 186.473055
 L 202.905557 186.42281 
 L 201.856192 186.372512 
 L 200.806828 186.322161 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 186.322161 
@@ -3446,7 +3446,7 @@ L 171.740947 201.881696
 L 171.095038 202.175521 
 L 170.44913 202.467535 
 L 169.803221 202.757761 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 202.757761 
@@ -3498,7 +3498,7 @@ L 162.409549 210.675366
 L 162.245246 210.837123 
 L 162.080942 210.99833 
 L 161.916638 211.158991 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 211.158991 
@@ -3550,7 +3550,7 @@ L 158.898325 213.866476
 L 158.831251 213.92492 
 L 158.764178 213.983292 
 L 158.697104 214.041592 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 214.041592 
@@ -3602,7 +3602,7 @@ L 154.543684 229.493591
 L 154.451386 229.785704 
 L 154.359088 230.076027 
 L 154.26679 230.364582 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 230.364582 
@@ -3654,11 +3654,11 @@ L 153.16961 235.985723
 L 153.145228 236.103367 
 L 153.120846 236.220719 
 L 153.096464 236.337782 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m87021c970a" d="M -1.25 2.5 
+     <path id="mf27bebf1b6" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p300c156ebd)">
-     <use xlink:href="#m87021c970a" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87021c970a" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87021c970a" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87021c970a" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87021c970a" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87021c970a" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87021c970a" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87021c970a" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87021c970a" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p77ecb5723f)">
+     <use xlink:href="#mf27bebf1b6" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27bebf1b6" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27bebf1b6" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27bebf1b6" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27bebf1b6" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27bebf1b6" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27bebf1b6" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27bebf1b6" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf27bebf1b6" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 147.037933
 L 252.377414 147.089635 
 L 251.306944 147.141281 
 L 250.236474 147.192871 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 147.192871 
@@ -3787,7 +3787,7 @@ L 226.969772 152.467777
 L 226.452735 152.578579 
 L 225.935697 152.689122 
 L 225.418659 152.799409 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 152.799409 
@@ -3839,7 +3839,7 @@ L 213.147044 158.556257
 L 212.874341 158.676569 
 L 212.601639 158.796576 
 L 212.328936 158.91628 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 158.91628 
@@ -3891,7 +3891,7 @@ L 209.236323 156.954621
 L 209.167599 156.910092 
 L 209.098874 156.865522 
 L 209.030149 156.82091 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 156.82091 
@@ -3943,7 +3943,7 @@ L 198.265399 167.356927
 L 198.026182 167.566396 
 L 197.786966 167.774943 
 L 197.547749 167.982576 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 167.982576 
@@ -3995,7 +3995,7 @@ L 194.989815 169.398061
 L 194.932972 169.429041 
 L 194.876129 169.460001 
 L 194.819287 169.49094 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 169.49094 
@@ -4047,7 +4047,7 @@ L 193.228821 176.568565
 L 193.193478 176.714439 
 L 193.158134 176.859866 
 L 193.12279 177.004847 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 177.004847 
@@ -4099,11 +4099,11 @@ L 192.818243 181.564429
 L 192.811475 181.660932 
 L 192.804707 181.75724 
 L 192.79794 181.853352 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m3a9a1688ee" d="M 0 -2.5 
+     <path id="mf68d21e6e9" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p300c156ebd)">
-     <use xlink:href="#m3a9a1688ee" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3a9a1688ee" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3a9a1688ee" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3a9a1688ee" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3a9a1688ee" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3a9a1688ee" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3a9a1688ee" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3a9a1688ee" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m3a9a1688ee" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p77ecb5723f)">
+     <use xlink:href="#mf68d21e6e9" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf68d21e6e9" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf68d21e6e9" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf68d21e6e9" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf68d21e6e9" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf68d21e6e9" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf68d21e6e9" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf68d21e6e9" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf68d21e6e9" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 117.963319
 L 206.45578 117.9566 
 L 206.45578 117.949879 
 L 206.45578 117.943158 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 117.943158 
@@ -4230,7 +4230,7 @@ L 206.45578 118.018397
 L 206.45578 118.020068 
 L 206.45578 118.021738 
 L 206.45578 118.023409 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.023409 
@@ -4282,7 +4282,7 @@ L 206.45578 118.009588
 L 206.45578 118.00928 
 L 206.45578 118.008973 
 L 206.45578 118.008666 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.008666 
@@ -4334,7 +4334,7 @@ L 173.935517 132.674231
 L 173.212844 132.953702 
 L 172.490172 133.231533 
 L 171.767499 133.507746 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 133.507746 
@@ -4386,7 +4386,7 @@ L 164.056872 143.78437
 L 163.885524 143.989231 
 L 163.714177 144.193211 
 L 163.54283 144.396316 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.396316 
@@ -4438,7 +4438,7 @@ L 160.385378 149.94789
 L 160.315212 150.064163 
 L 160.245047 150.180152 
 L 160.174881 150.295858 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 150.295858 
@@ -4490,7 +4490,7 @@ L 154.553946 167.637484
 L 154.429036 167.959116 
 L 154.304126 168.27858 
 L 154.179217 168.595905 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 168.595905 
@@ -4542,11 +4542,11 @@ L 152.549264 177.771325
 L 152.513043 177.956336 
 L 152.476822 178.140629 
 L 152.4406 178.324207 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m3ad4d8b8a5" d="M 0 -2.5 
+     <path id="m507bebf9c6" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p300c156ebd)">
-     <use xlink:href="#m3ad4d8b8a5" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3ad4d8b8a5" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3ad4d8b8a5" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3ad4d8b8a5" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3ad4d8b8a5" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3ad4d8b8a5" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3ad4d8b8a5" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3ad4d8b8a5" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3ad4d8b8a5" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p77ecb5723f)">
+     <use xlink:href="#m507bebf9c6" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m507bebf9c6" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m507bebf9c6" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m507bebf9c6" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m507bebf9c6" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m507bebf9c6" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m507bebf9c6" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m507bebf9c6" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m507bebf9c6" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 174.939703
 L 592.834055 174.969152 
 L 592.450726 174.998584 
 L 592.067397 175.027997 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 175.027997 
@@ -4669,7 +4669,7 @@ L 538.386544 181.016797
 L 537.193636 181.14165 
 L 536.000728 181.266176 
 L 534.807821 181.390376 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 181.390376 
@@ -4721,7 +4721,7 @@ L 340.74006 177.010188
 L 336.427443 176.9081 
 L 332.114826 176.805792 
 L 327.802209 176.703263 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.703263 
@@ -4773,7 +4773,7 @@ L 279.085397 186.459613
 L 278.002801 186.655155 
 L 276.920205 186.849893 
 L 275.83761 187.043834 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 187.043834 
@@ -4825,7 +4825,7 @@ L 259.350398 198.484046
 L 258.984015 198.709377 
 L 258.617633 198.933642 
 L 258.25125 199.15685 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 199.15685 
@@ -4877,7 +4877,7 @@ L 256.869193 203.812849
 L 256.838481 203.911293 
 L 256.807768 204.009533 
 L 256.777056 204.107569 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 204.107569 
@@ -4929,7 +4929,7 @@ L 249.270304 217.480153
 L 249.103487 217.738369 
 L 248.93667 217.995185 
 L 248.769854 218.250617 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 218.250617 
@@ -4981,7 +4981,7 @@ L 246.421172 227.44791
 L 246.368979 227.633321 
 L 246.316786 227.818009 
 L 246.264594 228.00198 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m6144a077ac" d="M 0 3.5 
+      <path id="m2f97ba8ec2" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m6144a077ac" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m2f97ba8ec2" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m52d038e996" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0d6ccb6e77" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m21ac5b7896" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma8ea8d25c2" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m47dc2085cd" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb185433dcf" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m0678f05679" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md806be60ef" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m5643790a8c" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6349dbad88" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m87021c970a" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf27bebf1b6" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m3a9a1688ee" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mf68d21e6e9" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m3ad4d8b8a5" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m507bebf9c6" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p300c156ebd)">
-     <use xlink:href="#m6144a077ac" x="289.669676" y="170.254203" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6144a077ac" x="223.847406" y="178.9334" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6144a077ac" x="212.215046" y="182.437536" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6144a077ac" x="186.58897" y="190.758474" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6144a077ac" x="169.057218" y="200.763315" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6144a077ac" x="158.596848" y="212.711943" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6144a077ac" x="152.867313" y="218.312857" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6144a077ac" x="150.950891" y="234.44945" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6144a077ac" x="119.37967" y="288.201372" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m6144a077ac" x="100.541635" y="312.810372" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p77ecb5723f)">
+     <use xlink:href="#m2f97ba8ec2" x="289.669676" y="170.450093" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2f97ba8ec2" x="223.847406" y="178.939725" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2f97ba8ec2" x="212.215046" y="182.256257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2f97ba8ec2" x="186.58897" y="191.095144" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2f97ba8ec2" x="169.057218" y="200.971834" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2f97ba8ec2" x="158.596848" y="211.485524" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2f97ba8ec2" x="152.867313" y="217.300511" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2f97ba8ec2" x="150.950891" y="231.736452" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2f97ba8ec2" x="119.37967" y="288.099234" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2f97ba8ec2" x="100.541635" y="312.648072" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 170.254203 
-L 288.298379 170.452222 
-L 286.927082 170.649418 
-L 285.555784 170.845796 
-L 284.184487 171.041364 
-L 282.81319 171.236128 
-L 281.441892 171.430094 
-L 280.070595 171.623271 
-L 278.699298 171.815662 
-L 277.328 172.007276 
-L 275.956703 172.198119 
-L 274.585406 172.388195 
-L 273.214109 172.577513 
-L 271.842811 172.766077 
-L 270.471514 172.953894 
-L 269.100217 173.140969 
-L 267.728919 173.327309 
-L 266.357622 173.512919 
-L 264.986325 173.697805 
-L 263.615028 173.881972 
-L 262.24373 174.065426 
-L 260.872433 174.248173 
-L 259.501136 174.430218 
-L 258.129838 174.611566 
-L 256.758541 174.792223 
-L 255.387244 174.972193 
-L 254.015947 175.151483 
-L 252.644649 175.330097 
-L 251.273352 175.50804 
-L 249.902055 175.685318 
-L 248.530757 175.861935 
-L 247.15946 176.037896 
-L 245.788163 176.213206 
-L 244.416866 176.38787 
-L 243.045568 176.561893 
-L 241.674271 176.735279 
-L 240.302974 176.908033 
-L 238.931676 177.080159 
-L 237.560379 177.251663 
-L 236.189082 177.422548 
-L 234.817784 177.592819 
-L 233.446487 177.76248 
-L 232.07519 177.931536 
-L 230.703893 178.099991 
-L 229.332595 178.26785 
-L 227.961298 178.435116 
-L 226.590001 178.601793 
-L 225.218703 178.767887 
-L 223.847406 178.9334 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 170.450093 
+L 288.298379 170.643399 
+L 286.927082 170.835919 
+L 285.555784 171.02766 
+L 284.184487 171.218628 
+L 282.81319 171.40883 
+L 281.441892 171.598271 
+L 280.070595 171.786959 
+L 278.699298 171.974898 
+L 277.328 172.162094 
+L 275.956703 172.348554 
+L 274.585406 172.534283 
+L 273.214109 172.719287 
+L 271.842811 172.903572 
+L 270.471514 173.087143 
+L 269.100217 173.270005 
+L 267.728919 173.452164 
+L 266.357622 173.633626 
+L 264.986325 173.814396 
+L 263.615028 173.994479 
+L 262.24373 174.17388 
+L 260.872433 174.352604 
+L 259.501136 174.530657 
+L 258.129838 174.708044 
+L 256.758541 174.884769 
+L 255.387244 175.060837 
+L 254.015947 175.236254 
+L 252.644649 175.411023 
+L 251.273352 175.585151 
+L 249.902055 175.758641 
+L 248.530757 175.931498 
+L 247.15946 176.103727 
+L 245.788163 176.275332 
+L 244.416866 176.446318 
+L 243.045568 176.61669 
+L 241.674271 176.786451 
+L 240.302974 176.955606 
+L 238.931676 177.124159 
+L 237.560379 177.292115 
+L 236.189082 177.459478 
+L 234.817784 177.626252 
+L 233.446487 177.792441 
+L 232.07519 177.958049 
+L 230.703893 178.12308 
+L 229.332595 178.287539 
+L 227.961298 178.451429 
+L 226.590001 178.614754 
+L 225.218703 178.777518 
+L 223.847406 178.939725 
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 178.9334 
-L 223.605065 179.00911 
-L 223.362724 179.084698 
-L 223.120384 179.160166 
-L 222.878043 179.235514 
-L 222.635702 179.310742 
-L 222.393361 179.385852 
-L 222.15102 179.460842 
-L 221.908679 179.535714 
-L 221.666339 179.610468 
-L 221.423998 179.685104 
-L 221.181657 179.759622 
-L 220.939316 179.834024 
-L 220.696975 179.908309 
-L 220.454635 179.982478 
-L 220.212294 180.056531 
-L 219.969953 180.130468 
-L 219.727612 180.20429 
-L 219.485271 180.277997 
-L 219.24293 180.35159 
-L 219.00059 180.425069 
-L 218.758249 180.498434 
-L 218.515908 180.571686 
-L 218.273567 180.644824 
-L 218.031226 180.71785 
-L 217.788885 180.790763 
-L 217.546545 180.863565 
-L 217.304204 180.936255 
-L 217.061863 181.008833 
-L 216.819522 181.081301 
-L 216.577181 181.153657 
-L 216.33484 181.225904 
-L 216.0925 181.29804 
-L 215.850159 181.370067 
-L 215.607818 181.441985 
-L 215.365477 181.513793 
-L 215.123136 181.585493 
-L 214.880795 181.657085 
-L 214.638455 181.728569 
-L 214.396114 181.799945 
-L 214.153773 181.871213 
-L 213.911432 181.942375 
-L 213.669091 182.01343 
-L 213.42675 182.084378 
-L 213.18441 182.155221 
-L 212.942069 182.225958 
-L 212.699728 182.296589 
-L 212.457387 182.367115 
-L 212.215046 182.437536 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 178.939725 
+L 223.605065 179.011241 
+L 223.362724 179.082649 
+L 223.120384 179.153949 
+L 222.878043 179.225143 
+L 222.635702 179.296229 
+L 222.393361 179.367209 
+L 222.15102 179.438083 
+L 221.908679 179.508851 
+L 221.666339 179.579514 
+L 221.423998 179.650071 
+L 221.181657 179.720523 
+L 220.939316 179.790871 
+L 220.696975 179.861115 
+L 220.454635 179.931254 
+L 220.212294 180.00129 
+L 219.969953 180.071223 
+L 219.727612 180.141052 
+L 219.485271 180.210779 
+L 219.24293 180.280403 
+L 219.00059 180.349926 
+L 218.758249 180.419346 
+L 218.515908 180.488665 
+L 218.273567 180.557882 
+L 218.031226 180.626999 
+L 217.788885 180.696015 
+L 217.546545 180.76493 
+L 217.304204 180.833746 
+L 217.061863 180.902462 
+L 216.819522 180.971078 
+L 216.577181 181.039595 
+L 216.33484 181.108013 
+L 216.0925 181.176332 
+L 215.850159 181.244553 
+L 215.607818 181.312677 
+L 215.365477 181.380702 
+L 215.123136 181.448629 
+L 214.880795 181.51646 
+L 214.638455 181.584194 
+L 214.396114 181.65183 
+L 214.153773 181.719371 
+L 213.911432 181.786815 
+L 213.669091 181.854164 
+L 213.42675 181.921417 
+L 213.18441 181.988574 
+L 212.942069 182.055637 
+L 212.699728 182.122605 
+L 212.457387 182.189478 
+L 212.215046 182.256257 
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 182.437536 
-L 211.68117 182.626662 
-L 211.147293 182.815036 
-L 210.613417 183.002664 
-L 210.07954 183.189552 
-L 209.545663 183.375706 
-L 209.011787 183.561132 
-L 208.47791 183.745835 
-L 207.944034 183.92982 
-L 207.410157 184.113095 
-L 206.87628 184.295663 
-L 206.342404 184.47753 
-L 205.808527 184.658702 
-L 205.274651 184.839184 
-L 204.740774 185.018982 
-L 204.206897 185.1981 
-L 203.673021 185.376543 
-L 203.139144 185.554317 
-L 202.605268 185.731426 
-L 202.071391 185.907876 
-L 201.537515 186.083672 
-L 201.003638 186.258818 
-L 200.469761 186.433318 
-L 199.935885 186.607179 
-L 199.402008 186.780404 
-L 198.868132 186.952998 
-L 198.334255 187.124966 
-L 197.800378 187.296312 
-L 197.266502 187.467041 
-L 196.732625 187.637157 
-L 196.198749 187.806664 
-L 195.664872 187.975567 
-L 195.130995 188.143871 
-L 194.597119 188.311578 
-L 194.063242 188.478695 
-L 193.529366 188.645224 
-L 192.995489 188.81117 
-L 192.461612 188.976536 
-L 191.927736 189.141328 
-L 191.393859 189.305549 
-L 190.859983 189.469202 
-L 190.326106 189.632293 
-L 189.79223 189.794824 
-L 189.258353 189.956799 
-L 188.724476 190.118223 
-L 188.1906 190.279098 
-L 187.656723 190.43943 
-L 187.122847 190.599221 
-L 186.58897 190.758474 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 182.256257 
+L 211.68117 182.458262 
+L 211.147293 182.659409 
+L 210.613417 182.859706 
+L 210.07954 183.059161 
+L 209.545663 183.257779 
+L 209.011787 183.455568 
+L 208.47791 183.652535 
+L 207.944034 183.848687 
+L 207.410157 184.04403 
+L 206.87628 184.238571 
+L 206.342404 184.432317 
+L 205.808527 184.625274 
+L 205.274651 184.817449 
+L 204.740774 185.008847 
+L 204.206897 185.199476 
+L 203.673021 185.389341 
+L 203.139144 185.578448 
+L 202.605268 185.766803 
+L 202.071391 185.954413 
+L 201.537515 186.141283 
+L 201.003638 186.327419 
+L 200.469761 186.512826 
+L 199.935885 186.697511 
+L 199.402008 186.881479 
+L 198.868132 187.064736 
+L 198.334255 187.247287 
+L 197.800378 187.429137 
+L 197.266502 187.610292 
+L 196.732625 187.790757 
+L 196.198749 187.970538 
+L 195.664872 188.149639 
+L 195.130995 188.328066 
+L 194.597119 188.505823 
+L 194.063242 188.682916 
+L 193.529366 188.85935 
+L 192.995489 189.035129 
+L 192.461612 189.210259 
+L 191.927736 189.384744 
+L 191.393859 189.558589 
+L 190.859983 189.731798 
+L 190.326106 189.904377 
+L 189.79223 190.07633 
+L 189.258353 190.24766 
+L 188.724476 190.418374 
+L 188.1906 190.588475 
+L 187.656723 190.757967 
+L 187.122847 190.926855 
+L 186.58897 191.095144 
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 186.58897 190.758474 
-L 186.223725 190.989978 
-L 185.85848 191.220357 
-L 185.493235 191.449621 
-L 185.127991 191.677781 
-L 184.762746 191.904848 
-L 184.397501 192.130833 
-L 184.032256 192.355744 
-L 183.667011 192.579593 
-L 183.301766 192.80239 
-L 182.936522 193.024144 
-L 182.571277 193.244866 
-L 182.206032 193.464564 
-L 181.840787 193.683248 
-L 181.475542 193.900928 
-L 181.110297 194.117612 
-L 180.745053 194.33331 
-L 180.379808 194.548031 
-L 180.014563 194.761783 
-L 179.649318 194.974576 
-L 179.284073 195.186417 
-L 178.918828 195.397315 
-L 178.553584 195.607279 
-L 178.188339 195.816317 
-L 177.823094 196.024437 
-L 177.457849 196.231647 
-L 177.092604 196.437954 
-L 176.727359 196.643368 
-L 176.362115 196.847894 
-L 175.99687 197.051542 
-L 175.631625 197.254319 
-L 175.26638 197.456231 
-L 174.901135 197.657287 
-L 174.53589 197.857493 
-L 174.170645 198.056858 
-L 173.805401 198.255387 
-L 173.440156 198.453087 
-L 173.074911 198.649967 
-L 172.709666 198.846031 
-L 172.344421 199.041288 
-L 171.979176 199.235744 
-L 171.613932 199.429405 
-L 171.248687 199.622278 
-L 170.883442 199.814369 
-L 170.518197 200.005684 
-L 170.152952 200.196231 
-L 169.787707 200.386014 
-L 169.422463 200.57504 
-L 169.057218 200.763315 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.58897 191.095144 
+L 186.223725 191.323371 
+L 185.85848 191.550504 
+L 185.493235 191.776554 
+L 185.127991 192.00153 
+L 184.762746 192.225444 
+L 184.397501 192.448305 
+L 184.032256 192.670122 
+L 183.667011 192.890906 
+L 183.301766 193.110666 
+L 182.936522 193.329412 
+L 182.571277 193.547152 
+L 182.206032 193.763897 
+L 181.840787 193.979655 
+L 181.475542 194.194435 
+L 181.110297 194.408246 
+L 180.745053 194.621096 
+L 180.379808 194.832995 
+L 180.014563 195.04395 
+L 179.649318 195.253971 
+L 179.284073 195.463065 
+L 178.918828 195.67124 
+L 178.553584 195.878505 
+L 178.188339 196.084867 
+L 177.823094 196.290335 
+L 177.457849 196.494915 
+L 177.092604 196.698617 
+L 176.727359 196.901446 
+L 176.362115 197.103411 
+L 175.99687 197.304518 
+L 175.631625 197.504776 
+L 175.26638 197.704192 
+L 174.901135 197.902771 
+L 174.53589 198.100522 
+L 174.170645 198.297451 
+L 173.805401 198.493565 
+L 173.440156 198.688871 
+L 173.074911 198.883375 
+L 172.709666 199.077085 
+L 172.344421 199.270005 
+L 171.979176 199.462144 
+L 171.613932 199.653506 
+L 171.248687 199.844099 
+L 170.883442 200.033928 
+L 170.518197 200.223 
+L 170.152952 200.411321 
+L 169.787707 200.598896 
+L 169.422463 200.785732 
+L 169.057218 200.971834 
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 169.057218 200.763315 
-L 168.839293 201.045598 
-L 168.621369 201.326209 
-L 168.403445 201.605168 
-L 168.18552 201.882495 
-L 167.967596 202.158208 
-L 167.749672 202.432326 
-L 167.531747 202.704868 
-L 167.313823 202.975851 
-L 167.095898 203.245294 
-L 166.877974 203.513213 
-L 166.66005 203.779626 
-L 166.442125 204.04455 
-L 166.224201 204.308001 
-L 166.006277 204.569995 
-L 165.788352 204.830549 
-L 165.570428 205.089678 
-L 165.352503 205.347398 
-L 165.134579 205.603723 
-L 164.916655 205.85867 
-L 164.69873 206.112253 
-L 164.480806 206.364486 
-L 164.262882 206.615383 
-L 164.044957 206.864959 
-L 163.827033 207.113227 
-L 163.609108 207.360202 
-L 163.391184 207.605896 
-L 163.17326 207.850323 
-L 162.955335 208.093496 
-L 162.737411 208.335427 
-L 162.519487 208.576129 
-L 162.301562 208.815615 
-L 162.083638 209.053896 
-L 161.865713 209.290986 
-L 161.647789 209.526895 
-L 161.429865 209.761636 
-L 161.21194 209.995219 
-L 160.994016 210.227657 
-L 160.776092 210.458961 
-L 160.558167 210.689141 
-L 160.340243 210.918208 
-L 160.122318 211.146173 
-L 159.904394 211.373047 
-L 159.68647 211.59884 
-L 159.468545 211.823562 
-L 159.250621 212.047224 
-L 159.032697 212.269834 
-L 158.814772 212.491404 
-L 158.596848 212.711943 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 169.057218 200.971834 
+L 168.839293 201.216436 
+L 168.621369 201.459781 
+L 168.403445 201.701883 
+L 168.18552 201.942755 
+L 167.967596 202.182409 
+L 167.749672 202.420857 
+L 167.531747 202.658111 
+L 167.313823 202.894183 
+L 167.095898 203.129084 
+L 166.877974 203.362828 
+L 166.66005 203.595424 
+L 166.442125 203.826883 
+L 166.224201 204.057218 
+L 166.006277 204.286439 
+L 165.788352 204.514556 
+L 165.570428 204.741581 
+L 165.352503 204.967523 
+L 165.134579 205.192393 
+L 164.916655 205.4162 
+L 164.69873 205.638956 
+L 164.480806 205.86067 
+L 164.262882 206.081351 
+L 164.044957 206.301009 
+L 163.827033 206.519654 
+L 163.609108 206.737295 
+L 163.391184 206.95394 
+L 163.17326 207.1696 
+L 162.955335 207.384283 
+L 162.737411 207.597997 
+L 162.519487 207.810752 
+L 162.301562 208.022557 
+L 162.083638 208.233418 
+L 161.865713 208.443346 
+L 161.647789 208.652348 
+L 161.429865 208.860432 
+L 161.21194 209.067606 
+L 160.994016 209.273878 
+L 160.776092 209.479257 
+L 160.558167 209.683749 
+L 160.340243 209.887363 
+L 160.122318 210.090105 
+L 159.904394 210.291984 
+L 159.68647 210.493007 
+L 159.468545 210.69318 
+L 159.250621 210.892511 
+L 159.032697 211.091008 
+L 158.814772 211.288676 
+L 158.596848 211.485524 
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 158.596848 212.711943 
-L 158.477483 212.835643 
-L 158.358117 212.95902 
-L 158.238752 213.082078 
-L 158.119387 213.204816 
-L 158.000021 213.327237 
-L 157.880656 213.449343 
-L 157.761291 213.571135 
-L 157.641925 213.692615 
-L 157.52256 213.813785 
-L 157.403195 213.934645 
-L 157.28383 214.055198 
-L 157.164464 214.175444 
-L 157.045099 214.295387 
-L 156.925734 214.415027 
-L 156.806368 214.534365 
-L 156.687003 214.653404 
-L 156.567638 214.772144 
-L 156.448272 214.890588 
-L 156.328907 215.008736 
-L 156.209542 215.126591 
-L 156.090177 215.244153 
-L 155.970811 215.361424 
-L 155.851446 215.478406 
-L 155.732081 215.595099 
-L 155.612715 215.711506 
-L 155.49335 215.827628 
-L 155.373985 215.943466 
-L 155.254619 216.059021 
-L 155.135254 216.174295 
-L 155.015889 216.28929 
-L 154.896524 216.404006 
-L 154.777158 216.518446 
-L 154.657793 216.632609 
-L 154.538428 216.746498 
-L 154.419062 216.860114 
-L 154.299697 216.973459 
-L 154.180332 217.086532 
-L 154.060966 217.199337 
-L 153.941601 217.311874 
-L 153.822236 217.424144 
-L 153.702871 217.536149 
-L 153.583505 217.64789 
-L 153.46414 217.759368 
-L 153.344775 217.870584 
-L 153.225409 217.98154 
-L 153.106044 218.092237 
-L 152.986679 218.202675 
-L 152.867313 218.312857 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.596848 211.485524 
+L 158.477483 211.614241 
+L 158.358117 211.742609 
+L 158.238752 211.87063 
+L 158.119387 211.998307 
+L 158.000021 212.125641 
+L 157.880656 212.252633 
+L 157.761291 212.379286 
+L 157.641925 212.505601 
+L 157.52256 212.63158 
+L 157.403195 212.757226 
+L 157.28383 212.882539 
+L 157.164464 213.007522 
+L 157.045099 213.132176 
+L 156.925734 213.256503 
+L 156.806368 213.380504 
+L 156.687003 213.504182 
+L 156.567638 213.627538 
+L 156.448272 213.750574 
+L 156.328907 213.873291 
+L 156.209542 213.995691 
+L 156.090177 214.117776 
+L 155.970811 214.239547 
+L 155.851446 214.361006 
+L 155.732081 214.482155 
+L 155.612715 214.602994 
+L 155.49335 214.723527 
+L 155.373985 214.843753 
+L 155.254619 214.963675 
+L 155.135254 215.083295 
+L 155.015889 215.202613 
+L 154.896524 215.321632 
+L 154.777158 215.440352 
+L 154.657793 215.558776 
+L 154.538428 215.676905 
+L 154.419062 215.794739 
+L 154.299697 215.912282 
+L 154.180332 216.029534 
+L 154.060966 216.146496 
+L 153.941601 216.26317 
+L 153.822236 216.379558 
+L 153.702871 216.495661 
+L 153.583505 216.61148 
+L 153.46414 216.727016 
+L 153.344775 216.842272 
+L 153.225409 216.957248 
+L 153.106044 217.071945 
+L 152.986679 217.186366 
+L 152.867313 217.300511 
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 152.867313 218.312857 
-L 152.827388 218.71168 
-L 152.787463 219.107174 
-L 152.747537 219.499395 
-L 152.707612 219.888396 
-L 152.667686 220.27423 
-L 152.627761 220.656948 
-L 152.587835 221.0366 
-L 152.54791 221.413234 
-L 152.507984 221.786899 
-L 152.468059 222.15764 
-L 152.428133 222.525503 
-L 152.388208 222.890533 
-L 152.348282 223.252772 
-L 152.308357 223.612264 
-L 152.268432 223.969048 
-L 152.228506 224.323167 
-L 152.188581 224.674659 
-L 152.148655 225.023563 
-L 152.10873 225.369917 
-L 152.068804 225.713758 
-L 152.028879 226.055123 
-L 151.988953 226.394045 
-L 151.949028 226.730561 
-L 151.909102 227.064705 
-L 151.869177 227.396508 
-L 151.829252 227.726005 
-L 151.789326 228.053226 
-L 151.749401 228.378203 
-L 151.709475 228.700967 
-L 151.66955 229.021548 
-L 151.629624 229.339974 
-L 151.589699 229.656275 
-L 151.549773 229.970479 
-L 151.509848 230.282613 
-L 151.469922 230.592705 
-L 151.429997 230.90078 
-L 151.390072 231.206866 
-L 151.350146 231.510988 
-L 151.310221 231.81317 
-L 151.270295 232.113438 
-L 151.23037 232.411815 
-L 151.190444 232.708325 
-L 151.150519 233.002991 
-L 151.110593 233.295836 
-L 151.070668 233.586883 
-L 151.030742 233.876153 
-L 150.990817 234.163668 
-L 150.950891 234.44945 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 152.867313 217.300511 
+L 152.827388 217.650799 
+L 152.787463 217.998516 
+L 152.747537 218.343701 
+L 152.707612 218.686389 
+L 152.667686 219.026617 
+L 152.627761 219.36442 
+L 152.587835 219.699832 
+L 152.54791 220.032886 
+L 152.507984 220.363616 
+L 152.468059 220.692054 
+L 152.428133 221.018231 
+L 152.388208 221.342179 
+L 152.348282 221.663927 
+L 152.308357 221.983505 
+L 152.268432 222.300943 
+L 152.228506 222.616268 
+L 152.188581 222.929509 
+L 152.148655 223.240693 
+L 152.10873 223.549847 
+L 152.068804 223.856997 
+L 152.028879 224.162169 
+L 151.988953 224.465388 
+L 151.949028 224.76668 
+L 151.909102 225.066068 
+L 151.869177 225.363577 
+L 151.829252 225.659229 
+L 151.789326 225.953048 
+L 151.749401 226.245057 
+L 151.709475 226.535278 
+L 151.66955 226.823732 
+L 151.629624 227.11044 
+L 151.589699 227.395425 
+L 151.549773 227.678706 
+L 151.509848 227.960303 
+L 151.469922 228.240238 
+L 151.429997 228.518528 
+L 151.390072 228.795193 
+L 151.350146 229.070253 
+L 151.310221 229.343725 
+L 151.270295 229.615629 
+L 151.23037 229.885981 
+L 151.190444 230.154799 
+L 151.150519 230.422101 
+L 151.110593 230.687904 
+L 151.070668 230.952224 
+L 151.030742 231.215078 
+L 150.990817 231.476482 
+L 150.950891 231.736452 
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 234.44945 
-L 150.293158 236.487073 
-L 149.635424 238.440683 
-L 148.97769 240.316933 
-L 148.319956 242.121719 
-L 147.662223 243.860284 
-L 147.004489 245.537316 
-L 146.346755 247.157023 
-L 145.689021 248.723195 
-L 145.031288 250.239257 
-L 144.373554 251.708318 
-L 143.71582 253.133203 
-L 143.058086 254.516492 
-L 142.400352 255.860546 
-L 141.742619 257.167528 
-L 141.084885 258.439429 
-L 140.427151 259.678083 
-L 139.769417 260.885183 
-L 139.111684 262.062299 
-L 138.45395 263.210882 
-L 137.796216 264.332285 
-L 137.138482 265.427763 
-L 136.480748 266.498488 
-L 135.823015 267.545554 
-L 135.165281 268.569984 
-L 134.507547 269.572737 
-L 133.849813 270.55471 
-L 133.19208 271.516747 
-L 132.534346 272.459642 
-L 131.876612 273.384142 
-L 131.218878 274.29095 
-L 130.561145 275.180731 
-L 129.903411 276.054114 
-L 129.245677 276.91169 
-L 128.587943 277.754023 
-L 127.930209 278.581644 
-L 127.272476 279.395059 
-L 126.614742 280.194747 
-L 125.957008 280.981165 
-L 125.299274 281.754744 
-L 124.641541 282.515898 
-L 123.983807 283.265019 
-L 123.326073 284.002483 
-L 122.668339 284.728645 
-L 122.010605 285.443848 
-L 121.352872 286.148417 
-L 120.695138 286.842664 
-L 120.037404 287.526887 
-L 119.37967 288.201372 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 150.950891 231.736452 
+L 150.293158 233.940316 
+L 149.635424 236.046224 
+L 148.97769 238.062517 
+L 148.319956 239.996511 
+L 147.662223 241.854661 
+L 147.004489 243.642692 
+L 146.346755 245.365705 
+L 145.689021 247.028262 
+L 145.031288 248.634463 
+L 144.373554 250.188003 
+L 143.71582 251.692226 
+L 143.058086 253.150167 
+L 142.400352 254.564589 
+L 141.742619 255.938016 
+L 141.084885 257.272756 
+L 140.427151 258.57093 
+L 139.769417 259.834487 
+L 139.111684 261.065227 
+L 138.45395 262.26481 
+L 137.796216 263.434776 
+L 137.138482 264.576552 
+L 136.480748 265.691464 
+L 135.823015 266.780747 
+L 135.165281 267.845553 
+L 134.507547 268.886959 
+L 133.849813 269.90597 
+L 133.19208 270.903529 
+L 132.534346 271.880522 
+L 131.876612 272.837778 
+L 131.218878 273.77608 
+L 130.561145 274.696164 
+L 129.903411 275.598724 
+L 129.245677 276.484414 
+L 128.587943 277.353854 
+L 127.930209 278.20763 
+L 127.272476 279.046295 
+L 126.614742 279.870376 
+L 125.957008 280.68037 
+L 125.299274 281.476753 
+L 124.641541 282.259972 
+L 123.983807 283.030458 
+L 123.326073 283.788616 
+L 122.668339 284.534835 
+L 122.010605 285.269486 
+L 121.352872 285.992921 
+L 120.695138 286.705479 
+L 120.037404 287.40748 
+L 119.37967 288.099234 
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 119.37967 288.201372 
-L 118.987211 288.86883 
-L 118.594752 289.527018 
-L 118.202293 290.176189 
-L 117.809834 290.816588 
-L 117.417375 291.448447 
-L 117.024916 292.071993 
-L 116.632457 292.68744 
-L 116.239998 293.294997 
-L 115.847539 293.894863 
-L 115.45508 294.48723 
-L 115.062621 295.072284 
-L 114.670162 295.650203 
-L 114.277703 296.221159 
-L 113.885243 296.785317 
-L 113.492784 297.342839 
-L 113.100325 297.893877 
-L 112.707866 298.438582 
-L 112.315407 298.977096 
-L 111.922948 299.50956 
-L 111.530489 300.036107 
-L 111.13803 300.556868 
-L 110.745571 301.071969 
-L 110.353112 301.58153 
-L 109.960653 302.085671 
-L 109.568194 302.584505 
-L 109.175735 303.078142 
-L 108.783276 303.566691 
-L 108.390817 304.050254 
-L 107.998358 304.528932 
-L 107.605898 305.002824 
-L 107.213439 305.472023 
-L 106.82098 305.936623 
-L 106.428521 306.396712 
-L 106.036062 306.852377 
-L 105.643603 307.303702 
-L 105.251144 307.750769 
-L 104.858685 308.193658 
-L 104.466226 308.632446 
-L 104.073767 309.067208 
-L 103.681308 309.498018 
-L 103.288849 309.924947 
-L 102.89639 310.348064 
-L 102.503931 310.767436 
-L 102.111472 311.18313 
-L 101.719013 311.595209 
-L 101.326553 312.003735 
-L 100.934094 312.40877 
-L 100.541635 312.810372 
-" clip-path="url(#p300c156ebd)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.37967 288.099234 
+L 118.987211 288.764617 
+L 118.594752 289.420786 
+L 118.202293 290.067993 
+L 117.809834 290.70648 
+L 117.417375 291.336479 
+L 117.024916 291.958212 
+L 116.632457 292.571894 
+L 116.239998 293.17773 
+L 115.847539 293.775918 
+L 115.45508 294.36665 
+L 115.062621 294.950108 
+L 114.670162 295.52647 
+L 114.277703 296.095906 
+L 113.885243 296.658581 
+L 113.492784 297.214653 
+L 113.100325 297.764276 
+L 112.707866 298.307597 
+L 112.315407 298.844759 
+L 111.922948 299.375901 
+L 111.530489 299.901156 
+L 111.13803 300.420652 
+L 110.745571 300.934515 
+L 110.353112 301.442866 
+L 109.960653 301.945821 
+L 109.568194 302.443494 
+L 109.175735 302.935996 
+L 108.783276 303.423431 
+L 108.390817 303.905903 
+L 107.998358 304.383513 
+L 107.605898 304.856357 
+L 107.213439 305.32453 
+L 106.82098 305.788123 
+L 106.428521 306.247224 
+L 106.036062 306.70192 
+L 105.643603 307.152295 
+L 105.251144 307.59843 
+L 104.858685 308.040404 
+L 104.466226 308.478294 
+L 104.073767 308.912175 
+L 103.681308 309.342119 
+L 103.288849 309.768197 
+L 102.89639 310.190479 
+L 102.503931 310.609031 
+L 102.111472 311.023918 
+L 101.719013 311.435205 
+L 101.326553 311.842953 
+L 100.934094 312.247222 
+L 100.541635 312.648072 
+" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.606953 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6348,6 +6348,61 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6389,12 +6444,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -6434,109 +6489,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p300c156ebd">
+  <clipPath id="p77ecb5723f">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p7bdb3b9abd)">
+   <g clip-path="url(#p46fcca6da1)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="imagede25e685e8" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="image84a8b5bcf3" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mf5ce59eb56" d="M 0 0 
+       <path id="mf50d714f34" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf5ce59eb56" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mf5ce59eb56" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mf5ce59eb56" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf5ce59eb56" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mf5ce59eb56" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf5ce59eb56" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mf5ce59eb56" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf5ce59eb56" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mf5ce59eb56" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf5ce59eb56" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mf5ce59eb56" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf50d714f34" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m472cabdbd9" d="M 0 0 
+       <path id="m4f02612aeb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m472cabdbd9" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f02612aeb" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m472cabdbd9" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f02612aeb" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m472cabdbd9" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f02612aeb" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m472cabdbd9" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f02612aeb" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m472cabdbd9" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f02612aeb" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m472cabdbd9" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f02612aeb" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m472cabdbd9" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f02612aeb" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m472cabdbd9" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4f02612aeb" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image0eeea53abc" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8167ca3bb2" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mcd12853107" d="M 0 0 
+       <path id="m2d60ffca9f" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcd12853107" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d60ffca9f" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mcd12853107" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d60ffca9f" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mcd12853107" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d60ffca9f" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mcd12853107" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d60ffca9f" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mcd12853107" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d60ffca9f" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mcd12853107" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d60ffca9f" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mcd12853107" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d60ffca9f" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mcd12853107" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d60ffca9f" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mcd12853107" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2d60ffca9f" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.606953 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.904453 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2953,12 +2953,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2998,109 +2998,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7bdb3b9abd">
+  <clipPath id="p46fcca6da1">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.186094pt" height="386.202469pt" viewBox="0 0 569.186094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.591094pt" height="386.202469pt" viewBox="0 0 568.591094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 569.186094 386.202469 
-L 569.186094 0 
+L 568.591094 386.202469 
+L 568.591094 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.718047 104.1264 
-L 291.343047 104.1264 
-L 291.343047 74.7432 
-L 186.718047 74.7432 
+    <path d="M 186.420547 104.1264 
+L 291.045547 104.1264 
+L 291.045547 74.7432 
+L 186.420547 74.7432 
 z
-" clip-path="url(#p7818709b64)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.343047 104.1264 
-L 395.968047 104.1264 
-L 395.968047 74.7432 
-L 291.343047 74.7432 
+    <path d="M 291.045547 104.1264 
+L 395.670547 104.1264 
+L 395.670547 74.7432 
+L 291.045547 74.7432 
 z
-" clip-path="url(#p7818709b64)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.968047 104.1264 
-L 500.593047 104.1264 
-L 500.593047 74.7432 
-L 395.968047 74.7432 
+    <path d="M 395.670547 104.1264 
+L 500.295547 104.1264 
+L 500.295547 74.7432 
+L 395.670547 74.7432 
 z
-" clip-path="url(#p7818709b64)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.718047 133.5096 
-L 291.343047 133.5096 
-L 291.343047 104.1264 
-L 186.718047 104.1264 
+    <path d="M 186.420547 133.5096 
+L 291.045547 133.5096 
+L 291.045547 104.1264 
+L 186.420547 104.1264 
 z
-" clip-path="url(#p7818709b64)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.343047 133.5096 
-L 395.968047 133.5096 
-L 395.968047 104.1264 
-L 291.343047 104.1264 
+    <path d="M 291.045547 133.5096 
+L 395.670547 133.5096 
+L 395.670547 104.1264 
+L 291.045547 104.1264 
 z
-" clip-path="url(#p7818709b64)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.968047 133.5096 
-L 500.593047 133.5096 
-L 500.593047 104.1264 
-L 395.968047 104.1264 
+    <path d="M 395.670547 133.5096 
+L 500.295547 133.5096 
+L 500.295547 104.1264 
+L 395.670547 104.1264 
 z
-" clip-path="url(#p7818709b64)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.718047 162.8928 
-L 291.343047 162.8928 
-L 291.343047 133.5096 
-L 186.718047 133.5096 
+    <path d="M 186.420547 162.8928 
+L 291.045547 162.8928 
+L 291.045547 133.5096 
+L 186.420547 133.5096 
 z
-" clip-path="url(#p7818709b64)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.343047 162.8928 
-L 395.968047 162.8928 
-L 395.968047 133.5096 
-L 291.343047 133.5096 
+    <path d="M 291.045547 162.8928 
+L 395.670547 162.8928 
+L 395.670547 133.5096 
+L 291.045547 133.5096 
 z
-" clip-path="url(#p7818709b64)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.968047 162.8928 
-L 500.593047 162.8928 
-L 500.593047 133.5096 
-L 395.968047 133.5096 
+    <path d="M 395.670547 162.8928 
+L 500.295547 162.8928 
+L 500.295547 133.5096 
+L 395.670547 133.5096 
 z
-" clip-path="url(#p7818709b64)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.718047 192.276 
-L 291.343047 192.276 
-L 291.343047 162.8928 
-L 186.718047 162.8928 
+    <path d="M 186.420547 192.276 
+L 291.045547 192.276 
+L 291.045547 162.8928 
+L 186.420547 162.8928 
 z
-" clip-path="url(#p7818709b64)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.343047 192.276 
-L 395.968047 192.276 
-L 395.968047 162.8928 
-L 291.343047 162.8928 
+    <path d="M 291.045547 192.276 
+L 395.670547 192.276 
+L 395.670547 162.8928 
+L 291.045547 162.8928 
 z
-" clip-path="url(#p7818709b64)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.968047 192.276 
-L 500.593047 192.276 
-L 500.593047 162.8928 
-L 395.968047 162.8928 
+    <path d="M 395.670547 192.276 
+L 500.295547 192.276 
+L 500.295547 162.8928 
+L 395.670547 162.8928 
 z
-" clip-path="url(#p7818709b64)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.718047 221.6592 
-L 291.343047 221.6592 
-L 291.343047 192.276 
-L 186.718047 192.276 
+    <path d="M 186.420547 221.6592 
+L 291.045547 221.6592 
+L 291.045547 192.276 
+L 186.420547 192.276 
 z
-" clip-path="url(#p7818709b64)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.343047 221.6592 
-L 395.968047 221.6592 
-L 395.968047 192.276 
-L 291.343047 192.276 
+    <path d="M 291.045547 221.6592 
+L 395.670547 221.6592 
+L 395.670547 192.276 
+L 291.045547 192.276 
 z
-" clip-path="url(#p7818709b64)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.968047 221.6592 
-L 500.593047 221.6592 
-L 500.593047 192.276 
-L 395.968047 192.276 
+    <path d="M 395.670547 221.6592 
+L 500.295547 221.6592 
+L 500.295547 192.276 
+L 395.670547 192.276 
 z
-" clip-path="url(#p7818709b64)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.718047 251.0424 
-L 291.343047 251.0424 
-L 291.343047 221.6592 
-L 186.718047 221.6592 
+    <path d="M 186.420547 251.0424 
+L 291.045547 251.0424 
+L 291.045547 221.6592 
+L 186.420547 221.6592 
 z
-" clip-path="url(#p7818709b64)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.343047 251.0424 
-L 395.968047 251.0424 
-L 395.968047 221.6592 
-L 291.343047 221.6592 
+    <path d="M 291.045547 251.0424 
+L 395.670547 251.0424 
+L 395.670547 221.6592 
+L 291.045547 221.6592 
 z
-" clip-path="url(#p7818709b64)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.968047 251.0424 
-L 500.593047 251.0424 
-L 500.593047 221.6592 
-L 395.968047 221.6592 
+    <path d="M 395.670547 251.0424 
+L 500.295547 251.0424 
+L 500.295547 221.6592 
+L 395.670547 221.6592 
 z
-" clip-path="url(#p7818709b64)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.718047 280.4256 
-L 291.343047 280.4256 
-L 291.343047 251.0424 
-L 186.718047 251.0424 
+    <path d="M 186.420547 280.4256 
+L 291.045547 280.4256 
+L 291.045547 251.0424 
+L 186.420547 251.0424 
 z
-" clip-path="url(#p7818709b64)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.343047 280.4256 
-L 395.968047 280.4256 
-L 395.968047 251.0424 
-L 291.343047 251.0424 
+    <path d="M 291.045547 280.4256 
+L 395.670547 280.4256 
+L 395.670547 251.0424 
+L 291.045547 251.0424 
 z
-" clip-path="url(#p7818709b64)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.968047 280.4256 
-L 500.593047 280.4256 
-L 500.593047 251.0424 
-L 395.968047 251.0424 
+    <path d="M 395.670547 280.4256 
+L 500.295547 280.4256 
+L 500.295547 251.0424 
+L 395.670547 251.0424 
 z
-" clip-path="url(#p7818709b64)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.718047 309.8088 
-L 291.343047 309.8088 
-L 291.343047 280.4256 
-L 186.718047 280.4256 
+    <path d="M 186.420547 309.8088 
+L 291.045547 309.8088 
+L 291.045547 280.4256 
+L 186.420547 280.4256 
 z
-" clip-path="url(#p7818709b64)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.343047 309.8088 
-L 395.968047 309.8088 
-L 395.968047 280.4256 
-L 291.343047 280.4256 
+    <path d="M 291.045547 309.8088 
+L 395.670547 309.8088 
+L 395.670547 280.4256 
+L 291.045547 280.4256 
 z
-" clip-path="url(#p7818709b64)" style="fill: #f67c4a; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.968047 309.8088 
-L 500.593047 309.8088 
-L 500.593047 280.4256 
-L 395.968047 280.4256 
+    <path d="M 395.670547 309.8088 
+L 500.295547 309.8088 
+L 500.295547 280.4256 
+L 395.670547 280.4256 
 z
-" clip-path="url(#p7818709b64)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.718047 339.192 
-L 291.343047 339.192 
-L 291.343047 309.8088 
-L 186.718047 309.8088 
+    <path d="M 186.420547 339.192 
+L 291.045547 339.192 
+L 291.045547 309.8088 
+L 186.420547 309.8088 
 z
-" clip-path="url(#p7818709b64)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.343047 339.192 
-L 395.968047 339.192 
-L 395.968047 309.8088 
-L 291.343047 309.8088 
+    <path d="M 291.045547 339.192 
+L 395.670547 339.192 
+L 395.670547 309.8088 
+L 291.045547 309.8088 
 z
-" clip-path="url(#p7818709b64)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.968047 339.192 
-L 500.593047 339.192 
-L 500.593047 309.8088 
-L 395.968047 309.8088 
+    <path d="M 395.670547 339.192 
+L 500.295547 339.192 
+L 500.295547 309.8088 
+L 395.670547 309.8088 
 z
-" clip-path="url(#p7818709b64)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2db511f2e0)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.705313 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.407813 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.989531 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.692031 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.561641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.264141 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.913359 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.615859 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.643047 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.345547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.579297 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.020547 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.723047 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.645547 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.281172 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.983672 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.579297 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.565547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.645547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.544297 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.246797 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.579297 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.565547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.645547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.850547 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.553047 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.579297 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.565547 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.645547 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.006797 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(118.709297 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.579297 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.565547 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.645547 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- OCaml decompress -->
-    <g transform="translate(95.467422 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(95.169922 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1629,7 +1629,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.321 -->
-    <g transform="translate(227.579297 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1639,14 +1639,14 @@ z
    </g>
    <g id="text_27">
     <!-- 23 -->
-    <g transform="translate(338.565547 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 117 -->
-    <g transform="translate(440.645547 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1654,7 +1654,7 @@ z
    </g>
    <g id="text_29">
     <!-- Go compress/flate -->
-    <g transform="translate(97.974297 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.676797 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1710,7 +1710,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.299 -->
-    <g transform="translate(227.579297 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1720,21 +1720,21 @@ z
    </g>
    <g id="text_31">
     <!-- 18 -->
-    <g transform="translate(338.565547 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 88 -->
-    <g transform="translate(443.190547 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(442.893047 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.352422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.054922 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1843,7 +1843,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.298 -->
-    <g transform="translate(226.378672 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(226.081172 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1973,8 +1973,8 @@ z
     </g>
    </g>
    <g id="text_35">
-    <!-- 17 -->
-    <g transform="translate(338.089297 297.3247) scale(0.08 -0.08)">
+    <!-- 18 -->
+    <g transform="translate(337.791797 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1990,32 +1990,49 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 208 -->
-    <g transform="translate(439.931172 297.3247) scale(0.08 -0.08)">
+    <!-- 205 -->
+    <g transform="translate(439.633672 297.3247) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.688672 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.391172 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2026,7 +2043,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.579297 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2036,13 +2053,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.110547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.813047 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.280547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.983047 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2058,7 +2075,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.101797 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(133.804297 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2271,7 +2288,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2413,12 +2430,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2458,110 +2475,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7818709b64">
-   <rect x="82.093047" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p2db511f2e0">
+   <rect x="81.795547" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p9a109575d5)">
+   <g clip-path="url(#pd857d41445)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ70lEQVR4nO3XvY6dVxmGYe+ZzRhsRziJ4wiQrDSBCqQIKhrOgILDSJmWnpI6bfqcQCpQqkgIQZdUJEoiFGxA+THBnj2zhyOgstb9jj9d1xE80vez7rU7/uudqxtbdngyvYBncbyYXrDW7mR6wVoX59ML1rp1d3rBWk8fTy9Y6/RsegHPYuvv59mt6QVLbfz0AwDguhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9n8+fDK9Yan9yen0hKWOV1fTE5a6/8L96QlLffL1Z9MT1tr4FffH3707PWGpw82z6QlL/eXhh9MTlvrZvdenJyz19Ow4PWGp3e7b6QlLbfx4AADguhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9gxdem96w1N2b96cnLPXoyefTE5b64bfbviPdefmn0xOWOt3tpycsdbxxnJ6w1Cs37k1PWOri3vn0hKVevfVgesJSh+O2n9/t823/X7Z9ugMAcO0IUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUvvdbtsN+s3h39MTlvre6Z3pCUtdvvzS9ISlvvjqr9MTlnp8/mR6wlI/f/EX0xOWOj+dXrDWfw7fTE/gGXz59OH0hLVu3p9esNS26xMAgGtHgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNpdvv/W1fSIpY7H6QXw/524Az7X/F+eb1v//rb+fnp+z7WNPz0AAK4bAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGr/6p8+mt6w1Ml+24398MNH0xOWevvNN6YnLPW7D/4xPWGpXz34/vSEpd7948fTE5b67W9+Mj1hqd//4dPpCUv9+o0fTE9Y6tOvnk5PWOqXP7o9PWGpbdcZAADXjgAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0Ol+9dTY9Y6fTiYnrCWif76QVrXTyZXrDW2a3pBWvtNn7HvTpOL1jr4Pt7rl1u+/w77Lb9/X1n4/2y8dMBAIDrRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDan14epzes9ehv0wvWuv3S9IK1Hv9zesFaN+9ML1jrZON33K0/vy//Pr1grXuvTS9Y679fTy9Yav/Fx9MT1nrxlekFS238dAAA4LoRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApP4H+sh5n1658IwAAAAASUVORK5CYII=" id="image501fcf60be" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ8ElEQVR4nO3YvY6cZx2HYc/uZG0cJ5jErAVIVhpCBVJEKhrOgILDoKSlp0ydlp4ToCJKhYQQ6QI0iYILsAX5JNg761mOgMp67v/61XUdwW/0fjz3O7vjv35zdWPLDk+mF/A8jpfTC9banUwvWOvyYnrBWrfvTi9Y6+lX0wvWOj2bXsDz2Pr9eXZ7esFSGz/9AAC4bgQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/Z8OH09vWGp/cjo9Yanj1dX0hKXOXzmfnrDUx1/8fXrCWhv/xH3z1t3pCUsdbp5NT1jqz48+nJ6w1I/ufX96wlJPz47TE5ba7b6enrDUxo8HAACuGwEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNo/eOWN6Q1L3b15Pj1hqcdPHk5PWOq7X2/7G+nO6z+cnrDU6W4/PWGp443j9ISlvn3j3vSEpS7vXUxPWOr+7QfTE5Y6HLd9/V6+2Pb7ZdunOwAA144ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtd/ttt2gXx7+PT1hqW+c3pmesNSz11+bnrDUPz7/YHrCUl9dPJmesNSPv/X29ISlLk6nF6z1n8OX0xN4Dp89fTQ9Ya2b59MLltp2fQIAcO0IUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUrtn7//yanrEUsfj9AL4/058A77QvF9ebFt//rZ+f7p+L7SNXz0AAK4bAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGp//49/md6w1Ml+24396MPH0xOWevcXb01PWOrXf/jn9ISlfvrgm9MTlvrtex9NT1jqVz//wfSEpd75/SfTE5b62VvfmZ6w1CefP52esNRPvvfy9ISltl1nAABcOwIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILU7PPvd1fSIlU4vL6cnrHWyn16w1uWT6QVrnd2eXrDWbuPfuFfH6QVrHTx/L7Rn2z7/DrttP38vbbxfNn46AABw3QhQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS+9PdfnrDWo//Nr1grVfPpxes9cWj6QVr3bozvWCtl25NL1hrv/Hf9+nD6QVr3X9zesFa//1sesFS+4d/nZ6w1mv3pxcs5R9QAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNT/AEq5d6j8B9WxAAAAAElFTkSuQmCC" id="image25ee3bcbd5" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m16c00044bc" d="M 0 0 
+       <path id="m32f56a09c4" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m16c00044bc" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m16c00044bc" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m16c00044bc" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m16c00044bc" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m16c00044bc" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m16c00044bc" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m16c00044bc" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m16c00044bc" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m16c00044bc" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m16c00044bc" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m16c00044bc" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m16c00044bc" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32f56a09c4" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="ma274cb65a1" d="M 0 0 
+       <path id="m8efcee9f32" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma274cb65a1" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8efcee9f32" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma274cb65a1" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8efcee9f32" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#ma274cb65a1" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8efcee9f32" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#ma274cb65a1" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8efcee9f32" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#ma274cb65a1" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8efcee9f32" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma274cb65a1" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8efcee9f32" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#ma274cb65a1" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8efcee9f32" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma274cb65a1" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8efcee9f32" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,42 +1138,48 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- -9 -->
-    <g transform="translate(112.574598 69.553235) scale(0.065 -0.065)">
+    <!-- +0 -->
+    <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
 z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
@@ -1236,16 +1242,40 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- -29 -->
+    <!-- -25 -->
     <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- -53 -->
+    <!-- -51 -->
     <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -36 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1279,24 +1309,6 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -39 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -36 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1333,9 +1345,100 @@ z
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_26">
+    <!-- -27 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_27">
-    <!-- -24 -->
+    <!-- -19 -->
     <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -52 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -7 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -25 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -73 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -44 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1358,98 +1461,13 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -54 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -15 -->
-    <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -33 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -73 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -47 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- +6 -->
     <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
@@ -1556,29 +1574,6 @@ z
    <g id="text_47">
     <!-- +305 -->
     <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
@@ -2198,18 +2193,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image32d9f5842e" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image99965922fd" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m4e4493e31b" d="M 0 0 
+       <path id="ma26d2a544e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4e4493e31b" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma26d2a544e" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2232,7 +2227,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m4e4493e31b" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma26d2a544e" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2246,7 +2241,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m4e4493e31b" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma26d2a544e" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2260,7 +2255,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m4e4493e31b" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma26d2a544e" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2273,7 +2268,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4e4493e31b" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma26d2a544e" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2286,7 +2281,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m4e4493e31b" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma26d2a544e" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2299,7 +2294,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m4e4493e31b" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma26d2a544e" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2915,8 +2910,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.606953 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3008,12 +3003,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3053,109 +3048,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9a109575d5">
+  <clipPath id="pd857d41445">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="me7ce4edff6" d="M 0 0 
+       <path id="me6fc6cb238" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me7ce4edff6" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6fc6cb238" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me7ce4edff6" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6fc6cb238" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me7ce4edff6" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6fc6cb238" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me7ce4edff6" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6fc6cb238" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me7ce4edff6" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6fc6cb238" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me7ce4edff6" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6fc6cb238" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me7ce4edff6" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me6fc6cb238" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m65dd581b63" d="M 0 0 
+       <path id="m995be5c19b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m65dd581b63" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m995be5c19b" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m65dd581b63" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m995be5c19b" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m65dd581b63" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m995be5c19b" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m0bcfde6d37" d="M 0 0 
+       <path id="mbb61d6ef9c" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m0bcfde6d37" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 130.866393) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 131.089735) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.149529 323.932112) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.149529 323.824547) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m9243d9e984" d="M -2.5 2.5 
+     <path id="m6789f5b565" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89c096f61a)">
-     <use xlink:href="#m9243d9e984" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9243d9e984" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9243d9e984" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9243d9e984" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9243d9e984" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9243d9e984" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9243d9e984" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9243d9e984" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9243d9e984" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0134e1669f)">
+     <use xlink:href="#m6789f5b565" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6789f5b565" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6789f5b565" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6789f5b565" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6789f5b565" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6789f5b565" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6789f5b565" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6789f5b565" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6789f5b565" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 111.868554
 L 326.02264 111.96025 
 L 324.91204 112.051791 
 L 323.801439 112.143178 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 112.143178 
@@ -1807,7 +1807,7 @@ L 275.861725 127.410211
 L 274.796398 127.705019 
 L 273.731071 127.99823 
 L 272.665744 128.289861 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 128.289861 
@@ -1859,7 +1859,7 @@ L 237.512385 129.68632
 L 236.7312 129.716946 
 L 235.950014 129.747556 
 L 235.168828 129.778148 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 129.778148 
@@ -1911,7 +1911,7 @@ L 189.28705 148.994297
 L 188.267455 149.352551 
 L 187.24786 149.708449 
 L 186.228265 150.062022 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 150.062022 
@@ -1963,7 +1963,7 @@ L 160.048483 171.011997
 L 159.46671 171.396655 
 L 158.884937 171.778598 
 L 158.303164 172.157864 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 172.157864 
@@ -2015,7 +2015,7 @@ L 150.040398 181.598676
 L 149.856781 181.790851 
 L 149.673164 181.982345 
 L 149.489547 182.173164 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.173164 
@@ -2067,7 +2067,7 @@ L 141.121061 201.502451
 L 140.935095 201.862455 
 L 140.749129 202.220079 
 L 140.563162 202.575355 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.575355 
@@ -2119,26 +2119,26 @@ L 139.083497 208.86883
 L 139.050616 209.000699 
 L 139.017734 209.132247 
 L 138.984853 209.263476 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m54a7e200ff" d="M 0 -2.5 
+     <path id="mc247189574" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89c096f61a)">
-     <use xlink:href="#m54a7e200ff" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m54a7e200ff" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m54a7e200ff" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m54a7e200ff" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m54a7e200ff" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m54a7e200ff" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m54a7e200ff" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m54a7e200ff" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m54a7e200ff" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0134e1669f)">
+     <use xlink:href="#mc247189574" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc247189574" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc247189574" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc247189574" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc247189574" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc247189574" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc247189574" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc247189574" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc247189574" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.20247
 L 331.988718 100.690952 
 L 325.934838 101.175064 
 L 319.880958 101.654884 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.654884 
@@ -2243,7 +2243,7 @@ L 217.131235 128.404389
 L 214.847908 128.871381 
 L 212.564581 129.334377 
 L 210.281253 129.793447 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.793447 
@@ -2295,7 +2295,7 @@ L 197.161712 133.343265
 L 196.870166 133.419565 
 L 196.578621 133.495757 
 L 196.287076 133.571842 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.571842 
@@ -2347,7 +2347,7 @@ L 177.31896 146.664131
 L 176.897447 146.921938 
 L 176.475933 147.178523 
 L 176.054419 147.433896 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.433896 
@@ -2399,7 +2399,7 @@ L 153.654726 173.470231
 L 153.156955 173.927574 
 L 152.659184 174.381084 
 L 152.161413 174.830826 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.830826 
@@ -2451,7 +2451,7 @@ L 147.060283 185.961812
 L 146.946925 186.184927 
 L 146.833566 186.407126 
 L 146.720208 186.628416 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.628416 
@@ -2503,7 +2503,7 @@ L 144.164409 195.79469
 L 144.107613 195.981745 
 L 144.050817 196.168156 
 L 143.994022 196.353927 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.353927 
@@ -2555,30 +2555,30 @@ L 142.749036 200.0341
 L 142.72137 200.113105 
 L 142.693704 200.191995 
 L 142.666037 200.270771 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m1dc411d95f" d="M -0 3.535534 
+     <path id="m4704f05c0c" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89c096f61a)">
-     <use xlink:href="#m1dc411d95f" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1dc411d95f" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0134e1669f)">
+     <use xlink:href="#m4704f05c0c" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4704f05c0c" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.665392
 L 244.888911 79.95196 
 L 243.864032 80.237018 
 L 242.839153 80.520583 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.520583 
@@ -2683,7 +2683,7 @@ L 219.787941 85.73042
 L 219.275692 85.840684 
 L 218.763443 85.950723 
 L 218.251194 86.060539 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.060539 
@@ -2735,7 +2735,7 @@ L 199.092247 89.895187
 L 198.666492 89.97739 
 L 198.240738 90.059468 
 L 197.814984 90.141422 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.141422 
@@ -2787,7 +2787,7 @@ L 168.343148 98.26681
 L 167.688219 98.434213 
 L 167.033289 98.601101 
 L 166.378359 98.767475 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 98.767475 
@@ -2839,7 +2839,7 @@ L 147.11464 109.552827
 L 146.686557 109.769695 
 L 146.258475 109.985696 
 L 145.830392 110.20084 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.20084 
@@ -2891,7 +2891,7 @@ L 135.300472 124.91473
 L 135.066474 125.20027 
 L 134.832476 125.484312 
 L 134.598477 125.76687 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 125.76687 
@@ -2943,7 +2943,7 @@ L 124.734843 147.930147
 L 124.515652 148.332777 
 L 124.29646 148.732435 
 L 124.077268 149.129162 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.129162 
@@ -2995,7 +2995,7 @@ L 122.56387 156.732863
 L 122.530239 156.890271 
 L 122.496607 157.047223 
 L 122.462976 157.203722 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.203722 
@@ -3047,7 +3047,7 @@ L 83.602758 217.017639
 L 82.739198 217.816123 
 L 81.875637 218.602997 
 L 81.012077 219.378594 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 219.378594 
@@ -3099,7 +3099,7 @@ L 77.665842 237.784894
 L 77.591481 238.130517 
 L 77.517121 238.473948 
 L 77.44276 238.815213 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 238.815213 
@@ -3151,23 +3151,23 @@ L 76.984008 251.144668
 L 76.973814 251.389134 
 L 76.96362 251.6325 
 L 76.953425 251.874777 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m33d2ec03b9" d="M -0 2.5 
+     <path id="ma62e7a49b5" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89c096f61a)">
-     <use xlink:href="#m33d2ec03b9" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0134e1669f)">
+     <use xlink:href="#ma62e7a49b5" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m167b397267" d="M -0.833333 2.5 
+     <path id="mb22cc37b00" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89c096f61a)">
-     <use xlink:href="#m167b397267" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m167b397267" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m167b397267" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m167b397267" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m167b397267" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m167b397267" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m167b397267" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m167b397267" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m167b397267" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0134e1669f)">
+     <use xlink:href="#mb22cc37b00" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb22cc37b00" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb22cc37b00" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb22cc37b00" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb22cc37b00" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb22cc37b00" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb22cc37b00" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb22cc37b00" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb22cc37b00" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 117.229073
 L 306.11717 117.494902 
 L 303.36982 117.759433 
 L 300.62247 118.022676 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 118.022676 
@@ -3296,7 +3296,7 @@ L 269.071051 125.234719
 L 268.369908 125.384559 
 L 267.668766 125.533985 
 L 266.967623 125.683 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 125.683 
@@ -3348,7 +3348,7 @@ L 228.598863 126.122913
 L 227.746224 126.132648 
 L 226.893585 126.142382 
 L 226.040946 126.152114 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 126.152114 
@@ -3400,7 +3400,7 @@ L 183.801673 143.118416
 L 182.863022 143.441102 
 L 181.924372 143.761876 
 L 180.985721 144.080759 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 144.080759 
@@ -3452,7 +3452,7 @@ L 165.475826 157.662961
 L 165.131161 157.929236 
 L 164.786497 158.194207 
 L 164.441833 158.457887 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 158.457887 
@@ -3504,7 +3504,7 @@ L 158.178848 166.505572
 L 158.03967 166.671493 
 L 157.900493 166.836907 
 L 157.761315 167.001817 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 167.001817 
@@ -3556,7 +3556,7 @@ L 151.674847 180.456413
 L 151.539592 180.720489 
 L 151.404337 180.983284 
 L 151.269082 181.244808 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 181.244808 
@@ -3608,11 +3608,11 @@ L 150.385962 186.640888
 L 150.366337 186.754896 
 L 150.346712 186.868665 
 L 150.327087 186.982195 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m9aa0d425c0" d="M -1.25 2.5 
+     <path id="m23497b7c26" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89c096f61a)">
-     <use xlink:href="#m9aa0d425c0" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9aa0d425c0" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9aa0d425c0" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9aa0d425c0" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9aa0d425c0" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9aa0d425c0" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9aa0d425c0" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9aa0d425c0" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9aa0d425c0" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0134e1669f)">
+     <use xlink:href="#m23497b7c26" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m23497b7c26" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m23497b7c26" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m23497b7c26" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m23497b7c26" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m23497b7c26" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m23497b7c26" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m23497b7c26" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m23497b7c26" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 141.492222
 L 276.351005 141.626293 
 L 274.857964 141.760033 
 L 273.364924 141.893443 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 141.893443 
@@ -3741,7 +3741,7 @@ L 242.760262 147.575596
 L 242.080158 147.695331 
 L 241.400055 147.814802 
 L 240.719951 147.934009 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 147.934009 
@@ -3793,7 +3793,7 @@ L 222.564351 152.930779
 L 222.160893 153.036743 
 L 221.757435 153.142499 
 L 221.353978 153.24805 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 153.24805 
@@ -3845,7 +3845,7 @@ L 208.018647 155.070715
 L 207.722306 155.110529 
 L 207.425965 155.150315 
 L 207.129625 155.190071 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 155.190071 
@@ -3897,7 +3897,7 @@ L 182.693853 166.038872
 L 182.150836 166.256889 
 L 181.607819 166.474032 
 L 181.064802 166.690306 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.690306 
@@ -3949,7 +3949,7 @@ L 179.393584 170.067361
 L 179.356445 170.140065 
 L 179.319307 170.21267 
 L 179.282169 170.285179 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.285179 
@@ -4001,7 +4001,7 @@ L 177.817012 175.338922
 L 177.784453 175.446037 
 L 177.751894 175.552941 
 L 177.719335 175.659634 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.659634 
@@ -4053,11 +4053,11 @@ L 177.648651 180.712426
 L 177.64708 180.819522 
 L 177.645509 180.926407 
 L 177.643939 181.03308 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mfc94265a71" d="M 0 -2.5 
+     <path id="mf6a3cf47cf" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p89c096f61a)">
-     <use xlink:href="#mfc94265a71" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfc94265a71" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfc94265a71" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfc94265a71" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfc94265a71" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfc94265a71" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfc94265a71" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfc94265a71" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfc94265a71" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p0134e1669f)">
+     <use xlink:href="#mf6a3cf47cf" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf6a3cf47cf" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf6a3cf47cf" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf6a3cf47cf" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf6a3cf47cf" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf6a3cf47cf" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf6a3cf47cf" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf6a3cf47cf" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mf6a3cf47cf" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.101113
 L 226.871027 113.101614 
 L 226.871027 113.102116 
 L 226.871027 113.102618 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.102618 
@@ -4184,7 +4184,7 @@ L 226.871027 113.241886
 L 226.871027 113.244976 
 L 226.871027 113.248067 
 L 226.871027 113.251157 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.251157 
@@ -4236,7 +4236,7 @@ L 226.871027 113.165529
 L 226.871027 113.163625 
 L 226.871027 113.16172 
 L 226.871027 113.159816 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.159816 
@@ -4288,7 +4288,7 @@ L 180.837336 131.090576
 L 179.814365 131.428693 
 L 178.791394 131.764711 
 L 177.768423 132.098656 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.098656 
@@ -4340,7 +4340,7 @@ L 161.462117 144.555386
 L 161.099755 144.802091 
 L 160.737393 145.047676 
 L 160.37503 145.292152 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.292152 
@@ -4392,7 +4392,7 @@ L 154.394483 152.007915
 L 154.261581 152.148084 
 L 154.12868 152.287891 
 L 153.995779 152.427338 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.427338 
@@ -4444,7 +4444,7 @@ L 147.537442 166.80191
 L 147.393924 167.081716 
 L 147.250405 167.360084 
 L 147.106887 167.637027 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 167.637027 
@@ -4496,11 +4496,11 @@ L 145.948902 174.483819
 L 145.923169 174.626551 
 L 145.897436 174.768906 
 L 145.871703 174.910889 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="me99c880a60" d="M 0 -2.5 
+     <path id="m6da1a12773" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p89c096f61a)">
-     <use xlink:href="#me99c880a60" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me99c880a60" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me99c880a60" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me99c880a60" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me99c880a60" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me99c880a60" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me99c880a60" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me99c880a60" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me99c880a60" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p0134e1669f)">
+     <use xlink:href="#m6da1a12773" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6da1a12773" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6da1a12773" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6da1a12773" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6da1a12773" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6da1a12773" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6da1a12773" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6da1a12773" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6da1a12773" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 176.312658
 L 529.583102 176.354957 
 L 528.363847 176.397222 
 L 527.144592 176.439455 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 176.439455 
@@ -4623,7 +4623,7 @@ L 461.70225 184.0537
 L 460.247976 184.211312 
 L 458.793701 184.368466 
 L 457.339427 184.525165 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 184.525165 
@@ -4675,7 +4675,7 @@ L 302.450749 179.565773
 L 299.008779 179.450234 
 L 295.566808 179.334447 
 L 292.124837 179.218412 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 179.218412 
@@ -4727,7 +4727,7 @@ L 246.191563 190.241103
 L 245.170823 190.462265 
 L 244.150084 190.682527 
 L 243.129344 190.901895 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.901895 
@@ -4779,7 +4779,7 @@ L 215.390639 204.06672
 L 214.774224 204.325785 
 L 214.157808 204.583617 
 L 213.541392 204.840226 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.840226 
@@ -4831,7 +4831,7 @@ L 205.113797 212.010949
 L 204.926517 212.159987 
 L 204.739237 212.308616 
 L 204.551957 212.456838 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.456838 
@@ -4883,7 +4883,7 @@ L 196.403329 227.996875
 L 196.222248 228.296222 
 L 196.041168 228.593923 
 L 195.860087 228.889995 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.889995 
@@ -4935,7 +4935,7 @@ L 194.134867 234.076634
 L 194.096529 234.18643 
 L 194.058191 234.296004 
 L 194.019853 234.405357 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m22462678e4" d="M 0 3.5 
+      <path id="m2b0bc7559e" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m22462678e4" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m2b0bc7559e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m9243d9e984" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6789f5b565" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m54a7e200ff" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc247189574" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m1dc411d95f" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4704f05c0c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m33d2ec03b9" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma62e7a49b5" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m167b397267" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb22cc37b00" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m9aa0d425c0" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m23497b7c26" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mfc94265a71" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mf6a3cf47cf" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#me99c880a60" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6da1a12773" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p89c096f61a)">
-     <use xlink:href="#m22462678e4" x="319.643112" y="135.866393" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22462678e4" x="269.129958" y="149.996859" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22462678e4" x="247.452898" y="154.653035" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22462678e4" x="199.905291" y="168.655914" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22462678e4" x="190.316224" y="181.598644" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22462678e4" x="165.455859" y="201.108991" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22462678e4" x="159.141659" y="209.528698" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22462678e4" x="157.246106" y="231.9046" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22462678e4" x="128.707405" y="299.638966" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m22462678e4" x="99.149529" y="328.932112" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p0134e1669f)">
+     <use xlink:href="#m2b0bc7559e" x="319.643112" y="136.089735" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2b0bc7559e" x="269.129958" y="149.699067" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2b0bc7559e" x="247.452898" y="154.407085" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2b0bc7559e" x="199.905291" y="169.152636" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2b0bc7559e" x="190.316224" y="181.919959" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2b0bc7559e" x="165.455859" y="197.690105" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2b0bc7559e" x="159.141659" y="206.527677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2b0bc7559e" x="157.246106" y="227.246142" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2b0bc7559e" x="128.707405" y="299.848409" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m2b0bc7559e" x="99.149529" y="328.824547" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 135.866393 
-L 318.590755 136.201744 
-L 317.538397 136.53503 
-L 316.48604 136.866276 
-L 315.433682 137.195506 
-L 314.381325 137.522746 
-L 313.328968 137.848019 
-L 312.27661 138.171349 
-L 311.224253 138.492758 
-L 310.171896 138.81227 
-L 309.119538 139.129906 
-L 308.067181 139.445689 
-L 307.014823 139.759641 
-L 305.962466 140.071781 
-L 304.910109 140.382131 
-L 303.857751 140.690712 
-L 302.805394 140.997543 
-L 301.753037 141.302645 
-L 300.700679 141.606036 
-L 299.648322 141.907735 
-L 298.595965 142.207762 
-L 297.543607 142.506135 
-L 296.49125 142.802872 
-L 295.438892 143.097991 
-L 294.386535 143.391509 
-L 293.334178 143.683444 
-L 292.28182 143.973812 
-L 291.229463 144.262631 
-L 290.177106 144.549916 
-L 289.124748 144.835685 
-L 288.072391 145.119952 
-L 287.020033 145.402735 
-L 285.967676 145.684047 
-L 284.915319 145.963904 
-L 283.862961 146.242322 
-L 282.810604 146.519315 
-L 281.758247 146.794897 
-L 280.705889 147.069083 
-L 279.653532 147.341887 
-L 278.601175 147.613323 
-L 277.548817 147.883404 
-L 276.49646 148.152143 
-L 275.444102 148.419555 
-L 274.391745 148.685652 
-L 273.339388 148.950447 
-L 272.28703 149.213953 
-L 271.234673 149.476182 
-L 270.182316 149.737147 
-L 269.129958 149.996859 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 136.089735 
+L 318.590755 136.411142 
+L 317.538397 136.730652 
+L 316.48604 137.048286 
+L 315.433682 137.364067 
+L 314.381325 137.678016 
+L 313.328968 137.990155 
+L 312.27661 138.300503 
+L 311.224253 138.609082 
+L 310.171896 138.915911 
+L 309.119538 139.22101 
+L 308.067181 139.524399 
+L 307.014823 139.826097 
+L 305.962466 140.126122 
+L 304.910109 140.424493 
+L 303.857751 140.721228 
+L 302.805394 141.016345 
+L 301.753037 141.309862 
+L 300.700679 141.601795 
+L 299.648322 141.892161 
+L 298.595965 142.180978 
+L 297.543607 142.468262 
+L 296.49125 142.754029 
+L 295.438892 143.038295 
+L 294.386535 143.321075 
+L 293.334178 143.602386 
+L 292.28182 143.882242 
+L 291.229463 144.160658 
+L 290.177106 144.437649 
+L 289.124748 144.71323 
+L 288.072391 144.987414 
+L 287.020033 145.260216 
+L 285.967676 145.53165 
+L 284.915319 145.80173 
+L 283.862961 146.070468 
+L 282.810604 146.337879 
+L 281.758247 146.603974 
+L 280.705889 146.868768 
+L 279.653532 147.132272 
+L 278.601175 147.3945 
+L 277.548817 147.655463 
+L 276.49646 147.915174 
+L 275.444102 148.173644 
+L 274.391745 148.430886 
+L 273.339388 148.68691 
+L 272.28703 148.94173 
+L 271.234673 149.195355 
+L 270.182316 149.447797 
+L 269.129958 149.699067 
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 149.996859 
-L 268.678353 150.098063 
-L 268.226747 150.199078 
-L 267.775142 150.299905 
-L 267.323537 150.400545 
-L 266.871931 150.500998 
-L 266.420326 150.601265 
-L 265.96872 150.701346 
-L 265.517115 150.801242 
-L 265.065509 150.900955 
-L 264.613904 151.000484 
-L 264.162299 151.09983 
-L 263.710693 151.198995 
-L 263.259088 151.297978 
-L 262.807482 151.39678 
-L 262.355877 151.495402 
-L 261.904271 151.593845 
-L 261.452666 151.692109 
-L 261.001061 151.790195 
-L 260.549455 151.888104 
-L 260.09785 151.985835 
-L 259.646244 152.083391 
-L 259.194639 152.180771 
-L 258.743034 152.277976 
-L 258.291428 152.375007 
-L 257.839823 152.471864 
-L 257.388217 152.568548 
-L 256.936612 152.66506 
-L 256.485006 152.7614 
-L 256.033401 152.857568 
-L 255.581796 152.953566 
-L 255.13019 153.049395 
-L 254.678585 153.145053 
-L 254.226979 153.240543 
-L 253.775374 153.335865 
-L 253.323769 153.431019 
-L 252.872163 153.526006 
-L 252.420558 153.620827 
-L 251.968952 153.715482 
-L 251.517347 153.809971 
-L 251.065741 153.904296 
-L 250.614136 153.998457 
-L 250.162531 154.092454 
-L 249.710925 154.186289 
-L 249.25932 154.279961 
-L 248.807714 154.373471 
-L 248.356109 154.466819 
-L 247.904503 154.560007 
-L 247.452898 154.653035 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 149.699067 
+L 268.678353 149.801446 
+L 268.226747 149.903633 
+L 267.775142 150.005626 
+L 267.323537 150.107428 
+L 266.871931 150.209039 
+L 266.420326 150.310459 
+L 265.96872 150.41169 
+L 265.517115 150.512732 
+L 265.065509 150.613585 
+L 264.613904 150.714251 
+L 264.162299 150.814729 
+L 263.710693 150.915022 
+L 263.259088 151.015129 
+L 262.807482 151.115051 
+L 262.355877 151.21479 
+L 261.904271 151.314344 
+L 261.452666 151.413716 
+L 261.001061 151.512906 
+L 260.549455 151.611914 
+L 260.09785 151.710741 
+L 259.646244 151.809389 
+L 259.194639 151.907857 
+L 258.743034 152.006145 
+L 258.291428 152.104256 
+L 257.839823 152.20219 
+L 257.388217 152.299946 
+L 256.936612 152.397526 
+L 256.485006 152.49493 
+L 256.033401 152.59216 
+L 255.581796 152.689215 
+L 255.13019 152.786096 
+L 254.678585 152.882804 
+L 254.226979 152.97934 
+L 253.775374 153.075704 
+L 253.323769 153.171897 
+L 252.872163 153.267918 
+L 252.420558 153.36377 
+L 251.968952 153.459453 
+L 251.517347 153.554966 
+L 251.065741 153.650311 
+L 250.614136 153.745489 
+L 250.162531 153.840499 
+L 249.710925 153.935343 
+L 249.25932 154.030021 
+L 248.807714 154.124534 
+L 248.356109 154.218881 
+L 247.904503 154.313065 
+L 247.452898 154.407085 
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 154.653035 
-L 246.462323 154.98496 
-L 245.471748 155.314862 
-L 244.481173 155.642765 
-L 243.490597 155.968693 
-L 242.500022 156.29267 
-L 241.509447 156.614719 
-L 240.518872 156.934862 
-L 239.528297 157.253123 
-L 238.537722 157.569524 
-L 237.547147 157.884085 
-L 236.556571 158.196829 
-L 235.565996 158.507775 
-L 234.575421 158.816946 
-L 233.584846 159.12436 
-L 232.594271 159.430037 
-L 231.603696 159.733998 
-L 230.613121 160.036261 
-L 229.622545 160.336845 
-L 228.63197 160.635769 
-L 227.641395 160.933051 
-L 226.65082 161.228709 
-L 225.660245 161.52276 
-L 224.66967 161.815223 
-L 223.679095 162.106113 
-L 222.688519 162.395448 
-L 221.697944 162.683244 
-L 220.707369 162.969519 
-L 219.716794 163.254286 
-L 218.726219 163.537563 
-L 217.735644 163.819365 
-L 216.745069 164.099708 
-L 215.754493 164.378605 
-L 214.763918 164.656073 
-L 213.773343 164.932125 
-L 212.782768 165.206776 
-L 211.792193 165.480041 
-L 210.801618 165.751932 
-L 209.811043 166.022465 
-L 208.820467 166.291652 
-L 207.829892 166.559506 
-L 206.839317 166.826041 
-L 205.848742 167.091271 
-L 204.858167 167.355206 
-L 203.867592 167.617861 
-L 202.877017 167.879247 
-L 201.886441 168.139376 
-L 200.895866 168.398261 
-L 199.905291 168.655914 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 154.407085 
+L 246.462323 154.759063 
+L 245.471748 155.108766 
+L 244.481173 155.456224 
+L 243.490597 155.801465 
+L 242.500022 156.144518 
+L 241.509447 156.48541 
+L 240.518872 156.824168 
+L 239.528297 157.160818 
+L 238.537722 157.495388 
+L 237.547147 157.827902 
+L 236.556571 158.158385 
+L 235.565996 158.486863 
+L 234.575421 158.813358 
+L 233.584846 159.137896 
+L 232.594271 159.4605 
+L 231.603696 159.781191 
+L 230.613121 160.099993 
+L 229.622545 160.416929 
+L 228.63197 160.732019 
+L 227.641395 161.045285 
+L 226.65082 161.356749 
+L 225.660245 161.66643 
+L 224.66967 161.974349 
+L 223.679095 162.280525 
+L 222.688519 162.58498 
+L 221.697944 162.887731 
+L 220.707369 163.188798 
+L 219.716794 163.4882 
+L 218.726219 163.785954 
+L 217.735644 164.082079 
+L 216.745069 164.376592 
+L 215.754493 164.669512 
+L 214.763918 164.960854 
+L 213.773343 165.250636 
+L 212.782768 165.538875 
+L 211.792193 165.825587 
+L 210.801618 166.110788 
+L 209.811043 166.394494 
+L 208.820467 166.67672 
+L 207.829892 166.957483 
+L 206.839317 167.236796 
+L 205.848742 167.514675 
+L 204.858167 167.791134 
+L 203.867592 168.066188 
+L 202.877017 168.339852 
+L 201.886441 168.612139 
+L 200.895866 168.883062 
+L 199.905291 169.152636 
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 199.905291 168.655914 
-L 199.705519 168.959675 
-L 199.505747 169.26174 
-L 199.305974 169.562129 
-L 199.106202 169.860859 
-L 198.90643 170.15795 
-L 198.706658 170.453418 
-L 198.506885 170.747282 
-L 198.307113 171.03956 
-L 198.107341 171.330267 
-L 197.907569 171.61942 
-L 197.707797 171.907038 
-L 197.508024 172.193134 
-L 197.308252 172.477726 
-L 197.10848 172.76083 
-L 196.908708 173.04246 
-L 196.708935 173.322632 
-L 196.509163 173.601361 
-L 196.309391 173.878662 
-L 196.109619 174.154549 
-L 195.909846 174.429037 
-L 195.710074 174.70214 
-L 195.510302 174.973872 
-L 195.31053 175.244246 
-L 195.110758 175.513276 
-L 194.910985 175.780975 
-L 194.711213 176.047356 
-L 194.511441 176.312433 
-L 194.311669 176.576218 
-L 194.111896 176.838723 
-L 193.912124 177.099961 
-L 193.712352 177.359944 
-L 193.51258 177.618684 
-L 193.312807 177.876193 
-L 193.113035 178.132482 
-L 192.913263 178.387564 
-L 192.713491 178.641448 
-L 192.513719 178.894148 
-L 192.313946 179.145673 
-L 192.114174 179.396034 
-L 191.914402 179.645242 
-L 191.71463 179.893308 
-L 191.514857 180.140242 
-L 191.315085 180.386055 
-L 191.115313 180.630756 
-L 190.915541 180.874356 
-L 190.715768 181.116864 
-L 190.515996 181.35829 
-L 190.316224 181.598644 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.905291 169.152636 
+L 199.705519 169.451788 
+L 199.505747 169.749296 
+L 199.305974 170.045177 
+L 199.106202 170.33945 
+L 198.90643 170.632131 
+L 198.706658 170.923237 
+L 198.506885 171.212786 
+L 198.307113 171.500795 
+L 198.107341 171.787278 
+L 197.907569 172.072253 
+L 197.707797 172.355735 
+L 197.508024 172.63774 
+L 197.308252 172.918283 
+L 197.10848 173.19738 
+L 196.908708 173.475044 
+L 196.708935 173.751291 
+L 196.509163 174.026135 
+L 196.309391 174.299591 
+L 196.109619 174.571671 
+L 195.909846 174.842391 
+L 195.710074 175.111763 
+L 195.510302 175.379801 
+L 195.31053 175.646518 
+L 195.110758 175.911926 
+L 194.910985 176.17604 
+L 194.711213 176.438871 
+L 194.511441 176.700431 
+L 194.311669 176.960734 
+L 194.111896 177.21979 
+L 193.912124 177.477613 
+L 193.712352 177.734213 
+L 193.51258 177.989602 
+L 193.312807 178.243791 
+L 193.113035 178.496792 
+L 192.913263 178.748616 
+L 192.713491 178.999273 
+L 192.513719 179.248775 
+L 192.313946 179.497132 
+L 192.114174 179.744354 
+L 191.914402 179.990453 
+L 191.71463 180.235437 
+L 191.514857 180.479317 
+L 191.315085 180.722103 
+L 191.115313 180.963804 
+L 190.915541 181.204431 
+L 190.715768 181.443993 
+L 190.515996 181.682499 
+L 190.316224 181.919959 
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 190.316224 181.598644 
-L 189.7983 182.085837 
-L 189.280375 182.568683 
-L 188.762451 183.047259 
-L 188.244527 183.52164 
-L 187.726603 183.991899 
-L 187.208678 184.458107 
-L 186.690754 184.920333 
-L 186.17283 185.378644 
-L 185.654906 185.833107 
-L 185.136981 186.283785 
-L 184.619057 186.730741 
-L 184.101133 187.174036 
-L 183.583208 187.613729 
-L 183.065284 188.049879 
-L 182.54736 188.482542 
-L 182.029436 188.911773 
-L 181.511511 189.337627 
-L 180.993587 189.760155 
-L 180.475663 190.179411 
-L 179.957739 190.595443 
-L 179.439814 191.008302 
-L 178.92189 191.418035 
-L 178.403966 191.824689 
-L 177.886041 192.22831 
-L 177.368117 192.628943 
-L 176.850193 193.026632 
-L 176.332269 193.42142 
-L 175.814344 193.813349 
-L 175.29642 194.20246 
-L 174.778496 194.588793 
-L 174.260572 194.972388 
-L 173.742647 195.353283 
-L 173.224723 195.731516 
-L 172.706799 196.107124 
-L 172.188874 196.480142 
-L 171.67095 196.850608 
-L 171.153026 197.218554 
-L 170.635102 197.584016 
-L 170.117177 197.947027 
-L 169.599253 198.307618 
-L 169.081329 198.665823 
-L 168.563404 199.021673 
-L 168.04548 199.375198 
-L 167.527556 199.726429 
-L 167.009632 200.075395 
-L 166.491707 200.422125 
-L 165.973783 200.766648 
-L 165.455859 201.108991 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 190.316224 181.919959 
+L 189.7983 182.300044 
+L 189.280375 182.677478 
+L 188.762451 183.052298 
+L 188.244527 183.42454 
+L 187.726603 183.794239 
+L 187.208678 184.16143 
+L 186.690754 184.526146 
+L 186.17283 184.888421 
+L 185.654906 185.248286 
+L 185.136981 185.605775 
+L 184.619057 185.960917 
+L 184.101133 186.313745 
+L 183.583208 186.664286 
+L 183.065284 187.012572 
+L 182.54736 187.358631 
+L 182.029436 187.702491 
+L 181.511511 188.04418 
+L 180.993587 188.383725 
+L 180.475663 188.721153 
+L 179.957739 189.05649 
+L 179.439814 189.389762 
+L 178.92189 189.720995 
+L 178.403966 190.050212 
+L 177.886041 190.377439 
+L 177.368117 190.702699 
+L 176.850193 191.026016 
+L 176.332269 191.347413 
+L 175.814344 191.666912 
+L 175.29642 191.984536 
+L 174.778496 192.300307 
+L 174.260572 192.614246 
+L 173.742647 192.926375 
+L 173.224723 193.236713 
+L 172.706799 193.545282 
+L 172.188874 193.852102 
+L 171.67095 194.157192 
+L 171.153026 194.460572 
+L 170.635102 194.76226 
+L 170.117177 195.062276 
+L 169.599253 195.360638 
+L 169.081329 195.657364 
+L 168.563404 195.952473 
+L 168.04548 196.24598 
+L 167.527556 196.537904 
+L 167.009632 196.828263 
+L 166.491707 197.117071 
+L 165.973783 197.404347 
+L 165.455859 197.690105 
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 165.455859 201.108991 
-L 165.324313 201.298451 
-L 165.192767 201.487249 
-L 165.061221 201.675392 
-L 164.929675 201.862882 
-L 164.79813 202.049726 
-L 164.666584 202.235926 
-L 164.535038 202.421488 
-L 164.403492 202.606416 
-L 164.271946 202.790714 
-L 164.1404 202.974387 
-L 164.008855 203.157438 
-L 163.877309 203.339872 
-L 163.745763 203.521694 
-L 163.614217 203.702906 
-L 163.482671 203.883514 
-L 163.351125 204.063521 
-L 163.21958 204.242931 
-L 163.088034 204.421749 
-L 162.956488 204.599977 
-L 162.824942 204.777621 
-L 162.693396 204.954683 
-L 162.56185 205.131168 
-L 162.430305 205.30708 
-L 162.298759 205.482421 
-L 162.167213 205.657196 
-L 162.035667 205.831408 
-L 161.904121 206.005062 
-L 161.772575 206.17816 
-L 161.64103 206.350706 
-L 161.509484 206.522704 
-L 161.377938 206.694157 
-L 161.246392 206.865068 
-L 161.114846 207.035441 
-L 160.9833 207.20528 
-L 160.851754 207.374587 
-L 160.720209 207.543367 
-L 160.588663 207.711621 
-L 160.457117 207.879354 
-L 160.325571 208.046569 
-L 160.194025 208.213269 
-L 160.062479 208.379457 
-L 159.930934 208.545136 
-L 159.799388 208.710309 
-L 159.667842 208.87498 
-L 159.536296 209.039152 
-L 159.40475 209.202826 
-L 159.273204 209.366008 
-L 159.141659 209.528698 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.455859 197.690105 
+L 165.324313 197.889739 
+L 165.192767 198.088638 
+L 165.061221 198.28681 
+L 164.929675 198.484258 
+L 164.79813 198.680988 
+L 164.666584 198.877006 
+L 164.535038 199.072317 
+L 164.403492 199.266925 
+L 164.271946 199.460836 
+L 164.1404 199.654055 
+L 164.008855 199.846586 
+L 163.877309 200.038435 
+L 163.745763 200.229606 
+L 163.614217 200.420104 
+L 163.482671 200.609934 
+L 163.351125 200.7991 
+L 163.21958 200.987608 
+L 163.088034 201.175461 
+L 162.956488 201.362664 
+L 162.824942 201.549222 
+L 162.693396 201.735139 
+L 162.56185 201.920419 
+L 162.430305 202.105068 
+L 162.298759 202.289088 
+L 162.167213 202.472485 
+L 162.035667 202.655263 
+L 161.904121 202.837425 
+L 161.772575 203.018976 
+L 161.64103 203.199921 
+L 161.509484 203.380262 
+L 161.377938 203.560004 
+L 161.246392 203.739151 
+L 161.114846 203.917707 
+L 160.9833 204.095676 
+L 160.851754 204.273062 
+L 160.720209 204.449868 
+L 160.588663 204.626099 
+L 160.457117 204.801757 
+L 160.325571 204.976847 
+L 160.194025 205.151373 
+L 160.062479 205.325337 
+L 159.930934 205.498744 
+L 159.799388 205.671597 
+L 159.667842 205.8439 
+L 159.536296 206.015656 
+L 159.40475 206.186868 
+L 159.273204 206.357541 
+L 159.141659 206.527677 
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 159.141659 209.528698 
-L 159.102168 210.102952 
-L 159.062677 210.671177 
-L 159.023187 211.233497 
-L 158.983696 211.790035 
-L 158.944205 212.340907 
-L 158.904715 212.886229 
-L 158.865224 213.42611 
-L 158.825733 213.960659 
-L 158.786243 214.48998 
-L 158.746752 215.014173 
-L 158.707261 215.533338 
-L 158.667771 216.04757 
-L 158.62828 216.556961 
-L 158.588789 217.061603 
-L 158.549299 217.561582 
-L 158.509808 218.056984 
-L 158.470317 218.547893 
-L 158.430827 219.034388 
-L 158.391336 219.516549 
-L 158.351845 219.994453 
-L 158.312355 220.468173 
-L 158.272864 220.937782 
-L 158.233373 221.403351 
-L 158.193882 221.86495 
-L 158.154392 222.322644 
-L 158.114901 222.7765 
-L 158.07541 223.226582 
-L 158.03592 223.672951 
-L 157.996429 224.115668 
-L 157.956938 224.554794 
-L 157.917448 224.990385 
-L 157.877957 225.422497 
-L 157.838466 225.851187 
-L 157.798976 226.276508 
-L 157.759485 226.698512 
-L 157.719994 227.117251 
-L 157.680504 227.532775 
-L 157.641013 227.945133 
-L 157.601522 228.354372 
-L 157.562032 228.760541 
-L 157.522541 229.163683 
-L 157.48305 229.563845 
-L 157.44356 229.961069 
-L 157.404069 230.355399 
-L 157.364578 230.746876 
-L 157.325088 231.135543 
-L 157.285597 231.521437 
-L 157.246106 231.9046 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.141659 206.527677 
+L 159.102168 207.051031 
+L 159.062677 207.569372 
+L 159.023187 208.082795 
+L 158.983696 208.591393 
+L 158.944205 209.095256 
+L 158.904715 209.594471 
+L 158.865224 210.089123 
+L 158.825733 210.579295 
+L 158.786243 211.065067 
+L 158.746752 211.546518 
+L 158.707261 212.023723 
+L 158.667771 212.496757 
+L 158.62828 212.965692 
+L 158.588789 213.430598 
+L 158.549299 213.891545 
+L 158.509808 214.348599 
+L 158.470317 214.801825 
+L 158.430827 215.251287 
+L 158.391336 215.697047 
+L 158.351845 216.139166 
+L 158.312355 216.577702 
+L 158.272864 217.012712 
+L 158.233373 217.444254 
+L 158.193882 217.872382 
+L 158.154392 218.29715 
+L 158.114901 218.71861 
+L 158.07541 219.136812 
+L 158.03592 219.551808 
+L 157.996429 219.963646 
+L 157.956938 220.372374 
+L 157.917448 220.778037 
+L 157.877957 221.180683 
+L 157.838466 221.580355 
+L 157.798976 221.977096 
+L 157.759485 222.370951 
+L 157.719994 222.76196 
+L 157.680504 223.150164 
+L 157.641013 223.535603 
+L 157.601522 223.918317 
+L 157.562032 224.298343 
+L 157.522541 224.675719 
+L 157.48305 225.050481 
+L 157.44356 225.422667 
+L 157.404069 225.79231 
+L 157.364578 226.159446 
+L 157.325088 226.524108 
+L 157.285597 226.886329 
+L 157.246106 227.246142 
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 157.246106 231.9046 
-L 156.65155 234.647937 
-L 156.056994 237.258894 
-L 155.462438 239.749662 
-L 154.867881 242.13082 
-L 154.273325 244.411611 
-L 153.678769 246.600153 
-L 153.084212 248.70362 
-L 152.489656 250.72838 
-L 151.8951 252.680111 
-L 151.300544 254.563898 
-L 150.705987 256.384313 
-L 150.111431 258.145481 
-L 149.516875 259.851137 
-L 148.922318 261.504675 
-L 148.327762 263.109184 
-L 147.733206 264.66749 
-L 147.13865 266.182178 
-L 146.544093 267.655625 
-L 145.949537 269.090016 
-L 145.354981 270.487368 
-L 144.760424 271.849547 
-L 144.165868 273.178279 
-L 143.571312 274.475169 
-L 142.976756 275.741706 
-L 142.382199 276.979278 
-L 141.787643 278.189182 
-L 141.193087 279.372626 
-L 140.598531 280.530745 
-L 140.003974 281.664598 
-L 139.409418 282.775183 
-L 138.814862 283.863434 
-L 138.220305 284.930233 
-L 137.625749 285.976408 
-L 137.031193 287.002743 
-L 136.436637 288.009975 
-L 135.84208 288.998804 
-L 135.247524 289.969888 
-L 134.652968 290.923854 
-L 134.058411 291.861296 
-L 133.463855 292.782775 
-L 132.869299 293.688826 
-L 132.274743 294.579958 
-L 131.680186 295.456653 
-L 131.08563 296.319373 
-L 130.491074 297.168555 
-L 129.896517 298.004618 
-L 129.301961 298.827961 
-L 128.707405 299.638966 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 157.246106 227.246142 
+L 156.65155 230.340969 
+L 156.056994 233.268347 
+L 155.462438 236.045471 
+L 154.867881 238.687015 
+L 154.273325 241.205601 
+L 153.678769 243.612171 
+L 153.084212 245.916265 
+L 152.489656 248.126255 
+L 151.8951 250.249528 
+L 151.300544 252.292632 
+L 150.705987 254.261401 
+L 150.111431 256.161056 
+L 149.516875 257.996285 
+L 148.922318 259.771315 
+L 148.327762 261.48997 
+L 147.733206 263.155721 
+L 147.13865 264.771727 
+L 146.544093 266.340875 
+L 145.949537 267.865806 
+L 145.354981 269.348942 
+L 144.760424 270.792514 
+L 144.165868 272.198578 
+L 143.571312 273.569035 
+L 142.976756 274.905642 
+L 142.382199 276.210032 
+L 141.787643 277.483722 
+L 141.193087 278.728123 
+L 140.598531 279.944552 
+L 140.003974 281.13424 
+L 139.409418 282.298336 
+L 138.814862 283.437918 
+L 138.220305 284.553999 
+L 137.625749 285.647527 
+L 137.031193 286.719395 
+L 136.436637 287.770446 
+L 135.84208 288.801473 
+L 135.247524 289.813224 
+L 134.652968 290.806406 
+L 134.058411 291.78169 
+L 133.463855 292.739709 
+L 132.869299 293.681063 
+L 132.274743 294.606322 
+L 131.680186 295.516028 
+L 131.08563 296.410695 
+L 130.491074 297.290812 
+L 129.896517 298.156844 
+L 129.301961 299.009236 
+L 128.707405 299.848409 
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 128.707405 299.638966 
-L 128.091616 300.442717 
-L 127.475827 301.234705 
-L 126.860038 302.015271 
-L 126.244249 302.784737 
-L 125.62846 303.543417 
-L 125.01267 304.291608 
-L 124.396881 305.029595 
-L 123.781092 305.757655 
-L 123.165303 306.476049 
-L 122.549514 307.185032 
-L 121.933725 307.884847 
-L 121.317936 308.575729 
-L 120.702147 309.257901 
-L 120.086358 309.931581 
-L 119.470569 310.596978 
-L 118.85478 311.254294 
-L 118.238991 311.903721 
-L 117.623201 312.545447 
-L 117.007412 313.179653 
-L 116.391623 313.806513 
-L 115.775834 314.426195 
-L 115.160045 315.038862 
-L 114.544256 315.64467 
-L 113.928467 316.243772 
-L 113.312678 316.836314 
-L 112.696889 317.422439 
-L 112.0811 318.002284 
-L 111.465311 318.575981 
-L 110.849522 319.143661 
-L 110.233733 319.705448 
-L 109.617943 320.261463 
-L 109.002154 320.811824 
-L 108.386365 321.356644 
-L 107.770576 321.896034 
-L 107.154787 322.430101 
-L 106.538998 322.958949 
-L 105.923209 323.482679 
-L 105.30742 324.001389 
-L 104.691631 324.515174 
-L 104.075842 325.024128 
-L 103.460053 325.52834 
-L 102.844264 326.027897 
-L 102.228474 326.522886 
-L 101.612685 327.013388 
-L 100.996896 327.499484 
-L 100.381107 327.981253 
-L 99.765318 328.458771 
-L 99.149529 328.932112 
-" clip-path="url(#p89c096f61a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 128.707405 299.848409 
+L 128.091616 300.641012 
+L 127.475827 301.422173 
+L 126.860038 302.192219 
+L 126.244249 302.951462 
+L 125.62846 303.7002 
+L 125.01267 304.438721 
+L 124.396881 305.167299 
+L 123.781092 305.886199 
+L 123.165303 306.595674 
+L 122.549514 307.295968 
+L 121.933725 307.987316 
+L 121.317936 308.669943 
+L 120.702147 309.344068 
+L 120.086358 310.009898 
+L 119.470569 310.667636 
+L 118.85478 311.317476 
+L 118.238991 311.959605 
+L 117.623201 312.594205 
+L 117.007412 313.221449 
+L 116.391623 313.841507 
+L 115.775834 314.454541 
+L 115.160045 315.060708 
+L 114.544256 315.660161 
+L 113.928467 316.253047 
+L 113.312678 316.839508 
+L 112.696889 317.419681 
+L 112.0811 317.993701 
+L 111.465311 318.561696 
+L 110.849522 319.123792 
+L 110.233733 319.68011 
+L 109.617943 320.230767 
+L 109.002154 320.775877 
+L 108.386365 321.315552 
+L 107.770576 321.849897 
+L 107.154787 322.379019 
+L 106.538998 322.903017 
+L 105.923209 323.421991 
+L 105.30742 323.936034 
+L 104.691631 324.445241 
+L 104.075842 324.949702 
+L 103.460053 325.449504 
+L 102.844264 325.944732 
+L 102.228474 326.435469 
+L 101.612685 326.921796 
+L 100.996896 327.403792 
+L 100.381107 327.881534 
+L 99.765318 328.355094 
+L 99.149529 328.824547 
+" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.606953 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6260,6 +6260,61 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6301,12 +6356,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -6346,109 +6401,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p89c096f61a">
+  <clipPath id="p0134e1669f">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p8961c73747)">
+   <g clip-path="url(#p7d072673eb)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="imagefdeb789502" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image6e071d0153" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m52736d8c06" d="M 0 0 
+       <path id="m788cfe65c8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m52736d8c06" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m52736d8c06" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m52736d8c06" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m52736d8c06" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m52736d8c06" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m52736d8c06" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m52736d8c06" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m52736d8c06" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m52736d8c06" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m52736d8c06" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m52736d8c06" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m52736d8c06" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m788cfe65c8" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="md63a601b9b" d="M 0 0 
+       <path id="mc3b7041bf3" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md63a601b9b" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3b7041bf3" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md63a601b9b" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3b7041bf3" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md63a601b9b" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3b7041bf3" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md63a601b9b" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3b7041bf3" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md63a601b9b" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3b7041bf3" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md63a601b9b" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3b7041bf3" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md63a601b9b" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3b7041bf3" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md63a601b9b" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc3b7041bf3" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image657f2a2ec9" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image708b568888" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mda9bbca44c" d="M 0 0 
+       <path id="m74d4724ea1" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mda9bbca44c" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74d4724ea1" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mda9bbca44c" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74d4724ea1" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mda9bbca44c" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74d4724ea1" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mda9bbca44c" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74d4724ea1" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mda9bbca44c" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m74d4724ea1" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.606953 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.904453 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2871,12 +2871,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2916,109 +2916,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p8961c73747">
+  <clipPath id="p7d072673eb">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.186094pt" height="386.202469pt" viewBox="0 0 569.186094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.591094pt" height="386.202469pt" viewBox="0 0 568.591094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 569.186094 386.202469 
-L 569.186094 0 
+L 568.591094 386.202469 
+L 568.591094 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.718047 104.1264 
-L 291.343047 104.1264 
-L 291.343047 74.7432 
-L 186.718047 74.7432 
+    <path d="M 186.420547 104.1264 
+L 291.045547 104.1264 
+L 291.045547 74.7432 
+L 186.420547 74.7432 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.343047 104.1264 
-L 395.968047 104.1264 
-L 395.968047 74.7432 
-L 291.343047 74.7432 
+    <path d="M 291.045547 104.1264 
+L 395.670547 104.1264 
+L 395.670547 74.7432 
+L 291.045547 74.7432 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.968047 104.1264 
-L 500.593047 104.1264 
-L 500.593047 74.7432 
-L 395.968047 74.7432 
+    <path d="M 395.670547 104.1264 
+L 500.295547 104.1264 
+L 500.295547 74.7432 
+L 395.670547 74.7432 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.718047 133.5096 
-L 291.343047 133.5096 
-L 291.343047 104.1264 
-L 186.718047 104.1264 
+    <path d="M 186.420547 133.5096 
+L 291.045547 133.5096 
+L 291.045547 104.1264 
+L 186.420547 104.1264 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.343047 133.5096 
-L 395.968047 133.5096 
-L 395.968047 104.1264 
-L 291.343047 104.1264 
+    <path d="M 291.045547 133.5096 
+L 395.670547 133.5096 
+L 395.670547 104.1264 
+L 291.045547 104.1264 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.968047 133.5096 
-L 500.593047 133.5096 
-L 500.593047 104.1264 
-L 395.968047 104.1264 
+    <path d="M 395.670547 133.5096 
+L 500.295547 133.5096 
+L 500.295547 104.1264 
+L 395.670547 104.1264 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.718047 162.8928 
-L 291.343047 162.8928 
-L 291.343047 133.5096 
-L 186.718047 133.5096 
+    <path d="M 186.420547 162.8928 
+L 291.045547 162.8928 
+L 291.045547 133.5096 
+L 186.420547 133.5096 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.343047 162.8928 
-L 395.968047 162.8928 
-L 395.968047 133.5096 
-L 291.343047 133.5096 
+    <path d="M 291.045547 162.8928 
+L 395.670547 162.8928 
+L 395.670547 133.5096 
+L 291.045547 133.5096 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.968047 162.8928 
-L 500.593047 162.8928 
-L 500.593047 133.5096 
-L 395.968047 133.5096 
+    <path d="M 395.670547 162.8928 
+L 500.295547 162.8928 
+L 500.295547 133.5096 
+L 395.670547 133.5096 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.718047 192.276 
-L 291.343047 192.276 
-L 291.343047 162.8928 
-L 186.718047 162.8928 
+    <path d="M 186.420547 192.276 
+L 291.045547 192.276 
+L 291.045547 162.8928 
+L 186.420547 162.8928 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.343047 192.276 
-L 395.968047 192.276 
-L 395.968047 162.8928 
-L 291.343047 162.8928 
+    <path d="M 291.045547 192.276 
+L 395.670547 192.276 
+L 395.670547 162.8928 
+L 291.045547 162.8928 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.968047 192.276 
-L 500.593047 192.276 
-L 500.593047 162.8928 
-L 395.968047 162.8928 
+    <path d="M 395.670547 192.276 
+L 500.295547 192.276 
+L 500.295547 162.8928 
+L 395.670547 162.8928 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.718047 221.6592 
-L 291.343047 221.6592 
-L 291.343047 192.276 
-L 186.718047 192.276 
+    <path d="M 186.420547 221.6592 
+L 291.045547 221.6592 
+L 291.045547 192.276 
+L 186.420547 192.276 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.343047 221.6592 
-L 395.968047 221.6592 
-L 395.968047 192.276 
-L 291.343047 192.276 
+    <path d="M 291.045547 221.6592 
+L 395.670547 221.6592 
+L 395.670547 192.276 
+L 291.045547 192.276 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.968047 221.6592 
-L 500.593047 221.6592 
-L 500.593047 192.276 
-L 395.968047 192.276 
+    <path d="M 395.670547 221.6592 
+L 500.295547 221.6592 
+L 500.295547 192.276 
+L 395.670547 192.276 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.718047 251.0424 
-L 291.343047 251.0424 
-L 291.343047 221.6592 
-L 186.718047 221.6592 
+    <path d="M 186.420547 251.0424 
+L 291.045547 251.0424 
+L 291.045547 221.6592 
+L 186.420547 221.6592 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.343047 251.0424 
-L 395.968047 251.0424 
-L 395.968047 221.6592 
-L 291.343047 221.6592 
+    <path d="M 291.045547 251.0424 
+L 395.670547 251.0424 
+L 395.670547 221.6592 
+L 291.045547 221.6592 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.968047 251.0424 
-L 500.593047 251.0424 
-L 500.593047 221.6592 
-L 395.968047 221.6592 
+    <path d="M 395.670547 251.0424 
+L 500.295547 251.0424 
+L 500.295547 221.6592 
+L 395.670547 221.6592 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.718047 280.4256 
-L 291.343047 280.4256 
-L 291.343047 251.0424 
-L 186.718047 251.0424 
+    <path d="M 186.420547 280.4256 
+L 291.045547 280.4256 
+L 291.045547 251.0424 
+L 186.420547 251.0424 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.343047 280.4256 
-L 395.968047 280.4256 
-L 395.968047 251.0424 
-L 291.343047 251.0424 
+    <path d="M 291.045547 280.4256 
+L 395.670547 280.4256 
+L 395.670547 251.0424 
+L 291.045547 251.0424 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fba05b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.968047 280.4256 
-L 500.593047 280.4256 
-L 500.593047 251.0424 
-L 395.968047 251.0424 
+    <path d="M 395.670547 280.4256 
+L 500.295547 280.4256 
+L 500.295547 251.0424 
+L 395.670547 251.0424 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.718047 309.8088 
-L 291.343047 309.8088 
-L 291.343047 280.4256 
-L 186.718047 280.4256 
+    <path d="M 186.420547 309.8088 
+L 291.045547 309.8088 
+L 291.045547 280.4256 
+L 186.420547 280.4256 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.343047 309.8088 
-L 395.968047 309.8088 
-L 395.968047 280.4256 
-L 291.343047 280.4256 
+    <path d="M 291.045547 309.8088 
+L 395.670547 309.8088 
+L 395.670547 280.4256 
+L 291.045547 280.4256 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.968047 309.8088 
-L 500.593047 309.8088 
-L 500.593047 280.4256 
-L 395.968047 280.4256 
+    <path d="M 395.670547 309.8088 
+L 500.295547 309.8088 
+L 500.295547 280.4256 
+L 395.670547 280.4256 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.718047 339.192 
-L 291.343047 339.192 
-L 291.343047 309.8088 
-L 186.718047 309.8088 
+    <path d="M 186.420547 339.192 
+L 291.045547 339.192 
+L 291.045547 309.8088 
+L 186.420547 309.8088 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.343047 339.192 
-L 395.968047 339.192 
-L 395.968047 309.8088 
-L 291.343047 309.8088 
+    <path d="M 291.045547 339.192 
+L 395.670547 339.192 
+L 395.670547 309.8088 
+L 291.045547 309.8088 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.968047 339.192 
-L 500.593047 339.192 
-L 500.593047 309.8088 
-L 395.968047 309.8088 
+    <path d="M 395.670547 339.192 
+L 500.295547 339.192 
+L 500.295547 309.8088 
+L 395.670547 309.8088 
 z
-" clip-path="url(#pc63a3693a8)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p2c645dc69c)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.705313 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.407813 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.989531 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.692031 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.561641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.264141 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.913359 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.615859 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.643047 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.345547 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.579297 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.020547 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.723047 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.645547 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.281172 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(109.983672 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.579297 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.565547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.645547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.974297 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.676797 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.579297 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.565547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.645547 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.006797 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(118.709297 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.579297 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.565547 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.645547 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.544297 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.246797 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.579297 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.565547 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.645547 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(110.850547 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(110.553047 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(227.579297 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(338.565547 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(440.645547 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.348047 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.352422 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.054922 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.325 -->
-    <g transform="translate(226.378672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.081172 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1878,15 +1878,15 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 22 -->
-    <g transform="translate(338.089297 267.9415) scale(0.08 -0.08)">
+    <!-- 23 -->
+    <g transform="translate(337.791797 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 261 -->
-    <g transform="translate(439.931172 267.9415) scale(0.08 -0.08)">
+    <!-- 262 -->
+    <g transform="translate(439.633672 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-36" d="M 2316 2303 
 Q 2000 2303 1842 2098 
@@ -1918,29 +1918,15 @@ Q 2900 4744 3203 4694
 Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.467422 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.169922 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2005,7 +1991,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.579297 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2015,21 +2001,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.565547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.268047 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.190547 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.893047 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.688672 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.391172 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2040,7 +2026,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.579297 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.281797 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2050,13 +2036,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.110547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(340.813047 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.280547 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(443.983047 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2072,7 +2058,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.194766 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(150.897266 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2186,7 +2172,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-03T03:26:41Z  ·  Linux chungus x86_64  ·  commit f46604b4  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2328,12 +2314,12 @@ z
     <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2373,110 +2359,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3043.457031 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
     <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3425.048828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3488.671875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3520.458984 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3552.246094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3584.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3615.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3647.607422 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3675.390625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3736.914062 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3798.193359 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3861.572266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3925.048828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3963.912109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4025.09375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4084.273438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4145.796875 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4186.910156 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4220.601562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4248.384766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4309.908203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4371.1875 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4434.566406 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4498.189453 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4531.880859 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4591.060547 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4654.683594 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4686.470703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4750.09375 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4813.716797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4845.503906 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4909.126953 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4945.210938 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4984.074219 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5039.054688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5102.677734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5134.464844 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5166.251953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5198.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5229.826172 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5261.613281 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5300.822266 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5364.201172 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5403.064453 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5527.625 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5591.101562 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5654.480469 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5717.957031 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5781.335938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5820.544922 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5852.332031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5936.121094 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5967.908203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6065.320312 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6126.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6190.320312 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6218.103516 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6279.382812 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6342.761719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6374.548828 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6426.648438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6490.027344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6551.306641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6614.783203 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6666.882812 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6730.261719 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6791.443359 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6830.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6864.34375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6896.130859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6937.244141 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6998.523438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7037.732422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7065.515625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7126.697266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7158.484375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7186.267578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7238.367188 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7270.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7333.630859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7395.154297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7434.363281 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7495.886719 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7535.25 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7632.662109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7660.445312 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7723.824219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7751.607422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7803.707031 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7842.916016 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7870.699219 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc63a3693a8">
-   <rect x="82.093047" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p2c645dc69c">
+   <rect x="81.795547" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-03T03:26:41Z",
+  "date": "2026-07-03T07:47:31Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "f46604b4",
+  "git_commit": "3f1689c5",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 54.97,
-   "decompress_mbps": 187.38
+   "compress_mbps": 54.52,
+   "decompress_mbps": 188.84
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 42.23,
-   "decompress_mbps": 213.15
+   "compress_mbps": 42.14,
+   "decompress_mbps": 214.46
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 38.03,
-   "decompress_mbps": 233.09
+   "compress_mbps": 38.15,
+   "decompress_mbps": 232.41
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 28.99,
-   "decompress_mbps": 236.4
+   "compress_mbps": 28.86,
+   "decompress_mbps": 234.53
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54437,
    "ratio": 0.3579,
-   "compress_mbps": 22.91,
-   "decompress_mbps": 238.41
+   "compress_mbps": 22.72,
+   "decompress_mbps": 237.37
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54348,
    "ratio": 0.3573,
-   "compress_mbps": 19.05,
-   "decompress_mbps": 245.54
+   "compress_mbps": 20.37,
+   "decompress_mbps": 244.44
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 16.77,
-   "decompress_mbps": 246.34
+   "compress_mbps": 17.83,
+   "decompress_mbps": 244.81
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 13.61,
-   "decompress_mbps": 246.3
+   "compress_mbps": 15.4,
+   "decompress_mbps": 246.17
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 53082,
    "ratio": 0.349,
-   "compress_mbps": 3.23,
-   "decompress_mbps": 242.78
+   "compress_mbps": 3.17,
+   "decompress_mbps": 245.73
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 49.96,
-   "decompress_mbps": 180.32
+   "compress_mbps": 49.75,
+   "decompress_mbps": 181.16
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 38.94,
-   "decompress_mbps": 196.51
+   "compress_mbps": 38.76,
+   "decompress_mbps": 196.7
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 35.79,
-   "decompress_mbps": 214.24
+   "compress_mbps": 36.01,
+   "decompress_mbps": 214.49
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 27.2,
-   "decompress_mbps": 217.74
+   "compress_mbps": 26.99,
+   "decompress_mbps": 217.91
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48891,
    "ratio": 0.3906,
-   "compress_mbps": 23.57,
-   "decompress_mbps": 219.2
+   "compress_mbps": 23.42,
+   "decompress_mbps": 218.77
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48715,
    "ratio": 0.3892,
-   "compress_mbps": 18.11,
-   "decompress_mbps": 223.35
+   "compress_mbps": 19.59,
+   "decompress_mbps": 222.75
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 17.17,
-   "decompress_mbps": 223.78
+   "compress_mbps": 18.35,
+   "decompress_mbps": 222.67
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 13.71,
-   "decompress_mbps": 224.02
+   "compress_mbps": 15.84,
+   "decompress_mbps": 222.66
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 47620,
    "ratio": 0.3804,
-   "compress_mbps": 3.41,
-   "decompress_mbps": 224.53
+   "compress_mbps": 3.4,
+   "decompress_mbps": 223.86
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 39.89,
-   "decompress_mbps": 217.23
+   "compress_mbps": 39.53,
+   "decompress_mbps": 215.45
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 35.22,
-   "decompress_mbps": 224.64
+   "compress_mbps": 34.89,
+   "decompress_mbps": 221.09
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 34.4,
-   "decompress_mbps": 229.75
+   "compress_mbps": 34.07,
+   "decompress_mbps": 226.25
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 31.07,
-   "decompress_mbps": 237.18
+   "compress_mbps": 30.75,
+   "decompress_mbps": 233.5
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7932,
    "ratio": 0.3224,
-   "compress_mbps": 26.45,
-   "decompress_mbps": 245.01
+   "compress_mbps": 26.27,
+   "decompress_mbps": 241.68
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7938,
    "ratio": 0.3226,
-   "compress_mbps": 23.03,
-   "decompress_mbps": 246.07
+   "compress_mbps": 22.84,
+   "decompress_mbps": 243.0
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 22.08,
-   "decompress_mbps": 248.25
+   "compress_mbps": 21.76,
+   "decompress_mbps": 243.51
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 16.17,
-   "decompress_mbps": 248.91
+   "compress_mbps": 16.63,
+   "decompress_mbps": 243.52
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7806,
    "ratio": 0.3173,
-   "compress_mbps": 4.14,
-   "decompress_mbps": 249.31
+   "compress_mbps": 4.19,
+   "decompress_mbps": 244.77
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 26.08,
-   "decompress_mbps": 151.57
+   "compress_mbps": 25.84,
+   "decompress_mbps": 147.5
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 24.14,
-   "decompress_mbps": 153.81
+   "compress_mbps": 24.1,
+   "decompress_mbps": 149.97
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 23.41,
-   "decompress_mbps": 157.24
+   "compress_mbps": 23.37,
+   "decompress_mbps": 153.0
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.76,
-   "decompress_mbps": 160.23
+   "compress_mbps": 21.58,
+   "decompress_mbps": 155.39
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 19.66,
-   "decompress_mbps": 160.73
+   "compress_mbps": 19.52,
+   "decompress_mbps": 156.23
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3135,
    "ratio": 0.2812,
-   "compress_mbps": 18.05,
-   "decompress_mbps": 162.25
+   "compress_mbps": 17.83,
+   "decompress_mbps": 157.2
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 17.35,
-   "decompress_mbps": 162.93
+   "compress_mbps": 17.2,
+   "decompress_mbps": 157.61
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 11.64,
-   "decompress_mbps": 162.65
+   "compress_mbps": 11.62,
+   "decompress_mbps": 156.67
   },
   {
    "compressor": "native",
@@ -365,7 +365,7 @@
    "out_size": 3057,
    "ratio": 0.2742,
    "compress_mbps": 4.15,
-   "decompress_mbps": 162.59
+   "decompress_mbps": 156.58
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 12.51,
-   "decompress_mbps": 71.4
+   "compress_mbps": 12.48,
+   "decompress_mbps": 68.63
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 11.95,
-   "decompress_mbps": 72.06
+   "compress_mbps": 11.96,
+   "decompress_mbps": 69.1
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 11.84,
-   "decompress_mbps": 71.99
+   "compress_mbps": 11.86,
+   "decompress_mbps": 69.1
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.77,
-   "decompress_mbps": 72.31
+   "compress_mbps": 11.6,
+   "decompress_mbps": 69.71
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.43,
-   "decompress_mbps": 72.35
+   "compress_mbps": 11.36,
+   "decompress_mbps": 69.65
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 10.4,
-   "decompress_mbps": 72.68
+   "compress_mbps": 10.28,
+   "decompress_mbps": 70.0
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 10.4,
-   "decompress_mbps": 72.47
+   "compress_mbps": 10.25,
+   "decompress_mbps": 70.04
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 6.18,
-   "decompress_mbps": 72.47
+   "compress_mbps": 5.99,
+   "decompress_mbps": 69.78
   },
   {
    "compressor": "native",
@@ -455,7 +455,7 @@
    "out_size": 1205,
    "ratio": 0.3238,
    "compress_mbps": 3.41,
-   "decompress_mbps": 72.8
+   "decompress_mbps": 69.84
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 104.94,
-   "decompress_mbps": 342.73
+   "compress_mbps": 105.13,
+   "decompress_mbps": 342.6
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 78.17,
-   "decompress_mbps": 371.99
+   "compress_mbps": 78.37,
+   "decompress_mbps": 370.89
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 65.23,
-   "decompress_mbps": 393.88
+   "compress_mbps": 65.78,
+   "decompress_mbps": 392.85
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 60.42,
-   "decompress_mbps": 417.13
+   "compress_mbps": 60.25,
+   "decompress_mbps": 412.31
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 215530,
    "ratio": 0.2093,
-   "compress_mbps": 30.01,
-   "decompress_mbps": 389.37
+   "compress_mbps": 30.05,
+   "decompress_mbps": 398.65
   },
   {
    "compressor": "native",
@@ -515,7 +515,7 @@
    "out_size": 201414,
    "ratio": 0.1956,
    "compress_mbps": 20.12,
-   "decompress_mbps": 415.4
+   "decompress_mbps": 411.72
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 13.12,
-   "decompress_mbps": 418.61
+   "compress_mbps": 13.14,
+   "decompress_mbps": 415.93
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 8.16,
-   "decompress_mbps": 424.28
+   "compress_mbps": 8.38,
+   "decompress_mbps": 422.69
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 183445,
    "ratio": 0.1781,
-   "compress_mbps": 2.51,
-   "decompress_mbps": 425.93
+   "compress_mbps": 2.55,
+   "decompress_mbps": 422.4
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 61.26,
-   "decompress_mbps": 198.55
+   "compress_mbps": 60.85,
+   "decompress_mbps": 198.41
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 46.35,
-   "decompress_mbps": 214.99
+   "compress_mbps": 46.09,
+   "decompress_mbps": 213.77
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 41.66,
-   "decompress_mbps": 239.44
+   "compress_mbps": 41.61,
+   "decompress_mbps": 237.88
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 31.36,
-   "decompress_mbps": 242.08
+   "compress_mbps": 31.04,
+   "decompress_mbps": 241.32
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145321,
    "ratio": 0.3405,
-   "compress_mbps": 25.25,
-   "decompress_mbps": 244.73
+   "compress_mbps": 25.14,
+   "decompress_mbps": 244.63
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145046,
    "ratio": 0.3399,
-   "compress_mbps": 20.32,
-   "decompress_mbps": 249.5
+   "compress_mbps": 22.05,
+   "decompress_mbps": 249.28
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 18.36,
-   "decompress_mbps": 250.29
+   "compress_mbps": 19.86,
+   "decompress_mbps": 250.49
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 14.97,
-   "decompress_mbps": 250.94
+   "compress_mbps": 16.98,
+   "decompress_mbps": 250.9
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 141031,
    "ratio": 0.3305,
-   "compress_mbps": 3.23,
-   "decompress_mbps": 251.73
+   "compress_mbps": 3.25,
+   "decompress_mbps": 251.13
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 52.3,
-   "decompress_mbps": 171.03
+   "compress_mbps": 51.8,
+   "decompress_mbps": 171.06
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 38.93,
-   "decompress_mbps": 190.63
+   "compress_mbps": 39.22,
+   "decompress_mbps": 190.62
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 35.02,
-   "decompress_mbps": 210.44
+   "compress_mbps": 35.38,
+   "decompress_mbps": 209.61
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 24.59,
-   "decompress_mbps": 213.35
+   "compress_mbps": 24.41,
+   "decompress_mbps": 212.96
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 194902,
    "ratio": 0.4045,
-   "compress_mbps": 20.74,
-   "decompress_mbps": 212.15
+   "compress_mbps": 20.66,
+   "decompress_mbps": 211.94
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 195177,
    "ratio": 0.405,
-   "compress_mbps": 17.65,
-   "decompress_mbps": 216.56
+   "compress_mbps": 19.2,
+   "decompress_mbps": 216.11
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 15.79,
-   "decompress_mbps": 216.87
+   "compress_mbps": 17.05,
+   "decompress_mbps": 216.16
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 12.97,
-   "decompress_mbps": 216.78
+   "compress_mbps": 14.97,
+   "decompress_mbps": 216.05
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 190711,
    "ratio": 0.3958,
-   "compress_mbps": 2.98,
-   "decompress_mbps": 216.38
+   "compress_mbps": 3.01,
+   "decompress_mbps": 216.62
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 160.01,
-   "decompress_mbps": 465.04
+   "compress_mbps": 160.88,
+   "decompress_mbps": 470.03
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 123.86,
-   "decompress_mbps": 497.18
+   "compress_mbps": 126.28,
+   "decompress_mbps": 496.4
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 108.63,
-   "decompress_mbps": 536.07
+   "compress_mbps": 111.56,
+   "decompress_mbps": 538.29
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 76.13,
-   "decompress_mbps": 458.22
+   "compress_mbps": 75.5,
+   "decompress_mbps": 454.31
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 54950,
    "ratio": 0.1071,
-   "compress_mbps": 51.19,
-   "decompress_mbps": 488.29
+   "compress_mbps": 50.59,
+   "decompress_mbps": 481.02
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55259,
    "ratio": 0.1077,
-   "compress_mbps": 36.24,
-   "decompress_mbps": 534.13
+   "compress_mbps": 36.39,
+   "decompress_mbps": 531.58
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53713,
    "ratio": 0.1047,
-   "compress_mbps": 26.75,
-   "decompress_mbps": 567.86
+   "compress_mbps": 26.6,
+   "decompress_mbps": 567.71
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 18.69,
-   "decompress_mbps": 612.6
+   "compress_mbps": 19.63,
+   "decompress_mbps": 605.96
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 52729,
    "ratio": 0.1027,
-   "compress_mbps": 4.73,
-   "decompress_mbps": 628.15
+   "compress_mbps": 4.75,
+   "decompress_mbps": 613.73
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 29.56,
-   "decompress_mbps": 183.43
+   "compress_mbps": 29.38,
+   "decompress_mbps": 182.6
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 27.04,
-   "decompress_mbps": 188.78
+   "compress_mbps": 26.8,
+   "decompress_mbps": 187.4
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 26.18,
-   "decompress_mbps": 191.71
+   "compress_mbps": 26.08,
+   "decompress_mbps": 191.06
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 23.31,
-   "decompress_mbps": 199.5
+   "compress_mbps": 23.2,
+   "decompress_mbps": 197.85
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13346,
    "ratio": 0.349,
-   "compress_mbps": 20.1,
-   "decompress_mbps": 208.72
+   "compress_mbps": 20.0,
+   "decompress_mbps": 206.98
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13040,
    "ratio": 0.341,
-   "compress_mbps": 9.47,
-   "decompress_mbps": 214.49
+   "compress_mbps": 9.44,
+   "decompress_mbps": 209.84
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13035,
    "ratio": 0.3409,
-   "compress_mbps": 8.57,
-   "decompress_mbps": 215.68
+   "compress_mbps": 8.54,
+   "decompress_mbps": 211.64
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 6.1,
-   "decompress_mbps": 218.11
+   "compress_mbps": 6.27,
+   "decompress_mbps": 213.07
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12522,
    "ratio": 0.3275,
-   "compress_mbps": 3.54,
-   "decompress_mbps": 217.78
+   "compress_mbps": 3.53,
+   "decompress_mbps": 215.84
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 13.91,
-   "decompress_mbps": 77.53
+   "compress_mbps": 13.95,
+   "decompress_mbps": 74.76
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 13.36,
-   "decompress_mbps": 76.84
+   "compress_mbps": 13.37,
+   "decompress_mbps": 74.68
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 13.31,
-   "decompress_mbps": 77.6
+   "compress_mbps": 13.34,
+   "decompress_mbps": 74.83
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 13.06,
-   "decompress_mbps": 78.97
+   "compress_mbps": 13.07,
+   "decompress_mbps": 75.86
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 12.8,
-   "decompress_mbps": 78.75
+   "compress_mbps": 12.93,
+   "decompress_mbps": 75.6
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 11.23,
-   "decompress_mbps": 78.96
+   "compress_mbps": 11.28,
+   "decompress_mbps": 75.59
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 11.3,
-   "decompress_mbps": 78.97
+   "compress_mbps": 11.27,
+   "decompress_mbps": 75.35
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 6.81,
-   "decompress_mbps": 79.04
+   "compress_mbps": 6.77,
+   "decompress_mbps": 75.28
   },
   {
    "compressor": "native",
@@ -995,7 +995,7 @@
    "out_size": 1708,
    "ratio": 0.4041,
    "compress_mbps": 3.9,
-   "decompress_mbps": 78.24
+   "decompress_mbps": 75.56
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 55.48,
-   "decompress_mbps": 175.13
+   "compress_mbps": 55.21,
+   "decompress_mbps": 174.44
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 41.33,
-   "decompress_mbps": 190.42
+   "compress_mbps": 41.4,
+   "decompress_mbps": 190.44
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 36.93,
-   "decompress_mbps": 209.15
+   "compress_mbps": 37.08,
+   "decompress_mbps": 211.4
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 26.78,
-   "decompress_mbps": 213.66
+   "compress_mbps": 26.68,
+   "decompress_mbps": 213.36
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3870984,
    "ratio": 0.3798,
-   "compress_mbps": 22.24,
-   "decompress_mbps": 213.24
+   "compress_mbps": 22.15,
+   "decompress_mbps": 212.63
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3878499,
    "ratio": 0.3805,
-   "compress_mbps": 19.39,
-   "decompress_mbps": 221.48
+   "compress_mbps": 21.29,
+   "decompress_mbps": 219.84
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 17.03,
-   "decompress_mbps": 219.16
+   "compress_mbps": 18.43,
+   "decompress_mbps": 220.24
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 13.68,
-   "decompress_mbps": 219.27
+   "compress_mbps": 16.27,
+   "decompress_mbps": 219.04
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3790404,
    "ratio": 0.3719,
-   "compress_mbps": 3.13,
-   "decompress_mbps": 219.59
+   "compress_mbps": 3.08,
+   "decompress_mbps": 226.72
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 70.17,
-   "decompress_mbps": 192.7
+   "compress_mbps": 69.79,
+   "decompress_mbps": 190.77
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 56.03,
-   "decompress_mbps": 200.74
+   "compress_mbps": 56.17,
+   "decompress_mbps": 199.22
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 52.53,
-   "decompress_mbps": 200.3
+   "compress_mbps": 52.12,
+   "decompress_mbps": 205.46
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 39.36,
-   "decompress_mbps": 211.67
+   "compress_mbps": 39.17,
+   "decompress_mbps": 209.17
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20264932,
    "ratio": 0.3956,
-   "compress_mbps": 27.75,
-   "decompress_mbps": 220.02
+   "compress_mbps": 27.81,
+   "decompress_mbps": 218.86
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 19208910,
    "ratio": 0.375,
-   "compress_mbps": 16.0,
-   "decompress_mbps": 224.16
+   "compress_mbps": 16.18,
+   "decompress_mbps": 222.71
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 19177573,
    "ratio": 0.3744,
-   "compress_mbps": 12.71,
-   "decompress_mbps": 226.13
+   "compress_mbps": 12.92,
+   "decompress_mbps": 222.09
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 8.06,
-   "decompress_mbps": 227.83
+   "compress_mbps": 8.33,
+   "decompress_mbps": 215.01
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18723512,
    "ratio": 0.3655,
-   "compress_mbps": 3.21,
-   "decompress_mbps": 224.78
+   "compress_mbps": 3.17,
+   "decompress_mbps": 222.62
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 68.39,
-   "decompress_mbps": 205.5
+   "compress_mbps": 67.65,
+   "decompress_mbps": 206.01
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 53.45,
-   "decompress_mbps": 214.49
+   "compress_mbps": 53.8,
+   "decompress_mbps": 214.41
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 46.13,
-   "decompress_mbps": 224.58
+   "compress_mbps": 46.83,
+   "decompress_mbps": 224.61
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 31.41,
-   "decompress_mbps": 209.35
+   "compress_mbps": 30.98,
+   "decompress_mbps": 208.24
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3705174,
    "ratio": 0.3716,
-   "compress_mbps": 24.67,
-   "decompress_mbps": 205.65
+   "compress_mbps": 24.41,
+   "decompress_mbps": 204.38
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3612809,
    "ratio": 0.3623,
-   "compress_mbps": 18.76,
-   "decompress_mbps": 214.84
+   "compress_mbps": 19.73,
+   "decompress_mbps": 211.07
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3608980,
    "ratio": 0.362,
-   "compress_mbps": 16.25,
-   "decompress_mbps": 218.34
+   "compress_mbps": 17.02,
+   "decompress_mbps": 212.35
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 10.4,
-   "decompress_mbps": 219.46
+   "compress_mbps": 11.29,
+   "decompress_mbps": 218.25
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3598941,
    "ratio": 0.361,
-   "compress_mbps": 3.58,
-   "decompress_mbps": 227.82
+   "compress_mbps": 3.54,
+   "decompress_mbps": 227.94
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 200.7,
-   "decompress_mbps": 597.03
+   "compress_mbps": 200.96,
+   "decompress_mbps": 601.26
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 129.81,
-   "decompress_mbps": 670.78
+   "compress_mbps": 133.15,
+   "decompress_mbps": 669.91
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 113.5,
-   "decompress_mbps": 745.87
+   "compress_mbps": 114.56,
+   "decompress_mbps": 746.36
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 86.31,
-   "decompress_mbps": 746.85
+   "compress_mbps": 85.18,
+   "decompress_mbps": 747.13
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3145121,
    "ratio": 0.0937,
-   "compress_mbps": 56.88,
-   "decompress_mbps": 826.5
+   "compress_mbps": 56.56,
+   "decompress_mbps": 829.26
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3158854,
    "ratio": 0.0941,
-   "compress_mbps": 52.7,
-   "decompress_mbps": 880.99
+   "compress_mbps": 55.75,
+   "decompress_mbps": 881.59
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3124878,
    "ratio": 0.0931,
-   "compress_mbps": 36.79,
-   "decompress_mbps": 893.38
+   "compress_mbps": 38.04,
+   "decompress_mbps": 813.17
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 27.52,
-   "decompress_mbps": 914.41
+   "compress_mbps": 29.37,
+   "decompress_mbps": 908.42
   },
   {
    "compressor": "native",
@@ -4324,8 +4324,8 @@
    "level": 9,
    "out_size": 3083394,
    "ratio": 0.0919,
-   "compress_mbps": 3.08,
-   "decompress_mbps": 908.14
+   "compress_mbps": 3.03,
+   "decompress_mbps": 905.73
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 48.27,
-   "decompress_mbps": 128.85
+   "compress_mbps": 49.09,
+   "decompress_mbps": 128.08
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 41.14,
-   "decompress_mbps": 132.57
+   "compress_mbps": 40.76,
+   "decompress_mbps": 132.16
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 39.54,
-   "decompress_mbps": 137.07
+   "compress_mbps": 39.47,
+   "decompress_mbps": 136.17
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 32.36,
-   "decompress_mbps": 146.09
+   "compress_mbps": 31.82,
+   "decompress_mbps": 144.05
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3233792,
    "ratio": 0.5256,
-   "compress_mbps": 28.73,
-   "decompress_mbps": 150.94
+   "compress_mbps": 28.47,
+   "decompress_mbps": 149.19
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3168386,
    "ratio": 0.515,
-   "compress_mbps": 15.9,
-   "decompress_mbps": 155.33
+   "compress_mbps": 16.84,
+   "decompress_mbps": 152.46
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3165783,
    "ratio": 0.5146,
-   "compress_mbps": 14.78,
-   "decompress_mbps": 157.74
+   "compress_mbps": 15.52,
+   "decompress_mbps": 151.64
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 8.64,
-   "decompress_mbps": 157.45
+   "compress_mbps": 9.34,
+   "decompress_mbps": 153.45
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3055775,
    "ratio": 0.4967,
-   "compress_mbps": 3.72,
-   "decompress_mbps": 156.25
+   "compress_mbps": 3.77,
+   "decompress_mbps": 152.66
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 78.07,
-   "decompress_mbps": 230.29
+   "compress_mbps": 77.39,
+   "decompress_mbps": 226.51
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 59.51,
-   "decompress_mbps": 238.0
+   "compress_mbps": 59.85,
+   "decompress_mbps": 235.9
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 57.57,
-   "decompress_mbps": 242.95
+   "compress_mbps": 57.53,
+   "decompress_mbps": 242.01
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 51.95,
-   "decompress_mbps": 257.74
+   "compress_mbps": 51.16,
+   "decompress_mbps": 255.48
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3707010,
    "ratio": 0.3676,
-   "compress_mbps": 48.42,
-   "decompress_mbps": 259.67
+   "compress_mbps": 47.74,
+   "decompress_mbps": 257.14
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3707065,
    "ratio": 0.3676,
-   "compress_mbps": 31.44,
-   "decompress_mbps": 254.2
+   "compress_mbps": 35.74,
+   "decompress_mbps": 266.68
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 31.18,
-   "decompress_mbps": 255.25
+   "compress_mbps": 35.83,
+   "decompress_mbps": 271.59
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 15.95,
-   "decompress_mbps": 256.08
+   "compress_mbps": 18.33,
+   "decompress_mbps": 271.7
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3693258,
    "ratio": 0.3662,
-   "compress_mbps": 4.84,
-   "decompress_mbps": 269.3
+   "compress_mbps": 4.83,
+   "decompress_mbps": 267.92
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 69.34,
-   "decompress_mbps": 222.38
+   "compress_mbps": 69.38,
+   "decompress_mbps": 221.68
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 48.71,
-   "decompress_mbps": 233.42
+   "compress_mbps": 49.41,
+   "decompress_mbps": 236.01
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 39.96,
-   "decompress_mbps": 254.89
+   "compress_mbps": 41.18,
+   "decompress_mbps": 259.48
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 26.08,
-   "decompress_mbps": 263.35
+   "compress_mbps": 25.84,
+   "decompress_mbps": 263.01
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1874829,
    "ratio": 0.2829,
-   "compress_mbps": 15.73,
-   "decompress_mbps": 261.36
+   "compress_mbps": 15.82,
+   "decompress_mbps": 262.62
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1867098,
    "ratio": 0.2817,
-   "compress_mbps": 17.43,
-   "decompress_mbps": 276.89
+   "compress_mbps": 18.53,
+   "decompress_mbps": 278.32
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1843421,
    "ratio": 0.2782,
-   "compress_mbps": 12.08,
-   "decompress_mbps": 280.45
+   "compress_mbps": 12.55,
+   "decompress_mbps": 282.13
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 9.72,
-   "decompress_mbps": 282.83
+   "compress_mbps": 10.38,
+   "decompress_mbps": 280.75
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 1794155,
    "ratio": 0.2707,
-   "compress_mbps": 2.47,
-   "decompress_mbps": 290.71
+   "compress_mbps": 2.45,
+   "decompress_mbps": 290.18
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 95.14,
-   "decompress_mbps": 293.3
+   "compress_mbps": 94.48,
+   "decompress_mbps": 292.53
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 72.18,
-   "decompress_mbps": 313.32
+   "compress_mbps": 73.31,
+   "decompress_mbps": 311.35
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 66.12,
-   "decompress_mbps": 325.67
+   "compress_mbps": 66.5,
+   "decompress_mbps": 322.99
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 49.54,
-   "decompress_mbps": 333.64
+   "compress_mbps": 49.81,
+   "decompress_mbps": 333.09
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5839944,
    "ratio": 0.2703,
-   "compress_mbps": 37.45,
-   "decompress_mbps": 344.38
+   "compress_mbps": 37.56,
+   "decompress_mbps": 342.46
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5425813,
    "ratio": 0.2511,
-   "compress_mbps": 26.23,
-   "decompress_mbps": 352.69
+   "compress_mbps": 27.26,
+   "decompress_mbps": 350.18
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5409983,
    "ratio": 0.2504,
-   "compress_mbps": 23.21,
-   "decompress_mbps": 354.43
+   "compress_mbps": 23.85,
+   "decompress_mbps": 350.59
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 16.46,
-   "decompress_mbps": 358.75
+   "compress_mbps": 17.77,
+   "decompress_mbps": 353.58
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 9,
    "out_size": 5257833,
    "ratio": 0.2433,
-   "compress_mbps": 3.99,
-   "decompress_mbps": 355.78
+   "compress_mbps": 3.97,
+   "decompress_mbps": 347.97
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 41.24,
-   "decompress_mbps": 129.07
+   "compress_mbps": 40.66,
+   "decompress_mbps": 126.75
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 35.17,
-   "decompress_mbps": 132.08
+   "compress_mbps": 35.09,
+   "decompress_mbps": 130.84
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 33.18,
-   "decompress_mbps": 136.64
+   "compress_mbps": 33.27,
+   "decompress_mbps": 133.95
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 27.58,
-   "decompress_mbps": 139.21
+   "compress_mbps": 27.21,
+   "decompress_mbps": 137.63
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5496802,
    "ratio": 0.758,
-   "compress_mbps": 25.9,
-   "decompress_mbps": 137.44
+   "compress_mbps": 25.59,
+   "decompress_mbps": 135.65
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5478405,
    "ratio": 0.7554,
-   "compress_mbps": 17.38,
-   "decompress_mbps": 137.38
+   "compress_mbps": 19.08,
+   "decompress_mbps": 135.58
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5474648,
    "ratio": 0.7549,
-   "compress_mbps": 16.62,
-   "decompress_mbps": 138.9
+   "compress_mbps": 18.17,
+   "decompress_mbps": 136.89
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 7.87,
-   "decompress_mbps": 140.64
+   "compress_mbps": 8.23,
+   "decompress_mbps": 137.98
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5301868,
    "ratio": 0.7311,
-   "compress_mbps": 3.62,
-   "decompress_mbps": 141.55
+   "compress_mbps": 3.63,
+   "decompress_mbps": 138.44
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 71.12,
-   "decompress_mbps": 223.0
+   "compress_mbps": 70.95,
+   "decompress_mbps": 224.96
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 54.34,
-   "decompress_mbps": 241.35
+   "compress_mbps": 54.11,
+   "decompress_mbps": 244.21
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 50.41,
-   "decompress_mbps": 262.78
+   "compress_mbps": 50.2,
+   "decompress_mbps": 262.7
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 37.77,
-   "decompress_mbps": 260.4
+   "compress_mbps": 37.54,
+   "decompress_mbps": 266.37
   },
   {
    "compressor": "native",
@@ -4825,7 +4825,7 @@
    "out_size": 12123671,
    "ratio": 0.2924,
    "compress_mbps": 27.53,
-   "decompress_mbps": 272.44
+   "decompress_mbps": 272.04
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12167341,
    "ratio": 0.2935,
-   "compress_mbps": 24.55,
-   "decompress_mbps": 279.69
+   "compress_mbps": 27.52,
+   "decompress_mbps": 279.38
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 20.64,
-   "decompress_mbps": 282.14
+   "compress_mbps": 22.74,
+   "decompress_mbps": 280.46
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 16.36,
-   "decompress_mbps": 282.46
+   "compress_mbps": 18.95,
+   "decompress_mbps": 282.69
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 9,
    "out_size": 11868997,
    "ratio": 0.2863,
-   "compress_mbps": 3.24,
-   "decompress_mbps": 282.41
+   "compress_mbps": 3.23,
+   "decompress_mbps": 281.63
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 39.06,
-   "decompress_mbps": 126.15
+   "compress_mbps": 38.82,
+   "decompress_mbps": 124.74
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 37.61,
-   "decompress_mbps": 126.96
+   "compress_mbps": 37.4,
+   "decompress_mbps": 126.21
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 37.91,
-   "decompress_mbps": 128.38
+   "compress_mbps": 37.18,
+   "decompress_mbps": 126.86
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 35.76,
-   "decompress_mbps": 117.44
+   "compress_mbps": 35.3,
+   "decompress_mbps": 115.56
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 35.9,
-   "decompress_mbps": 119.02
+   "compress_mbps": 35.06,
+   "decompress_mbps": 115.82
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 9.54,
-   "decompress_mbps": 119.21
+   "compress_mbps": 9.59,
+   "decompress_mbps": 116.36
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 9.45,
-   "decompress_mbps": 120.52
+   "compress_mbps": 9.56,
+   "decompress_mbps": 118.39
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 5.47,
-   "decompress_mbps": 119.2
+   "compress_mbps": 5.75,
+   "decompress_mbps": 118.4
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5949045,
    "ratio": 0.702,
-   "compress_mbps": 4.32,
-   "decompress_mbps": 121.14
+   "compress_mbps": 4.35,
+   "decompress_mbps": 120.01
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 151.44,
-   "decompress_mbps": 419.29
+   "compress_mbps": 150.14,
+   "decompress_mbps": 435.7
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 101.03,
-   "decompress_mbps": 455.3
+   "compress_mbps": 102.64,
+   "decompress_mbps": 504.57
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 92.34,
-   "decompress_mbps": 503.3
+   "compress_mbps": 94.35,
+   "decompress_mbps": 561.39
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 69.35,
-   "decompress_mbps": 556.85
+   "compress_mbps": 68.93,
+   "decompress_mbps": 548.46
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 710636,
    "ratio": 0.1329,
-   "compress_mbps": 50.05,
-   "decompress_mbps": 606.76
+   "compress_mbps": 49.91,
+   "decompress_mbps": 602.4
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 688375,
    "ratio": 0.1288,
-   "compress_mbps": 42.12,
-   "decompress_mbps": 594.59
+   "compress_mbps": 44.22,
+   "decompress_mbps": 650.29
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 676544,
    "ratio": 0.1266,
-   "compress_mbps": 34.28,
-   "decompress_mbps": 666.22
+   "compress_mbps": 35.66,
+   "decompress_mbps": 659.32
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 26.55,
-   "decompress_mbps": 676.43
+   "compress_mbps": 28.72,
+   "decompress_mbps": 669.27
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 9,
    "out_size": 669438,
    "ratio": 0.1252,
-   "compress_mbps": 3.92,
-   "decompress_mbps": 664.14
+   "compress_mbps": 3.94,
+   "decompress_mbps": 652.99
   },
   {
    "compressor": "zlib",
@@ -17264,7 +17264,7 @@
    "level": 10,
    "out_size": 52115,
    "ratio": 0.3427,
-   "compress_mbps": 1.82,
+   "compress_mbps": 1.81,
    "decompress_mbps": null
   },
   {
@@ -17274,7 +17274,7 @@
    "level": 10,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 2.08,
+   "compress_mbps": 2.06,
    "decompress_mbps": null
   },
   {
@@ -17284,7 +17284,7 @@
    "level": 10,
    "out_size": 7730,
    "ratio": 0.3142,
-   "compress_mbps": 2.53,
+   "compress_mbps": 2.54,
    "decompress_mbps": null
   },
   {
@@ -17294,7 +17294,7 @@
    "level": 10,
    "out_size": 3030,
    "ratio": 0.2717,
-   "compress_mbps": 2.44,
+   "compress_mbps": 2.45,
    "decompress_mbps": null
   },
   {
@@ -17304,7 +17304,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.14,
+   "compress_mbps": 2.15,
    "decompress_mbps": null
   },
   {
@@ -17314,7 +17314,7 @@
    "level": 10,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 1.17,
+   "compress_mbps": 1.2,
    "decompress_mbps": null
   },
   {
@@ -17324,7 +17324,7 @@
    "level": 10,
    "out_size": 138684,
    "ratio": 0.325,
-   "compress_mbps": 1.93,
+   "compress_mbps": 1.92,
    "decompress_mbps": null
   },
   {
@@ -17334,7 +17334,7 @@
    "level": 10,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.79,
+   "compress_mbps": 1.8,
    "decompress_mbps": null
   },
   {
@@ -17344,7 +17344,7 @@
    "level": 10,
    "out_size": 52368,
    "ratio": 0.102,
-   "compress_mbps": 3.12,
+   "compress_mbps": 3.14,
    "decompress_mbps": null
   },
   {
@@ -17364,7 +17364,7 @@
    "level": 10,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 2.47,
+   "compress_mbps": 2.49,
    "decompress_mbps": null
   },
   {
@@ -17374,7 +17374,7 @@
    "level": 10,
    "out_size": 3712353,
    "ratio": 0.3642,
-   "compress_mbps": 1.8,
+   "compress_mbps": 1.78,
    "decompress_mbps": null
   },
   {
@@ -17384,7 +17384,7 @@
    "level": 10,
    "out_size": 18524576,
    "ratio": 0.3617,
-   "compress_mbps": 1.77,
+   "compress_mbps": 1.78,
    "decompress_mbps": null
   },
   {
@@ -17394,7 +17394,7 @@
    "level": 10,
    "out_size": 3523172,
    "ratio": 0.3534,
-   "compress_mbps": 1.86,
+   "compress_mbps": 1.88,
    "decompress_mbps": null
   },
   {
@@ -17404,7 +17404,7 @@
    "level": 10,
    "out_size": 2930422,
    "ratio": 0.0873,
-   "compress_mbps": 1.68,
+   "compress_mbps": 1.69,
    "decompress_mbps": null
   },
   {
@@ -17424,7 +17424,7 @@
    "level": 10,
    "out_size": 3647718,
    "ratio": 0.3617,
-   "compress_mbps": 2.77,
+   "compress_mbps": 2.76,
    "decompress_mbps": null
   },
   {
@@ -17434,7 +17434,7 @@
    "level": 10,
    "out_size": 1724649,
    "ratio": 0.2602,
-   "compress_mbps": 1.18,
+   "compress_mbps": 1.17,
    "decompress_mbps": null
   },
   {
@@ -17454,7 +17454,7 @@
    "level": 10,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 2.52,
+   "compress_mbps": 2.53,
    "decompress_mbps": null
   },
   {
@@ -17474,7 +17474,7 @@
    "level": 10,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 3.31,
+   "compress_mbps": 3.38,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR replaces the level 6-8 `deflateRaw` dispatch that emitted every split candidate (base + observation-divergence split, plus the fixed-cadence split at L8) and kept the smallest via `pickSmaller` with a size-arbitrated one that emits only the winner. Each candidate is *prepared* — sized to its flushed byte count with its per-block Huffman trees captured — and only the winner's emit thunk is forced, reusing the trees the sizing pass already built. Output is byte-identical to the old dispatch on every input (same winner decided by the same ⌈bits/8⌉ counts), so the compression ratio is unchanged; the saving is the discarded emit passes (a second full emit at L5-L7, a third at L8).

The tree capture is load-bearing. A naive size-then-emit-winner *regresses*, because sizing a dynamic block is not cheap — it costs a full frequency pass plus the per-block Huffman-tree build and `writeDynamicHeader`, roughly 0.72x the cost of emitting it. Reusing the sized trees for the winner's emit (so the winner skips the second frequency/Huffman pass) is what turns it into a real win. Measured on the Silesia corpus with clean nix-shell builds (a stale `.lake` from a stray bare-shell build imposes a flat ~10% handicap that masks the effect entirely — rebuild from a clean `.lake`):

| level | geomean | range |
|------|---------|-------|
| L5 | ~0% (unchanged, no split path) | — |
| L6 | ~+6.7% | +3.8% (samba) … +12.2% (osdb) |
| L7 | ~+6.5% | +3.3% (xml) … +13.2% (osdb) |
| L8 | ~+9.7% | +5.8% (sao) … +15.3% (dickens) |

Correctness is preserved at two levels. `emitSmallerBy` / `deflateRawBasePPrep` / `deflateDynamicBlocksSharedAtSizedP` are pinned byte-identical to the retired `pickSmaller`-of-emitted-blocks path by the `SizeHelpers` conformance tests (each sizer's `.1` equals the emitted `.size`, each emit thunk equals the reference emitter, and `deflateRaw` at L6/L7/L8 is asserted byte-identical to the old emit-every-candidate dispatch across the sample set) — these tests were previously compiled-but-never-run, and this PR wires them into the test runner. The unified roundtrip, padding, and `goR` proofs in `DeflateRoundtrip` go through `deflateRawBasePPrep_emit` and `deflateDynamicBlocksSharedAtSizedP_emit`; the latter (packed sized-tree emit equals the reference packed emit) is proved in `LZ77PackedCorrect` as the packed twin of the Wave-5 (#2552) boxed pipeline.

Relation: composes with #2743 (per-block stored/fixed/dynamic choice inside the split emit) — both touch this dispatch, so they should land in sequence, either order.

Closes #2753.

🤖 Prepared with Claude Code