### PR TITLE
perf: USize-native chain walk (untag the Nat position arithmetic in chainWalkPacked)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1026,6 +1026,102 @@ decreasing_by all_goals omega
     let p := lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos
     p.2 * 512 + p.1
 
+/-- USize-native de-boxed twin of `chainWalkPacked` (Wave 7 P1b): the per-position
+    chain-walk bookkeeping — the fuel counter, the best-length/best-position
+    accumulator, and the `scan_end` prefilter's index arithmetic — runs on unboxed
+    `USize` rather than tagged `Nat`, so the hot loop pays no per-step tag test /
+    untag on its scalar arithmetic. The chain link `cand` itself stays `Nat`: it is
+    read straight from the `Nat` `prev` ring and handed to `countMatch` and the mask
+    index with no conversion, matching the measured `UInt32`-ring tax the
+    `chainWinSize` docstring records — only the accumulators move to `USize`. One
+    runtime `data.size < USize.size` addressability witness (`hsz`, established by
+    the guarded wrapper exactly as `countMatch` does for `goUW`) makes every
+    `USize` add faithful, and the result is repacked into the `Nat`
+    `bestPos * 512 + bestLen` at the leaves via `.toNat`, so no `USize` multiply can
+    overflow. The invariant `USize` copies of `pos`/`maxLen`/`min niceLen maxLen`
+    (`posU`/`maxLenU`/`cutoffU`, computed once by the wrapper) carry their `toNat`
+    identities so the loop never reconverts them. Proven equal to `chainWalkPacked`
+    (`chainWalkPackedU_eq`). -/
+def chainWalkPackedU (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (hps : min chainWinSize data.size ≤ prev.size) (hsz : data.size < USize.size)
+    (posU maxLenU cutoffU : USize) (hposU : posU.toNat = pos) (hmaxU : maxLenU.toNat = maxLen)
+    (hcutU : cutoffU.toNat = min niceLen maxLen)
+    (cand : Nat) (fuelU bestLenU bestPosU : USize) : Nat :=
+  if fuelU = 0 then bestPosU.toNat * 512 + bestLenU.toNat
+  else if hc : cand < pos ∧ pos - cand ≤ windowSize then
+    have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+    have hcand : cand + maxLen ≤ data.size := by omega
+    have hcandlt : cand < USize.size := by omega
+    let candU : USize := cand.toUSize
+    have hcandU : candU.toNat = cand := toUSize_toNat_of_lt hcandlt
+    let skip : Bool := if hbl : bestLenU < maxLenU then
+        have hbln : bestLenU.toNat < maxLen := by rw [← hmaxU]; exact USize.lt_iff_toNat_lt.mp hbl
+        have hb1 : (candU + bestLenU).toNat < data.size := by
+          have e : (candU + bestLenU).toNat = cand + bestLenU.toNat := by
+            rw [USize.toNat_add, hcandU]; apply Nat.mod_eq_of_lt; omega
+          omega
+        have hb2 : (posU + bestLenU).toNat < data.size := by
+          have e : (posU + bestLenU).toNat = pos + bestLenU.toNat := by
+            rw [USize.toNat_add, hposU]; apply Nat.mod_eq_of_lt; omega
+          omega
+        data.uget (candU + bestLenU) hb1 != data.uget (posU + bestLenU) hb2
+      else false
+    if skip then
+      if bestLenU ≥ cutoffU then bestPosU.toNat * 512 + bestLenU.toNat
+      else chainWalkPackedU data prev windowSize pos maxLen niceLen hpm hps hsz posU maxLenU cutoffU
+        hposU hmaxU hcutU
+        (prev[cand &&& 0x7FFF]'(by have h1 := winMask_lt cand; have h2 := Nat.and_le_left (n := cand) (m := 0x7FFF); simp only [chainWinSize] at h1 hps; omega))
+        (fuelU - 1) bestLenU bestPosU
+    else
+      let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
+      let mlU : USize := ml.toUSize
+      let blU : USize := if mlU > bestLenU then mlU else bestLenU
+      let bpU : USize := if mlU > bestLenU then candU else bestPosU
+      if blU ≥ cutoffU then bpU.toNat * 512 + blU.toNat
+      else chainWalkPackedU data prev windowSize pos maxLen niceLen hpm hps hsz posU maxLenU cutoffU
+        hposU hmaxU hcutU
+        (prev[cand &&& 0x7FFF]'(by have h1 := winMask_lt cand; have h2 := Nat.and_le_left (n := cand) (m := 0x7FFF); simp only [chainWinSize] at h1 hps; omega))
+        (fuelU - 1) blU bpU
+  else bestPosU.toNat * 512 + bestLenU.toNat
+termination_by fuelU.toNat
+decreasing_by
+  all_goals
+    have hfz : ¬ fuelU = 0 := by assumption
+    have hpos : 0 < fuelU.toNat := by
+      rcases Nat.eq_zero_or_pos fuelU.toNat with h | h
+      · exact absurd (USize.toNat_inj.mp (by rw [h, USize.toNat_zero])) hfz
+      · exact h
+    have hle : (1 : USize) ≤ fuelU := by rw [USize.le_iff_toNat_le, USize.toNat_one]; omega
+    have heq : (fuelU - 1).toNat = fuelU.toNat - 1 := by
+      rw [USize.toNat_sub_of_le _ _ hle, USize.toNat_one]
+    omega
+
+/-- One runtime addressability + accumulator-faithfulness check guards the whole
+    `chainWalkPackedU` inner loop: the single `Nat`-round-trip test
+    `data.size.toUSize.toNat = data.size` witnesses `data.size < USize.size` (the
+    `hsz` the loop needs), and the three `_.toUSize.toNat = _` conjuncts witness
+    that `fuel`/`bestLen`/`bestPos` are representable. Every miss (never taken for
+    the production matcher: `data.size` fits a `size_t`, `fuel = maxChain` is tiny,
+    and the walk starts at `bestLen = bestPos = 0`) falls back to `chainWalkPacked`,
+    so this equals `chainWalkGuardedPacked` (`chainWalkGuardedPackedU_eq`). -/
+@[inline] def chainWalkGuardedPackedU (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (cand fuel bestLen bestPos : Nat) : Nat :=
+  if hps : min chainWinSize data.size ≤ prev.size then
+    if hg : data.size.toUSize.toNat = data.size ∧ fuel.toUSize.toNat = fuel ∧
+        bestLen.toUSize.toNat = bestLen ∧ bestPos.toUSize.toNat = bestPos then
+      have hsz : data.size < USize.size := by rw [← hg.1]; exact USize.toNat_lt_two_pow_numBits _
+      chainWalkPackedU data prev windowSize pos maxLen niceLen hpm hps hsz
+        pos.toUSize maxLen.toUSize (min niceLen maxLen).toUSize
+        (toUSize_toNat_of_lt (by omega)) (toUSize_toNat_of_lt (by omega))
+        (toUSize_toNat_of_lt (by omega)) cand fuel.toUSize bestLen.toUSize bestPos.toUSize
+    else
+      chainWalkPacked data prev windowSize pos maxLen niceLen hpm hps cand fuel bestLen bestPos
+  else
+    let p := lz77Chain.chainWalk data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos
+    p.2 * 512 + p.1
+
 /-- Proven-bounds copy of `lz77Chain.updateHashes`: the bucket index `hsh` is
     `< hashSize ≤ hashTable.size`, so `hashTable[hsh]` needs no runtime check. -/
 def updateHashesFast (data : ByteArray) (hashSize : Nat)
@@ -1379,7 +1475,7 @@ where
       let prev := guardedSet prev (pos &&& 0x7FFF) head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let r := chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPackedU data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
       let matchLen := r % 512
       let matchPos := r / 512
       if hge : matchLen ≥ 3 then
@@ -1424,7 +1520,7 @@ where
       let prev := guardedSet prev (pos &&& 0x7FFF) head
       let maxLen := min 258 (data.size - pos)
       have hmaxLenP : pos + maxLen ≤ data.size := by omega
-      let r := chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
+      let r := chainWalkGuardedPackedU data prev windowSize pos maxLen niceLen hmaxLenP head maxChain 0 0
       let matchLen := r % 512
       let matchPos := r / 512
       if hge : matchLen ≥ 3 then
@@ -1441,7 +1537,7 @@ where
               let maxLen2 := min 258 (data.size - (pos + 1))
               have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
               let r2 :=
-                chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 maxChain 0 0
+                chainWalkGuardedPackedU data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 maxChain 0 0
               let matchLen2 := r2 % 512
               let matchPos2 := r2 / 512
               if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then

--- a/Zip/Spec/LZ77ChainCorrect.lean
+++ b/Zip/Spec/LZ77ChainCorrect.lean
@@ -330,6 +330,142 @@ theorem chainWalkGuardedPacked_eq (data : ByteArray) (prev : Array Nat)
   · rw [chainWalkPacked_eq, chainWalkFast_eq]
   · rfl
 
+/-! ## USize-native packed chain walk (Wave 7 P1b)
+
+`chainWalkPackedU` runs `chainWalkPacked`'s per-position bookkeeping — fuel,
+the best-length/best-position accumulator, and the `scan_end` prefilter's
+index arithmetic — on unboxed `USize`, with the chain link `cand` left on the
+`Nat` ring. `chainWalkPackedU_eq` is the lockstep equality: identical control
+flow, every `USize` operation the faithful image of its `Nat` twin
+(`toUSize_toNat_of_lt` round-trips, `uget_eq_getElem` for the prefilter reads),
+so it holds whenever the buffer is `USize`-addressable and the accumulators
+round-trip (the wrapper's runtime guard). -/
+
+/-- The packed `USize` walk computes exactly the same `Nat` result as
+    `chainWalkPacked`: same branch tree, each `USize` add/compare the image of
+    the `Nat` one under the round-trip identities. -/
+theorem chainWalkPackedU_eq (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (hps : min chainWinSize data.size ≤ prev.size) (hsz : data.size < USize.size)
+    (posU maxLenU cutoffU : USize) (hposU : posU.toNat = pos) (hmaxU : maxLenU.toNat = maxLen)
+    (hcutU : cutoffU.toNat = min niceLen maxLen)
+    (cand fuel bestLen bestPos : Nat)
+    (hfuel : fuel < USize.size) (hbl : bestLen < USize.size) (hbp : bestPos < USize.size) :
+    chainWalkPackedU data prev windowSize pos maxLen niceLen hpm hps hsz posU maxLenU cutoffU
+        hposU hmaxU hcutU cand fuel.toUSize bestLen.toUSize bestPos.toUSize =
+      chainWalkPacked data prev windowSize pos maxLen niceLen hpm hps cand fuel bestLen bestPos := by
+  induction fuel generalizing cand bestLen bestPos hbl hbp with
+  | zero =>
+    rw [chainWalkPackedU, chainWalkPacked]
+    have h0 : ((0 : Nat).toUSize) = 0 := by
+      apply USize.toNat_inj.mp; rw [toUSize_toNat_of_lt (by omega), USize.toNat_zero]
+    rw [if_pos h0, if_pos rfl, toUSize_toNat_of_lt hbp, toUSize_toNat_of_lt hbl]
+  | succ k ih =>
+    rw [chainWalkPackedU, chainWalkPacked]
+    have hfk : (k + 1 : Nat).toUSize.toNat = k + 1 := toUSize_toNat_of_lt hfuel
+    have hfne : ¬ ((k + 1 : Nat).toUSize = 0) := fun h => by
+      rw [h, USize.toNat_zero] at hfk; omega
+    have h1le : (1 : USize) ≤ (k + 1 : Nat).toUSize := by
+      rw [USize.le_iff_toNat_le, USize.toNat_one, hfk]; omega
+    have hsub : (k + 1 : Nat).toUSize - 1 = (k : Nat).toUSize := by
+      apply USize.toNat_inj.mp
+      rw [USize.toNat_sub_of_le _ _ h1le, USize.toNat_one, hfk, toUSize_toNat_of_lt (show k < USize.size by omega)]
+      omega
+    rw [if_neg hfne, if_neg (by omega : ¬ (k + 1 = 0))]
+    by_cases hc : cand < pos ∧ pos - cand ≤ windowSize
+    · rw [dif_pos hc, dif_pos hc]
+      have hUS : USize.size = 2 ^ System.Platform.numBits := rfl
+      have hcand : cand + maxLen ≤ data.size := by omega
+      have hcandlt : cand < USize.size := by omega
+      have hcU : cand.toUSize.toNat = cand := toUSize_toNat_of_lt hcandlt
+      have hblU : bestLen.toUSize.toNat = bestLen := toUSize_toNat_of_lt hbl
+      have hbpU : bestPos.toUSize.toNat = bestPos := toUSize_toNat_of_lt hbp
+      simp only []
+      -- The prefilter condition `bestLen < maxLen` is shared (USize compare = Nat compare).
+      have hcond : (bestLen.toUSize < maxLenU) = (bestLen < maxLen) := by
+        rw [eq_iff_iff, USize.lt_iff_toNat_lt, hblU, hmaxU]
+      -- The cutoff comparison, shared for any `n < USize.size`.
+      have hcut : ∀ n : Nat, n < USize.size → (n.toUSize ≥ cutoffU) = (n ≥ min niceLen maxLen) := by
+        intro n hn
+        rw [eq_iff_iff, ge_iff_le, ge_iff_le, USize.le_iff_toNat_le, hcutU, toUSize_toNat_of_lt hn]
+      -- The shared `countMatch` continuation (reached when the prefilter does not skip).
+      have hstep :
+          (let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
+           let blU := if ml.toUSize > bestLen.toUSize then ml.toUSize else bestLen.toUSize
+           let bpU := if ml.toUSize > bestLen.toUSize then cand.toUSize else bestPos.toUSize
+           if blU ≥ cutoffU then bpU.toNat * 512 + blU.toNat
+           else chainWalkPackedU data prev windowSize pos maxLen niceLen hpm hps hsz posU maxLenU cutoffU
+             hposU hmaxU hcutU
+             (prev[cand &&& 0x7FFF]'(by have h1 := winMask_lt cand; have h2 := Nat.and_le_left (n := cand) (m := 0x7FFF); simp only [chainWinSize] at h1 hps; omega))
+             ((k + 1 : Nat).toUSize - 1) blU bpU) =
+          (let ml := lz77Greedy.countMatch data cand pos maxLen hcand hpm
+           let bl := if ml > bestLen then ml else bestLen
+           let bp := if ml > bestLen then cand else bestPos
+           if bl ≥ min niceLen maxLen then bp * 512 + bl
+           else chainWalkPacked data prev windowSize pos maxLen niceLen hpm hps
+             (prev[cand &&& 0x7FFF]'(by have := winMask_lt cand; have := Nat.and_le_left (n := cand) (m := 0x7FFF); omega))
+             k bl bp) := by
+        have hml_le : lz77Greedy.countMatch data cand pos maxLen hcand hpm ≤ maxLen :=
+          (lz77Greedy.countMatch_matches data cand pos maxLen hcand hpm).2
+        have hmllt : lz77Greedy.countMatch data cand pos maxLen hcand hpm < USize.size := by omega
+        have hmlU : (lz77Greedy.countMatch data cand pos maxLen hcand hpm).toUSize.toNat
+            = lz77Greedy.countMatch data cand pos maxLen hcand hpm := toUSize_toNat_of_lt hmllt
+        have hmlcond : ((lz77Greedy.countMatch data cand pos maxLen hcand hpm).toUSize > bestLen.toUSize)
+            = (lz77Greedy.countMatch data cand pos maxLen hcand hpm > bestLen) := by
+          rw [eq_iff_iff, gt_iff_lt, gt_iff_lt, USize.lt_iff_toNat_lt, hblU, hmlU]
+        simp only [hmlcond]
+        by_cases hml : lz77Greedy.countMatch data cand pos maxLen hcand hpm > bestLen
+        · simp only [hml, ↓reduceIte, hcut _ hmllt]
+          by_cases hge : lz77Greedy.countMatch data cand pos maxLen hcand hpm ≥ min niceLen maxLen
+          · simp only [hge, ↓reduceIte, hmlU, hcU]
+          · simp only [hge, ↓reduceIte]; rw [hsub]; exact ih _ _ _ (by omega) hmllt hcandlt
+        · simp only [hml, ↓reduceIte, hcut _ hbl]
+          by_cases hge : bestLen ≥ min niceLen maxLen
+          · simp only [hge, ↓reduceIte, hblU, hbpU]
+          · simp only [hge, ↓reduceIte]; rw [hsub]; exact ih _ _ _ (by omega) hbl hbp
+      -- Reduce the shared `skip` prefilter Bool on both sides.
+      by_cases hlt : bestLen < maxLen
+      · simp only [dif_pos (show bestLen.toUSize < maxLenU by rw [hcond]; exact hlt), dif_pos hlt,
+          uget_eq_getElem]
+        have e1 : (cand.toUSize + bestLen.toUSize).toNat = cand + bestLen := by
+          rw [USize.toNat_add, hcU, hblU]; apply Nat.mod_eq_of_lt; omega
+        have e2 : (posU + bestLen.toUSize).toNat = pos + bestLen := by
+          rw [USize.toNat_add, hposU, hblU]; apply Nat.mod_eq_of_lt; omega
+        simp only [e1, e2]
+        by_cases hbyte : data[cand + bestLen]'(by omega) = data[pos + bestLen]'(by omega)
+        · simp only [hbyte, bne_self_eq_false, Bool.false_eq_true, ↓reduceIte]; exact hstep
+        · simp only [bne_iff_ne.mpr hbyte, ↓reduceIte, hcut _ hbl]
+          by_cases hge : bestLen ≥ min niceLen maxLen
+          · simp only [hge, ↓reduceIte, hblU, hbpU]
+          · simp only [hge, ↓reduceIte]; rw [hsub]; exact ih _ _ _ (by omega) hbl hbp
+      · simp only [dif_neg (show ¬ (bestLen.toUSize < maxLenU) by rw [hcond]; exact hlt), dif_neg hlt,
+          Bool.false_eq_true, ↓reduceIte]
+        exact hstep
+    · rw [dif_neg hc, dif_neg hc, toUSize_toNat_of_lt hbp, toUSize_toNat_of_lt hbl]
+
+/-- The runtime-guarded `USize` walk equals the runtime-guarded `Nat` walk
+    (`chainWalkGuardedPacked`) unconditionally: when the addressability +
+    accumulator-faithfulness check passes it is `chainWalkPackedU_eq`, and every
+    other branch is literally `chainWalkGuardedPacked`'s branch. Callers can
+    therefore substitute the `USize` walk with no change to any downstream
+    contract — its result decodes with the existing `chainWalkGuardedPacked_mod`
+    / `_div` lemmas after rewriting through this equation. -/
+theorem chainWalkGuardedPackedU_eq (data : ByteArray) (prev : Array Nat)
+    (windowSize pos maxLen niceLen : Nat) (hpm : pos + maxLen ≤ data.size)
+    (cand fuel bestLen bestPos : Nat) :
+    chainWalkGuardedPackedU data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos =
+      chainWalkGuardedPacked data prev windowSize pos maxLen niceLen hpm cand fuel bestLen bestPos := by
+  unfold chainWalkGuardedPackedU chainWalkGuardedPacked
+  split
+  · split
+    · rename_i _ hg
+      rw [chainWalkPackedU_eq]
+      · rw [← hg.2.1]; exact USize.toNat_lt_two_pow_numBits _
+      · rw [← hg.2.2.1]; exact USize.toNat_lt_two_pow_numBits _
+      · rw [← hg.2.2.2]; exact USize.toNat_lt_two_pow_numBits _
+    · rfl
+  · rfl
+
 /-- From a zero-initialised best length, the reference walk's best length
     never exceeds `maxLen` (specialisation of `chainWalk_spec`). -/
 theorem chainWalk_fst_le (data : ByteArray) (prev : Array Nat)

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -56,6 +56,7 @@ private theorem mainLoopP_eq (data : ByteArray) (windowSize hashSize maxChain in
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainIterP.mainLoop lz77ChainIter.mainLoop
+    simp only [chainWalkGuardedPackedU_eq]
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
       split
@@ -88,6 +89,7 @@ private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChai
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainLazyIterP.mainLoop lz77ChainLazyIter.mainLoop
+    simp only [chainWalkGuardedPackedU_eq]
     by_cases hlt : pos + 2 < data.size
     · simp only [hlt, ↓reduceDIte]
       -- Branch tree: hge / hle / h3lt / gate / deferral / hle2

--- a/bench/graphs/.hid_canterbury_compress_pareto.svg
+++ b/bench/graphs/.hid_canterbury_compress_pareto.svg
@@ -1,0 +1,2715 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="648pt" height="468pt" viewBox="0 0 648 468" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 468 
+L 648 468 
+L 648 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 66.078125 412.80375 
+L 637.2 412.80375 
+L 637.2 48.583125 
+L 66.078125 48.583125 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 68.420093 412.80375 
+L 68.420093 48.583125 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mb0d470d418" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mb0d470d418" x="68.420093" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.295 -->
+      <g transform="translate(54.10603 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-39" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 150.166489 412.80375 
+L 150.166489 48.583125 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mb0d470d418" x="150.166489" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.300 -->
+      <g transform="translate(135.852426 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 231.912885 412.80375 
+L 231.912885 48.583125 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mb0d470d418" x="231.912885" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.305 -->
+      <g transform="translate(217.598823 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 313.659281 412.80375 
+L 313.659281 48.583125 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mb0d470d418" x="313.659281" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0.310 -->
+      <g transform="translate(299.345219 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 395.405677 412.80375 
+L 395.405677 48.583125 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mb0d470d418" x="395.405677" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.315 -->
+      <g transform="translate(381.091615 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 477.152073 412.80375 
+L 477.152073 48.583125 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mb0d470d418" x="477.152073" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.320 -->
+      <g transform="translate(462.838011 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 558.89847 412.80375 
+L 558.89847 48.583125 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mb0d470d418" x="558.89847" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.325 -->
+      <g transform="translate(544.584407 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- compression ratio   (compressed / original  —  ← smaller is better) -->
+     <g transform="translate(186.210156 441.080312) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2190" d="M 313 1866 
+L 313 2147 
+L 1541 3375 
+L 1916 3000 
+L 1188 2272 
+L 4997 2272 
+L 4997 1741 
+L 1188 1741 
+L 1916 1013 
+L 1541 638 
+L 313 1866 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-63"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(116.162109 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(213.574219 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(277.050781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(315.914062 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(377.4375 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(429.537109 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(481.636719 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(509.419922 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(570.601562 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(633.980469 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(665.767578 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(706.880859 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(768.160156 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(807.369141 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(835.152344 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(896.333984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(928.121094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(959.908203 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(991.695312 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1030.708984 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1085.689453 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1146.871094 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1244.283203 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1307.759766 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1346.623047 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1408.146484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1460.246094 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1512.345703 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1573.869141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1637.345703 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(1669.132812 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1702.824219 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1734.611328 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1795.792969 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1836.90625 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1864.689453 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1928.166016 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1955.949219 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2019.328125 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2080.607422 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2108.390625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2140.177734 0)"/>
+      <use xlink:href="#DejaVuSans-2014" transform="translate(2171.964844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2271.964844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2303.751953 0)"/>
+      <use xlink:href="#DejaVuSans-2190" transform="translate(2335.539062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2419.328125 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2451.115234 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(2503.214844 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2600.626953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2661.90625 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2689.689453 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2717.472656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2778.996094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2820.109375 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(2851.896484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2879.679688 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2931.779297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(2963.566406 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(3027.042969 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(3088.566406 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(3127.775391 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(3166.984375 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(3228.507812 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(3269.621094 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_15">
+      <path d="M 66.078125 228.330502 
+L 637.2 228.330502 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="m55604ed0bf" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m55604ed0bf" x="66.078125" y="228.330502" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{2\times10^{1}}$ -->
+      <g transform="translate(24.478125 232.129721) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-d7" d="M 4488 3438 
+L 3059 2003 
+L 4488 575 
+L 4116 197 
+L 2681 1631 
+L 1247 197 
+L 878 575 
+L 2303 2003 
+L 878 3438 
+L 1247 3816 
+L 2681 2381 
+L 4116 3816 
+L 4488 3438 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-d7" transform="translate(83.105469 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.376953 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(250 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(314.580078 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_17">
+      <path d="M 66.078125 120.190768 
+L 637.2 120.190768 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m55604ed0bf" x="66.078125" y="120.190768" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{3\times10^{1}}$ -->
+      <g transform="translate(24.478125 123.989987) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-d7" transform="translate(83.105469 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.376953 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(250 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(314.580078 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_11">
+     <!-- compression speed   (MB/s, log) -->
+     <g transform="translate(18.398438 310.591094) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-63"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(116.162109 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(213.574219 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(277.050781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(315.914062 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(377.4375 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(429.537109 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(481.636719 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(509.419922 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(570.601562 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(633.980469 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(665.767578 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(717.867188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(781.34375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(842.867188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(904.390625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(967.867188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(999.654297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1031.441406 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1063.228516 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(1102.242188 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(1188.521484 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(1257.125 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1290.816406 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1342.916016 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1374.703125 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1406.490234 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1434.273438 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1495.455078 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1558.931641 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 66.078125 412.80375 
+L 66.078125 48.583125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 637.2 412.80375 
+L 637.2 48.583125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 66.078125 412.80375 
+L 637.2 412.80375 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 66.078125 48.583125 
+L 637.2 48.583125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_12">
+    <!-- L1 -->
+    <g style="fill: #d62728" transform="translate(616.239915 60.138608) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-Bold-4c" d="M 588 4666 
+L 1791 4666 
+L 1791 909 
+L 3903 909 
+L 3903 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-4c"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(63.720703 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- L8 -->
+    <g style="fill: #d62728" transform="translate(97.03821 391.248267) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-4c"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(63.720703 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- ↖ fast &amp; small = best -->
+    <g style="fill: #2a8a3a" transform="translate(74.644953 61.644872) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-Bold-2196" d="M 872 3850 
+L 1181 4159 
+L 2919 4159 
+L 2919 3519 
+L 2044 3519 
+L 4606 956 
+L 4075 425 
+L 1513 2988 
+L 1513 2113 
+L 872 2113 
+L 872 3850 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-66" d="M 2841 4863 
+L 2841 4128 
+L 2222 4128 
+Q 1984 4128 1890 4042 
+Q 1797 3956 1797 3744 
+L 1797 3500 
+L 2753 3500 
+L 2753 2700 
+L 1797 2700 
+L 1797 0 
+L 678 0 
+L 678 2700 
+L 122 2700 
+L 122 3500 
+L 678 3500 
+L 678 3744 
+Q 678 4316 997 4589 
+Q 1316 4863 1984 4863 
+L 2841 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-26" d="M 2497 3097 
+L 3775 1691 
+Q 3941 1909 4027 2181 
+Q 4113 2453 4128 2797 
+L 5100 2797 
+Q 5053 2228 4879 1784 
+Q 4706 1341 4397 1006 
+L 5313 0 
+L 3988 0 
+L 3681 341 
+Q 3353 122 2990 15 
+Q 2628 -91 2222 -91 
+Q 1400 -91 892 342 
+Q 384 775 384 1459 
+Q 384 1916 607 2267 
+Q 831 2619 1338 2950 
+Q 1206 3116 1143 3281 
+Q 1081 3447 1081 3628 
+Q 1081 4138 1478 4444 
+Q 1875 4750 2534 4750 
+Q 2819 4750 3126 4704 
+Q 3434 4659 3769 4569 
+L 3769 3700 
+Q 3475 3850 3212 3922 
+Q 2950 3994 2700 3994 
+Q 2459 3994 2326 3901 
+Q 2194 3809 2194 3641 
+Q 2194 3534 2270 3398 
+Q 2347 3263 2497 3097 
+z
+M 1875 2322 
+Q 1672 2175 1569 1989 
+Q 1466 1803 1466 1581 
+Q 1466 1222 1731 969 
+Q 1997 716 2369 716 
+Q 2578 716 2759 780 
+Q 2941 844 3097 972 
+L 1875 2322 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-3d" d="M 678 3084 
+L 4684 3084 
+L 4684 2350 
+L 678 2350 
+L 678 3084 
+z
+M 678 1663 
+L 4684 1663 
+L 4684 922 
+L 678 922 
+L 678 1663 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-62" d="M 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+z
+M 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-2196"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-66" transform="translate(118.603516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(162.109375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(229.589844 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(289.111328 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(336.914062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-26" transform="translate(371.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(458.935547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(493.75 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(553.271484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(657.470703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(724.951172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(759.228516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(793.505859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3d" transform="translate(828.320312 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(912.109375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-62" transform="translate(946.923828 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1018.505859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1086.328125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1145.849609 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 540.7225 408.80375 
+L 631.6 408.80375 
+Q 633.2 408.80375 633.2 407.20375 
+L 633.2 396.26125 
+Q 633.2 394.66125 631.6 394.66125 
+L 540.7225 394.66125 
+Q 539.1225 394.66125 539.1225 396.26125 
+L 539.1225 407.20375 
+Q 539.1225 408.80375 540.7225 408.80375 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_19">
+     <defs>
+      <path id="m6b6b5f01c0" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #d62728; stroke-width: 1.3"/>
+     </defs>
+     <g>
+      <use xlink:href="#m6b6b5f01c0" x="550.3225" y="401.14" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     </g>
+    </g>
+    <g id="text_15">
+     <!-- lean-zip (native) -->
+     <g transform="translate(564.7225 403.94) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-6c"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(27.783203 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(89.306641 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(150.585938 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(213.964844 0)"/>
+      <use xlink:href="#DejaVuSans-7a" transform="translate(250.048828 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(302.539062 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(330.322266 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(393.798828 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(425.585938 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(464.599609 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(527.978516 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(589.257812 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(628.466797 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(656.25 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(715.429688 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_20">
+    <g clip-path="url(#p0bdadc0729)">
+     <use xlink:href="#m6b6b5f01c0" x="611.239915" y="65.138608" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6b6b5f01c0" x="364.877932" y="123.266349" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6b6b5f01c0" x="321.339914" y="138.727103" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6b6b5f01c0" x="225.425705" y="188.862667" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6b6b5f01c0" x="159.807226" y="242.078361" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6b6b5f01c0" x="120.655773" y="292.607153" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6b6b5f01c0" x="99.211064" y="323.358567" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6b6b5f01c0" x="92.03821" y="396.248267" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    </g>
+   </g>
+   <g id="line2d_21">
+    <path d="M 611.239915 65.138608 
+L 606.107373 66.488282 
+L 600.974832 67.831159 
+L 595.842291 69.16731 
+L 590.70975 70.4968 
+L 585.577208 71.819695 
+L 580.444667 73.136061 
+L 575.312126 74.445961 
+L 570.179584 75.74946 
+L 565.047043 77.046619 
+L 559.914502 78.337499 
+L 554.781961 79.622162 
+L 549.649419 80.900666 
+L 544.516878 82.173071 
+L 539.384337 83.439434 
+L 534.251795 84.699813 
+L 529.119254 85.954263 
+L 523.986713 87.202841 
+L 518.854171 88.445601 
+L 513.72163 89.682597 
+L 508.589089 90.913882 
+L 503.456548 92.139508 
+L 498.324006 93.359529 
+L 493.191465 94.573993 
+L 488.058924 95.782953 
+L 482.926382 96.986457 
+L 477.793841 98.184555 
+L 472.6613 99.377294 
+L 467.528758 100.564724 
+L 462.396217 101.74689 
+L 457.263676 102.923839 
+L 452.131135 104.095617 
+L 446.998593 105.26227 
+L 441.866052 106.423841 
+L 436.733511 107.580376 
+L 431.600969 108.731917 
+L 426.468428 109.878507 
+L 421.335887 111.020189 
+L 416.203345 112.157005 
+L 411.070804 113.288996 
+L 405.938263 114.416203 
+L 400.805722 115.538665 
+L 395.67318 116.656423 
+L 390.540639 117.769517 
+L 385.408098 118.877984 
+L 380.275556 119.981863 
+L 375.143015 121.081192 
+L 370.010474 122.176009 
+L 364.877932 123.266349 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_22">
+    <path d="M 364.877932 123.266349 
+L 363.97089 123.597761 
+L 363.063848 123.928762 
+L 362.156806 124.259352 
+L 361.249764 124.589534 
+L 360.342722 124.919307 
+L 359.43568 125.248672 
+L 358.528638 125.577632 
+L 357.621596 125.906186 
+L 356.714554 126.234336 
+L 355.807512 126.562082 
+L 354.90047 126.889427 
+L 353.993428 127.21637 
+L 353.086386 127.542913 
+L 352.179344 127.869056 
+L 351.272302 128.194802 
+L 350.36526 128.520149 
+L 349.458217 128.845101 
+L 348.551175 129.169657 
+L 347.644133 129.493818 
+L 346.737091 129.817586 
+L 345.830049 130.140962 
+L 344.923007 130.463945 
+L 344.015965 130.786539 
+L 343.108923 131.108742 
+L 342.201881 131.430557 
+L 341.294839 131.751983 
+L 340.387797 132.073023 
+L 339.480755 132.393677 
+L 338.573713 132.713946 
+L 337.666671 133.033831 
+L 336.759629 133.353332 
+L 335.852587 133.672452 
+L 334.945545 133.991189 
+L 334.038502 134.309547 
+L 333.13146 134.627525 
+L 332.224418 134.945124 
+L 331.317376 135.262345 
+L 330.410334 135.57919 
+L 329.503292 135.895658 
+L 328.59625 136.211752 
+L 327.689208 136.527471 
+L 326.782166 136.842817 
+L 325.875124 137.157791 
+L 324.968082 137.472393 
+L 324.06104 137.786624 
+L 323.153998 138.100486 
+L 322.246956 138.413979 
+L 321.339914 138.727103 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_23">
+    <path d="M 321.339914 138.727103 
+L 319.341701 139.87375 
+L 317.343488 141.015488 
+L 315.345276 142.152359 
+L 313.347063 143.284404 
+L 311.34885 144.411665 
+L 309.350637 145.534182 
+L 307.352425 146.651993 
+L 305.354212 147.765139 
+L 303.355999 148.873659 
+L 301.357787 149.97759 
+L 299.359574 151.076971 
+L 297.361361 152.171839 
+L 295.363149 153.26223 
+L 293.364936 154.348182 
+L 291.366723 155.42973 
+L 289.368511 156.506909 
+L 287.370298 157.579756 
+L 285.372085 158.648304 
+L 283.373873 159.712588 
+L 281.37566 160.772643 
+L 279.377447 161.8285 
+L 277.379235 162.880194 
+L 275.381022 163.927757 
+L 273.382809 164.971222 
+L 271.384596 166.01062 
+L 269.386384 167.045983 
+L 267.388171 168.077342 
+L 265.389958 169.104728 
+L 263.391746 170.128172 
+L 261.393533 171.147703 
+L 259.39532 172.163352 
+L 257.397108 173.175148 
+L 255.398895 174.18312 
+L 253.400682 175.187297 
+L 251.40247 176.187707 
+L 249.404257 177.184379 
+L 247.406044 178.17734 
+L 245.407832 179.166618 
+L 243.409619 180.15224 
+L 241.411406 181.134233 
+L 239.413194 182.112623 
+L 237.414981 183.087438 
+L 235.416768 184.058702 
+L 233.418555 185.026442 
+L 231.420343 185.990684 
+L 229.42213 186.951452 
+L 227.423917 187.908771 
+L 225.425705 188.862667 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_24">
+    <path d="M 225.425705 188.862667 
+L 224.058653 190.086857 
+L 222.691601 191.305454 
+L 221.32455 192.518508 
+L 219.957498 193.72607 
+L 218.590446 194.928189 
+L 217.223395 196.124915 
+L 215.856343 197.316294 
+L 214.489292 198.502375 
+L 213.12224 199.683205 
+L 211.755188 200.858829 
+L 210.388137 202.029295 
+L 209.021085 203.194646 
+L 207.654033 204.354927 
+L 206.286982 205.510182 
+L 204.91993 206.660455 
+L 203.552878 207.805789 
+L 202.185827 208.946224 
+L 200.818775 210.081804 
+L 199.451723 211.21257 
+L 198.084672 212.338561 
+L 196.71762 213.459819 
+L 195.350569 214.576382 
+L 193.983517 215.688291 
+L 192.616465 216.795583 
+L 191.249414 217.898297 
+L 189.882362 218.99647 
+L 188.51531 220.09014 
+L 187.148259 221.179344 
+L 185.781207 222.264118 
+L 184.414155 223.344497 
+L 183.047104 224.420518 
+L 181.680052 225.492214 
+L 180.313 226.559622 
+L 178.945949 227.622775 
+L 177.578897 228.681706 
+L 176.211845 229.73645 
+L 174.844794 230.787039 
+L 173.477742 231.833506 
+L 172.110691 232.875883 
+L 170.743639 233.914201 
+L 169.376587 234.948493 
+L 168.009536 235.97879 
+L 166.642484 237.005122 
+L 165.275432 238.027519 
+L 163.908381 239.046012 
+L 162.541329 240.060631 
+L 161.174277 241.071404 
+L 159.807226 242.078361 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_25">
+    <path d="M 159.807226 242.078361 
+L 158.99157 243.234859 
+L 158.175915 244.386363 
+L 157.36026 245.532917 
+L 156.544605 246.674564 
+L 155.728949 247.811344 
+L 154.913294 248.9433 
+L 154.097639 250.070471 
+L 153.281984 251.192899 
+L 152.466328 252.310623 
+L 151.650673 253.423682 
+L 150.835018 254.532116 
+L 150.019363 255.635961 
+L 149.203707 256.735257 
+L 148.388052 257.830041 
+L 147.572397 258.920349 
+L 146.756742 260.006218 
+L 145.941086 261.087683 
+L 145.125431 262.164782 
+L 144.309776 263.237547 
+L 143.494121 264.306015 
+L 142.678465 265.37022 
+L 141.86281 266.430195 
+L 141.047155 267.485975 
+L 140.231499 268.537591 
+L 139.415844 269.585077 
+L 138.600189 270.628465 
+L 137.784534 271.667787 
+L 136.968878 272.703075 
+L 136.153223 273.734359 
+L 135.337568 274.761672 
+L 134.521913 275.785042 
+L 133.706257 276.8045 
+L 132.890602 277.820077 
+L 132.074947 278.831801 
+L 131.259292 279.839702 
+L 130.443636 280.843808 
+L 129.627981 281.844148 
+L 128.812326 282.84075 
+L 127.996671 283.833641 
+L 127.181015 284.822851 
+L 126.36536 285.808404 
+L 125.549705 286.790329 
+L 124.73405 287.768653 
+L 123.918394 288.743401 
+L 123.102739 289.714599 
+L 122.287084 290.682273 
+L 121.471429 291.64645 
+L 120.655773 292.607153 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_26">
+    <path d="M 120.655773 292.607153 
+L 120.209008 293.28534 
+L 119.762244 293.961807 
+L 119.315479 294.636562 
+L 118.868714 295.309614 
+L 118.421949 295.980973 
+L 117.975185 296.650645 
+L 117.52842 297.318641 
+L 117.081655 297.984967 
+L 116.63489 298.649633 
+L 116.188126 299.312647 
+L 115.741361 299.974016 
+L 115.294596 300.633749 
+L 114.847831 301.291855 
+L 114.401066 301.94834 
+L 113.954302 302.603214 
+L 113.507537 303.256484 
+L 113.060772 303.908157 
+L 112.614007 304.558242 
+L 112.167243 305.206746 
+L 111.720478 305.853677 
+L 111.273713 306.499043 
+L 110.826948 307.142851 
+L 110.380183 307.785109 
+L 109.933419 308.425823 
+L 109.486654 309.065002 
+L 109.039889 309.702653 
+L 108.593124 310.338783 
+L 108.14636 310.9734 
+L 107.699595 311.60651 
+L 107.25283 312.23812 
+L 106.806065 312.868239 
+L 106.3593 313.496872 
+L 105.912536 314.124027 
+L 105.465771 314.74971 
+L 105.019006 315.37393 
+L 104.572241 315.996691 
+L 104.125477 316.618002 
+L 103.678712 317.237869 
+L 103.231947 317.856299 
+L 102.785182 318.473298 
+L 102.338417 319.088872 
+L 101.891653 319.70303 
+L 101.444888 320.315776 
+L 100.998123 320.927118 
+L 100.551358 321.537061 
+L 100.104594 322.145613 
+L 99.657829 322.75278 
+L 99.211064 323.358567 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_27">
+    <path d="M 99.211064 323.358567 
+L 99.06163 325.099184 
+L 98.912195 326.828516 
+L 98.762761 328.546706 
+L 98.613326 330.253898 
+L 98.463892 331.950232 
+L 98.314457 333.635844 
+L 98.165023 335.31087 
+L 98.015588 336.975442 
+L 97.866154 338.62969 
+L 97.716719 340.27374 
+L 97.567285 341.907717 
+L 97.417851 343.531745 
+L 97.268416 345.145944 
+L 97.118982 346.750432 
+L 96.969547 348.345325 
+L 96.820113 349.930737 
+L 96.670678 351.506781 
+L 96.521244 353.073566 
+L 96.371809 354.6312 
+L 96.222375 356.17979 
+L 96.07294 357.71944 
+L 95.923506 359.250254 
+L 95.774072 360.77233 
+L 95.624637 362.28577 
+L 95.475203 363.79067 
+L 95.325768 365.287126 
+L 95.176334 366.775233 
+L 95.026899 368.255082 
+L 94.877465 369.726766 
+L 94.72803 371.190373 
+L 94.578596 372.645993 
+L 94.429161 374.093711 
+L 94.279727 375.533613 
+L 94.130293 376.965783 
+L 93.980858 378.390303 
+L 93.831424 379.807255 
+L 93.681989 381.216719 
+L 93.532555 382.618774 
+L 93.38312 384.013496 
+L 93.233686 385.400963 
+L 93.084251 386.78125 
+L 92.934817 388.154429 
+L 92.785382 389.520575 
+L 92.635948 390.879758 
+L 92.486514 392.23205 
+L 92.337079 393.57752 
+L 92.187645 394.916237 
+L 92.03821 396.248267 
+" clip-path="url(#p0bdadc0729)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_16">
+   <!-- Compression speed vs ratio  (.hid_canterbury — geomean over 11 files) -->
+   <g transform="translate(61.923047 19.237969) scale(0.13 -0.13)">
+    <defs>
+     <path id="DejaVuSans-Bold-43" d="M 4288 256 
+Q 3956 84 3597 -3 
+Q 3238 -91 2847 -91 
+Q 1681 -91 1000 561 
+Q 319 1213 319 2328 
+Q 319 3447 1000 4098 
+Q 1681 4750 2847 4750 
+Q 3238 4750 3597 4662 
+Q 3956 4575 4288 4403 
+L 4288 3438 
+Q 3953 3666 3628 3772 
+Q 3303 3878 2944 3878 
+Q 2300 3878 1931 3465 
+Q 1563 3053 1563 2328 
+Q 1563 1606 1931 1193 
+Q 2300 781 2944 781 
+Q 3303 781 3628 887 
+Q 3953 994 4288 1222 
+L 4288 256 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2e" d="M 653 1209 
+L 1778 1209 
+L 1778 0 
+L 653 0 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-68" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-5f" d="M 3200 -916 
+L 3200 -1509 
+L 0 -1509 
+L 0 -916 
+L 3200 -916 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-63" d="M 3366 3391 
+L 3366 2478 
+Q 3138 2634 2908 2709 
+Q 2678 2784 2431 2784 
+Q 1963 2784 1702 2511 
+Q 1441 2238 1441 1747 
+Q 1441 1256 1702 982 
+Q 1963 709 2431 709 
+Q 2694 709 2930 787 
+Q 3166 866 3366 1019 
+L 3366 103 
+Q 3103 6 2833 -42 
+Q 2563 -91 2291 -91 
+Q 1344 -91 809 395 
+Q 275 881 275 1747 
+Q 275 2613 809 3098 
+Q 1344 3584 2291 3584 
+Q 2566 3584 2833 3536 
+Q 3100 3488 3366 3391 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-75" d="M 500 1363 
+L 500 3500 
+L 1625 3500 
+L 1625 3150 
+Q 1625 2866 1622 2436 
+Q 1619 2006 1619 1863 
+Q 1619 1441 1641 1255 
+Q 1663 1069 1716 984 
+Q 1784 875 1895 815 
+Q 2006 756 2150 756 
+Q 2500 756 2700 1025 
+Q 2900 1294 2900 1772 
+L 2900 3500 
+L 4019 3500 
+L 4019 0 
+L 2900 0 
+L 2900 506 
+Q 2647 200 2364 54 
+Q 2081 -91 1741 -91 
+Q 1134 -91 817 281 
+Q 500 653 500 1363 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-79" d="M 78 3500 
+L 1197 3500 
+L 2138 1125 
+L 2938 3500 
+L 4056 3500 
+L 2584 -331 
+Q 2363 -916 2067 -1148 
+Q 1772 -1381 1288 -1381 
+L 641 -1381 
+L 641 -647 
+L 991 -647 
+Q 1275 -647 1404 -556 
+Q 1534 -466 1606 -231 
+L 1638 -134 
+L 78 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2014" d="M 344 2156 
+L 6056 2156 
+L 6056 1350 
+L 344 1350 
+L 344 2156 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-67" d="M 2919 594 
+Q 2688 288 2409 144 
+Q 2131 0 1766 0 
+Q 1125 0 706 504 
+Q 288 1009 288 1791 
+Q 288 2575 706 3076 
+Q 1125 3578 1766 3578 
+Q 2131 3578 2409 3434 
+Q 2688 3291 2919 2981 
+L 2919 3500 
+L 4044 3500 
+L 4044 353 
+Q 4044 -491 3511 -936 
+Q 2978 -1381 1966 -1381 
+Q 1638 -1381 1331 -1331 
+Q 1025 -1281 716 -1178 
+L 716 -306 
+Q 1009 -475 1290 -558 
+Q 1572 -641 1856 -641 
+Q 2406 -641 2662 -400 
+Q 2919 -159 2919 353 
+L 2919 594 
+z
+M 2181 2772 
+Q 1834 2772 1640 2515 
+Q 1447 2259 1447 1791 
+Q 1447 1309 1634 1061 
+Q 1822 813 2181 813 
+Q 2531 813 2725 1069 
+Q 2919 1325 2919 1791 
+Q 2919 2259 2725 2515 
+Q 2531 2772 2181 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Bold-43"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(73.388672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(142.089844 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(246.289062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(317.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(367.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(435.009766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(494.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(554.052734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(588.330078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(657.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(728.222656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(763.037109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(822.558594 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(894.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(961.962891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(1029.785156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1101.367188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(1136.181641 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1201.367188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1260.888672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1345.019531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1412.5 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1460.302734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1494.580078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1563.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1598.095703 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-28" transform="translate(1632.910156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(1678.613281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-68" transform="translate(1716.601562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1787.792969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(1822.070312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-5f" transform="translate(1893.652344 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(1943.652344 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(2002.929688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(2070.410156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2141.601562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2189.404297 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(2257.226562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-62" transform="translate(2306.542969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-75" transform="translate(2378.125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(2449.316406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-79" transform="translate(2498.632812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2563.818359 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2014" transform="translate(2598.632812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2698.632812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-67" transform="translate(2733.447266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2805.029297 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(2872.851562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(2941.552734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3045.751953 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(3113.574219 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(3181.054688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3252.246094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(3287.060547 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(3355.761719 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3420.947266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(3488.769531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3538.085938 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-31" transform="translate(3572.900391 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-31" transform="translate(3642.480469 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3712.060547 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-66" transform="translate(3746.875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3790.380859 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3824.658203 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3858.935547 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(3926.757812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3986.279297 0)"/>
+   </g>
+  </g>
+  <g id="text_17">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6c9ecf85b56b1034ba71f9c2c5d11115f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(-20.961641 465.66) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-32"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3562.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3626.611328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3688.134766 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3743.115234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3778.320312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3841.943359 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3905.566406 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3969.042969 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4032.666016 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(4096.289062 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(4159.765625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4223.388672 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4350.634766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(4414.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4477.734375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(4539.013672 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(4602.636719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(4666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(4701.464844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4820.068359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4883.691406 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(4938.671875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(5002.294922 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5065.771484 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5129.394531 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5193.017578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5256.640625 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(5320.263672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(5383.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5419.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5450.878906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5482.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5514.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5546.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5578.027344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5605.810547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5667.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(5728.613281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5791.992188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5855.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5894.332031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(5955.513672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6014.693359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6076.216797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(6117.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(6151.021484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6178.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6240.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.607422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(6364.986328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(6428.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(6462.300781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(6521.480469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(6585.103516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(6616.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(6680.513672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(6744.136719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(6775.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(6839.546875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6875.630859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(6914.494141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(6969.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7033.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7064.884766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(7096.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7128.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7160.246094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7192.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7231.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7294.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7394.666016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(7458.044922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7521.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(7584.900391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7648.376953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7711.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7750.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(7782.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7866.541016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7898.328125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7995.740234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(8057.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(8120.740234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8148.523438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(8209.802734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8273.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(8304.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(8357.068359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8420.447266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(8481.726562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(8545.203125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(8597.302734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(8660.681641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(8721.863281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(8761.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8794.763672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(8826.550781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(8928.943359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(8968.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(8995.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(9057.117188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9088.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(9116.6875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(9168.787109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(9200.574219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(9264.050781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(9325.574219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(9364.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(9426.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(9465.669922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9563.082031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(9590.865234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9654.244141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(9682.027344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(9734.126953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(9801.119141 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p0bdadc0729">
+   <rect x="66.078125" y="48.583125" width="571.121875" height="364.220625"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/bench/graphs/.hid_canterbury_summary.svg
+++ b/bench/graphs/.hid_canterbury_summary.svg
@@ -1,0 +1,2006 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="704.323281pt" height="134.778469pt" viewBox="0 0 704.323281 134.778469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 134.778469 
+L 704.323281 134.778469 
+L 704.323281 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 254.286641 113.688 
+L 358.911641 113.688 
+L 358.911641 66.564 
+L 254.286641 66.564 
+z
+" clip-path="url(#pd49e9bb480)" style="fill: #feffbe; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 358.911641 113.688 
+L 463.536641 113.688 
+L 463.536641 66.564 
+L 358.911641 66.564 
+z
+" clip-path="url(#pd49e9bb480)" style="fill: #feffbe; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 463.536641 113.688 
+L 568.161641 113.688 
+L 568.161641 66.564 
+L 463.536641 66.564 
+z
+" clip-path="url(#pd49e9bb480)" style="fill: #feffbe; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_1">
+    <!-- codec -->
+    <g transform="translate(187.273906 45.485438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391 
+L 3366 2478 
+Q 3138 2634 2908 2709 
+Q 2678 2784 2431 2784 
+Q 1963 2784 1702 2511 
+Q 1441 2238 1441 1747 
+Q 1441 1256 1702 982 
+Q 1963 709 2431 709 
+Q 2694 709 2930 787 
+Q 3166 866 3366 1019 
+L 3366 103 
+Q 3103 6 2833 -42 
+Q 2563 -91 2291 -91 
+Q 1344 -91 809 395 
+Q 275 881 275 1747 
+Q 275 2613 809 3098 
+Q 1344 3584 2291 3584 
+Q 2566 3584 2833 3536 
+Q 3100 3488 3366 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-63"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(59.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(127.978516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(199.560547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(267.382812 0)"/>
+    </g>
+   </g>
+   <g id="text_2">
+    <!-- ratio -->
+    <g transform="translate(294.558125 45.485438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-72"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(49.316406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(116.796875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(164.599609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(198.876953 0)"/>
+    </g>
+   </g>
+   <g id="text_3">
+    <!-- compress MB/s -->
+    <g transform="translate(373.130234 45.485438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4d" d="M 588 4666 
+L 2119 4666 
+L 3181 2169 
+L 4250 4666 
+L 5778 4666 
+L 5778 0 
+L 4641 0 
+L 4641 3413 
+L 3566 897 
+L 2803 897 
+L 1728 3413 
+L 1728 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-42" d="M 2456 2859 
+Q 2741 2859 2887 2984 
+Q 3034 3109 3034 3353 
+Q 3034 3594 2887 3720 
+Q 2741 3847 2456 3847 
+L 1791 3847 
+L 1791 2859 
+L 2456 2859 
+z
+M 2497 819 
+Q 2859 819 3042 972 
+Q 3225 1125 3225 1434 
+Q 3225 1738 3044 1889 
+Q 2863 2041 2497 2041 
+L 1791 2041 
+L 1791 819 
+L 2497 819 
+z
+M 3616 2497 
+Q 4003 2384 4215 2081 
+Q 4428 1778 4428 1338 
+Q 4428 663 3972 331 
+Q 3516 0 2584 0 
+L 588 0 
+L 588 4666 
+L 2394 4666 
+Q 3366 4666 3802 4372 
+Q 4238 4078 4238 3431 
+Q 4238 3091 4078 2852 
+Q 3919 2613 3616 2497 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2f" d="M 1644 4666 
+L 2338 4666 
+L 691 -594 
+L 0 -594 
+L 1644 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-63"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(59.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(127.978516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(232.177734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(303.759766 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(353.076172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(420.898438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(480.419922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(539.941406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4d" transform="translate(574.755859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-42" transform="translate(674.267578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(750.488281 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(787.011719 0)"/>
+    </g>
+   </g>
+   <g id="text_4">
+    <!-- decompress MB/s -->
+    <g transform="translate(471.481953 45.485438) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-64"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(198.681641 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(267.382812 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(371.582031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(443.164062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(492.480469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(560.302734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(619.824219 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(679.345703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4d" transform="translate(714.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-42" transform="translate(813.671875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(889.892578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(926.416016 0)"/>
+    </g>
+   </g>
+   <g id="text_5">
+    <!-- lean-zip (native) -->
+    <g transform="translate(164.921016 92.3335) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297 
+L 2309 2297 
+L 2309 1388 
+L 347 1388 
+L 347 2297 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-7a" d="M 366 3500 
+L 3419 3500 
+L 3419 2719 
+L 1575 800 
+L 3419 800 
+L 3419 0 
+L 288 0 
+L 288 781 
+L 2131 2700 
+L 366 2700 
+L 366 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-6c"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(34.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(102.099609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(169.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(240.771484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(282.275391 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(340.478516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(374.755859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(446.337891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-28" transform="translate(481.152344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(526.855469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(598.046875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(665.527344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(713.330078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-76" transform="translate(747.607422 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(812.792969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
+    </g>
+   </g>
+   <g id="text_6">
+    <!-- 0.298 -->
+    <g transform="translate(293.947266 92.3335) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2e" d="M 653 1209 
+L 1778 1209 
+L 1778 0 
+L 653 0 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_7">
+    <!-- 16 -->
+    <g transform="translate(405.657891 92.3335) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <!-- 134 -->
+    <g transform="translate(507.499766 92.3335) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_9">
+   <!-- .hid_canterbury — geomean over files, level 6 -->
+   <g transform="translate(184.443359 17.077969) scale(0.13 -0.13)">
+    <defs>
+     <path id="DejaVuSans-Bold-68" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-5f" d="M 3200 -916 
+L 3200 -1509 
+L 0 -1509 
+L 0 -916 
+L 3200 -916 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-62" d="M 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+z
+M 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-75" d="M 500 1363 
+L 500 3500 
+L 1625 3500 
+L 1625 3150 
+Q 1625 2866 1622 2436 
+Q 1619 2006 1619 1863 
+Q 1619 1441 1641 1255 
+Q 1663 1069 1716 984 
+Q 1784 875 1895 815 
+Q 2006 756 2150 756 
+Q 2500 756 2700 1025 
+Q 2900 1294 2900 1772 
+L 2900 3500 
+L 4019 3500 
+L 4019 0 
+L 2900 0 
+L 2900 506 
+Q 2647 200 2364 54 
+Q 2081 -91 1741 -91 
+Q 1134 -91 817 281 
+Q 500 653 500 1363 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-79" d="M 78 3500 
+L 1197 3500 
+L 2138 1125 
+L 2938 3500 
+L 4056 3500 
+L 2584 -331 
+Q 2363 -916 2067 -1148 
+Q 1772 -1381 1288 -1381 
+L 641 -1381 
+L 641 -647 
+L 991 -647 
+Q 1275 -647 1404 -556 
+Q 1534 -466 1606 -231 
+L 1638 -134 
+L 78 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2014" d="M 344 2156 
+L 6056 2156 
+L 6056 1350 
+L 344 1350 
+L 344 2156 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-67" d="M 2919 594 
+Q 2688 288 2409 144 
+Q 2131 0 1766 0 
+Q 1125 0 706 504 
+Q 288 1009 288 1791 
+Q 288 2575 706 3076 
+Q 1125 3578 1766 3578 
+Q 2131 3578 2409 3434 
+Q 2688 3291 2919 2981 
+L 2919 3500 
+L 4044 3500 
+L 4044 353 
+Q 4044 -491 3511 -936 
+Q 2978 -1381 1966 -1381 
+Q 1638 -1381 1331 -1331 
+Q 1025 -1281 716 -1178 
+L 716 -306 
+Q 1009 -475 1290 -558 
+Q 1572 -641 1856 -641 
+Q 2406 -641 2662 -400 
+Q 2919 -159 2919 353 
+L 2919 594 
+z
+M 2181 2772 
+Q 1834 2772 1640 2515 
+Q 1447 2259 1447 1791 
+Q 1447 1309 1634 1061 
+Q 1822 813 2181 813 
+Q 2531 813 2725 1069 
+Q 2919 1325 2919 1791 
+Q 2919 2259 2725 2515 
+Q 2531 2772 2181 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-66" d="M 2841 4863 
+L 2841 4128 
+L 2222 4128 
+Q 1984 4128 1890 4042 
+Q 1797 3956 1797 3744 
+L 1797 3500 
+L 2753 3500 
+L 2753 2700 
+L 1797 2700 
+L 1797 0 
+L 678 0 
+L 678 2700 
+L 122 2700 
+L 122 3500 
+L 678 3500 
+L 678 3744 
+Q 678 4316 997 4589 
+Q 1316 4863 1984 4863 
+L 2841 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2c" d="M 653 1209 
+L 1778 1209 
+L 1778 256 
+L 1006 -909 
+L 341 -909 
+L 653 256 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Bold-2e"/>
+    <use xlink:href="#DejaVuSans-Bold-68" transform="translate(37.988281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(109.179688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(143.457031 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-5f" transform="translate(215.039062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(265.039062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(324.316406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(391.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(462.988281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(510.791016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(578.613281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-62" transform="translate(627.929688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-75" transform="translate(699.511719 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(770.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-79" transform="translate(820.019531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(885.205078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2014" transform="translate(920.019531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1020.019531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-67" transform="translate(1054.833984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1126.416016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1194.238281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(1262.939453 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1367.138672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1434.960938 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1502.441406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1573.632812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1608.447266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(1677.148438 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1742.333984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1810.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1859.472656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-66" transform="translate(1894.287109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1937.792969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1972.070312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2006.347656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(2074.169922 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2c" transform="translate(2133.691406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2171.679688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2206.494141 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2240.771484 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(2308.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2373.779297 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2441.601562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2475.878906 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-36" transform="translate(2510.693359 0)"/>
+   </g>
+  </g>
+  <g id="text_10">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6c9ecf85b56b1034ba71f9c2c5d11115f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(7.2 125.928) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-32"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3562.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3626.611328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3688.134766 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3743.115234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3778.320312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3841.943359 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3905.566406 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3969.042969 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4032.666016 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(4096.289062 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(4159.765625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4223.388672 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4350.634766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(4414.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4477.734375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(4539.013672 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(4602.636719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(4666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(4701.464844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4820.068359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4883.691406 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(4938.671875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(5002.294922 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5065.771484 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5129.394531 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5193.017578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5256.640625 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(5320.263672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(5383.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5419.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5450.878906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5482.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5514.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5546.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5578.027344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5605.810547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5667.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(5728.613281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5791.992188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5855.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5894.332031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(5955.513672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6014.693359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6076.216797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(6117.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(6151.021484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6178.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6240.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.607422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(6364.986328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(6428.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(6462.300781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(6521.480469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(6585.103516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(6616.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(6680.513672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(6744.136719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(6775.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(6839.546875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6875.630859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(6914.494141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(6969.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7033.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7064.884766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(7096.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7128.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7160.246094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7192.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7231.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7294.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7394.666016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(7458.044922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7521.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(7584.900391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7648.376953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7711.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7750.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(7782.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7866.541016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7898.328125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7995.740234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(8057.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(8120.740234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8148.523438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(8209.802734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8273.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(8304.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(8357.068359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8420.447266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(8481.726562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(8545.203125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(8597.302734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(8660.681641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(8721.863281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(8761.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8794.763672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(8826.550781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(8928.943359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(8968.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(8995.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(9057.117188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9088.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(9116.6875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(9168.787109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(9200.574219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(9264.050781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(9325.574219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(9364.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(9426.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(9465.669922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9563.082031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(9590.865234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9654.244141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(9682.027344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(9734.126953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(9801.119141 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pd49e9bb480">
+   <rect x="149.661641" y="19.44" width="418.5" height="94.248"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/bench/graphs/.hid_silesia_compress_pareto.svg
+++ b/bench/graphs/.hid_silesia_compress_pareto.svg
@@ -1,0 +1,2751 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="648pt" height="468pt" viewBox="0 0 648 468" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 468 
+L 648 468 
+L 648 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 66.078125 412.80375 
+L 637.2 412.80375 
+L 637.2 48.583125 
+L 66.078125 48.583125 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 121.037193 412.80375 
+L 121.037193 48.583125 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mc17a801b49" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc17a801b49" x="121.037193" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.325 -->
+      <g transform="translate(106.723131 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 188.324243 412.80375 
+L 188.324243 48.583125 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mc17a801b49" x="188.324243" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.330 -->
+      <g transform="translate(174.010181 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 255.611293 412.80375 
+L 255.611293 48.583125 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mc17a801b49" x="255.611293" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.335 -->
+      <g transform="translate(241.297231 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 322.898343 412.80375 
+L 322.898343 48.583125 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mc17a801b49" x="322.898343" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0.340 -->
+      <g transform="translate(308.58428 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 390.185393 412.80375 
+L 390.185393 48.583125 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mc17a801b49" x="390.185393" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0.345 -->
+      <g transform="translate(375.87133 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 457.472443 412.80375 
+L 457.472443 48.583125 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mc17a801b49" x="457.472443" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.350 -->
+      <g transform="translate(443.15838 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 524.759493 412.80375 
+L 524.759493 48.583125 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mc17a801b49" x="524.759493" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.355 -->
+      <g transform="translate(510.44543 427.402188) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 592.046542 412.80375 
+L 592.046542 48.583125 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#mc17a801b49" x="592.046542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.360 -->
+      <g transform="translate(577.73248 427.402188) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(159.033203 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(222.65625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_9">
+     <!-- compression ratio   (compressed / original  —  ← smaller is better) -->
+     <g transform="translate(186.210156 441.080312) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2190" d="M 313 1866 
+L 313 2147 
+L 1541 3375 
+L 1916 3000 
+L 1188 2272 
+L 4997 2272 
+L 4997 1741 
+L 1188 1741 
+L 1916 1013 
+L 1541 638 
+L 313 1866 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-63"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(116.162109 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(213.574219 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(277.050781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(315.914062 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(377.4375 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(429.537109 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(481.636719 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(509.419922 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(570.601562 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(633.980469 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(665.767578 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(706.880859 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(768.160156 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(807.369141 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(835.152344 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(896.333984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(928.121094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(959.908203 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(991.695312 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1030.708984 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1085.689453 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1146.871094 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1244.283203 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1307.759766 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1346.623047 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1408.146484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1460.246094 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1512.345703 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1573.869141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1637.345703 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(1669.132812 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1702.824219 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1734.611328 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1795.792969 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1836.90625 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1864.689453 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(1928.166016 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1955.949219 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2019.328125 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2080.607422 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2108.390625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2140.177734 0)"/>
+      <use xlink:href="#DejaVuSans-2014" transform="translate(2171.964844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2271.964844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2303.751953 0)"/>
+      <use xlink:href="#DejaVuSans-2190" transform="translate(2335.539062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2419.328125 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2451.115234 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(2503.214844 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(2600.626953 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2661.90625 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(2689.689453 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(2717.472656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(2778.996094 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2820.109375 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(2851.896484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(2879.679688 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(2931.779297 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(2963.566406 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(3027.042969 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(3088.566406 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(3127.775391 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(3166.984375 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(3228.507812 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(3269.621094 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_17">
+      <path d="M 66.078125 289.937526 
+L 637.2 289.937526 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <defs>
+       <path id="ma2c19762c1" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma2c19762c1" x="66.078125" y="289.937526" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{2\times10^{1}}$ -->
+      <g transform="translate(24.478125 293.736745) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-d7" d="M 4488 3438 
+L 3059 2003 
+L 4488 575 
+L 4116 197 
+L 2681 1631 
+L 1247 197 
+L 878 575 
+L 2303 2003 
+L 878 3438 
+L 1247 3816 
+L 2681 2381 
+L 4116 3816 
+L 4488 3438 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-d7" transform="translate(83.105469 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.376953 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(250 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(314.580078 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_19">
+      <path d="M 66.078125 206.284993 
+L 637.2 206.284993 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#ma2c19762c1" x="66.078125" y="206.284993" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{3\times10^{1}}$ -->
+      <g transform="translate(24.478125 210.084212) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-d7" transform="translate(83.105469 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.376953 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(250 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(314.580078 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_21">
+      <path d="M 66.078125 146.932576 
+L 637.2 146.932576 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#ma2c19762c1" x="66.078125" y="146.932576" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{4\times10^{1}}$ -->
+      <g transform="translate(24.478125 150.731795) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-d7" transform="translate(83.105469 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.376953 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(250 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(314.580078 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_23">
+      <path d="M 66.078125 100.895265 
+L 637.2 100.895265 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#ma2c19762c1" x="66.078125" y="100.895265" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_25">
+      <path d="M 66.078125 63.280043 
+L 637.2 63.280043 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#ma2c19762c1" x="66.078125" y="63.280043" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- $\mathdefault{6\times10^{1}}$ -->
+      <g transform="translate(24.478125 67.079261) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-d7" transform="translate(83.105469 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.376953 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(250 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(314.580078 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- compression speed   (MB/s, log) -->
+     <g transform="translate(18.398438 310.591094) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-63"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(116.162109 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(213.574219 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(277.050781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(315.914062 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(377.4375 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(429.537109 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(481.636719 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(509.419922 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(570.601562 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(633.980469 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(665.767578 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(717.867188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(781.34375 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(842.867188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(904.390625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(967.867188 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(999.654297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1031.441406 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1063.228516 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(1102.242188 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(1188.521484 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(1257.125 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1290.816406 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(1342.916016 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1374.703125 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1406.490234 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1434.273438 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1495.455078 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1558.931641 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 66.078125 412.80375 
+L 66.078125 48.583125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 637.2 412.80375 
+L 637.2 48.583125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 66.078125 412.80375 
+L 637.2 412.80375 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 66.078125 48.583125 
+L 637.2 48.583125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- L1 -->
+    <g style="fill: #d62728" transform="translate(616.239915 60.138608) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-Bold-4c" d="M 588 4666 
+L 1791 4666 
+L 1791 909 
+L 3903 909 
+L 3903 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-4c"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(63.720703 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- L8 -->
+    <g style="fill: #d62728" transform="translate(97.03821 391.248267) scale(0.07 -0.07)">
+     <defs>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-4c"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(63.720703 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- ↖ fast &amp; small = best -->
+    <g style="fill: #2a8a3a" transform="translate(74.644953 61.644872) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-Bold-2196" d="M 872 3850 
+L 1181 4159 
+L 2919 4159 
+L 2919 3519 
+L 2044 3519 
+L 4606 956 
+L 4075 425 
+L 1513 2988 
+L 1513 2113 
+L 872 2113 
+L 872 3850 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-66" d="M 2841 4863 
+L 2841 4128 
+L 2222 4128 
+Q 1984 4128 1890 4042 
+Q 1797 3956 1797 3744 
+L 1797 3500 
+L 2753 3500 
+L 2753 2700 
+L 1797 2700 
+L 1797 0 
+L 678 0 
+L 678 2700 
+L 122 2700 
+L 122 3500 
+L 678 3500 
+L 678 3744 
+Q 678 4316 997 4589 
+Q 1316 4863 1984 4863 
+L 2841 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-26" d="M 2497 3097 
+L 3775 1691 
+Q 3941 1909 4027 2181 
+Q 4113 2453 4128 2797 
+L 5100 2797 
+Q 5053 2228 4879 1784 
+Q 4706 1341 4397 1006 
+L 5313 0 
+L 3988 0 
+L 3681 341 
+Q 3353 122 2990 15 
+Q 2628 -91 2222 -91 
+Q 1400 -91 892 342 
+Q 384 775 384 1459 
+Q 384 1916 607 2267 
+Q 831 2619 1338 2950 
+Q 1206 3116 1143 3281 
+Q 1081 3447 1081 3628 
+Q 1081 4138 1478 4444 
+Q 1875 4750 2534 4750 
+Q 2819 4750 3126 4704 
+Q 3434 4659 3769 4569 
+L 3769 3700 
+Q 3475 3850 3212 3922 
+Q 2950 3994 2700 3994 
+Q 2459 3994 2326 3901 
+Q 2194 3809 2194 3641 
+Q 2194 3534 2270 3398 
+Q 2347 3263 2497 3097 
+z
+M 1875 2322 
+Q 1672 2175 1569 1989 
+Q 1466 1803 1466 1581 
+Q 1466 1222 1731 969 
+Q 1997 716 2369 716 
+Q 2578 716 2759 780 
+Q 2941 844 3097 972 
+L 1875 2322 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-3d" d="M 678 3084 
+L 4684 3084 
+L 4684 2350 
+L 678 2350 
+L 678 3084 
+z
+M 678 1663 
+L 4684 1663 
+L 4684 922 
+L 678 922 
+L 678 1663 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-62" d="M 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+z
+M 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-2196"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-66" transform="translate(118.603516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(162.109375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(229.589844 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(289.111328 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(336.914062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-26" transform="translate(371.728516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(458.935547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(493.75 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(553.271484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(657.470703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(724.951172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(759.228516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(793.505859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3d" transform="translate(828.320312 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(912.109375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-62" transform="translate(946.923828 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1018.505859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1086.328125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1145.849609 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 540.7225 408.80375 
+L 631.6 408.80375 
+Q 633.2 408.80375 633.2 407.20375 
+L 633.2 396.26125 
+Q 633.2 394.66125 631.6 394.66125 
+L 540.7225 394.66125 
+Q 539.1225 394.66125 539.1225 396.26125 
+L 539.1225 407.20375 
+Q 539.1225 408.80375 540.7225 408.80375 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_27">
+     <defs>
+      <path id="m04d72ba17c" d="M 0 3.5 
+C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
+C 3.131218 1.81853 3.5 0.928211 3.5 0 
+C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
+C 1.81853 -3.131218 0.928211 -3.5 0 -3.5 
+C -0.928211 -3.5 -1.81853 -3.131218 -2.474874 -2.474874 
+C -3.131218 -1.81853 -3.5 -0.928211 -3.5 0 
+C -3.5 0.928211 -3.131218 1.81853 -2.474874 2.474874 
+C -1.81853 3.131218 -0.928211 3.5 0 3.5 
+z
+" style="stroke: #d62728; stroke-width: 1.3"/>
+     </defs>
+     <g>
+      <use xlink:href="#m04d72ba17c" x="550.3225" y="401.14" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- lean-zip (native) -->
+     <g transform="translate(564.7225 403.94) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500 
+L 3084 3500 
+L 3084 2975 
+L 922 459 
+L 3084 459 
+L 3084 0 
+L 275 0 
+L 275 525 
+L 2438 3041 
+L 353 3041 
+L 353 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-6c"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(27.783203 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(89.306641 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(150.585938 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(213.964844 0)"/>
+      <use xlink:href="#DejaVuSans-7a" transform="translate(250.048828 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(302.539062 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(330.322266 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(393.798828 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(425.585938 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(464.599609 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(527.978516 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(589.257812 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(628.466797 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(656.25 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(715.429688 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(776.953125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_28">
+    <g clip-path="url(#pb21c1e4984)">
+     <use xlink:href="#m04d72ba17c" x="611.239915" y="65.138608" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m04d72ba17c" x="449.743615" y="124.368285" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m04d72ba17c" x="380.439587" y="140.637273" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m04d72ba17c" x="228.424478" y="194.87847" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m04d72ba17c" x="197.767139" y="241.877174" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m04d72ba17c" x="118.285723" y="292.314392" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m04d72ba17c" x="98.098506" y="323.708694" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m04d72ba17c" x="92.03821" y="396.248267" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    </g>
+   </g>
+   <g id="line2d_29">
+    <path d="M 611.239915 65.138608 
+L 607.875409 66.562997 
+L 604.510902 67.97762 
+L 601.146396 69.382609 
+L 597.78189 70.778094 
+L 594.417384 72.164204 
+L 591.052877 73.541064 
+L 587.688371 74.908795 
+L 584.323865 76.267519 
+L 580.959359 77.617354 
+L 577.594852 78.958414 
+L 574.230346 80.290814 
+L 570.86584 81.614663 
+L 567.501334 82.930073 
+L 564.136827 84.237148 
+L 560.772321 85.535995 
+L 557.407815 86.826716 
+L 554.043309 88.109412 
+L 550.678802 89.384182 
+L 547.314296 90.651125 
+L 543.94979 91.910334 
+L 540.585284 93.161905 
+L 537.220777 94.405929 
+L 533.856271 95.642497 
+L 530.491765 96.871697 
+L 527.127259 98.093617 
+L 523.762752 99.308343 
+L 520.398246 100.515959 
+L 517.03374 101.716547 
+L 513.669234 102.910188 
+L 510.304727 104.096964 
+L 506.940221 105.276952 
+L 503.575715 106.45023 
+L 500.211209 107.616872 
+L 496.846702 108.776955 
+L 493.482196 109.930552 
+L 490.11769 111.077733 
+L 486.753184 112.218572 
+L 483.388677 113.353136 
+L 480.024171 114.481496 
+L 476.659665 115.603717 
+L 473.295159 116.719868 
+L 469.930652 117.830012 
+L 466.566146 118.934215 
+L 463.20164 120.03254 
+L 459.837134 121.125048 
+L 456.472627 122.211802 
+L 453.108121 123.292861 
+L 449.743615 124.368285 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_30">
+    <path d="M 449.743615 124.368285 
+L 448.299781 124.720644 
+L 446.855947 125.072401 
+L 445.412113 125.423559 
+L 443.968279 125.774121 
+L 442.524445 126.124089 
+L 441.080611 126.473463 
+L 439.636778 126.822247 
+L 438.192944 127.170443 
+L 436.74911 127.518051 
+L 435.305276 127.865075 
+L 433.861442 128.211517 
+L 432.417608 128.557377 
+L 430.973774 128.902659 
+L 429.52994 129.247364 
+L 428.086106 129.591493 
+L 426.642272 129.93505 
+L 425.198438 130.278036 
+L 423.754604 130.620452 
+L 422.310771 130.962301 
+L 420.866937 131.303585 
+L 419.423103 131.644305 
+L 417.979269 131.984463 
+L 416.535435 132.324061 
+L 415.091601 132.663101 
+L 413.647767 133.001585 
+L 412.203933 133.339514 
+L 410.760099 133.676891 
+L 409.316265 134.013717 
+L 407.872431 134.349994 
+L 406.428597 134.685724 
+L 404.984764 135.020909 
+L 403.54093 135.355549 
+L 402.097096 135.689648 
+L 400.653262 136.023207 
+L 399.209428 136.356227 
+L 397.765594 136.688711 
+L 396.32176 137.020659 
+L 394.877926 137.352075 
+L 393.434092 137.682959 
+L 391.990258 138.013313 
+L 390.546424 138.343138 
+L 389.102591 138.672438 
+L 387.658757 139.001213 
+L 386.214923 139.329464 
+L 384.771089 139.657194 
+L 383.327255 139.984405 
+L 381.883421 140.311097 
+L 380.439587 140.637273 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_31">
+    <path d="M 380.439587 140.637273 
+L 377.272606 141.925733 
+L 374.105624 143.206196 
+L 370.938643 144.478762 
+L 367.771661 145.743526 
+L 364.60468 147.000583 
+L 361.437698 148.250028 
+L 358.270717 149.491952 
+L 355.103735 150.726445 
+L 351.936754 151.953594 
+L 348.769773 153.173488 
+L 345.602791 154.386211 
+L 342.43581 155.591847 
+L 339.268828 156.790479 
+L 336.101847 157.982187 
+L 332.934865 159.167051 
+L 329.767884 160.345149 
+L 326.600902 161.516559 
+L 323.433921 162.681354 
+L 320.26694 163.83961 
+L 317.099958 164.9914 
+L 313.932977 166.136796 
+L 310.765995 167.275868 
+L 307.599014 168.408685 
+L 304.432032 169.535316 
+L 301.265051 170.655828 
+L 298.098069 171.770288 
+L 294.931088 172.87876 
+L 291.764106 173.981307 
+L 288.597125 175.077995 
+L 285.430144 176.168883 
+L 282.263162 177.254034 
+L 279.096181 178.333506 
+L 275.929199 179.407361 
+L 272.762218 180.475654 
+L 269.595236 181.538445 
+L 266.428255 182.595788 
+L 263.261273 183.647741 
+L 260.094292 184.694357 
+L 256.927311 185.73569 
+L 253.760329 186.771794 
+L 250.593348 187.80272 
+L 247.426366 188.828521 
+L 244.259385 189.849246 
+L 241.092403 190.864946 
+L 237.925422 191.875671 
+L 234.75844 192.881468 
+L 231.591459 193.882385 
+L 228.424478 194.87847 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_32">
+    <path d="M 228.424478 194.87847 
+L 227.785783 195.975189 
+L 227.147088 197.066109 
+L 226.508394 198.15129 
+L 225.869699 199.230794 
+L 225.231005 200.304679 
+L 224.59231 201.373003 
+L 223.953616 202.435823 
+L 223.314921 203.493196 
+L 222.676227 204.545178 
+L 222.037532 205.591823 
+L 221.398837 206.633185 
+L 220.760143 207.669317 
+L 220.121448 208.700272 
+L 219.482754 209.7261 
+L 218.844059 210.746853 
+L 218.205365 211.762581 
+L 217.56667 212.773332 
+L 216.927976 213.779156 
+L 216.289281 214.780099 
+L 215.650586 215.77621 
+L 215.011892 216.767535 
+L 214.373197 217.75412 
+L 213.734503 218.736008 
+L 213.095808 219.713246 
+L 212.457114 220.685877 
+L 211.818419 221.653945 
+L 211.179725 222.61749 
+L 210.54103 223.576557 
+L 209.902336 224.531186 
+L 209.263641 225.481418 
+L 208.624946 226.427294 
+L 207.986252 227.368853 
+L 207.347557 228.306135 
+L 206.708863 229.239177 
+L 206.070168 230.168019 
+L 205.431474 231.092698 
+L 204.792779 232.013251 
+L 204.154085 232.929715 
+L 203.51539 233.842126 
+L 202.876695 234.750519 
+L 202.238001 235.654931 
+L 201.599306 236.555394 
+L 200.960612 237.451945 
+L 200.321917 238.344617 
+L 199.683223 239.233443 
+L 199.044528 240.118456 
+L 198.405834 240.999689 
+L 197.767139 241.877174 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_33">
+    <path d="M 197.767139 241.877174 
+L 196.111276 243.064109 
+L 194.455413 244.244255 
+L 192.799551 245.417688 
+L 191.143688 246.584485 
+L 189.487825 247.74472 
+L 187.831962 248.898467 
+L 186.176099 250.045798 
+L 184.520236 251.186783 
+L 182.864374 252.321494 
+L 181.208511 253.449997 
+L 179.552648 254.572361 
+L 177.896785 255.688653 
+L 176.240922 256.798937 
+L 174.585059 257.903278 
+L 172.929197 259.001739 
+L 171.273334 260.094382 
+L 169.617471 261.18127 
+L 167.961608 262.262461 
+L 166.305745 263.338016 
+L 164.649882 264.407993 
+L 162.994019 265.47245 
+L 161.338157 266.531442 
+L 159.682294 267.585027 
+L 158.026431 268.633258 
+L 156.370568 269.676191 
+L 154.714705 270.713878 
+L 153.058842 271.746372 
+L 151.40298 272.773724 
+L 149.747117 273.795986 
+L 148.091254 274.813208 
+L 146.435391 275.825439 
+L 144.779528 276.832728 
+L 143.123665 277.835123 
+L 141.467803 278.832671 
+L 139.81194 279.825419 
+L 138.156077 280.813413 
+L 136.500214 281.796698 
+L 134.844351 282.775319 
+L 133.188488 283.74932 
+L 131.532626 284.718744 
+L 129.876763 285.683634 
+L 128.2209 286.644033 
+L 126.565037 287.599982 
+L 124.909174 288.551522 
+L 123.253311 289.498693 
+L 121.597449 290.441536 
+L 119.941586 291.380089 
+L 118.285723 292.314392 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_34">
+    <path d="M 118.285723 292.314392 
+L 117.865156 293.01962 
+L 117.444589 293.722444 
+L 117.024022 294.422883 
+L 116.603455 295.120952 
+L 116.182888 295.816666 
+L 115.762321 296.510043 
+L 115.341754 297.201097 
+L 114.921187 297.889844 
+L 114.50062 298.576299 
+L 114.080053 299.260478 
+L 113.659486 299.942396 
+L 113.238919 300.622067 
+L 112.818352 301.299506 
+L 112.397785 301.974728 
+L 111.977218 302.647748 
+L 111.556651 303.318579 
+L 111.136084 303.987236 
+L 110.715517 304.653733 
+L 110.29495 305.318083 
+L 109.874383 305.980302 
+L 109.453816 306.640401 
+L 109.033249 307.298395 
+L 108.612682 307.954298 
+L 108.192115 308.608121 
+L 107.771548 309.25988 
+L 107.35098 309.909585 
+L 106.930413 310.557252 
+L 106.509846 311.202891 
+L 106.089279 311.846516 
+L 105.668712 312.48814 
+L 105.248145 313.127774 
+L 104.827578 313.765431 
+L 104.407011 314.401124 
+L 103.986444 315.034864 
+L 103.565877 315.666663 
+L 103.14531 316.296533 
+L 102.724743 316.924486 
+L 102.304176 317.550534 
+L 101.883609 318.174688 
+L 101.463042 318.796959 
+L 101.042475 319.417359 
+L 100.621908 320.035899 
+L 100.201341 320.65259 
+L 99.780774 321.267443 
+L 99.360207 321.880469 
+L 98.93964 322.491679 
+L 98.519073 323.101084 
+L 98.098506 323.708694 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_35">
+    <path d="M 98.098506 323.708694 
+L 97.97225 325.511788 
+L 97.845994 327.29926 
+L 97.719738 329.071378 
+L 97.593482 330.828405 
+L 97.467225 332.570594 
+L 97.340969 334.298195 
+L 97.214713 336.011449 
+L 97.088457 337.710594 
+L 96.962201 339.395858 
+L 96.835945 341.067468 
+L 96.709688 342.725643 
+L 96.583432 344.370597 
+L 96.457176 346.00254 
+L 96.33092 347.621675 
+L 96.204664 349.228201 
+L 96.078408 350.822315 
+L 95.952151 352.404206 
+L 95.825895 353.97406 
+L 95.699639 355.532058 
+L 95.573383 357.07838 
+L 95.447127 358.613198 
+L 95.320871 360.136682 
+L 95.194614 361.648999 
+L 95.068358 363.150311 
+L 94.942102 364.640776 
+L 94.815846 366.120552 
+L 94.68959 367.589789 
+L 94.563334 369.048637 
+L 94.437077 370.497242 
+L 94.310821 371.935746 
+L 94.184565 373.364291 
+L 94.058309 374.783011 
+L 93.932053 376.192042 
+L 93.805797 377.591516 
+L 93.67954 378.98156 
+L 93.553284 380.362301 
+L 93.427028 381.733863 
+L 93.300772 383.096368 
+L 93.174516 384.449933 
+L 93.04826 385.794675 
+L 92.922003 387.13071 
+L 92.795747 388.458148 
+L 92.669491 389.7771 
+L 92.543235 391.087673 
+L 92.416979 392.389973 
+L 92.290723 393.684105 
+L 92.164466 394.97017 
+L 92.03821 396.248267 
+" clip-path="url(#pb21c1e4984)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_19">
+   <!-- Compression speed vs ratio  (.hid_silesia — geomean over 12 files) -->
+   <g transform="translate(79.016016 19.237969) scale(0.13 -0.13)">
+    <defs>
+     <path id="DejaVuSans-Bold-43" d="M 4288 256 
+Q 3956 84 3597 -3 
+Q 3238 -91 2847 -91 
+Q 1681 -91 1000 561 
+Q 319 1213 319 2328 
+Q 319 3447 1000 4098 
+Q 1681 4750 2847 4750 
+Q 3238 4750 3597 4662 
+Q 3956 4575 4288 4403 
+L 4288 3438 
+Q 3953 3666 3628 3772 
+Q 3303 3878 2944 3878 
+Q 2300 3878 1931 3465 
+Q 1563 3053 1563 2328 
+Q 1563 1606 1931 1193 
+Q 2300 781 2944 781 
+Q 3303 781 3628 887 
+Q 3953 994 4288 1222 
+L 4288 256 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2e" d="M 653 1209 
+L 1778 1209 
+L 1778 0 
+L 653 0 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-68" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-5f" d="M 3200 -916 
+L 3200 -1509 
+L 0 -1509 
+L 0 -916 
+L 3200 -916 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2014" d="M 344 2156 
+L 6056 2156 
+L 6056 1350 
+L 344 1350 
+L 344 2156 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-67" d="M 2919 594 
+Q 2688 288 2409 144 
+Q 2131 0 1766 0 
+Q 1125 0 706 504 
+Q 288 1009 288 1791 
+Q 288 2575 706 3076 
+Q 1125 3578 1766 3578 
+Q 2131 3578 2409 3434 
+Q 2688 3291 2919 2981 
+L 2919 3500 
+L 4044 3500 
+L 4044 353 
+Q 4044 -491 3511 -936 
+Q 2978 -1381 1966 -1381 
+Q 1638 -1381 1331 -1331 
+Q 1025 -1281 716 -1178 
+L 716 -306 
+Q 1009 -475 1290 -558 
+Q 1572 -641 1856 -641 
+Q 2406 -641 2662 -400 
+Q 2919 -159 2919 353 
+L 2919 594 
+z
+M 2181 2772 
+Q 1834 2772 1640 2515 
+Q 1447 2259 1447 1791 
+Q 1447 1309 1634 1061 
+Q 1822 813 2181 813 
+Q 2531 813 2725 1069 
+Q 2919 1325 2919 1791 
+Q 2919 2259 2725 2515 
+Q 2531 2772 2181 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Bold-43"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(73.388672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(142.089844 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(246.289062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(317.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(367.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(435.009766 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(494.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(554.052734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(588.330078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(657.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(728.222656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(763.037109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(822.558594 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(894.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(961.962891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(1029.785156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1101.367188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(1136.181641 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1201.367188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1260.888672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1295.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1345.019531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1412.5 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1460.302734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1494.580078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1563.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1598.095703 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-28" transform="translate(1632.910156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(1678.613281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-68" transform="translate(1716.601562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1787.792969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(1822.070312 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-5f" transform="translate(1893.652344 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1943.652344 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(2003.173828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2037.451172 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(2139.550781 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(2199.072266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(2233.349609 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2300.830078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2014" transform="translate(2335.644531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2435.644531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-67" transform="translate(2470.458984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2542.041016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(2609.863281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(2678.564453 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2782.763672 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(2850.585938 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(2918.066406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2989.257812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(3024.072266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(3092.773438 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3157.958984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(3225.78125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3275.097656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-31" transform="translate(3309.912109 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32" transform="translate(3379.492188 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3449.072266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-66" transform="translate(3483.886719 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3527.392578 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3561.669922 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3595.947266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(3663.769531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-29" transform="translate(3723.291016 0)"/>
+   </g>
+  </g>
+  <g id="text_20">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6c9ecf85b56b1034ba71f9c2c5d11115f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(-20.961641 465.66) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-32"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3562.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3626.611328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3688.134766 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3743.115234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3778.320312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3841.943359 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3905.566406 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3969.042969 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4032.666016 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(4096.289062 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(4159.765625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4223.388672 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4350.634766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(4414.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4477.734375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(4539.013672 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(4602.636719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(4666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(4701.464844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4820.068359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4883.691406 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(4938.671875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(5002.294922 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5065.771484 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5129.394531 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5193.017578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5256.640625 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(5320.263672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(5383.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5419.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5450.878906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5482.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5514.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5546.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5578.027344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5605.810547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5667.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(5728.613281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5791.992188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5855.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5894.332031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(5955.513672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6014.693359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6076.216797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(6117.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(6151.021484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6178.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6240.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.607422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(6364.986328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(6428.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(6462.300781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(6521.480469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(6585.103516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(6616.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(6680.513672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(6744.136719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(6775.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(6839.546875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6875.630859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(6914.494141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(6969.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7033.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7064.884766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(7096.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7128.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7160.246094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7192.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7231.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7294.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7394.666016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(7458.044922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7521.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(7584.900391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7648.376953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7711.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7750.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(7782.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7866.541016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7898.328125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7995.740234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(8057.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(8120.740234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8148.523438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(8209.802734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8273.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(8304.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(8357.068359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8420.447266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(8481.726562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(8545.203125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(8597.302734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(8660.681641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(8721.863281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(8761.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8794.763672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(8826.550781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(8928.943359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(8968.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(8995.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(9057.117188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9088.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(9116.6875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(9168.787109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(9200.574219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(9264.050781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(9325.574219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(9364.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(9426.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(9465.669922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9563.082031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(9590.865234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9654.244141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(9682.027344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(9734.126953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(9801.119141 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb21c1e4984">
+   <rect x="66.078125" y="48.583125" width="571.121875" height="364.220625"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/bench/graphs/.hid_silesia_summary.svg
+++ b/bench/graphs/.hid_silesia_summary.svg
@@ -1,0 +1,1921 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="704.323281pt" height="134.778469pt" viewBox="0 0 704.323281 134.778469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1980-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 134.778469 
+L 704.323281 134.778469 
+L 704.323281 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 254.286641 113.688 
+L 358.911641 113.688 
+L 358.911641 66.564 
+L 254.286641 66.564 
+z
+" clip-path="url(#pb491404708)" style="fill: #feffbe; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 358.911641 113.688 
+L 463.536641 113.688 
+L 463.536641 66.564 
+L 358.911641 66.564 
+z
+" clip-path="url(#pb491404708)" style="fill: #feffbe; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 463.536641 113.688 
+L 568.161641 113.688 
+L 568.161641 66.564 
+L 463.536641 66.564 
+z
+" clip-path="url(#pb491404708)" style="fill: #feffbe; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_1">
+    <!-- codec -->
+    <g transform="translate(187.273906 45.485438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391 
+L 3366 2478 
+Q 3138 2634 2908 2709 
+Q 2678 2784 2431 2784 
+Q 1963 2784 1702 2511 
+Q 1441 2238 1441 1747 
+Q 1441 1256 1702 982 
+Q 1963 709 2431 709 
+Q 2694 709 2930 787 
+Q 3166 866 3366 1019 
+L 3366 103 
+Q 3103 6 2833 -42 
+Q 2563 -91 2291 -91 
+Q 1344 -91 809 395 
+Q 275 881 275 1747 
+Q 275 2613 809 3098 
+Q 1344 3584 2291 3584 
+Q 2566 3584 2833 3536 
+Q 3100 3488 3366 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-63"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(59.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(127.978516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(199.560547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(267.382812 0)"/>
+    </g>
+   </g>
+   <g id="text_2">
+    <!-- ratio -->
+    <g transform="translate(294.558125 45.485438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-72"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(49.316406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(116.796875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(164.599609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(198.876953 0)"/>
+    </g>
+   </g>
+   <g id="text_3">
+    <!-- compress MB/s -->
+    <g transform="translate(373.130234 45.485438) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4d" d="M 588 4666 
+L 2119 4666 
+L 3181 2169 
+L 4250 4666 
+L 5778 4666 
+L 5778 0 
+L 4641 0 
+L 4641 3413 
+L 3566 897 
+L 2803 897 
+L 1728 3413 
+L 1728 0 
+L 588 0 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-42" d="M 2456 2859 
+Q 2741 2859 2887 2984 
+Q 3034 3109 3034 3353 
+Q 3034 3594 2887 3720 
+Q 2741 3847 2456 3847 
+L 1791 3847 
+L 1791 2859 
+L 2456 2859 
+z
+M 2497 819 
+Q 2859 819 3042 972 
+Q 3225 1125 3225 1434 
+Q 3225 1738 3044 1889 
+Q 2863 2041 2497 2041 
+L 1791 2041 
+L 1791 819 
+L 2497 819 
+z
+M 3616 2497 
+Q 4003 2384 4215 2081 
+Q 4428 1778 4428 1338 
+Q 4428 663 3972 331 
+Q 3516 0 2584 0 
+L 588 0 
+L 588 4666 
+L 2394 4666 
+Q 3366 4666 3802 4372 
+Q 4238 4078 4238 3431 
+Q 4238 3091 4078 2852 
+Q 3919 2613 3616 2497 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2f" d="M 1644 4666 
+L 2338 4666 
+L 691 -594 
+L 0 -594 
+L 1644 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-63"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(59.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(127.978516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(232.177734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(303.759766 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(353.076172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(420.898438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(480.419922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(539.941406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4d" transform="translate(574.755859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-42" transform="translate(674.267578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(750.488281 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(787.011719 0)"/>
+    </g>
+   </g>
+   <g id="text_4">
+    <!-- decompress MB/s -->
+    <g transform="translate(471.481953 45.485438) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-64"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(198.681641 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(267.382812 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(371.582031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(443.164062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(492.480469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(560.302734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(619.824219 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(679.345703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4d" transform="translate(714.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-42" transform="translate(813.671875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(889.892578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(926.416016 0)"/>
+    </g>
+   </g>
+   <g id="text_5">
+    <!-- lean-zip (native) -->
+    <g transform="translate(164.921016 92.3335) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297 
+L 2309 2297 
+L 2309 1388 
+L 347 1388 
+L 347 2297 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-7a" d="M 366 3500 
+L 3419 3500 
+L 3419 2719 
+L 1575 800 
+L 3419 800 
+L 3419 0 
+L 288 0 
+L 288 781 
+L 2131 2700 
+L 366 2700 
+L 366 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-76" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-6c"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(34.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(102.099609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(169.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(240.771484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-7a" transform="translate(282.275391 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(340.478516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(374.755859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(446.337891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-28" transform="translate(481.152344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(526.855469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(598.046875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(665.527344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(713.330078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-76" transform="translate(747.607422 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(812.792969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
+    </g>
+   </g>
+   <g id="text_6">
+    <!-- 0.325 -->
+    <g transform="translate(293.947266 92.3335) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2e" d="M 653 1209 
+L 1778 1209 
+L 1778 0 
+L 653 0 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-30"/>
+     <use xlink:href="#DejaVuSans-Bold-2e" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(107.568359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(177.148438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(246.728516 0)"/>
+    </g>
+   </g>
+   <g id="text_7">
+    <!-- 20 -->
+    <g transform="translate(405.657891 92.3335) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <!-- 178 -->
+    <g transform="translate(507.499766 92.3335) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_9">
+   <!-- .hid_silesia — geomean over files, level 6 -->
+   <g transform="translate(201.536328 17.077969) scale(0.13 -0.13)">
+    <defs>
+     <path id="DejaVuSans-Bold-68" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-5f" d="M 3200 -916 
+L 3200 -1509 
+L 0 -1509 
+L 0 -916 
+L 3200 -916 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2014" d="M 344 2156 
+L 6056 2156 
+L 6056 1350 
+L 344 1350 
+L 344 2156 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-67" d="M 2919 594 
+Q 2688 288 2409 144 
+Q 2131 0 1766 0 
+Q 1125 0 706 504 
+Q 288 1009 288 1791 
+Q 288 2575 706 3076 
+Q 1125 3578 1766 3578 
+Q 2131 3578 2409 3434 
+Q 2688 3291 2919 2981 
+L 2919 3500 
+L 4044 3500 
+L 4044 353 
+Q 4044 -491 3511 -936 
+Q 2978 -1381 1966 -1381 
+Q 1638 -1381 1331 -1331 
+Q 1025 -1281 716 -1178 
+L 716 -306 
+Q 1009 -475 1290 -558 
+Q 1572 -641 1856 -641 
+Q 2406 -641 2662 -400 
+Q 2919 -159 2919 353 
+L 2919 594 
+z
+M 2181 2772 
+Q 1834 2772 1640 2515 
+Q 1447 2259 1447 1791 
+Q 1447 1309 1634 1061 
+Q 1822 813 2181 813 
+Q 2531 813 2725 1069 
+Q 2919 1325 2919 1791 
+Q 2919 2259 2725 2515 
+Q 2531 2772 2181 2772 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-66" d="M 2841 4863 
+L 2841 4128 
+L 2222 4128 
+Q 1984 4128 1890 4042 
+Q 1797 3956 1797 3744 
+L 1797 3500 
+L 2753 3500 
+L 2753 2700 
+L 1797 2700 
+L 1797 0 
+L 678 0 
+L 678 2700 
+L 122 2700 
+L 122 3500 
+L 678 3500 
+L 678 3744 
+Q 678 4316 997 4589 
+Q 1316 4863 1984 4863 
+L 2841 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-2c" d="M 653 1209 
+L 1778 1209 
+L 1778 256 
+L 1006 -909 
+L 341 -909 
+L 653 256 
+L 653 1209 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Bold-2e"/>
+    <use xlink:href="#DejaVuSans-Bold-68" transform="translate(37.988281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(109.179688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(143.457031 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-5f" transform="translate(215.039062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(265.039062 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(324.560547 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(358.837891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(393.115234 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(460.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(520.458984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(554.736328 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(622.216797 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2014" transform="translate(657.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(757.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-67" transform="translate(791.845703 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(863.427734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(931.25 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(999.951172 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1104.150391 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1171.972656 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1239.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1310.644531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1345.458984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(1414.160156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1479.345703 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1547.167969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1596.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-66" transform="translate(1631.298828 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1674.804688 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1709.082031 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1743.359375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1811.181641 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2c" transform="translate(1870.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1908.691406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1943.505859 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1977.783203 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-76" transform="translate(2045.605469 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2110.791016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2178.613281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2212.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-36" transform="translate(2247.705078 0)"/>
+   </g>
+  </g>
+  <g id="text_10">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6c9ecf85b56b1034ba71f9c2c5d11115f  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(7.2 125.928) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5a" d="M 359 4666 
+L 4025 4666 
+L 4025 4184 
+L 1075 531 
+L 4097 531 
+L 4097 0 
+L 288 0 
+L 288 481 
+L 3238 4134 
+L 359 4134 
+L 359 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-32"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(1223.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1255.224609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(1318.798828 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1374.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1402.294922 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1465.673828 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(1529.052734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1588.232422 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1620.019531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1675 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1738.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1801.757812 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3562.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3626.611328 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3688.134766 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3743.115234 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3778.320312 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3841.943359 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3905.566406 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3969.042969 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4032.666016 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(4096.289062 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(4159.765625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4223.388672 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4287.011719 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4350.634766 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(4414.257812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4477.734375 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(4539.013672 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(4602.636719 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(4666.259766 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(4701.464844 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(4820.068359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4883.691406 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(4938.671875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(5002.294922 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5065.771484 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5129.394531 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5193.017578 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(5256.640625 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(5320.263672 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(5383.886719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5419.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5450.878906 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5482.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5514.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5546.240234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5578.027344 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5605.810547 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5667.333984 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(5728.613281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5791.992188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5855.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5894.332031 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(5955.513672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6014.693359 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6076.216797 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(6117.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(6151.021484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6178.804688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6240.328125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6301.607422 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(6364.986328 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(6428.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(6462.300781 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(6521.480469 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(6585.103516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(6616.890625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(6680.513672 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(6744.136719 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(6775.923828 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(6839.546875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6875.630859 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(6914.494141 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(6969.474609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7033.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7064.884766 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(7096.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7128.458984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7160.246094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7192.033203 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7231.242188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7294.621094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7333.484375 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7394.666016 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(7458.044922 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7521.521484 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(7584.900391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(7648.376953 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7711.755859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7750.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(7782.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7866.541016 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7898.328125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7995.740234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(8057.263672 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(8120.740234 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8148.523438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(8209.802734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8273.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(8304.96875 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(8357.068359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8420.447266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(8481.726562 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(8545.203125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(8597.302734 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(8660.681641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(8721.863281 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(8761.072266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(8794.763672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(8826.550781 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(8867.664062 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(8928.943359 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(8968.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(8995.935547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(9057.117188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9088.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(9116.6875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(9168.787109 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(9200.574219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(9264.050781 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(9325.574219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(9364.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(9426.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(9465.669922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9563.082031 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(9590.865234 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9654.244141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(9682.027344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(9734.126953 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(9773.335938 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(9801.119141 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb491404708">
+   <rect x="149.661641" y="19.44" width="418.5" height="94.248"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p93a7c51671)">
+   <g clip-path="url(#p27329e298f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3YwarcZx2H8TMnk1DCIbRC2hpEilBX7l14DW68EK/Au/AKhIIrtyK6dOclSFuK0LSYQ2Lj6cnkZDL/7twXnpefHT6fK/gOA+8889udvvnjdsEPy+FmesE6h5fTC5bY3txNT1hm9+j96Qlr3H9nesE6l5fTC9Z4c5hesM7uPL+z7cXT6QnLnOc3BgAwSGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT2X1xcT29Y4s3pMD1hmR+/+7PpCctcbR9OT1hi9+3z6QnL/P3VP6cnLPGTB+9PT1jmeLqbnrDEzdvzfffvTsfpCUv88tFPpycs44IFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsd3L13/apkes8Op4Mz1hmcenh9MT1jneTS9Y4+Z6esE6H/x8esESN9vt9IRlzvV9fLxdTU9Y5unF8+kJSzy5/s/0hGVcsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2v3pxPb1hiav9g+kJ6xy+nl6wzHbzzfSENU6n6QXL7B7+e3rCEuf8hlztH01PWOPBO9MLlnny6m56whLb7VfTE5ZxwQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiO2366+nN/B9nU7TC+B/ti8/n56wxqX/nz843kb+j3hBAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAILb/7bN/TW9Y4sXh7fSEZf7x9OX0hGX+/JtfTU9Y4sOHH01PWOYXf/hkesISv/74R9MTlvnsxWF6At/TX/766fSEJW5//7vpCcu4YAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBsdzz9bZsescLb03F6wjKXu/Pt4nuH2+kJa9zbTy9Y59vn0wuWOL33ZHrCMtt2mp6wxL0zvhm82c7zN+3+8Tw/18WFCxYAQE5gAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE9pevb6c3LHF5uZ+esM6zT6cXLLPd/nd6whrH4/SCZXbvPZ6esMTl3WF6wjoPHk4vWOPZ59MLlrn/+mZ6whLbzZm++RcuWAAAOYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABD7DjZrjMJlrDqzAAAAAElFTkSuQmCC" id="image44679fc0e8" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEUlEQVR4nO3YQYrkZx2H8a6emmEYmsEIE5NBJAi6cu/CM7jxIDmBt/AEguDKrYS4dOcRgglBcAyxmTFjp6fsrql/du4Dz8svKT6fE3yLgree+u1OX/1xu+D75XAzvWCdw+vpBUts93fTE5bZPX13esIaDx9PL1jn8nJ6wRr3h+kF6+zO8zvbXr2YnrDMeX5jAACDBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGz/+cX19IYl7k+H6QnLvP+Dn05PWOZqe296whK7r19OT1jmr28+mZ6wxI8fvTs9YZnj6W56whI3b8/33b87HacnLPHLpz+ZnrCMCxYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEdq//96dtesQKb4430xOWeXZ6Mj1hnePd9II1bq6nF6zzo59PL1jiZrudnrDMub6Pz7ar6QnLvLh4OT1hiefX/5mesIwLFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT2V6+upzcscbV/ND1hncMX0wuW2W6+mp6wxuk0vWCZ3ZMvpycscc5vyNX+6fSENR49nl6wzPM3d9MTlthu/zU9YRkXLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2H67/mJ6A9/W6TS9AP5v++dn0xPWuPT/83vH28h3iBcEACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYvsP//2P6Q1LvDq8nZ6wzN9evJ6esMyff/Or6QlLvPfkg+kJy/zi93+YnrDEr3/2w+kJy3z66jA9gW/po4//Pj1hidvf/XZ6wjIuWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDbHU9/2aZHrPD2dJyesMzl7ny7+MHhdnrCGg/20wvW+frl9IIlTu88n56wzLadpics8eCMbwb323n+pj08nufnurhwwQIAyAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY/vLuML1hicvL/fSEdb78ZHrBMtvtf6cnrHE8Ti9YZvfOs+kJS1ze301PWOfh4+kFa1x/Pr1gmYeH19MTlthuzvTNv3DBAgDICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNg3QK+MwhJEWrMAAAAASUVORK5CYII=" id="image1fedd2b214" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me203e183aa" d="M 0 0 
+       <path id="m08e097bc63" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me203e183aa" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me203e183aa" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me203e183aa" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me203e183aa" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me203e183aa" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me203e183aa" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#me203e183aa" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me203e183aa" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#me203e183aa" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me203e183aa" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#me203e183aa" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m08e097bc63" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m09e1d7bef1" d="M 0 0 
+       <path id="m5f5fca30c4" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m09e1d7bef1" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f5fca30c4" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m09e1d7bef1" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f5fca30c4" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m09e1d7bef1" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f5fca30c4" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m09e1d7bef1" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f5fca30c4" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m09e1d7bef1" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f5fca30c4" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m09e1d7bef1" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f5fca30c4" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m09e1d7bef1" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f5fca30c4" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m09e1d7bef1" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f5fca30c4" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,95 +1303,8 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -20 -->
+    <!-- -18 -->
     <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- -14 -->
-    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -67 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -88 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1434,6 +1347,62 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- -12 -->
+    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -66 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -88 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
@@ -1441,95 +1410,51 @@ z
    <g id="text_24">
     <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -60 -->
+    <!-- -59 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -17 -->
+    <!-- -15 -->
     <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- -2 -->
-    <g transform="translate(386.816887 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -53 -->
-    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -72 -->
-    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -94 -->
-    <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- +4 -->
-    <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
+    <!-- +1 -->
+    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1547,6 +1472,49 @@ L 2944 4013
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -52 -->
+    <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -71 -->
+    <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -94 -->
+    <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- +4 -->
+    <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
@@ -1648,6 +1616,40 @@ z
    <g id="text_44">
     <!-- +303 -->
     <g transform="translate(184.87641 139.606222) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
@@ -2182,18 +2184,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image1ea8fc0ac2" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image645472a039" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mda747980dc" d="M 0 0 
+       <path id="m420c199f84" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mda747980dc" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m420c199f84" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2216,7 +2218,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mda747980dc" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m420c199f84" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2230,7 +2232,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mda747980dc" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m420c199f84" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2244,7 +2246,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mda747980dc" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m420c199f84" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2257,7 +2259,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mda747980dc" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m420c199f84" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2270,7 +2272,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mda747980dc" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m420c199f84" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2283,7 +2285,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mda747980dc" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m420c199f84" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2944,8 +2946,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.904453 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.929375 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3060,109 +3062,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.794922 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3571.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.15625 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3666.943359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3694.726562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.25 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.529297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3880.908203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.384766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.248047 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.429688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4103.609375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4239.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4267.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.523438 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4453.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.525391 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.216797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.396484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.019531 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4705.806641 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.429688 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4864.839844 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.462891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.546875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.410156 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.800781 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5185.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.162109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5280.949219 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.158203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.400391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5483.582031 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5546.960938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.4375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5673.816406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.292969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5800.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5839.880859 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5871.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.457031 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.244141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6084.65625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6209.65625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6298.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.097656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6393.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6445.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.363281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.119141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6749.597656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6810.779297 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6883.679688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.466797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6956.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7017.859375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7084.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.033203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7177.820312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7205.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7257.703125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7352.966797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7453.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.222656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7554.585938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7651.998047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7679.78125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7770.943359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.035156 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p93a7c51671">
+  <clipPath id="p27329e298f">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m8f378e7576" d="M 0 0 
+       <path id="md281eafb8a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8f378e7576" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md281eafb8a" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8f378e7576" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md281eafb8a" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8f378e7576" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md281eafb8a" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8f378e7576" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md281eafb8a" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8f378e7576" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md281eafb8a" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8f378e7576" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md281eafb8a" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8f378e7576" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md281eafb8a" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m33de64ba0f" d="M 0 0 
+       <path id="m8888dccafa" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m33de64ba0f" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8888dccafa" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m33de64ba0f" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8888dccafa" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m33de64ba0f" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8888dccafa" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m6a4ae2333b" d="M 0 0 
+       <path id="m44420e93f5" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m6a4ae2333b" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m44420e93f5" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 165.450093) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 165.016833) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m0d6ccb6e77" d="M -2.5 2.5 
+     <path id="me71d31dd74" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p77ecb5723f)">
-     <use xlink:href="#m0d6ccb6e77" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d6ccb6e77" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d6ccb6e77" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d6ccb6e77" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d6ccb6e77" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d6ccb6e77" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d6ccb6e77" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d6ccb6e77" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0d6ccb6e77" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p41f2b14896)">
+     <use xlink:href="#me71d31dd74" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me71d31dd74" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me71d31dd74" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me71d31dd74" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me71d31dd74" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me71d31dd74" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me71d31dd74" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me71d31dd74" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me71d31dd74" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.211803
 L 310.240844 102.355284 
 L 309.257387 102.498333 
 L 308.273931 102.64095 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.64095 
@@ -1853,7 +1853,7 @@ L 273.545396 115.495372
 L 272.773651 115.744903 
 L 272.001906 115.993127 
 L 271.230161 116.240058 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.240058 
@@ -1905,7 +1905,7 @@ L 221.171803 119.753456
 L 220.059395 119.828647 
 L 218.946988 119.90372 
 L 217.83458 119.978674 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 119.978674 
@@ -1957,7 +1957,7 @@ L 179.624997 137.397353
 L 178.775895 137.720164 
 L 177.926794 138.04079 
 L 177.077692 138.359262 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.359262 
@@ -2009,7 +2009,7 @@ L 163.767861 156.658214
 L 163.472087 156.994351 
 L 163.176313 157.328121 
 L 162.880539 157.659557 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.659557 
@@ -2061,7 +2061,7 @@ L 160.875139 164.650114
 L 160.830574 164.794326 
 L 160.78601 164.9381 
 L 160.741445 165.081439 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.081439 
@@ -2113,7 +2113,7 @@ L 154.390101 182.353217
 L 154.24896 182.673779 
 L 154.107819 182.992187 
 L 153.966678 183.30847 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.30847 
@@ -2165,26 +2165,26 @@ L 151.73818 193.734619
 L 151.688658 193.942139 
 L 151.639136 194.148754 
 L 151.589614 194.354473 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="ma8ea8d25c2" d="M 0 -2.5 
+     <path id="m364219b9db" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p77ecb5723f)">
-     <use xlink:href="#ma8ea8d25c2" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8ea8d25c2" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8ea8d25c2" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8ea8d25c2" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8ea8d25c2" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8ea8d25c2" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8ea8d25c2" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8ea8d25c2" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8ea8d25c2" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p41f2b14896)">
+     <use xlink:href="#m364219b9db" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m364219b9db" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m364219b9db" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m364219b9db" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m364219b9db" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m364219b9db" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m364219b9db" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m364219b9db" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m364219b9db" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.610561
 L 294.051648 97.995945 
 L 288.886486 98.37822 
 L 283.721324 98.757435 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 98.757435 
@@ -2289,7 +2289,7 @@ L 222.934499 119.784103
 L 221.583681 120.159977 
 L 220.232863 120.532893 
 L 218.882044 120.902897 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 120.902897 
@@ -2341,7 +2341,7 @@ L 189.411904 126.368029
 L 188.757012 126.482596 
 L 188.10212 126.596887 
 L 187.447228 126.710903 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 126.710903 
@@ -2393,7 +2393,7 @@ L 177.036521 137.569875
 L 176.805172 137.785045 
 L 176.573823 137.999242 
 L 176.342474 138.212475 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.212475 
@@ -2445,7 +2445,7 @@ L 163.884824 160.054818
 L 163.607987 160.442131 
 L 163.33115 160.826303 
 L 163.054314 161.207386 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.207386 
@@ -2497,7 +2497,7 @@ L 162.263275 168.244909
 L 162.245696 168.390018 
 L 162.228118 168.534683 
 L 162.210539 168.678909 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.678909 
@@ -2549,7 +2549,7 @@ L 159.485481 175.228819
 L 159.424925 175.364567 
 L 159.364368 175.499927 
 L 159.303811 175.634901 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.634901 
@@ -2601,30 +2601,30 @@ L 157.888296 179.180942
 L 157.85684 179.256806 
 L 157.825384 179.332549 
 L 157.793928 179.408171 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="mb185433dcf" d="M -0 3.535534 
+     <path id="m514e3c0a7c" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p77ecb5723f)">
-     <use xlink:href="#mb185433dcf" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb185433dcf" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p41f2b14896)">
+     <use xlink:href="#m514e3c0a7c" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m514e3c0a7c" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.99106
 L 205.766837 81.29344 
 L 204.771342 81.593904 
 L 203.775848 81.892474 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.892474 
@@ -2729,7 +2729,7 @@ L 188.032264 88.395253
 L 187.682406 88.530091 
 L 187.332549 88.664546 
 L 186.982691 88.798621 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.798621 
@@ -2781,7 +2781,7 @@ L 180.229518 90.954599
 L 180.079447 91.001413 
 L 179.929376 91.048181 
 L 179.779306 91.094902 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.094902 
@@ -2833,7 +2833,7 @@ L 158.995974 98.861987
 L 158.534122 99.02092 
 L 158.07227 99.179321 
 L 157.610419 99.337194 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.337194 
@@ -2885,7 +2885,7 @@ L 149.27802 107.306615
 L 149.092855 107.469343 
 L 148.907691 107.631514 
 L 148.722526 107.793132 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.793132 
@@ -2937,7 +2937,7 @@ L 144.65906 120.462338
 L 144.568761 120.708742 
 L 144.478462 120.95387 
 L 144.388162 121.197738 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.197738 
@@ -2989,7 +2989,7 @@ L 128.153555 143.293159
 L 127.792786 143.68398 
 L 127.432016 144.071604 
 L 127.071247 144.456083 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.456083 
@@ -3041,7 +3041,7 @@ L 124.653192 151.618794
 L 124.599457 151.76629 
 L 124.545723 151.913329 
 L 124.491988 152.059912 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.059912 
@@ -3093,7 +3093,7 @@ L 94.606058 205.368437
 L 93.941926 206.074323 
 L 93.277794 206.769849 
 L 92.613662 207.455314 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.455314 
@@ -3145,7 +3145,7 @@ L 87.677774 224.060225
 L 87.568088 224.37049 
 L 87.458402 224.678737 
 L 87.348715 224.984992 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 224.984992 
@@ -3197,23 +3197,23 @@ L 86.134388 240.678828
 L 86.107403 240.974786 
 L 86.080418 241.268907 
 L 86.053433 241.561213 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="md806be60ef" d="M -0 2.5 
+     <path id="m650a503453" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p77ecb5723f)">
-     <use xlink:href="#md806be60ef" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p41f2b14896)">
+     <use xlink:href="#m650a503453" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m6349dbad88" d="M -0.833333 2.5 
+     <path id="mea7191cfda" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p77ecb5723f)">
-     <use xlink:href="#m6349dbad88" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6349dbad88" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6349dbad88" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6349dbad88" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6349dbad88" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6349dbad88" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6349dbad88" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6349dbad88" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6349dbad88" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p41f2b14896)">
+     <use xlink:href="#mea7191cfda" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea7191cfda" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea7191cfda" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea7191cfda" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea7191cfda" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea7191cfda" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea7191cfda" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea7191cfda" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mea7191cfda" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 180.888961
 L 282.301002 180.947904 
 L 280.549589 181.006774 
 L 278.798176 181.06557 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 181.06557 
@@ -3342,7 +3342,7 @@ L 252.902686 188.238912
 L 252.327231 188.386611 
 L 251.751776 188.53385 
 L 251.17632 188.680634 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 188.680634 
@@ -3394,7 +3394,7 @@ L 203.954921 186.473055
 L 202.905557 186.42281 
 L 201.856192 186.372512 
 L 200.806828 186.322161 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 186.322161 
@@ -3446,7 +3446,7 @@ L 171.740947 201.881696
 L 171.095038 202.175521 
 L 170.44913 202.467535 
 L 169.803221 202.757761 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 202.757761 
@@ -3498,7 +3498,7 @@ L 162.409549 210.675366
 L 162.245246 210.837123 
 L 162.080942 210.99833 
 L 161.916638 211.158991 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 211.158991 
@@ -3550,7 +3550,7 @@ L 158.898325 213.866476
 L 158.831251 213.92492 
 L 158.764178 213.983292 
 L 158.697104 214.041592 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 214.041592 
@@ -3602,7 +3602,7 @@ L 154.543684 229.493591
 L 154.451386 229.785704 
 L 154.359088 230.076027 
 L 154.26679 230.364582 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 230.364582 
@@ -3654,11 +3654,11 @@ L 153.16961 235.985723
 L 153.145228 236.103367 
 L 153.120846 236.220719 
 L 153.096464 236.337782 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="mf27bebf1b6" d="M -1.25 2.5 
+     <path id="mfb295981ab" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p77ecb5723f)">
-     <use xlink:href="#mf27bebf1b6" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27bebf1b6" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27bebf1b6" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27bebf1b6" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27bebf1b6" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27bebf1b6" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27bebf1b6" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27bebf1b6" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf27bebf1b6" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p41f2b14896)">
+     <use xlink:href="#mfb295981ab" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfb295981ab" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfb295981ab" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfb295981ab" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfb295981ab" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfb295981ab" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfb295981ab" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfb295981ab" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfb295981ab" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 147.037933
 L 252.377414 147.089635 
 L 251.306944 147.141281 
 L 250.236474 147.192871 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 147.192871 
@@ -3787,7 +3787,7 @@ L 226.969772 152.467777
 L 226.452735 152.578579 
 L 225.935697 152.689122 
 L 225.418659 152.799409 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 152.799409 
@@ -3839,7 +3839,7 @@ L 213.147044 158.556257
 L 212.874341 158.676569 
 L 212.601639 158.796576 
 L 212.328936 158.91628 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 158.91628 
@@ -3891,7 +3891,7 @@ L 209.236323 156.954621
 L 209.167599 156.910092 
 L 209.098874 156.865522 
 L 209.030149 156.82091 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 156.82091 
@@ -3943,7 +3943,7 @@ L 198.265399 167.356927
 L 198.026182 167.566396 
 L 197.786966 167.774943 
 L 197.547749 167.982576 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 167.982576 
@@ -3995,7 +3995,7 @@ L 194.989815 169.398061
 L 194.932972 169.429041 
 L 194.876129 169.460001 
 L 194.819287 169.49094 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 169.49094 
@@ -4047,7 +4047,7 @@ L 193.228821 176.568565
 L 193.193478 176.714439 
 L 193.158134 176.859866 
 L 193.12279 177.004847 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 177.004847 
@@ -4099,11 +4099,11 @@ L 192.818243 181.564429
 L 192.811475 181.660932 
 L 192.804707 181.75724 
 L 192.79794 181.853352 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="mf68d21e6e9" d="M 0 -2.5 
+     <path id="m2a2ee71052" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p77ecb5723f)">
-     <use xlink:href="#mf68d21e6e9" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf68d21e6e9" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf68d21e6e9" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf68d21e6e9" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf68d21e6e9" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf68d21e6e9" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf68d21e6e9" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf68d21e6e9" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf68d21e6e9" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p41f2b14896)">
+     <use xlink:href="#m2a2ee71052" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2a2ee71052" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2a2ee71052" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2a2ee71052" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2a2ee71052" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2a2ee71052" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2a2ee71052" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2a2ee71052" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m2a2ee71052" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 117.963319
 L 206.45578 117.9566 
 L 206.45578 117.949879 
 L 206.45578 117.943158 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 117.943158 
@@ -4230,7 +4230,7 @@ L 206.45578 118.018397
 L 206.45578 118.020068 
 L 206.45578 118.021738 
 L 206.45578 118.023409 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.023409 
@@ -4282,7 +4282,7 @@ L 206.45578 118.009588
 L 206.45578 118.00928 
 L 206.45578 118.008973 
 L 206.45578 118.008666 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.008666 
@@ -4334,7 +4334,7 @@ L 173.935517 132.674231
 L 173.212844 132.953702 
 L 172.490172 133.231533 
 L 171.767499 133.507746 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 133.507746 
@@ -4386,7 +4386,7 @@ L 164.056872 143.78437
 L 163.885524 143.989231 
 L 163.714177 144.193211 
 L 163.54283 144.396316 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.396316 
@@ -4438,7 +4438,7 @@ L 160.385378 149.94789
 L 160.315212 150.064163 
 L 160.245047 150.180152 
 L 160.174881 150.295858 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 150.295858 
@@ -4490,7 +4490,7 @@ L 154.553946 167.637484
 L 154.429036 167.959116 
 L 154.304126 168.27858 
 L 154.179217 168.595905 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 168.595905 
@@ -4542,11 +4542,11 @@ L 152.549264 177.771325
 L 152.513043 177.956336 
 L 152.476822 178.140629 
 L 152.4406 178.324207 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m507bebf9c6" d="M 0 -2.5 
+     <path id="m4d5358c770" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p77ecb5723f)">
-     <use xlink:href="#m507bebf9c6" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m507bebf9c6" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m507bebf9c6" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m507bebf9c6" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m507bebf9c6" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m507bebf9c6" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m507bebf9c6" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m507bebf9c6" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m507bebf9c6" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p41f2b14896)">
+     <use xlink:href="#m4d5358c770" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5358c770" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5358c770" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5358c770" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5358c770" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5358c770" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5358c770" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5358c770" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d5358c770" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 174.939703
 L 592.834055 174.969152 
 L 592.450726 174.998584 
 L 592.067397 175.027997 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 175.027997 
@@ -4669,7 +4669,7 @@ L 538.386544 181.016797
 L 537.193636 181.14165 
 L 536.000728 181.266176 
 L 534.807821 181.390376 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 181.390376 
@@ -4721,7 +4721,7 @@ L 340.74006 177.010188
 L 336.427443 176.9081 
 L 332.114826 176.805792 
 L 327.802209 176.703263 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.703263 
@@ -4773,7 +4773,7 @@ L 279.085397 186.459613
 L 278.002801 186.655155 
 L 276.920205 186.849893 
 L 275.83761 187.043834 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 187.043834 
@@ -4825,7 +4825,7 @@ L 259.350398 198.484046
 L 258.984015 198.709377 
 L 258.617633 198.933642 
 L 258.25125 199.15685 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 199.15685 
@@ -4877,7 +4877,7 @@ L 256.869193 203.812849
 L 256.838481 203.911293 
 L 256.807768 204.009533 
 L 256.777056 204.107569 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 204.107569 
@@ -4929,7 +4929,7 @@ L 249.270304 217.480153
 L 249.103487 217.738369 
 L 248.93667 217.995185 
 L 248.769854 218.250617 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 218.250617 
@@ -4981,7 +4981,7 @@ L 246.421172 227.44791
 L 246.368979 227.633321 
 L 246.316786 227.818009 
 L 246.264594 228.00198 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m2f97ba8ec2" d="M 0 3.5 
+      <path id="m6dc374787b" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m2f97ba8ec2" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m6dc374787b" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m0d6ccb6e77" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me71d31dd74" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#ma8ea8d25c2" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m364219b9db" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#mb185433dcf" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m514e3c0a7c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#md806be60ef" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m650a503453" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m6349dbad88" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mea7191cfda" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#mf27bebf1b6" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfb295981ab" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#mf68d21e6e9" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m2a2ee71052" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m507bebf9c6" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4d5358c770" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,434 +5416,434 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p77ecb5723f)">
-     <use xlink:href="#m2f97ba8ec2" x="289.669676" y="170.450093" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2f97ba8ec2" x="223.847406" y="178.939725" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2f97ba8ec2" x="212.215046" y="182.256257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2f97ba8ec2" x="186.58897" y="191.095144" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2f97ba8ec2" x="169.057218" y="200.971834" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2f97ba8ec2" x="158.596848" y="211.485524" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2f97ba8ec2" x="152.867313" y="217.300511" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2f97ba8ec2" x="150.950891" y="231.736452" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2f97ba8ec2" x="119.37967" y="288.099234" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2f97ba8ec2" x="100.541635" y="312.648072" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p41f2b14896)">
+     <use xlink:href="#m6dc374787b" x="289.669676" y="170.016833" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6dc374787b" x="223.847406" y="178.224234" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6dc374787b" x="212.215046" y="181.378098" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6dc374787b" x="186.58897" y="189.980783" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6dc374787b" x="169.057218" y="199.112555" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6dc374787b" x="158.596848" y="210.150215" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6dc374787b" x="152.867313" y="215.523009" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6dc374787b" x="150.950891" y="229.813146" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6dc374787b" x="119.37967" y="288.099234" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6dc374787b" x="100.541635" y="312.648072" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 170.450093 
-L 288.298379 170.643399 
-L 286.927082 170.835919 
-L 285.555784 171.02766 
-L 284.184487 171.218628 
-L 282.81319 171.40883 
-L 281.441892 171.598271 
-L 280.070595 171.786959 
-L 278.699298 171.974898 
-L 277.328 172.162094 
-L 275.956703 172.348554 
-L 274.585406 172.534283 
-L 273.214109 172.719287 
-L 271.842811 172.903572 
-L 270.471514 173.087143 
-L 269.100217 173.270005 
-L 267.728919 173.452164 
-L 266.357622 173.633626 
-L 264.986325 173.814396 
-L 263.615028 173.994479 
-L 262.24373 174.17388 
-L 260.872433 174.352604 
-L 259.501136 174.530657 
-L 258.129838 174.708044 
-L 256.758541 174.884769 
-L 255.387244 175.060837 
-L 254.015947 175.236254 
-L 252.644649 175.411023 
-L 251.273352 175.585151 
-L 249.902055 175.758641 
-L 248.530757 175.931498 
-L 247.15946 176.103727 
-L 245.788163 176.275332 
-L 244.416866 176.446318 
-L 243.045568 176.61669 
-L 241.674271 176.786451 
-L 240.302974 176.955606 
-L 238.931676 177.124159 
-L 237.560379 177.292115 
-L 236.189082 177.459478 
-L 234.817784 177.626252 
-L 233.446487 177.792441 
-L 232.07519 177.958049 
-L 230.703893 178.12308 
-L 229.332595 178.287539 
-L 227.961298 178.451429 
-L 226.590001 178.614754 
-L 225.218703 178.777518 
-L 223.847406 178.939725 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 170.016833 
+L 288.298379 170.203154 
+L 286.927082 170.388745 
+L 285.555784 170.573613 
+L 284.184487 170.757761 
+L 282.81319 170.941197 
+L 281.441892 171.123926 
+L 280.070595 171.305952 
+L 278.699298 171.487283 
+L 277.328 171.667922 
+L 275.956703 171.847875 
+L 274.585406 172.027147 
+L 273.214109 172.205744 
+L 271.842811 172.38367 
+L 270.471514 172.56093 
+L 269.100217 172.73753 
+L 267.728919 172.913474 
+L 266.357622 173.088768 
+L 264.986325 173.263415 
+L 263.615028 173.437421 
+L 262.24373 173.610791 
+L 260.872433 173.783529 
+L 259.501136 173.955639 
+L 258.129838 174.127126 
+L 256.758541 174.297995 
+L 255.387244 174.46825 
+L 254.015947 174.637896 
+L 252.644649 174.806937 
+L 251.273352 174.975376 
+L 249.902055 175.14322 
+L 248.530757 175.31047 
+L 247.15946 175.477133 
+L 245.788163 175.643211 
+L 244.416866 175.80871 
+L 243.045568 175.973632 
+L 241.674271 176.137983 
+L 240.302974 176.301765 
+L 238.931676 176.464984 
+L 237.560379 176.627642 
+L 236.189082 176.789743 
+L 234.817784 176.951293 
+L 233.446487 177.112293 
+L 232.07519 177.272748 
+L 230.703893 177.432662 
+L 229.332595 177.592038 
+L 227.961298 177.750879 
+L 226.590001 177.90919 
+L 225.218703 178.066974 
+L 223.847406 178.224234 
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 178.939725 
-L 223.605065 179.011241 
-L 223.362724 179.082649 
-L 223.120384 179.153949 
-L 222.878043 179.225143 
-L 222.635702 179.296229 
-L 222.393361 179.367209 
-L 222.15102 179.438083 
-L 221.908679 179.508851 
-L 221.666339 179.579514 
-L 221.423998 179.650071 
-L 221.181657 179.720523 
-L 220.939316 179.790871 
-L 220.696975 179.861115 
-L 220.454635 179.931254 
-L 220.212294 180.00129 
-L 219.969953 180.071223 
-L 219.727612 180.141052 
-L 219.485271 180.210779 
-L 219.24293 180.280403 
-L 219.00059 180.349926 
-L 218.758249 180.419346 
-L 218.515908 180.488665 
-L 218.273567 180.557882 
-L 218.031226 180.626999 
-L 217.788885 180.696015 
-L 217.546545 180.76493 
-L 217.304204 180.833746 
-L 217.061863 180.902462 
-L 216.819522 180.971078 
-L 216.577181 181.039595 
-L 216.33484 181.108013 
-L 216.0925 181.176332 
-L 215.850159 181.244553 
-L 215.607818 181.312677 
-L 215.365477 181.380702 
-L 215.123136 181.448629 
-L 214.880795 181.51646 
-L 214.638455 181.584194 
-L 214.396114 181.65183 
-L 214.153773 181.719371 
-L 213.911432 181.786815 
-L 213.669091 181.854164 
-L 213.42675 181.921417 
-L 213.18441 181.988574 
-L 212.942069 182.055637 
-L 212.699728 182.122605 
-L 212.457387 182.189478 
-L 212.215046 182.256257 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 178.224234 
+L 223.605065 178.292127 
+L 223.362724 178.359923 
+L 223.120384 178.427621 
+L 222.878043 178.495223 
+L 222.635702 178.562729 
+L 222.393361 178.630139 
+L 222.15102 178.697453 
+L 221.908679 178.764671 
+L 221.666339 178.831794 
+L 221.423998 178.898823 
+L 221.181657 178.965756 
+L 220.939316 179.032596 
+L 220.696975 179.099341 
+L 220.454635 179.165992 
+L 220.212294 179.23255 
+L 219.969953 179.299014 
+L 219.727612 179.365385 
+L 219.485271 179.431663 
+L 219.24293 179.497849 
+L 219.00059 179.563943 
+L 218.758249 179.629944 
+L 218.515908 179.695854 
+L 218.273567 179.761672 
+L 218.031226 179.827399 
+L 217.788885 179.893034 
+L 217.546545 179.958579 
+L 217.304204 180.024034 
+L 217.061863 180.089398 
+L 216.819522 180.154672 
+L 216.577181 180.219856 
+L 216.33484 180.284951 
+L 216.0925 180.349957 
+L 215.850159 180.414873 
+L 215.607818 180.479701 
+L 215.365477 180.54444 
+L 215.123136 180.609091 
+L 214.880795 180.673653 
+L 214.638455 180.738128 
+L 214.396114 180.802516 
+L 214.153773 180.866815 
+L 213.911432 180.931028 
+L 213.669091 180.995154 
+L 213.42675 181.059193 
+L 213.18441 181.123146 
+L 212.942069 181.187013 
+L 212.699728 181.250793 
+L 212.457387 181.314488 
+L 212.215046 181.378098 
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 182.256257 
-L 211.68117 182.458262 
-L 211.147293 182.659409 
-L 210.613417 182.859706 
-L 210.07954 183.059161 
-L 209.545663 183.257779 
-L 209.011787 183.455568 
-L 208.47791 183.652535 
-L 207.944034 183.848687 
-L 207.410157 184.04403 
-L 206.87628 184.238571 
-L 206.342404 184.432317 
-L 205.808527 184.625274 
-L 205.274651 184.817449 
-L 204.740774 185.008847 
-L 204.206897 185.199476 
-L 203.673021 185.389341 
-L 203.139144 185.578448 
-L 202.605268 185.766803 
-L 202.071391 185.954413 
-L 201.537515 186.141283 
-L 201.003638 186.327419 
-L 200.469761 186.512826 
-L 199.935885 186.697511 
-L 199.402008 186.881479 
-L 198.868132 187.064736 
-L 198.334255 187.247287 
-L 197.800378 187.429137 
-L 197.266502 187.610292 
-L 196.732625 187.790757 
-L 196.198749 187.970538 
-L 195.664872 188.149639 
-L 195.130995 188.328066 
-L 194.597119 188.505823 
-L 194.063242 188.682916 
-L 193.529366 188.85935 
-L 192.995489 189.035129 
-L 192.461612 189.210259 
-L 191.927736 189.384744 
-L 191.393859 189.558589 
-L 190.859983 189.731798 
-L 190.326106 189.904377 
-L 189.79223 190.07633 
-L 189.258353 190.24766 
-L 188.724476 190.418374 
-L 188.1906 190.588475 
-L 187.656723 190.757967 
-L 187.122847 190.926855 
-L 186.58897 191.095144 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 181.378098 
+L 211.68117 181.574212 
+L 211.147293 181.769518 
+L 210.613417 181.964023 
+L 210.07954 182.157732 
+L 209.545663 182.350653 
+L 209.011787 182.542792 
+L 208.47791 182.734155 
+L 207.944034 182.924748 
+L 207.410157 183.114578 
+L 206.87628 183.30365 
+L 206.342404 183.491971 
+L 205.808527 183.679547 
+L 205.274651 183.866383 
+L 204.740774 184.052485 
+L 204.206897 184.237859 
+L 203.673021 184.422511 
+L 203.139144 184.606447 
+L 202.605268 184.789671 
+L 202.071391 184.972189 
+L 201.537515 185.154007 
+L 201.003638 185.33513 
+L 200.469761 185.515564 
+L 199.935885 185.695313 
+L 199.402008 185.874383 
+L 198.868132 186.052779 
+L 198.334255 186.230506 
+L 197.800378 186.407568 
+L 197.266502 186.583972 
+L 196.732625 186.759721 
+L 196.198749 186.934821 
+L 195.664872 187.109277 
+L 195.130995 187.283092 
+L 194.597119 187.456273 
+L 194.063242 187.628822 
+L 193.529366 187.800746 
+L 192.995489 187.972048 
+L 192.461612 188.142734 
+L 191.927736 188.312806 
+L 191.393859 188.482271 
+L 190.859983 188.651131 
+L 190.326106 188.819392 
+L 189.79223 188.987058 
+L 189.258353 189.154133 
+L 188.724476 189.32062 
+L 188.1906 189.486525 
+L 187.656723 189.651851 
+L 187.122847 189.816603 
+L 186.58897 189.980783 
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 186.58897 191.095144 
-L 186.223725 191.323371 
-L 185.85848 191.550504 
-L 185.493235 191.776554 
-L 185.127991 192.00153 
-L 184.762746 192.225444 
-L 184.397501 192.448305 
-L 184.032256 192.670122 
-L 183.667011 192.890906 
-L 183.301766 193.110666 
-L 182.936522 193.329412 
-L 182.571277 193.547152 
-L 182.206032 193.763897 
-L 181.840787 193.979655 
-L 181.475542 194.194435 
-L 181.110297 194.408246 
-L 180.745053 194.621096 
-L 180.379808 194.832995 
-L 180.014563 195.04395 
-L 179.649318 195.253971 
-L 179.284073 195.463065 
-L 178.918828 195.67124 
-L 178.553584 195.878505 
-L 178.188339 196.084867 
-L 177.823094 196.290335 
-L 177.457849 196.494915 
-L 177.092604 196.698617 
-L 176.727359 196.901446 
-L 176.362115 197.103411 
-L 175.99687 197.304518 
-L 175.631625 197.504776 
-L 175.26638 197.704192 
-L 174.901135 197.902771 
-L 174.53589 198.100522 
-L 174.170645 198.297451 
-L 173.805401 198.493565 
-L 173.440156 198.688871 
-L 173.074911 198.883375 
-L 172.709666 199.077085 
-L 172.344421 199.270005 
-L 171.979176 199.462144 
-L 171.613932 199.653506 
-L 171.248687 199.844099 
-L 170.883442 200.033928 
-L 170.518197 200.223 
-L 170.152952 200.411321 
-L 169.787707 200.598896 
-L 169.422463 200.785732 
-L 169.057218 200.971834 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.58897 189.980783 
+L 186.223725 190.190132 
+L 185.85848 190.398559 
+L 185.493235 190.606074 
+L 185.127991 190.812685 
+L 184.762746 191.018398 
+L 184.397501 191.223222 
+L 184.032256 191.427165 
+L 183.667011 191.630234 
+L 183.301766 191.832437 
+L 182.936522 192.03378 
+L 182.571277 192.234271 
+L 182.206032 192.433918 
+L 181.840787 192.632727 
+L 181.475542 192.830706 
+L 181.110297 193.027861 
+L 180.745053 193.224199 
+L 180.379808 193.419727 
+L 180.014563 193.614452 
+L 179.649318 193.80838 
+L 179.284073 194.001517 
+L 178.918828 194.19387 
+L 178.553584 194.385446 
+L 178.188339 194.576251 
+L 177.823094 194.76629 
+L 177.457849 194.95557 
+L 177.092604 195.144097 
+L 176.727359 195.331877 
+L 176.362115 195.518916 
+L 175.99687 195.70522 
+L 175.631625 195.890794 
+L 175.26638 196.075644 
+L 174.901135 196.259776 
+L 174.53589 196.443196 
+L 174.170645 196.625908 
+L 173.805401 196.807918 
+L 173.440156 196.989232 
+L 173.074911 197.169855 
+L 172.709666 197.349792 
+L 172.344421 197.529048 
+L 171.979176 197.707629 
+L 171.613932 197.88554 
+L 171.248687 198.062785 
+L 170.883442 198.239369 
+L 170.518197 198.415298 
+L 170.152952 198.590577 
+L 169.787707 198.765209 
+L 169.422463 198.9392 
+L 169.057218 199.112555 
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 169.057218 200.971834 
-L 168.839293 201.216436 
-L 168.621369 201.459781 
-L 168.403445 201.701883 
-L 168.18552 201.942755 
-L 167.967596 202.182409 
-L 167.749672 202.420857 
-L 167.531747 202.658111 
-L 167.313823 202.894183 
-L 167.095898 203.129084 
-L 166.877974 203.362828 
-L 166.66005 203.595424 
-L 166.442125 203.826883 
-L 166.224201 204.057218 
-L 166.006277 204.286439 
-L 165.788352 204.514556 
-L 165.570428 204.741581 
-L 165.352503 204.967523 
-L 165.134579 205.192393 
-L 164.916655 205.4162 
-L 164.69873 205.638956 
-L 164.480806 205.86067 
-L 164.262882 206.081351 
-L 164.044957 206.301009 
-L 163.827033 206.519654 
-L 163.609108 206.737295 
-L 163.391184 206.95394 
-L 163.17326 207.1696 
-L 162.955335 207.384283 
-L 162.737411 207.597997 
-L 162.519487 207.810752 
-L 162.301562 208.022557 
-L 162.083638 208.233418 
-L 161.865713 208.443346 
-L 161.647789 208.652348 
-L 161.429865 208.860432 
-L 161.21194 209.067606 
-L 160.994016 209.273878 
-L 160.776092 209.479257 
-L 160.558167 209.683749 
-L 160.340243 209.887363 
-L 160.122318 210.090105 
-L 159.904394 210.291984 
-L 159.68647 210.493007 
-L 159.468545 210.69318 
-L 159.250621 210.892511 
-L 159.032697 211.091008 
-L 158.814772 211.288676 
-L 158.596848 211.485524 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 169.057218 199.112555 
+L 168.839293 199.370787 
+L 168.621369 199.62762 
+L 168.403445 199.883068 
+L 168.18552 200.137147 
+L 167.967596 200.38987 
+L 167.749672 200.641253 
+L 167.531747 200.89131 
+L 167.313823 201.140054 
+L 167.095898 201.387499 
+L 166.877974 201.633659 
+L 166.66005 201.878547 
+L 166.442125 202.122176 
+L 166.224201 202.364558 
+L 166.006277 202.605707 
+L 165.788352 202.845636 
+L 165.570428 203.084355 
+L 165.352503 203.321878 
+L 165.134579 203.558217 
+L 164.916655 203.793383 
+L 164.69873 204.027387 
+L 164.480806 204.260242 
+L 164.262882 204.491958 
+L 164.044957 204.722547 
+L 163.827033 204.952018 
+L 163.609108 205.180385 
+L 163.391184 205.407656 
+L 163.17326 205.633842 
+L 162.955335 205.858953 
+L 162.737411 206.083001 
+L 162.519487 206.305994 
+L 162.301562 206.527943 
+L 162.083638 206.748857 
+L 161.865713 206.968746 
+L 161.647789 207.187619 
+L 161.429865 207.405486 
+L 161.21194 207.622356 
+L 160.994016 207.838238 
+L 160.776092 208.053141 
+L 160.558167 208.267074 
+L 160.340243 208.480046 
+L 160.122318 208.692065 
+L 159.904394 208.903139 
+L 159.68647 209.113277 
+L 159.468545 209.322488 
+L 159.250621 209.530779 
+L 159.032697 209.738158 
+L 158.814772 209.944634 
+L 158.596848 210.150215 
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 158.596848 211.485524 
-L 158.477483 211.614241 
-L 158.358117 211.742609 
-L 158.238752 211.87063 
-L 158.119387 211.998307 
-L 158.000021 212.125641 
-L 157.880656 212.252633 
-L 157.761291 212.379286 
-L 157.641925 212.505601 
-L 157.52256 212.63158 
-L 157.403195 212.757226 
-L 157.28383 212.882539 
-L 157.164464 213.007522 
-L 157.045099 213.132176 
-L 156.925734 213.256503 
-L 156.806368 213.380504 
-L 156.687003 213.504182 
-L 156.567638 213.627538 
-L 156.448272 213.750574 
-L 156.328907 213.873291 
-L 156.209542 213.995691 
-L 156.090177 214.117776 
-L 155.970811 214.239547 
-L 155.851446 214.361006 
-L 155.732081 214.482155 
-L 155.612715 214.602994 
-L 155.49335 214.723527 
-L 155.373985 214.843753 
-L 155.254619 214.963675 
-L 155.135254 215.083295 
-L 155.015889 215.202613 
-L 154.896524 215.321632 
-L 154.777158 215.440352 
-L 154.657793 215.558776 
-L 154.538428 215.676905 
-L 154.419062 215.794739 
-L 154.299697 215.912282 
-L 154.180332 216.029534 
-L 154.060966 216.146496 
-L 153.941601 216.26317 
-L 153.822236 216.379558 
-L 153.702871 216.495661 
-L 153.583505 216.61148 
-L 153.46414 216.727016 
-L 153.344775 216.842272 
-L 153.225409 216.957248 
-L 153.106044 217.071945 
-L 152.986679 217.186366 
-L 152.867313 217.300511 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.596848 210.150215 
+L 158.477483 210.268592 
+L 158.358117 210.386674 
+L 158.238752 210.504463 
+L 158.119387 210.62196 
+L 158.000021 210.739166 
+L 157.880656 210.856083 
+L 157.761291 210.972712 
+L 157.641925 211.089055 
+L 157.52256 211.205113 
+L 157.403195 211.320888 
+L 157.28383 211.43638 
+L 157.164464 211.551592 
+L 157.045099 211.666524 
+L 156.925734 211.781178 
+L 156.806368 211.895555 
+L 156.687003 212.009657 
+L 156.567638 212.123485 
+L 156.448272 212.23704 
+L 156.328907 212.350323 
+L 156.209542 212.463337 
+L 156.090177 212.576082 
+L 155.970811 212.688558 
+L 155.851446 212.800769 
+L 155.732081 212.912715 
+L 155.612715 213.024396 
+L 155.49335 213.135816 
+L 155.373985 213.246973 
+L 155.254619 213.357871 
+L 155.135254 213.46851 
+L 155.015889 213.578891 
+L 154.896524 213.689016 
+L 154.777158 213.798885 
+L 154.657793 213.9085 
+L 154.538428 214.017862 
+L 154.419062 214.126972 
+L 154.299697 214.235832 
+L 154.180332 214.344442 
+L 154.060966 214.452804 
+L 153.941601 214.560919 
+L 153.822236 214.668787 
+L 153.702871 214.776411 
+L 153.583505 214.883791 
+L 153.46414 214.990927 
+L 153.344775 215.097823 
+L 153.225409 215.204477 
+L 153.106044 215.310892 
+L 152.986679 215.417069 
+L 152.867313 215.523009 
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 152.867313 217.300511 
-L 152.827388 217.650799 
-L 152.787463 217.998516 
-L 152.747537 218.343701 
-L 152.707612 218.686389 
-L 152.667686 219.026617 
-L 152.627761 219.36442 
-L 152.587835 219.699832 
-L 152.54791 220.032886 
-L 152.507984 220.363616 
-L 152.468059 220.692054 
-L 152.428133 221.018231 
-L 152.388208 221.342179 
-L 152.348282 221.663927 
-L 152.308357 221.983505 
-L 152.268432 222.300943 
-L 152.228506 222.616268 
-L 152.188581 222.929509 
-L 152.148655 223.240693 
-L 152.10873 223.549847 
-L 152.068804 223.856997 
-L 152.028879 224.162169 
-L 151.988953 224.465388 
-L 151.949028 224.76668 
-L 151.909102 225.066068 
-L 151.869177 225.363577 
-L 151.829252 225.659229 
-L 151.789326 225.953048 
-L 151.749401 226.245057 
-L 151.709475 226.535278 
-L 151.66955 226.823732 
-L 151.629624 227.11044 
-L 151.589699 227.395425 
-L 151.549773 227.678706 
-L 151.509848 227.960303 
-L 151.469922 228.240238 
-L 151.429997 228.518528 
-L 151.390072 228.795193 
-L 151.350146 229.070253 
-L 151.310221 229.343725 
-L 151.270295 229.615629 
-L 151.23037 229.885981 
-L 151.190444 230.154799 
-L 151.150519 230.422101 
-L 151.110593 230.687904 
-L 151.070668 230.952224 
-L 151.030742 231.215078 
-L 150.990817 231.476482 
-L 150.950891 231.736452 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 152.867313 215.523009 
+L 152.827388 215.869213 
+L 152.787463 216.212907 
+L 152.747537 216.554126 
+L 152.707612 216.892906 
+L 152.667686 217.229281 
+L 152.627761 217.563285 
+L 152.587835 217.894952 
+L 152.54791 218.224313 
+L 152.507984 218.551401 
+L 152.468059 218.876247 
+L 152.428133 219.198881 
+L 152.388208 219.519333 
+L 152.348282 219.837634 
+L 152.308357 220.15381 
+L 152.268432 220.467891 
+L 152.228506 220.779904 
+L 152.188581 221.089876 
+L 152.148655 221.397833 
+L 152.10873 221.703802 
+L 152.068804 222.007809 
+L 152.028879 222.309877 
+L 151.988953 222.610033 
+L 151.949028 222.908299 
+L 151.909102 223.204699 
+L 151.869177 223.499258 
+L 151.829252 223.791996 
+L 151.789326 224.082937 
+L 151.749401 224.372103 
+L 151.709475 224.659516 
+L 151.66955 224.945195 
+L 151.629624 225.229163 
+L 151.589699 225.511439 
+L 151.549773 225.792044 
+L 151.509848 226.070997 
+L 151.469922 226.348317 
+L 151.429997 226.624024 
+L 151.390072 226.898137 
+L 151.350146 227.170672 
+L 151.310221 227.44165 
+L 151.270295 227.711086 
+L 151.23037 227.979 
+L 151.190444 228.245407 
+L 151.150519 228.510325 
+L 151.110593 228.773771 
+L 151.070668 229.035759 
+L 151.030742 229.296308 
+L 150.990817 229.555431 
+L 150.950891 229.813146 
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 231.736452 
-L 150.293158 233.940316 
-L 149.635424 236.046224 
-L 148.97769 238.062517 
-L 148.319956 239.996511 
-L 147.662223 241.854661 
-L 147.004489 243.642692 
-L 146.346755 245.365705 
-L 145.689021 247.028262 
-L 145.031288 248.634463 
-L 144.373554 250.188003 
-L 143.71582 251.692226 
-L 143.058086 253.150167 
-L 142.400352 254.564589 
-L 141.742619 255.938016 
-L 141.084885 257.272756 
-L 140.427151 258.57093 
-L 139.769417 259.834487 
-L 139.111684 261.065227 
-L 138.45395 262.26481 
-L 137.796216 263.434776 
-L 137.138482 264.576552 
-L 136.480748 265.691464 
-L 135.823015 266.780747 
-L 135.165281 267.845553 
-L 134.507547 268.886959 
-L 133.849813 269.90597 
-L 133.19208 270.903529 
-L 132.534346 271.880522 
-L 131.876612 272.837778 
-L 131.218878 273.77608 
-L 130.561145 274.696164 
-L 129.903411 275.598724 
-L 129.245677 276.484414 
-L 128.587943 277.353854 
-L 127.930209 278.20763 
-L 127.272476 279.046295 
-L 126.614742 279.870376 
-L 125.957008 280.68037 
-L 125.299274 281.476753 
-L 124.641541 282.259972 
-L 123.983807 283.030458 
-L 123.326073 283.788616 
-L 122.668339 284.534835 
-L 122.010605 285.269486 
-L 121.352872 285.992921 
-L 120.695138 286.705479 
-L 120.037404 287.40748 
+    <path d="M 150.950891 229.813146 
+L 150.293158 232.145066 
+L 149.635424 234.367598 
+L 148.97769 236.490546 
+L 148.319956 238.522453 
+L 147.662223 240.470808 
+L 147.004489 242.342211 
+L 146.346755 244.14251 
+L 145.689021 245.876912 
+L 145.031288 247.550071 
+L 144.373554 249.166164 
+L 143.71582 250.728957 
+L 143.058086 252.241853 
+L 142.400352 253.70794 
+L 141.742619 255.130028 
+L 141.084885 256.51068 
+L 140.427151 257.852245 
+L 139.769417 259.156873 
+L 139.111684 260.426544 
+L 138.45395 261.663084 
+L 137.796216 262.868176 
+L 137.138482 264.043382 
+L 136.480748 265.190147 
+L 135.823015 266.309816 
+L 135.165281 267.40364 
+L 134.507547 268.472785 
+L 133.849813 269.51834 
+L 133.19208 270.541323 
+L 132.534346 271.54269 
+L 131.876612 272.523333 
+L 131.218878 273.484095 
+L 130.561145 274.425764 
+L 129.903411 275.349085 
+L 129.245677 276.25476 
+L 128.587943 277.14345 
+L 127.930209 278.01578 
+L 127.272476 278.872342 
+L 126.614742 279.713697 
+L 125.957008 280.540373 
+L 125.299274 281.352876 
+L 124.641541 282.151683 
+L 123.983807 282.937247 
+L 123.326073 283.710001 
+L 122.668339 284.470356 
+L 122.010605 285.218704 
+L 121.352872 285.955417 
+L 120.695138 286.680852 
+L 120.037404 287.39535 
 L 119.37967 288.099234 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
     <path d="M 119.37967 288.099234 
@@ -5895,7 +5895,7 @@ L 101.719013 311.435205
 L 101.326553 311.842953 
 L 100.934094 312.247222 
 L 100.541635 312.648072 
-" clip-path="url(#p77ecb5723f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p41f2b14896)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.904453 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.929375 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6348,61 +6348,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6489,109 +6434,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.794922 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3571.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.15625 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3666.943359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3694.726562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.25 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.529297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3880.908203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.384766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.248047 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.429688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4103.609375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4239.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4267.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.523438 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4453.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.525391 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.216797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.396484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.019531 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4705.806641 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.429688 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4864.839844 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.462891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.546875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.410156 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.800781 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5185.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.162109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5280.949219 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.158203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.400391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5483.582031 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5546.960938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.4375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5673.816406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.292969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5800.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5839.880859 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5871.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.457031 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.244141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6084.65625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6209.65625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6298.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.097656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6393.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6445.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.363281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.119141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6749.597656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6810.779297 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6883.679688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.466797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6956.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7017.859375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7084.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.033203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7177.820312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7205.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7257.703125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7352.966797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7453.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.222656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7554.585938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7651.998047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7679.78125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7770.943359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.035156 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p77ecb5723f">
+  <clipPath id="p41f2b14896">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p46fcca6da1)">
+   <g clip-path="url(#pf93f25d958)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="image84a8b5bcf3" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="image8e672da98f" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mf50d714f34" d="M 0 0 
+       <path id="m2ffd03e240" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf50d714f34" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mf50d714f34" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mf50d714f34" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf50d714f34" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mf50d714f34" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf50d714f34" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mf50d714f34" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf50d714f34" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mf50d714f34" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf50d714f34" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mf50d714f34" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2ffd03e240" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m4f02612aeb" d="M 0 0 
+       <path id="m4baddedac0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4f02612aeb" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4baddedac0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m4f02612aeb" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4baddedac0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m4f02612aeb" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4baddedac0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m4f02612aeb" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4baddedac0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m4f02612aeb" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4baddedac0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m4f02612aeb" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4baddedac0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m4f02612aeb" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4baddedac0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m4f02612aeb" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4baddedac0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8167ca3bb2" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image92d4a63f1b" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m2d60ffca9f" d="M 0 0 
+       <path id="m73cc68f558" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2d60ffca9f" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73cc68f558" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m2d60ffca9f" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73cc68f558" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2d60ffca9f" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73cc68f558" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m2d60ffca9f" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73cc68f558" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2d60ffca9f" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73cc68f558" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m2d60ffca9f" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73cc68f558" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2d60ffca9f" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73cc68f558" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m2d60ffca9f" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73cc68f558" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2d60ffca9f" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m73cc68f558" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.904453 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.929375 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2998,109 +2998,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.794922 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3571.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.15625 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3666.943359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3694.726562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.25 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.529297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3880.908203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.384766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.248047 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.429688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4103.609375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4239.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4267.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.523438 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4453.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.525391 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.216797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.396484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.019531 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4705.806641 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.429688 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4864.839844 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.462891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.546875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.410156 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.800781 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5185.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.162109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5280.949219 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.158203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.400391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5483.582031 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5546.960938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.4375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5673.816406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.292969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5800.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5839.880859 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5871.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.457031 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.244141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6084.65625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6209.65625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6298.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.097656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6393.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6445.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.363281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.119141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6749.597656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6810.779297 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6883.679688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.466797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6956.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7017.859375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7084.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.033203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7177.820312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7205.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7257.703125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7352.966797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7453.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.222656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7554.585938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7651.998047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7679.78125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7770.943359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.035156 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p46fcca6da1">
+  <clipPath id="pf93f25d958">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.591094pt" height="386.202469pt" viewBox="0 0 568.591094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.54125pt" height="386.202469pt" viewBox="0 0 570.54125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 568.591094 386.202469 
-L 568.591094 0 
+L 570.54125 386.202469 
+L 570.54125 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.420547 104.1264 
-L 291.045547 104.1264 
-L 291.045547 74.7432 
-L 186.420547 74.7432 
+    <path d="M 187.395625 104.1264 
+L 292.020625 104.1264 
+L 292.020625 74.7432 
+L 187.395625 74.7432 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.045547 104.1264 
-L 395.670547 104.1264 
-L 395.670547 74.7432 
-L 291.045547 74.7432 
+    <path d="M 292.020625 104.1264 
+L 396.645625 104.1264 
+L 396.645625 74.7432 
+L 292.020625 74.7432 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.670547 104.1264 
-L 500.295547 104.1264 
-L 500.295547 74.7432 
-L 395.670547 74.7432 
+    <path d="M 396.645625 104.1264 
+L 501.270625 104.1264 
+L 501.270625 74.7432 
+L 396.645625 74.7432 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.420547 133.5096 
-L 291.045547 133.5096 
-L 291.045547 104.1264 
-L 186.420547 104.1264 
+    <path d="M 187.395625 133.5096 
+L 292.020625 133.5096 
+L 292.020625 104.1264 
+L 187.395625 104.1264 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.045547 133.5096 
-L 395.670547 133.5096 
-L 395.670547 104.1264 
-L 291.045547 104.1264 
+    <path d="M 292.020625 133.5096 
+L 396.645625 133.5096 
+L 396.645625 104.1264 
+L 292.020625 104.1264 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.670547 133.5096 
-L 500.295547 133.5096 
-L 500.295547 104.1264 
-L 395.670547 104.1264 
+    <path d="M 396.645625 133.5096 
+L 501.270625 133.5096 
+L 501.270625 104.1264 
+L 396.645625 104.1264 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.420547 162.8928 
-L 291.045547 162.8928 
-L 291.045547 133.5096 
-L 186.420547 133.5096 
+    <path d="M 187.395625 162.8928 
+L 292.020625 162.8928 
+L 292.020625 133.5096 
+L 187.395625 133.5096 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.045547 162.8928 
-L 395.670547 162.8928 
-L 395.670547 133.5096 
-L 291.045547 133.5096 
+    <path d="M 292.020625 162.8928 
+L 396.645625 162.8928 
+L 396.645625 133.5096 
+L 292.020625 133.5096 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.670547 162.8928 
-L 500.295547 162.8928 
-L 500.295547 133.5096 
-L 395.670547 133.5096 
+    <path d="M 396.645625 162.8928 
+L 501.270625 162.8928 
+L 501.270625 133.5096 
+L 396.645625 133.5096 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.420547 192.276 
-L 291.045547 192.276 
-L 291.045547 162.8928 
-L 186.420547 162.8928 
+    <path d="M 187.395625 192.276 
+L 292.020625 192.276 
+L 292.020625 162.8928 
+L 187.395625 162.8928 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.045547 192.276 
-L 395.670547 192.276 
-L 395.670547 162.8928 
-L 291.045547 162.8928 
+    <path d="M 292.020625 192.276 
+L 396.645625 192.276 
+L 396.645625 162.8928 
+L 292.020625 162.8928 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.670547 192.276 
-L 500.295547 192.276 
-L 500.295547 162.8928 
-L 395.670547 162.8928 
+    <path d="M 396.645625 192.276 
+L 501.270625 192.276 
+L 501.270625 162.8928 
+L 396.645625 162.8928 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.420547 221.6592 
-L 291.045547 221.6592 
-L 291.045547 192.276 
-L 186.420547 192.276 
+    <path d="M 187.395625 221.6592 
+L 292.020625 221.6592 
+L 292.020625 192.276 
+L 187.395625 192.276 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.045547 221.6592 
-L 395.670547 221.6592 
-L 395.670547 192.276 
-L 291.045547 192.276 
+    <path d="M 292.020625 221.6592 
+L 396.645625 221.6592 
+L 396.645625 192.276 
+L 292.020625 192.276 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.670547 221.6592 
-L 500.295547 221.6592 
-L 500.295547 192.276 
-L 395.670547 192.276 
+    <path d="M 396.645625 221.6592 
+L 501.270625 221.6592 
+L 501.270625 192.276 
+L 396.645625 192.276 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.420547 251.0424 
-L 291.045547 251.0424 
-L 291.045547 221.6592 
-L 186.420547 221.6592 
+    <path d="M 187.395625 251.0424 
+L 292.020625 251.0424 
+L 292.020625 221.6592 
+L 187.395625 221.6592 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.045547 251.0424 
-L 395.670547 251.0424 
-L 395.670547 221.6592 
-L 291.045547 221.6592 
+    <path d="M 292.020625 251.0424 
+L 396.645625 251.0424 
+L 396.645625 221.6592 
+L 292.020625 221.6592 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.670547 251.0424 
-L 500.295547 251.0424 
-L 500.295547 221.6592 
-L 395.670547 221.6592 
+    <path d="M 396.645625 251.0424 
+L 501.270625 251.0424 
+L 501.270625 221.6592 
+L 396.645625 221.6592 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.420547 280.4256 
-L 291.045547 280.4256 
-L 291.045547 251.0424 
-L 186.420547 251.0424 
+    <path d="M 187.395625 280.4256 
+L 292.020625 280.4256 
+L 292.020625 251.0424 
+L 187.395625 251.0424 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.045547 280.4256 
-L 395.670547 280.4256 
-L 395.670547 251.0424 
-L 291.045547 251.0424 
+    <path d="M 292.020625 280.4256 
+L 396.645625 280.4256 
+L 396.645625 251.0424 
+L 292.020625 251.0424 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.670547 280.4256 
-L 500.295547 280.4256 
-L 500.295547 251.0424 
-L 395.670547 251.0424 
+    <path d="M 396.645625 280.4256 
+L 501.270625 280.4256 
+L 501.270625 251.0424 
+L 396.645625 251.0424 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.420547 309.8088 
-L 291.045547 309.8088 
-L 291.045547 280.4256 
-L 186.420547 280.4256 
+    <path d="M 187.395625 309.8088 
+L 292.020625 309.8088 
+L 292.020625 280.4256 
+L 187.395625 280.4256 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.045547 309.8088 
-L 395.670547 309.8088 
-L 395.670547 280.4256 
-L 291.045547 280.4256 
+    <path d="M 292.020625 309.8088 
+L 396.645625 309.8088 
+L 396.645625 280.4256 
+L 292.020625 280.4256 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.670547 309.8088 
-L 500.295547 309.8088 
-L 500.295547 280.4256 
-L 395.670547 280.4256 
+    <path d="M 396.645625 309.8088 
+L 501.270625 309.8088 
+L 501.270625 280.4256 
+L 396.645625 280.4256 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.420547 339.192 
-L 291.045547 339.192 
-L 291.045547 309.8088 
-L 186.420547 309.8088 
+    <path d="M 187.395625 339.192 
+L 292.020625 339.192 
+L 292.020625 309.8088 
+L 187.395625 309.8088 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.045547 339.192 
-L 395.670547 339.192 
-L 395.670547 309.8088 
-L 291.045547 309.8088 
+    <path d="M 292.020625 339.192 
+L 396.645625 339.192 
+L 396.645625 309.8088 
+L 292.020625 309.8088 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.670547 339.192 
-L 500.295547 339.192 
-L 500.295547 309.8088 
-L 395.670547 309.8088 
+    <path d="M 396.645625 339.192 
+L 501.270625 339.192 
+L 501.270625 309.8088 
+L 396.645625 309.8088 
 z
-" clip-path="url(#p2db511f2e0)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pc3520a8447)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.407813 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.382891 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.692031 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.667109 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.264141 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.239219 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.615859 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.590937 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.345547 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.320625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.281797 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(335.723047 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.698125 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.348047 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.983672 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.95875 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.281797 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.268047 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.348047 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.246797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.221875 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.281797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.268047 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.348047 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.553047 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.528125 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.281797 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.268047 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.348047 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(118.709297 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.684375 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.281797 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.268047 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.348047 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- OCaml decompress -->
-    <g transform="translate(95.169922 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(96.145 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1629,7 +1629,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.321 -->
-    <g transform="translate(227.281797 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1639,102 +1639,22 @@ z
    </g>
    <g id="text_27">
     <!-- 23 -->
-    <g transform="translate(338.268047 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 117 -->
-    <g transform="translate(440.348047 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- Go compress/flate -->
-    <g transform="translate(97.676797 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-47"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(77.490234 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(138.671875 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(170.458984 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(225.439453 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(286.621094 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(384.033203 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(447.509766 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(486.373047 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(547.896484 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(599.996094 0)"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(652.095703 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(685.787109 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(720.992188 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(748.775391 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(810.054688 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 0.299 -->
-    <g transform="translate(227.281797 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 18 -->
-    <g transform="translate(338.268047 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 88 -->
-    <g transform="translate(442.893047 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.054922 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.03 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1841,9 +1761,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_34">
+   <g id="text_30">
     <!-- 0.298 -->
-    <g transform="translate(226.081172 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.05625 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1972,9 +1892,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-38" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_35">
+   <g id="text_31">
     <!-- 18 -->
-    <g transform="translate(337.791797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.766875 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1995,9 +1915,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
     </g>
    </g>
-   <g id="text_36">
+   <g id="text_32">
     <!-- 205 -->
-    <g transform="translate(439.633672 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(440.60875 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-35" d="M 678 4666 
 L 3669 4666 
@@ -2030,9 +1950,89 @@ z
      <use xlink:href="#DejaVuSans-Bold-35" transform="translate(139.160156 0)"/>
     </g>
    </g>
+   <g id="text_33">
+    <!-- Go compress/flate -->
+    <g transform="translate(98.651875 297.3247) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-47"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(77.490234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(138.671875 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(170.458984 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(225.439453 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(286.621094 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(384.033203 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(447.509766 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(486.373047 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(547.896484 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(599.996094 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(652.095703 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(685.787109 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(720.992188 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(748.775391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(810.054688 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 0.299 -->
+    <g transform="translate(228.256875 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 18 -->
+    <g transform="translate(339.243125 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 88 -->
+    <g transform="translate(443.868125 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.391172 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.36625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2043,7 +2043,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.281797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2053,13 +2053,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(340.813047 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.788125 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.983047 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.958125 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2075,7 +2075,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(133.804297 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.779375 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2288,7 +2288,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2475,110 +2475,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.794922 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3571.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.15625 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3666.943359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3694.726562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.25 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.529297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3880.908203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.384766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.248047 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.429688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4103.609375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4239.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4267.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.523438 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4453.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.525391 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.216797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.396484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.019531 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4705.806641 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.429688 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4864.839844 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.462891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.546875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.410156 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.800781 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5185.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.162109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5280.949219 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.158203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.400391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5483.582031 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5546.960938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.4375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5673.816406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.292969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5800.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5839.880859 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5871.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.457031 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.244141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6084.65625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6209.65625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6298.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.097656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6393.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6445.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.363281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.119141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6749.597656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6810.779297 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6883.679688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.466797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6956.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7017.859375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7084.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.033203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7177.820312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7205.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7257.703125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7352.966797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7453.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.222656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7554.585938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7651.998047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7679.78125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7770.943359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.035156 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2db511f2e0">
-   <rect x="81.795547" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pc3520a8447">
+   <rect x="82.770625" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd857d41445)">
+   <g clip-path="url(#pa5d13a325f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ8ElEQVR4nO3YvY6cZx2HYc/uZG0cJ5jErAVIVhpCBVJEKhrOgILDoKSlp0ydlp4ToCJKhYQQ6QI0iYILsAX5JNg761mOgMp67v/61XUdwW/0fjz3O7vjv35zdWPLDk+mF/A8jpfTC9banUwvWOvyYnrBWrfvTi9Y6+lX0wvWOj2bXsDz2Pr9eXZ7esFSGz/9AAC4bgQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/Z8OH09vWGp/cjo9Yanj1dX0hKXOXzmfnrDUx1/8fXrCWhv/xH3z1t3pCUsdbp5NT1jqz48+nJ6w1I/ufX96wlJPz47TE5ba7b6enrDUxo8HAACuGwEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNo/eOWN6Q1L3b15Pj1hqcdPHk5PWOq7X2/7G+nO6z+cnrDU6W4/PWGp443j9ISlvn3j3vSEpS7vXUxPWOr+7QfTE5Y6HLd9/V6+2Pb7ZdunOwAA144ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtd/ttt2gXx7+PT1hqW+c3pmesNSz11+bnrDUPz7/YHrCUl9dPJmesNSPv/X29ISlLk6nF6z1n8OX0xN4Dp89fTQ9Ya2b59MLltp2fQIAcO0IUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUrtn7//yanrEUsfj9AL4/058A77QvF9ebFt//rZ+f7p+L7SNXz0AAK4bAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGp//49/md6w1Ml+24396MPH0xOWevcXb01PWOrXf/jn9ISlfvrgm9MTlvrtex9NT1jqVz//wfSEpd75/SfTE5b62VvfmZ6w1CefP52esNRPvvfy9ISltl1nAABcOwIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILU7PPvd1fSIlU4vL6cnrHWyn16w1uWT6QVrnd2eXrDWbuPfuFfH6QVrHTx/L7Rn2z7/DrttP38vbbxfNn46AABw3QhQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS+9PdfnrDWo//Nr1grVfPpxes9cWj6QVr3bozvWCtl25NL1hrv/Hf9+nD6QVr3X9zesFa//1sesFS+4d/nZ6w1mv3pxcs5R9QAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNT/AEq5d6j8B9WxAAAAAElFTkSuQmCC" id="image25ee3bcbd5" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ8ElEQVR4nO3XvY6dVxmGYe+ZnXFwHMVg42CQLBpIGpAiqGg4gxQ5DEra9ClTp6XnBKhAVEgIQWcqiJIUwRY/iUM0nj3ewxFQWet+x5+u6wge6ftZ99od//mrqxtbdjifXsCLOF5OL1hrdzK9YK3Li+kFa926M71grWdfTS9Y6/RsegEvYuvv59mt6QVLbfz0AwDguhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9n86fDy9Yan9yen0hKWOV1fTE5a6//r96QlLffzlp9MT1tr4FfeHr96ZnrDU4ebZ9ISl/vz40fSEpX587wfTE5Z6dnacnrDUbvf19ISlNn48AABw3QhQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNT+4evfn96w1J2b96cnLPXk/LPpCUt99+tt35Fu3/3R9ISlTnf76QlLHW8cpycs9e0b96YnLHV572J6wlJv3no4PWGpw3Hbz++1i23/X7Z9ugMAcO0IUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUvvdbtsN+vTwr+kJS33j9Pb0hKWe3/3W9ISlPv/iL9MTlvrq4nx6wlI/+eZPpycsdXE6vWCt/x6eTk/gBfzn2ePpCWvdvD+9YKlt1ycAANeOAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILV7/vtfXk2PWOp4nF4A/9+JO+BLzf/l5bb172/r76fn91Lb+NMDAOC6EaAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKT2b/7xr9MbljrZb7uxHz96Mj1hqY9+8c70hKU++MM/pics9fOHb0xPWOrXv/v79ISl3n/vrekJS33420+mJyz17jsPpics9ckXz6YnLPWz7702PWGpbdcZAADXjgAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0Oz39zNT1ipdPLy+kJa53spxesdXk+vWCts1vTC9babfyOe3WcXrDWwff3Unu+7fPvsNv29/fKxvtl46cDAADXjQAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC13+023qBP/ja9YK03vjO9YK2nj6cXrHXz9vSCtV55dXrBWqdn0wvW+vdn0wvWevD29IK1zr+cXrDU/tNH0xPWuvtgesFSG69PAACuGwEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDqf8L6d6/xAMsuAAAAAElFTkSuQmCC" id="image5ea262b9eb" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m32f56a09c4" d="M 0 0 
+       <path id="m5b8084ecf0" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m32f56a09c4" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m32f56a09c4" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m32f56a09c4" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m32f56a09c4" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m32f56a09c4" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m32f56a09c4" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m32f56a09c4" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m32f56a09c4" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m32f56a09c4" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m32f56a09c4" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m32f56a09c4" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m32f56a09c4" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b8084ecf0" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m8efcee9f32" d="M 0 0 
+       <path id="mfd8bd3e072" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8efcee9f32" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd8bd3e072" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8efcee9f32" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd8bd3e072" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m8efcee9f32" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd8bd3e072" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m8efcee9f32" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd8bd3e072" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m8efcee9f32" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd8bd3e072" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m8efcee9f32" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd8bd3e072" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m8efcee9f32" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd8bd3e072" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m8efcee9f32" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfd8bd3e072" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +0 -->
+    <!-- +3 -->
     <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,127 +1156,6 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -52 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -25 -->
-    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -51 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -36 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
 Q 3559 1806 3559 1356 
@@ -1309,66 +1188,124 @@ Q 3450 3153 3228 2886
 Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -50 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_26">
-    <!-- -27 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+   <g id="text_23">
+    <!-- -23 -->
+    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
-    <!-- -19 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+   <g id="text_24">
+    <!-- -49 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -1401,68 +1338,129 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- -52 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+   <g id="text_25">
+    <!-- -34 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- -7 -->
-    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -25 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -73 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -44 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+   <g id="text_26">
+    <!-- -26 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
 z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -17 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -51 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -5 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -23 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -72 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -43 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -2193,18 +2191,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image99965922fd" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image6a271c012e" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="ma26d2a544e" d="M 0 0 
+       <path id="m127318c89c" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma26d2a544e" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m127318c89c" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2227,7 +2225,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma26d2a544e" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m127318c89c" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2241,7 +2239,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma26d2a544e" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m127318c89c" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2255,7 +2253,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma26d2a544e" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m127318c89c" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2268,7 +2266,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma26d2a544e" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m127318c89c" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2281,7 +2279,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma26d2a544e" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m127318c89c" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2294,7 +2292,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#ma26d2a544e" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m127318c89c" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2910,8 +2908,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.904453 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.929375 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3048,109 +3046,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.794922 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3571.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.15625 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3666.943359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3694.726562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.25 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.529297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3880.908203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.384766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.248047 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.429688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4103.609375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4239.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4267.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.523438 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4453.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.525391 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.216797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.396484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.019531 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4705.806641 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.429688 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4864.839844 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.462891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.546875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.410156 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.800781 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5185.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.162109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5280.949219 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.158203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.400391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5483.582031 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5546.960938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.4375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5673.816406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.292969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5800.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5839.880859 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5871.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.457031 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.244141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6084.65625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6209.65625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6298.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.097656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6393.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6445.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.363281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.119141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6749.597656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6810.779297 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6883.679688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.466797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6956.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7017.859375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7084.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.033203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7177.820312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7205.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7257.703125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7352.966797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7453.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.222656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7554.585938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7651.998047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7679.78125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7770.943359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.035156 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd857d41445">
+  <clipPath id="pa5d13a325f">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="me6fc6cb238" d="M 0 0 
+       <path id="m16c652afc6" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me6fc6cb238" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c652afc6" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me6fc6cb238" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c652afc6" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me6fc6cb238" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c652afc6" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me6fc6cb238" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c652afc6" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me6fc6cb238" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c652afc6" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me6fc6cb238" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c652afc6" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me6fc6cb238" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m16c652afc6" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m995be5c19b" d="M 0 0 
+       <path id="m0259abbde9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m995be5c19b" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0259abbde9" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m995be5c19b" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0259abbde9" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m995be5c19b" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0259abbde9" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mbb61d6ef9c" d="M 0 0 
+       <path id="m923b5753fa" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mbb61d6ef9c" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m923b5753fa" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 131.089735) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 130.641894) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m6789f5b565" d="M -2.5 2.5 
+     <path id="mdf1c2ee344" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0134e1669f)">
-     <use xlink:href="#m6789f5b565" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6789f5b565" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6789f5b565" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6789f5b565" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6789f5b565" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6789f5b565" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6789f5b565" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6789f5b565" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6789f5b565" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc3458b8ffa)">
+     <use xlink:href="#mdf1c2ee344" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf1c2ee344" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf1c2ee344" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf1c2ee344" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf1c2ee344" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf1c2ee344" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf1c2ee344" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf1c2ee344" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf1c2ee344" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 111.868554
 L 326.02264 111.96025 
 L 324.91204 112.051791 
 L 323.801439 112.143178 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 112.143178 
@@ -1807,7 +1807,7 @@ L 275.861725 127.410211
 L 274.796398 127.705019 
 L 273.731071 127.99823 
 L 272.665744 128.289861 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 128.289861 
@@ -1859,7 +1859,7 @@ L 237.512385 129.68632
 L 236.7312 129.716946 
 L 235.950014 129.747556 
 L 235.168828 129.778148 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 129.778148 
@@ -1911,7 +1911,7 @@ L 189.28705 148.994297
 L 188.267455 149.352551 
 L 187.24786 149.708449 
 L 186.228265 150.062022 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 150.062022 
@@ -1963,7 +1963,7 @@ L 160.048483 171.011997
 L 159.46671 171.396655 
 L 158.884937 171.778598 
 L 158.303164 172.157864 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 172.157864 
@@ -2015,7 +2015,7 @@ L 150.040398 181.598676
 L 149.856781 181.790851 
 L 149.673164 181.982345 
 L 149.489547 182.173164 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.173164 
@@ -2067,7 +2067,7 @@ L 141.121061 201.502451
 L 140.935095 201.862455 
 L 140.749129 202.220079 
 L 140.563162 202.575355 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.575355 
@@ -2119,26 +2119,26 @@ L 139.083497 208.86883
 L 139.050616 209.000699 
 L 139.017734 209.132247 
 L 138.984853 209.263476 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="mc247189574" d="M 0 -2.5 
+     <path id="mb43371acf1" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0134e1669f)">
-     <use xlink:href="#mc247189574" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc247189574" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc247189574" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc247189574" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc247189574" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc247189574" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc247189574" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc247189574" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc247189574" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc3458b8ffa)">
+     <use xlink:href="#mb43371acf1" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb43371acf1" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb43371acf1" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb43371acf1" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb43371acf1" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb43371acf1" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb43371acf1" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb43371acf1" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb43371acf1" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.20247
 L 331.988718 100.690952 
 L 325.934838 101.175064 
 L 319.880958 101.654884 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.654884 
@@ -2243,7 +2243,7 @@ L 217.131235 128.404389
 L 214.847908 128.871381 
 L 212.564581 129.334377 
 L 210.281253 129.793447 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.793447 
@@ -2295,7 +2295,7 @@ L 197.161712 133.343265
 L 196.870166 133.419565 
 L 196.578621 133.495757 
 L 196.287076 133.571842 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.571842 
@@ -2347,7 +2347,7 @@ L 177.31896 146.664131
 L 176.897447 146.921938 
 L 176.475933 147.178523 
 L 176.054419 147.433896 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.433896 
@@ -2399,7 +2399,7 @@ L 153.654726 173.470231
 L 153.156955 173.927574 
 L 152.659184 174.381084 
 L 152.161413 174.830826 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.830826 
@@ -2451,7 +2451,7 @@ L 147.060283 185.961812
 L 146.946925 186.184927 
 L 146.833566 186.407126 
 L 146.720208 186.628416 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.628416 
@@ -2503,7 +2503,7 @@ L 144.164409 195.79469
 L 144.107613 195.981745 
 L 144.050817 196.168156 
 L 143.994022 196.353927 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.353927 
@@ -2555,30 +2555,30 @@ L 142.749036 200.0341
 L 142.72137 200.113105 
 L 142.693704 200.191995 
 L 142.666037 200.270771 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m4704f05c0c" d="M -0 3.535534 
+     <path id="mdf613ae536" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0134e1669f)">
-     <use xlink:href="#m4704f05c0c" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4704f05c0c" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc3458b8ffa)">
+     <use xlink:href="#mdf613ae536" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mdf613ae536" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.665392
 L 244.888911 79.95196 
 L 243.864032 80.237018 
 L 242.839153 80.520583 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.520583 
@@ -2683,7 +2683,7 @@ L 219.787941 85.73042
 L 219.275692 85.840684 
 L 218.763443 85.950723 
 L 218.251194 86.060539 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.060539 
@@ -2735,7 +2735,7 @@ L 199.092247 89.895187
 L 198.666492 89.97739 
 L 198.240738 90.059468 
 L 197.814984 90.141422 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.141422 
@@ -2787,7 +2787,7 @@ L 168.343148 98.26681
 L 167.688219 98.434213 
 L 167.033289 98.601101 
 L 166.378359 98.767475 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 98.767475 
@@ -2839,7 +2839,7 @@ L 147.11464 109.552827
 L 146.686557 109.769695 
 L 146.258475 109.985696 
 L 145.830392 110.20084 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.20084 
@@ -2891,7 +2891,7 @@ L 135.300472 124.91473
 L 135.066474 125.20027 
 L 134.832476 125.484312 
 L 134.598477 125.76687 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 125.76687 
@@ -2943,7 +2943,7 @@ L 124.734843 147.930147
 L 124.515652 148.332777 
 L 124.29646 148.732435 
 L 124.077268 149.129162 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.129162 
@@ -2995,7 +2995,7 @@ L 122.56387 156.732863
 L 122.530239 156.890271 
 L 122.496607 157.047223 
 L 122.462976 157.203722 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.203722 
@@ -3047,7 +3047,7 @@ L 83.602758 217.017639
 L 82.739198 217.816123 
 L 81.875637 218.602997 
 L 81.012077 219.378594 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 219.378594 
@@ -3099,7 +3099,7 @@ L 77.665842 237.784894
 L 77.591481 238.130517 
 L 77.517121 238.473948 
 L 77.44276 238.815213 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 238.815213 
@@ -3151,23 +3151,23 @@ L 76.984008 251.144668
 L 76.973814 251.389134 
 L 76.96362 251.6325 
 L 76.953425 251.874777 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="ma62e7a49b5" d="M -0 2.5 
+     <path id="mee0e1ae389" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0134e1669f)">
-     <use xlink:href="#ma62e7a49b5" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc3458b8ffa)">
+     <use xlink:href="#mee0e1ae389" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="mb22cc37b00" d="M -0.833333 2.5 
+     <path id="me1ef257283" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0134e1669f)">
-     <use xlink:href="#mb22cc37b00" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb22cc37b00" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb22cc37b00" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb22cc37b00" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb22cc37b00" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb22cc37b00" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb22cc37b00" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb22cc37b00" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb22cc37b00" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc3458b8ffa)">
+     <use xlink:href="#me1ef257283" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me1ef257283" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me1ef257283" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me1ef257283" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me1ef257283" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me1ef257283" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me1ef257283" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me1ef257283" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me1ef257283" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 117.229073
 L 306.11717 117.494902 
 L 303.36982 117.759433 
 L 300.62247 118.022676 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 118.022676 
@@ -3296,7 +3296,7 @@ L 269.071051 125.234719
 L 268.369908 125.384559 
 L 267.668766 125.533985 
 L 266.967623 125.683 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 125.683 
@@ -3348,7 +3348,7 @@ L 228.598863 126.122913
 L 227.746224 126.132648 
 L 226.893585 126.142382 
 L 226.040946 126.152114 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 126.152114 
@@ -3400,7 +3400,7 @@ L 183.801673 143.118416
 L 182.863022 143.441102 
 L 181.924372 143.761876 
 L 180.985721 144.080759 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 144.080759 
@@ -3452,7 +3452,7 @@ L 165.475826 157.662961
 L 165.131161 157.929236 
 L 164.786497 158.194207 
 L 164.441833 158.457887 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 158.457887 
@@ -3504,7 +3504,7 @@ L 158.178848 166.505572
 L 158.03967 166.671493 
 L 157.900493 166.836907 
 L 157.761315 167.001817 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 167.001817 
@@ -3556,7 +3556,7 @@ L 151.674847 180.456413
 L 151.539592 180.720489 
 L 151.404337 180.983284 
 L 151.269082 181.244808 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 181.244808 
@@ -3608,11 +3608,11 @@ L 150.385962 186.640888
 L 150.366337 186.754896 
 L 150.346712 186.868665 
 L 150.327087 186.982195 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m23497b7c26" d="M -1.25 2.5 
+     <path id="m57a508c0c2" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0134e1669f)">
-     <use xlink:href="#m23497b7c26" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m23497b7c26" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m23497b7c26" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m23497b7c26" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m23497b7c26" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m23497b7c26" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m23497b7c26" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m23497b7c26" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m23497b7c26" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc3458b8ffa)">
+     <use xlink:href="#m57a508c0c2" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m57a508c0c2" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m57a508c0c2" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m57a508c0c2" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m57a508c0c2" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m57a508c0c2" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m57a508c0c2" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m57a508c0c2" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m57a508c0c2" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 141.492222
 L 276.351005 141.626293 
 L 274.857964 141.760033 
 L 273.364924 141.893443 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 141.893443 
@@ -3741,7 +3741,7 @@ L 242.760262 147.575596
 L 242.080158 147.695331 
 L 241.400055 147.814802 
 L 240.719951 147.934009 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 147.934009 
@@ -3793,7 +3793,7 @@ L 222.564351 152.930779
 L 222.160893 153.036743 
 L 221.757435 153.142499 
 L 221.353978 153.24805 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 153.24805 
@@ -3845,7 +3845,7 @@ L 208.018647 155.070715
 L 207.722306 155.110529 
 L 207.425965 155.150315 
 L 207.129625 155.190071 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 155.190071 
@@ -3897,7 +3897,7 @@ L 182.693853 166.038872
 L 182.150836 166.256889 
 L 181.607819 166.474032 
 L 181.064802 166.690306 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.690306 
@@ -3949,7 +3949,7 @@ L 179.393584 170.067361
 L 179.356445 170.140065 
 L 179.319307 170.21267 
 L 179.282169 170.285179 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.285179 
@@ -4001,7 +4001,7 @@ L 177.817012 175.338922
 L 177.784453 175.446037 
 L 177.751894 175.552941 
 L 177.719335 175.659634 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.659634 
@@ -4053,11 +4053,11 @@ L 177.648651 180.712426
 L 177.64708 180.819522 
 L 177.645509 180.926407 
 L 177.643939 181.03308 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mf6a3cf47cf" d="M 0 -2.5 
+     <path id="m9202605972" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p0134e1669f)">
-     <use xlink:href="#mf6a3cf47cf" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf6a3cf47cf" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf6a3cf47cf" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf6a3cf47cf" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf6a3cf47cf" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf6a3cf47cf" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf6a3cf47cf" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf6a3cf47cf" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf6a3cf47cf" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pc3458b8ffa)">
+     <use xlink:href="#m9202605972" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9202605972" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9202605972" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9202605972" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9202605972" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9202605972" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9202605972" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9202605972" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m9202605972" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.101113
 L 226.871027 113.101614 
 L 226.871027 113.102116 
 L 226.871027 113.102618 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.102618 
@@ -4184,7 +4184,7 @@ L 226.871027 113.241886
 L 226.871027 113.244976 
 L 226.871027 113.248067 
 L 226.871027 113.251157 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.251157 
@@ -4236,7 +4236,7 @@ L 226.871027 113.165529
 L 226.871027 113.163625 
 L 226.871027 113.16172 
 L 226.871027 113.159816 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.159816 
@@ -4288,7 +4288,7 @@ L 180.837336 131.090576
 L 179.814365 131.428693 
 L 178.791394 131.764711 
 L 177.768423 132.098656 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.098656 
@@ -4340,7 +4340,7 @@ L 161.462117 144.555386
 L 161.099755 144.802091 
 L 160.737393 145.047676 
 L 160.37503 145.292152 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.292152 
@@ -4392,7 +4392,7 @@ L 154.394483 152.007915
 L 154.261581 152.148084 
 L 154.12868 152.287891 
 L 153.995779 152.427338 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.427338 
@@ -4444,7 +4444,7 @@ L 147.537442 166.80191
 L 147.393924 167.081716 
 L 147.250405 167.360084 
 L 147.106887 167.637027 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 167.637027 
@@ -4496,11 +4496,11 @@ L 145.948902 174.483819
 L 145.923169 174.626551 
 L 145.897436 174.768906 
 L 145.871703 174.910889 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m6da1a12773" d="M 0 -2.5 
+     <path id="m118f33c658" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0134e1669f)">
-     <use xlink:href="#m6da1a12773" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6da1a12773" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6da1a12773" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6da1a12773" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6da1a12773" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6da1a12773" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6da1a12773" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6da1a12773" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6da1a12773" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc3458b8ffa)">
+     <use xlink:href="#m118f33c658" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m118f33c658" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m118f33c658" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m118f33c658" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m118f33c658" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m118f33c658" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m118f33c658" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m118f33c658" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m118f33c658" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 176.312658
 L 529.583102 176.354957 
 L 528.363847 176.397222 
 L 527.144592 176.439455 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 176.439455 
@@ -4623,7 +4623,7 @@ L 461.70225 184.0537
 L 460.247976 184.211312 
 L 458.793701 184.368466 
 L 457.339427 184.525165 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 184.525165 
@@ -4675,7 +4675,7 @@ L 302.450749 179.565773
 L 299.008779 179.450234 
 L 295.566808 179.334447 
 L 292.124837 179.218412 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 179.218412 
@@ -4727,7 +4727,7 @@ L 246.191563 190.241103
 L 245.170823 190.462265 
 L 244.150084 190.682527 
 L 243.129344 190.901895 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.901895 
@@ -4779,7 +4779,7 @@ L 215.390639 204.06672
 L 214.774224 204.325785 
 L 214.157808 204.583617 
 L 213.541392 204.840226 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.840226 
@@ -4831,7 +4831,7 @@ L 205.113797 212.010949
 L 204.926517 212.159987 
 L 204.739237 212.308616 
 L 204.551957 212.456838 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.456838 
@@ -4883,7 +4883,7 @@ L 196.403329 227.996875
 L 196.222248 228.296222 
 L 196.041168 228.593923 
 L 195.860087 228.889995 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.889995 
@@ -4935,7 +4935,7 @@ L 194.134867 234.076634
 L 194.096529 234.18643 
 L 194.058191 234.296004 
 L 194.019853 234.405357 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m2b0bc7559e" d="M 0 3.5 
+      <path id="m254017619d" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m2b0bc7559e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m254017619d" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m6789f5b565" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdf1c2ee344" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#mc247189574" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb43371acf1" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m4704f05c0c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mdf613ae536" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#ma62e7a49b5" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mee0e1ae389" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#mb22cc37b00" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me1ef257283" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m23497b7c26" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m57a508c0c2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mf6a3cf47cf" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m9202605972" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m6da1a12773" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m118f33c658" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,434 +5370,434 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p0134e1669f)">
-     <use xlink:href="#m2b0bc7559e" x="319.643112" y="136.089735" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2b0bc7559e" x="269.129958" y="149.699067" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2b0bc7559e" x="247.452898" y="154.407085" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2b0bc7559e" x="199.905291" y="169.152636" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2b0bc7559e" x="190.316224" y="181.919959" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2b0bc7559e" x="165.455859" y="197.690105" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2b0bc7559e" x="159.141659" y="206.527677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2b0bc7559e" x="157.246106" y="227.246142" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2b0bc7559e" x="128.707405" y="299.848409" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m2b0bc7559e" x="99.149529" y="328.824547" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pc3458b8ffa)">
+     <use xlink:href="#m254017619d" x="319.643112" y="135.641894" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m254017619d" x="269.129958" y="149.220652" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m254017619d" x="247.452898" y="153.690388" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m254017619d" x="199.905291" y="167.902699" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m254017619d" x="190.316224" y="179.8478" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m254017619d" x="165.455859" y="196.332282" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m254017619d" x="159.141659" y="204.630041" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m254017619d" x="157.246106" y="225.25055" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m254017619d" x="128.707405" y="299.848409" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m254017619d" x="99.149529" y="328.824547" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 136.089735 
-L 318.590755 136.411142 
-L 317.538397 136.730652 
-L 316.48604 137.048286 
-L 315.433682 137.364067 
-L 314.381325 137.678016 
-L 313.328968 137.990155 
-L 312.27661 138.300503 
-L 311.224253 138.609082 
-L 310.171896 138.915911 
-L 309.119538 139.22101 
-L 308.067181 139.524399 
-L 307.014823 139.826097 
-L 305.962466 140.126122 
-L 304.910109 140.424493 
-L 303.857751 140.721228 
-L 302.805394 141.016345 
-L 301.753037 141.309862 
-L 300.700679 141.601795 
-L 299.648322 141.892161 
-L 298.595965 142.180978 
-L 297.543607 142.468262 
-L 296.49125 142.754029 
-L 295.438892 143.038295 
-L 294.386535 143.321075 
-L 293.334178 143.602386 
-L 292.28182 143.882242 
-L 291.229463 144.160658 
-L 290.177106 144.437649 
-L 289.124748 144.71323 
-L 288.072391 144.987414 
-L 287.020033 145.260216 
-L 285.967676 145.53165 
-L 284.915319 145.80173 
-L 283.862961 146.070468 
-L 282.810604 146.337879 
-L 281.758247 146.603974 
-L 280.705889 146.868768 
-L 279.653532 147.132272 
-L 278.601175 147.3945 
-L 277.548817 147.655463 
-L 276.49646 147.915174 
-L 275.444102 148.173644 
-L 274.391745 148.430886 
-L 273.339388 148.68691 
-L 272.28703 148.94173 
-L 271.234673 149.195355 
-L 270.182316 149.447797 
-L 269.129958 149.699067 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 135.641894 
+L 318.590755 135.962487 
+L 317.538397 136.281193 
+L 316.48604 136.598032 
+L 315.433682 136.913027 
+L 314.381325 137.226199 
+L 313.328968 137.53757 
+L 312.27661 137.847159 
+L 311.224253 138.154988 
+L 310.171896 138.461075 
+L 309.119538 138.765441 
+L 308.067181 139.068104 
+L 307.014823 139.369085 
+L 305.962466 139.668401 
+L 304.910109 139.96607 
+L 303.857751 140.262111 
+L 302.805394 140.556542 
+L 301.753037 140.849379 
+L 300.700679 141.14064 
+L 299.648322 141.430342 
+L 298.595965 141.718502 
+L 297.543607 142.005135 
+L 296.49125 142.290258 
+L 295.438892 142.573887 
+L 294.386535 142.856037 
+L 293.334178 143.136724 
+L 292.28182 143.415963 
+L 291.229463 143.693768 
+L 290.177106 143.970154 
+L 289.124748 144.245136 
+L 288.072391 144.518728 
+L 287.020033 144.790944 
+L 285.967676 145.061797 
+L 284.915319 145.331301 
+L 283.862961 145.59947 
+L 282.810604 145.866317 
+L 281.758247 146.131855 
+L 280.705889 146.396095 
+L 279.653532 146.659052 
+L 278.601175 146.920738 
+L 277.548817 147.181164 
+L 276.49646 147.440343 
+L 275.444102 147.698287 
+L 274.391745 147.955007 
+L 273.339388 148.210515 
+L 272.28703 148.464822 
+L 271.234673 148.71794 
+L 270.182316 148.96988 
+L 269.129958 149.220652 
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 149.699067 
-L 268.678353 149.801446 
-L 268.226747 149.903633 
-L 267.775142 150.005626 
-L 267.323537 150.107428 
-L 266.871931 150.209039 
-L 266.420326 150.310459 
-L 265.96872 150.41169 
-L 265.517115 150.512732 
-L 265.065509 150.613585 
-L 264.613904 150.714251 
-L 264.162299 150.814729 
-L 263.710693 150.915022 
-L 263.259088 151.015129 
-L 262.807482 151.115051 
-L 262.355877 151.21479 
-L 261.904271 151.314344 
-L 261.452666 151.413716 
-L 261.001061 151.512906 
-L 260.549455 151.611914 
-L 260.09785 151.710741 
-L 259.646244 151.809389 
-L 259.194639 151.907857 
-L 258.743034 152.006145 
-L 258.291428 152.104256 
-L 257.839823 152.20219 
-L 257.388217 152.299946 
-L 256.936612 152.397526 
-L 256.485006 152.49493 
-L 256.033401 152.59216 
-L 255.581796 152.689215 
-L 255.13019 152.786096 
-L 254.678585 152.882804 
-L 254.226979 152.97934 
-L 253.775374 153.075704 
-L 253.323769 153.171897 
-L 252.872163 153.267918 
-L 252.420558 153.36377 
-L 251.968952 153.459453 
-L 251.517347 153.554966 
-L 251.065741 153.650311 
-L 250.614136 153.745489 
-L 250.162531 153.840499 
-L 249.710925 153.935343 
-L 249.25932 154.030021 
-L 248.807714 154.124534 
-L 248.356109 154.218881 
-L 247.904503 154.313065 
-L 247.452898 154.407085 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 149.220652 
+L 268.678353 149.317638 
+L 268.226747 149.41445 
+L 267.775142 149.51109 
+L 267.323537 149.607557 
+L 266.871931 149.703853 
+L 266.420326 149.799978 
+L 265.96872 149.895932 
+L 265.517115 149.991717 
+L 265.065509 150.087332 
+L 264.613904 150.182779 
+L 264.162299 150.278057 
+L 263.710693 150.373168 
+L 263.259088 150.468113 
+L 262.807482 150.562891 
+L 262.355877 150.657503 
+L 261.904271 150.75195 
+L 261.452666 150.846233 
+L 261.001061 150.940352 
+L 260.549455 151.034307 
+L 260.09785 151.128099 
+L 259.646244 151.221729 
+L 259.194639 151.315198 
+L 258.743034 151.408505 
+L 258.291428 151.501652 
+L 257.839823 151.594639 
+L 257.388217 151.687466 
+L 256.936612 151.780134 
+L 256.485006 151.872644 
+L 256.033401 151.964996 
+L 255.581796 152.05719 
+L 255.13019 152.149228 
+L 254.678585 152.24111 
+L 254.226979 152.332836 
+L 253.775374 152.424406 
+L 253.323769 152.515822 
+L 252.872163 152.607084 
+L 252.420558 152.698192 
+L 251.968952 152.789147 
+L 251.517347 152.87995 
+L 251.065741 152.9706 
+L 250.614136 153.061099 
+L 250.162531 153.151446 
+L 249.710925 153.241644 
+L 249.25932 153.331691 
+L 248.807714 153.421588 
+L 248.356109 153.511336 
+L 247.904503 153.600936 
+L 247.452898 153.690388 
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 154.407085 
-L 246.462323 154.759063 
-L 245.471748 155.108766 
-L 244.481173 155.456224 
-L 243.490597 155.801465 
-L 242.500022 156.144518 
-L 241.509447 156.48541 
-L 240.518872 156.824168 
-L 239.528297 157.160818 
-L 238.537722 157.495388 
-L 237.547147 157.827902 
-L 236.556571 158.158385 
-L 235.565996 158.486863 
-L 234.575421 158.813358 
-L 233.584846 159.137896 
-L 232.594271 159.4605 
-L 231.603696 159.781191 
-L 230.613121 160.099993 
-L 229.622545 160.416929 
-L 228.63197 160.732019 
-L 227.641395 161.045285 
-L 226.65082 161.356749 
-L 225.660245 161.66643 
-L 224.66967 161.974349 
-L 223.679095 162.280525 
-L 222.688519 162.58498 
-L 221.697944 162.887731 
-L 220.707369 163.188798 
-L 219.716794 163.4882 
-L 218.726219 163.785954 
-L 217.735644 164.082079 
-L 216.745069 164.376592 
-L 215.754493 164.669512 
-L 214.763918 164.960854 
-L 213.773343 165.250636 
-L 212.782768 165.538875 
-L 211.792193 165.825587 
-L 210.801618 166.110788 
-L 209.811043 166.394494 
-L 208.820467 166.67672 
-L 207.829892 166.957483 
-L 206.839317 167.236796 
-L 205.848742 167.514675 
-L 204.858167 167.791134 
-L 203.867592 168.066188 
-L 202.877017 168.339852 
-L 201.886441 168.612139 
-L 200.895866 168.883062 
-L 199.905291 169.152636 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 153.690388 
+L 246.462323 154.027941 
+L 245.471748 154.363401 
+L 244.481173 154.696795 
+L 243.490597 155.028147 
+L 242.500022 155.357483 
+L 241.509447 155.684827 
+L 240.518872 156.010203 
+L 239.528297 156.333635 
+L 238.537722 156.655144 
+L 237.547147 156.974756 
+L 236.556571 157.29249 
+L 235.565996 157.60837 
+L 234.575421 157.922417 
+L 233.584846 158.234652 
+L 232.594271 158.545097 
+L 231.603696 158.85377 
+L 230.613121 159.160693 
+L 229.622545 159.465885 
+L 228.63197 159.769365 
+L 227.641395 160.071153 
+L 226.65082 160.371268 
+L 225.660245 160.669728 
+L 224.66967 160.96655 
+L 223.679095 161.261754 
+L 222.688519 161.555355 
+L 221.697944 161.847373 
+L 220.707369 162.137824 
+L 219.716794 162.426723 
+L 218.726219 162.714089 
+L 217.735644 162.999937 
+L 216.745069 163.284283 
+L 215.754493 163.567143 
+L 214.763918 163.848533 
+L 213.773343 164.128466 
+L 212.782768 164.40696 
+L 211.792193 164.684027 
+L 210.801618 164.959683 
+L 209.811043 165.233942 
+L 208.820467 165.506818 
+L 207.829892 165.778326 
+L 206.839317 166.048478 
+L 205.848742 166.317288 
+L 204.858167 166.584769 
+L 203.867592 166.850935 
+L 202.877017 167.115799 
+L 201.886441 167.379372 
+L 200.895866 167.641668 
+L 199.905291 167.902699 
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 199.905291 169.152636 
-L 199.705519 169.451788 
-L 199.505747 169.749296 
-L 199.305974 170.045177 
-L 199.106202 170.33945 
-L 198.90643 170.632131 
-L 198.706658 170.923237 
-L 198.506885 171.212786 
-L 198.307113 171.500795 
-L 198.107341 171.787278 
-L 197.907569 172.072253 
-L 197.707797 172.355735 
-L 197.508024 172.63774 
-L 197.308252 172.918283 
-L 197.10848 173.19738 
-L 196.908708 173.475044 
-L 196.708935 173.751291 
-L 196.509163 174.026135 
-L 196.309391 174.299591 
-L 196.109619 174.571671 
-L 195.909846 174.842391 
-L 195.710074 175.111763 
-L 195.510302 175.379801 
-L 195.31053 175.646518 
-L 195.110758 175.911926 
-L 194.910985 176.17604 
-L 194.711213 176.438871 
-L 194.511441 176.700431 
-L 194.311669 176.960734 
-L 194.111896 177.21979 
-L 193.912124 177.477613 
-L 193.712352 177.734213 
-L 193.51258 177.989602 
-L 193.312807 178.243791 
-L 193.113035 178.496792 
-L 192.913263 178.748616 
-L 192.713491 178.999273 
-L 192.513719 179.248775 
-L 192.313946 179.497132 
-L 192.114174 179.744354 
-L 191.914402 179.990453 
-L 191.71463 180.235437 
-L 191.514857 180.479317 
-L 191.315085 180.722103 
-L 191.115313 180.963804 
-L 190.915541 181.204431 
-L 190.715768 181.443993 
-L 190.515996 181.682499 
-L 190.316224 181.919959 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.905291 167.902699 
+L 199.705519 168.180442 
+L 199.505747 168.456767 
+L 199.305974 168.731689 
+L 199.106202 169.005221 
+L 198.90643 169.277378 
+L 198.706658 169.548172 
+L 198.506885 169.817619 
+L 198.307113 170.08573 
+L 198.107341 170.35252 
+L 197.907569 170.618001 
+L 197.707797 170.882186 
+L 197.508024 171.145088 
+L 197.308252 171.406719 
+L 197.10848 171.667091 
+L 196.908708 171.926216 
+L 196.708935 172.184107 
+L 196.509163 172.440774 
+L 196.309391 172.69623 
+L 196.109619 172.950486 
+L 195.909846 173.203553 
+L 195.710074 173.455441 
+L 195.510302 173.706163 
+L 195.31053 173.955729 
+L 195.110758 174.204149 
+L 194.910985 174.451434 
+L 194.711213 174.697594 
+L 194.511441 174.94264 
+L 194.311669 175.186581 
+L 194.111896 175.429428 
+L 193.912124 175.671189 
+L 193.712352 175.911876 
+L 193.51258 176.151496 
+L 193.312807 176.390061 
+L 193.113035 176.627578 
+L 192.913263 176.864058 
+L 192.713491 177.099508 
+L 192.513719 177.333939 
+L 192.313946 177.567359 
+L 192.114174 177.799776 
+L 191.914402 178.031199 
+L 191.71463 178.261637 
+L 191.514857 178.491098 
+L 191.315085 178.71959 
+L 191.115313 178.947121 
+L 190.915541 179.1737 
+L 190.715768 179.399334 
+L 190.515996 179.624031 
+L 190.316224 179.8478 
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 190.316224 181.919959 
-L 189.7983 182.300044 
-L 189.280375 182.677478 
-L 188.762451 183.052298 
-L 188.244527 183.42454 
-L 187.726603 183.794239 
-L 187.208678 184.16143 
-L 186.690754 184.526146 
-L 186.17283 184.888421 
-L 185.654906 185.248286 
-L 185.136981 185.605775 
-L 184.619057 185.960917 
-L 184.101133 186.313745 
-L 183.583208 186.664286 
-L 183.065284 187.012572 
-L 182.54736 187.358631 
-L 182.029436 187.702491 
-L 181.511511 188.04418 
-L 180.993587 188.383725 
-L 180.475663 188.721153 
-L 179.957739 189.05649 
-L 179.439814 189.389762 
-L 178.92189 189.720995 
-L 178.403966 190.050212 
-L 177.886041 190.377439 
-L 177.368117 190.702699 
-L 176.850193 191.026016 
-L 176.332269 191.347413 
-L 175.814344 191.666912 
-L 175.29642 191.984536 
-L 174.778496 192.300307 
-L 174.260572 192.614246 
-L 173.742647 192.926375 
-L 173.224723 193.236713 
-L 172.706799 193.545282 
-L 172.188874 193.852102 
-L 171.67095 194.157192 
-L 171.153026 194.460572 
-L 170.635102 194.76226 
-L 170.117177 195.062276 
-L 169.599253 195.360638 
-L 169.081329 195.657364 
-L 168.563404 195.952473 
-L 168.04548 196.24598 
-L 167.527556 196.537904 
-L 167.009632 196.828263 
-L 166.491707 197.117071 
-L 165.973783 197.404347 
-L 165.455859 197.690105 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 190.316224 179.8478 
+L 189.7983 180.247789 
+L 189.280375 180.644844 
+L 188.762451 181.039007 
+L 188.244527 181.43032 
+L 187.726603 181.818824 
+L 187.208678 182.204559 
+L 186.690754 182.587564 
+L 186.17283 182.967877 
+L 185.654906 183.345536 
+L 185.136981 183.720579 
+L 184.619057 184.09304 
+L 184.101133 184.462955 
+L 183.583208 184.830358 
+L 183.065284 185.195285 
+L 182.54736 185.557767 
+L 182.029436 185.917837 
+L 181.511511 186.275528 
+L 180.993587 186.630869 
+L 180.475663 186.983893 
+L 179.957739 187.334629 
+L 179.439814 187.683107 
+L 178.92189 188.029355 
+L 178.403966 188.373402 
+L 177.886041 188.715275 
+L 177.368117 189.055002 
+L 176.850193 189.39261 
+L 176.332269 189.728125 
+L 175.814344 190.061573 
+L 175.29642 190.392978 
+L 174.778496 190.722367 
+L 174.260572 191.049763 
+L 173.742647 191.37519 
+L 173.224723 191.698672 
+L 172.706799 192.020232 
+L 172.188874 192.339893 
+L 171.67095 192.657677 
+L 171.153026 192.973605 
+L 170.635102 193.2877 
+L 170.117177 193.599982 
+L 169.599253 193.910473 
+L 169.081329 194.219193 
+L 168.563404 194.526161 
+L 168.04548 194.831398 
+L 167.527556 195.134923 
+L 167.009632 195.436756 
+L 166.491707 195.736914 
+L 165.973783 196.035417 
+L 165.455859 196.332282 
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 165.455859 197.690105 
-L 165.324313 197.889739 
-L 165.192767 198.088638 
-L 165.061221 198.28681 
-L 164.929675 198.484258 
-L 164.79813 198.680988 
-L 164.666584 198.877006 
-L 164.535038 199.072317 
-L 164.403492 199.266925 
-L 164.271946 199.460836 
-L 164.1404 199.654055 
-L 164.008855 199.846586 
-L 163.877309 200.038435 
-L 163.745763 200.229606 
-L 163.614217 200.420104 
-L 163.482671 200.609934 
-L 163.351125 200.7991 
-L 163.21958 200.987608 
-L 163.088034 201.175461 
-L 162.956488 201.362664 
-L 162.824942 201.549222 
-L 162.693396 201.735139 
-L 162.56185 201.920419 
-L 162.430305 202.105068 
-L 162.298759 202.289088 
-L 162.167213 202.472485 
-L 162.035667 202.655263 
-L 161.904121 202.837425 
-L 161.772575 203.018976 
-L 161.64103 203.199921 
-L 161.509484 203.380262 
-L 161.377938 203.560004 
-L 161.246392 203.739151 
-L 161.114846 203.917707 
-L 160.9833 204.095676 
-L 160.851754 204.273062 
-L 160.720209 204.449868 
-L 160.588663 204.626099 
-L 160.457117 204.801757 
-L 160.325571 204.976847 
-L 160.194025 205.151373 
-L 160.062479 205.325337 
-L 159.930934 205.498744 
-L 159.799388 205.671597 
-L 159.667842 205.8439 
-L 159.536296 206.015656 
-L 159.40475 206.186868 
-L 159.273204 206.357541 
-L 159.141659 206.527677 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.455859 196.332282 
+L 165.324313 196.518787 
+L 165.192767 196.704651 
+L 165.061221 196.88988 
+L 164.929675 197.074476 
+L 164.79813 197.258445 
+L 164.666584 197.441791 
+L 164.535038 197.624518 
+L 164.403492 197.80663 
+L 164.271946 197.988131 
+L 164.1404 198.169025 
+L 164.008855 198.349317 
+L 163.877309 198.52901 
+L 163.745763 198.708108 
+L 163.614217 198.886616 
+L 163.482671 199.064537 
+L 163.351125 199.241875 
+L 163.21958 199.418633 
+L 163.088034 199.594817 
+L 162.956488 199.770428 
+L 162.824942 199.945472 
+L 162.693396 200.119951 
+L 162.56185 200.293869 
+L 162.430305 200.46723 
+L 162.298759 200.640038 
+L 162.167213 200.812296 
+L 162.035667 200.984007 
+L 161.904121 201.155175 
+L 161.772575 201.325803 
+L 161.64103 201.495895 
+L 161.509484 201.665454 
+L 161.377938 201.834484 
+L 161.246392 202.002987 
+L 161.114846 202.170968 
+L 160.9833 202.338428 
+L 160.851754 202.505372 
+L 160.720209 202.671802 
+L 160.588663 202.837723 
+L 160.457117 203.003136 
+L 160.325571 203.168045 
+L 160.194025 203.332453 
+L 160.062479 203.496363 
+L 159.930934 203.659778 
+L 159.799388 203.822701 
+L 159.667842 203.985136 
+L 159.536296 204.147084 
+L 159.40475 204.308549 
+L 159.273204 204.469533 
+L 159.141659 204.630041 
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 159.141659 206.527677 
-L 159.102168 207.051031 
-L 159.062677 207.569372 
-L 159.023187 208.082795 
-L 158.983696 208.591393 
-L 158.944205 209.095256 
-L 158.904715 209.594471 
-L 158.865224 210.089123 
-L 158.825733 210.579295 
-L 158.786243 211.065067 
-L 158.746752 211.546518 
-L 158.707261 212.023723 
-L 158.667771 212.496757 
-L 158.62828 212.965692 
-L 158.588789 213.430598 
-L 158.549299 213.891545 
-L 158.509808 214.348599 
-L 158.470317 214.801825 
-L 158.430827 215.251287 
-L 158.391336 215.697047 
-L 158.351845 216.139166 
-L 158.312355 216.577702 
-L 158.272864 217.012712 
-L 158.233373 217.444254 
-L 158.193882 217.872382 
-L 158.154392 218.29715 
-L 158.114901 218.71861 
-L 158.07541 219.136812 
-L 158.03592 219.551808 
-L 157.996429 219.963646 
-L 157.956938 220.372374 
-L 157.917448 220.778037 
-L 157.877957 221.180683 
-L 157.838466 221.580355 
-L 157.798976 221.977096 
-L 157.759485 222.370951 
-L 157.719994 222.76196 
-L 157.680504 223.150164 
-L 157.641013 223.535603 
-L 157.601522 223.918317 
-L 157.562032 224.298343 
-L 157.522541 224.675719 
-L 157.48305 225.050481 
-L 157.44356 225.422667 
-L 157.404069 225.79231 
-L 157.364578 226.159446 
-L 157.325088 226.524108 
-L 157.285597 226.886329 
-L 157.246106 227.246142 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.141659 204.630041 
+L 159.102168 205.150433 
+L 159.062677 205.665869 
+L 159.023187 206.176442 
+L 158.983696 206.682243 
+L 158.944205 207.183361 
+L 158.904715 207.679881 
+L 158.865224 208.171887 
+L 158.825733 208.65946 
+L 158.786243 209.14268 
+L 158.746752 209.621623 
+L 158.707261 210.096365 
+L 158.667771 210.566978 
+L 158.62828 211.033535 
+L 158.588789 211.496103 
+L 158.549299 211.954751 
+L 158.509808 212.409545 
+L 158.470317 212.860549 
+L 158.430827 213.307825 
+L 158.391336 213.751435 
+L 158.351845 214.191439 
+L 158.312355 214.627893 
+L 158.272864 215.060856 
+L 158.233373 215.490383 
+L 158.193882 215.916527 
+L 158.154392 216.339342 
+L 158.114901 216.758879 
+L 158.07541 217.175189 
+L 158.03592 217.588321 
+L 157.996429 217.998323 
+L 157.956938 218.405242 
+L 157.917448 218.809124 
+L 157.877957 219.210014 
+L 157.838466 219.607957 
+L 157.798976 220.002995 
+L 157.759485 220.39517 
+L 157.719994 220.784524 
+L 157.680504 221.171096 
+L 157.641013 221.554927 
+L 157.601522 221.936054 
+L 157.562032 222.314516 
+L 157.522541 222.69035 
+L 157.48305 223.063592 
+L 157.44356 223.434278 
+L 157.404069 223.802441 
+L 157.364578 224.168117 
+L 157.325088 224.531339 
+L 157.285597 224.892139 
+L 157.246106 225.25055 
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 157.246106 227.246142 
-L 156.65155 230.340969 
-L 156.056994 233.268347 
-L 155.462438 236.045471 
-L 154.867881 238.687015 
-L 154.273325 241.205601 
-L 153.678769 243.612171 
-L 153.084212 245.916265 
-L 152.489656 248.126255 
-L 151.8951 250.249528 
-L 151.300544 252.292632 
-L 150.705987 254.261401 
-L 150.111431 256.161056 
-L 149.516875 257.996285 
-L 148.922318 259.771315 
-L 148.327762 261.48997 
-L 147.733206 263.155721 
-L 147.13865 264.771727 
-L 146.544093 266.340875 
-L 145.949537 267.865806 
-L 145.354981 269.348942 
-L 144.760424 270.792514 
-L 144.165868 272.198578 
-L 143.571312 273.569035 
-L 142.976756 274.905642 
-L 142.382199 276.210032 
-L 141.787643 277.483722 
-L 141.193087 278.728123 
-L 140.598531 279.944552 
-L 140.003974 281.13424 
-L 139.409418 282.298336 
-L 138.814862 283.437918 
-L 138.220305 284.553999 
-L 137.625749 285.647527 
-L 137.031193 286.719395 
-L 136.436637 287.770446 
-L 135.84208 288.801473 
-L 135.247524 289.813224 
-L 134.652968 290.806406 
-L 134.058411 291.78169 
-L 133.463855 292.739709 
-L 132.869299 293.681063 
-L 132.274743 294.606322 
-L 131.680186 295.516028 
-L 131.08563 296.410695 
-L 130.491074 297.290812 
-L 129.896517 298.156844 
-L 129.301961 299.009236 
+    <path d="M 157.246106 225.25055 
+L 156.65155 228.498147 
+L 156.056994 231.561843 
+L 155.462438 234.461353 
+L 154.867881 237.213385 
+L 154.273325 239.832216 
+L 153.678769 242.330148 
+L 153.084212 244.717854 
+L 152.489656 247.00465 
+L 151.8951 249.198721 
+L 151.300544 251.307296 
+L 150.705987 253.336788 
+L 150.111431 255.292915 
+L 149.516875 257.180797 
+L 148.922318 259.005035 
+L 148.327762 260.769782 
+L 147.733206 262.478794 
+L 147.13865 264.135486 
+L 146.544093 265.742966 
+L 145.949537 267.304072 
+L 145.354981 268.821407 
+L 144.760424 270.297357 
+L 144.165868 271.734121 
+L 143.571312 273.133725 
+L 142.976756 274.498044 
+L 142.382199 275.828812 
+L 141.787643 277.127641 
+L 141.193087 278.396028 
+L 140.598531 279.635366 
+L 140.003974 280.846958 
+L 139.409418 282.032017 
+L 138.814862 283.191682 
+L 138.220305 284.327018 
+L 137.625749 285.439024 
+L 137.031193 286.52864 
+L 136.436637 287.596751 
+L 135.84208 288.644188 
+L 135.247524 289.671737 
+L 134.652968 290.680139 
+L 134.058411 291.670094 
+L 133.463855 292.642266 
+L 132.869299 293.597281 
+L 132.274743 294.535735 
+L 131.680186 295.458193 
+L 131.08563 296.365191 
+L 130.491074 297.257238 
+L 129.896517 298.134819 
+L 129.301961 298.998396 
 L 128.707405 299.848409 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
     <path d="M 128.707405 299.848409 
@@ -5849,7 +5849,7 @@ L 100.996896 327.403792
 L 100.381107 327.881534 
 L 99.765318 328.355094 
 L 99.149529 328.824547 
-" clip-path="url(#p0134e1669f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#pc3458b8ffa)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.904453 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.929375 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6260,61 +6260,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6401,109 +6346,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.794922 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3571.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.15625 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3666.943359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3694.726562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.25 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.529297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3880.908203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.384766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.248047 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.429688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4103.609375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4239.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4267.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.523438 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4453.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.525391 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.216797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.396484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.019531 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4705.806641 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.429688 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4864.839844 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.462891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.546875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.410156 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.800781 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5185.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.162109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5280.949219 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.158203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.400391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5483.582031 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5546.960938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.4375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5673.816406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.292969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5800.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5839.880859 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5871.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.457031 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.244141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6084.65625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6209.65625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6298.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.097656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6393.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6445.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.363281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.119141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6749.597656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6810.779297 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6883.679688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.466797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6956.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7017.859375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7084.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.033203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7177.820312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7205.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7257.703125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7352.966797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7453.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.222656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7554.585938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7651.998047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7679.78125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7770.943359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.035156 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0134e1669f">
+  <clipPath id="pc3458b8ffa">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mee70dc716c" d="M 0 0 
+       <path id="m7867f6eb99" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mee70dc716c" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7867f6eb99" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mee70dc716c" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7867f6eb99" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mee70dc716c" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7867f6eb99" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mee70dc716c" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7867f6eb99" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mee70dc716c" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7867f6eb99" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mee70dc716c" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7867f6eb99" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mee70dc716c" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7867f6eb99" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 388.333941 
 L 637.2 388.333941 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mc34e0aa2c5" d="M 0 0 
+       <path id="m8b6c5298dd" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc34e0aa2c5" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b6c5298dd" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 264.064771 
 L 637.2 264.064771 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc34e0aa2c5" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b6c5298dd" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 264.064771
      <g id="line2d_19">
       <path d="M 49.078125 139.7956 
 L 637.2 139.7956 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc34e0aa2c5" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8b6c5298dd" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.7956
      <g id="line2d_21">
       <path d="M 49.078125 407.583479 
 L 637.2 407.583479 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mc4a980db70" d="M 0 0 
+       <path id="m7b4cd574c1" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 400.376868 
 L 637.2 400.376868 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 400.376868
      <g id="line2d_25">
       <path d="M 49.078125 394.020186 
 L 637.2 394.020186 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 394.020186
      <g id="line2d_27">
       <path d="M 49.078125 350.925193 
 L 637.2 350.925193 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 350.925193
      <g id="line2d_29">
       <path d="M 49.078125 329.042478 
 L 637.2 329.042478 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 329.042478
      <g id="line2d_31">
       <path d="M 49.078125 313.516445 
 L 637.2 313.516445 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 313.516445
      <g id="line2d_33">
       <path d="M 49.078125 301.473518 
 L 637.2 301.473518 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 301.473518
      <g id="line2d_35">
       <path d="M 49.078125 291.633731 
 L 637.2 291.633731 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.633731
      <g id="line2d_37">
       <path d="M 49.078125 283.314309 
 L 637.2 283.314309 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.314309
      <g id="line2d_39">
       <path d="M 49.078125 276.107697 
 L 637.2 276.107697 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.107697
      <g id="line2d_41">
       <path d="M 49.078125 269.751016 
 L 637.2 269.751016 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.751016
      <g id="line2d_43">
       <path d="M 49.078125 226.656023 
 L 637.2 226.656023 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 226.656023
      <g id="line2d_45">
       <path d="M 49.078125 204.773308 
 L 637.2 204.773308 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 204.773308
      <g id="line2d_47">
       <path d="M 49.078125 189.247275 
 L 637.2 189.247275 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 189.247275
      <g id="line2d_49">
       <path d="M 49.078125 177.204348 
 L 637.2 177.204348 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.204348
      <g id="line2d_51">
       <path d="M 49.078125 167.36456 
 L 637.2 167.36456 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.36456
      <g id="line2d_53">
       <path d="M 49.078125 159.045138 
 L 637.2 159.045138 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.045138
      <g id="line2d_55">
       <path d="M 49.078125 151.838527 
 L 637.2 151.838527 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 151.838527
      <g id="line2d_57">
       <path d="M 49.078125 145.481845 
 L 637.2 145.481845 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.481845
      <g id="line2d_59">
       <path d="M 49.078125 102.386852 
 L 637.2 102.386852 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.386852
      <g id="line2d_61">
       <path d="M 49.078125 80.504138 
 L 637.2 80.504138 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 80.504138
      <g id="line2d_63">
       <path d="M 49.078125 64.978104 
 L 637.2 64.978104 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.978104
      <g id="line2d_65">
       <path d="M 49.078125 52.935177 
 L 637.2 52.935177 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mc4a980db70" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m7b4cd574c1" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p3bba1e6869)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p2c1ca258f9)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="mbe8d11b38a" d="M -2.5 2.5 
+     <path id="me3804118cc" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bba1e6869)">
-     <use xlink:href="#mbe8d11b38a" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbe8d11b38a" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2c1ca258f9)">
+     <use xlink:href="#me3804118cc" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3804118cc" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m2d004b8ac0" d="M 0 -2.5 
+     <path id="mc76a808a40" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bba1e6869)">
-     <use xlink:href="#m2d004b8ac0" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2d004b8ac0" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2c1ca258f9)">
+     <use xlink:href="#mc76a808a40" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc76a808a40" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="mbc94892416" d="M -0 3.535534 
+     <path id="m6a7b770cb8" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bba1e6869)">
-     <use xlink:href="#mbc94892416" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbc94892416" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2c1ca258f9)">
+     <use xlink:href="#m6a7b770cb8" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a7b770cb8" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="mb3b8af1d88" d="M -0.833333 2.5 
+     <path id="m58d9a1389a" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bba1e6869)">
-     <use xlink:href="#mb3b8af1d88" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb3b8af1d88" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2c1ca258f9)">
+     <use xlink:href="#m58d9a1389a" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m58d9a1389a" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m0fefece0e8" d="M -1.25 2.5 
+     <path id="md78d927176" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bba1e6869)">
-     <use xlink:href="#m0fefece0e8" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fefece0e8" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2c1ca258f9)">
+     <use xlink:href="#md78d927176" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md78d927176" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="mf3d55a56cc" d="M 0 -2.5 
+     <path id="m88899bcc5c" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p3bba1e6869)">
-     <use xlink:href="#mf3d55a56cc" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mf3d55a56cc" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p2c1ca258f9)">
+     <use xlink:href="#m88899bcc5c" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m88899bcc5c" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m88c3ebe006" d="M 0 -2.5 
+     <path id="md89f9442fc" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3bba1e6869)">
-     <use xlink:href="#m88c3ebe006" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m88c3ebe006" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p2c1ca258f9)">
+     <use xlink:href="#md89f9442fc" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md89f9442fc" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m780377906b" d="M 0 3.5 
+      <path id="ma1a0905f08" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m780377906b" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma1a0905f08" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#mbe8d11b38a" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me3804118cc" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m2d004b8ac0" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc76a808a40" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#mbc94892416" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6a7b770cb8" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#mb3b8af1d88" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m58d9a1389a" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m0fefece0e8" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md78d927176" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#mf3d55a56cc" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m88899bcc5c" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m88c3ebe006" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md89f9442fc" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p3bba1e6869)">
-     <use xlink:href="#m780377906b" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m780377906b" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p2c1ca258f9)">
+     <use xlink:href="#ma1a0905f08" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma1a0905f08" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3153,7 +3153,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p3bba1e6869">
+  <clipPath id="p2c1ca258f9">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.571865 308.04375 
 L 290.571865 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m4cc47e3ffb" d="M 0 0 
+       <path id="m06992f81fb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4cc47e3ffb" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06992f81fb" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 446.931505 308.04375 
 L 446.931505 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4cc47e3ffb" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06992f81fb" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.281168 308.04375 
 L 181.281168 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m2e33ed48b0" d="M 0 0 
+       <path id="m704f2d85c9" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m2e33ed48b0" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.814733 308.04375 
 L 208.814733 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.814733 56.7075
      <g id="line2d_9">
       <path d="M 228.350109 308.04375 
 L 228.350109 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.350109 56.7075
      <g id="line2d_11">
       <path d="M 243.502924 308.04375 
 L 243.502924 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.502924 56.7075
      <g id="line2d_13">
       <path d="M 255.883675 308.04375 
 L 255.883675 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 255.883675 56.7075
      <g id="line2d_15">
       <path d="M 266.351451 308.04375 
 L 266.351451 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.351451 56.7075
      <g id="line2d_17">
       <path d="M 275.419051 308.04375 
 L 275.419051 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.419051 56.7075
      <g id="line2d_19">
       <path d="M 283.417241 308.04375 
 L 283.417241 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.417241 56.7075
      <g id="line2d_21">
       <path d="M 337.640807 308.04375 
 L 337.640807 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.640807 56.7075
      <g id="line2d_23">
       <path d="M 365.174373 308.04375 
 L 365.174373 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.174373 56.7075
      <g id="line2d_25">
       <path d="M 384.709748 308.04375 
 L 384.709748 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 384.709748 56.7075
      <g id="line2d_27">
       <path d="M 399.862563 308.04375 
 L 399.862563 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 399.862563 56.7075
      <g id="line2d_29">
       <path d="M 412.243314 308.04375 
 L 412.243314 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.243314 56.7075
      <g id="line2d_31">
       <path d="M 422.71109 308.04375 
 L 422.71109 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 422.71109 56.7075
      <g id="line2d_33">
       <path d="M 431.77869 308.04375 
 L 431.77869 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 431.77869 56.7075
      <g id="line2d_35">
       <path d="M 439.77688 308.04375 
 L 439.77688 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 439.77688 56.7075
      <g id="line2d_37">
       <path d="M 494.000446 308.04375 
 L 494.000446 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.000446 56.7075
      <g id="line2d_39">
       <path d="M 521.534012 308.04375 
 L 521.534012 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 521.534012 56.7075
      <g id="line2d_41">
       <path d="M 541.069388 308.04375 
 L 541.069388 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.069388 56.7075
      <g id="line2d_43">
       <path d="M 556.222202 308.04375 
 L 556.222202 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m2e33ed48b0" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m704f2d85c9" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="me807060126" d="M 0 0 
+       <path id="m418a790134" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me807060126" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m418a790134" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#me807060126" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m418a790134" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1118,7 +1118,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#me807060126" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m418a790134" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1185,7 +1185,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#me807060126" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m418a790134" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#me807060126" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m418a790134" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#me807060126" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m418a790134" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#me807060126" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m418a790134" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#me807060126" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m418a790134" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.513283 296.619375 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 167.187538 263.978304 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 190.461899 231.337232 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.409213 198.696161 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.370107 166.055089 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 238.951072 133.414018 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 246.772854 100.772946 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.62053 68.131875 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.351473 308.04375 
 L 542.351473 56.7075 
-" clip-path="url(#pfc348b4c56)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p04249f2ad0)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1890,7 +1890,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m9cc4472b6c" d="M 0 3 
+     <path id="m9a6deed654" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1902,13 +1902,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pfc348b4c56)">
-     <use xlink:href="#m9cc4472b6c" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p04249f2ad0)">
+     <use xlink:href="#m9a6deed654" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m0ee5c74d9d" d="M 0 3 
+     <path id="mc99ba40fc8" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1920,13 +1920,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pfc348b4c56)">
-     <use xlink:href="#m0ee5c74d9d" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p04249f2ad0)">
+     <use xlink:href="#mc99ba40fc8" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m3f078d146a" d="M 0 3 
+     <path id="m763624ba90" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1938,13 +1938,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pfc348b4c56)">
-     <use xlink:href="#m3f078d146a" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p04249f2ad0)">
+     <use xlink:href="#m763624ba90" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="mb8f570a8ad" d="M 0 5 
+     <path id="m6ab0b13031" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1956,13 +1956,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pfc348b4c56)">
-     <use xlink:href="#mb8f570a8ad" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p04249f2ad0)">
+     <use xlink:href="#m6ab0b13031" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="mf4d2bd27d8" d="M 0 3 
+     <path id="meeca285115" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1974,13 +1974,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pfc348b4c56)">
-     <use xlink:href="#mf4d2bd27d8" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p04249f2ad0)">
+     <use xlink:href="#meeca285115" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m8f6f0807e0" d="M 0 3 
+     <path id="m45f7582e2e" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1992,13 +1992,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pfc348b4c56)">
-     <use xlink:href="#m8f6f0807e0" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p04249f2ad0)">
+     <use xlink:href="#m45f7582e2e" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m48aa16f746" d="M 0 3 
+     <path id="mee3b159bf7" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2010,13 +2010,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pfc348b4c56)">
-     <use xlink:href="#m48aa16f746" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p04249f2ad0)">
+     <use xlink:href="#mee3b159bf7" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m2c60072d5a" d="M 0 3 
+     <path id="m97725f6627" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2028,8 +2028,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pfc348b4c56)">
-     <use xlink:href="#m2c60072d5a" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p04249f2ad0)">
+     <use xlink:href="#m97725f6627" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2883,7 +2883,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pfc348b4c56">
+  <clipPath id="p04249f2ad0">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p7d072673eb)">
+   <g clip-path="url(#pc80f8d27e8)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image6e071d0153" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image8231deffed" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m788cfe65c8" d="M 0 0 
+       <path id="ma556a8f9f5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m788cfe65c8" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m788cfe65c8" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m788cfe65c8" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m788cfe65c8" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m788cfe65c8" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m788cfe65c8" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m788cfe65c8" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m788cfe65c8" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m788cfe65c8" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m788cfe65c8" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m788cfe65c8" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m788cfe65c8" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma556a8f9f5" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mc3b7041bf3" d="M 0 0 
+       <path id="m186e908aeb" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc3b7041bf3" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m186e908aeb" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc3b7041bf3" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m186e908aeb" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc3b7041bf3" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m186e908aeb" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc3b7041bf3" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m186e908aeb" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc3b7041bf3" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m186e908aeb" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc3b7041bf3" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m186e908aeb" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc3b7041bf3" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m186e908aeb" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc3b7041bf3" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m186e908aeb" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image708b568888" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagef1281fbc0e" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m74d4724ea1" d="M 0 0 
+       <path id="m4c6c21bd2d" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m74d4724ea1" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c6c21bd2d" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m74d4724ea1" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c6c21bd2d" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m74d4724ea1" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c6c21bd2d" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m74d4724ea1" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c6c21bd2d" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m74d4724ea1" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4c6c21bd2d" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.904453 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.929375 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2916,109 +2916,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.794922 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3571.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.15625 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3666.943359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3694.726562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.25 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.529297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3880.908203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.384766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.248047 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.429688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4103.609375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4239.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4267.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.523438 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4453.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.525391 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.216797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.396484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.019531 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4705.806641 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.429688 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4864.839844 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.462891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.546875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.410156 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.800781 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5185.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.162109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5280.949219 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.158203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.400391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5483.582031 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5546.960938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.4375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5673.816406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.292969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5800.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5839.880859 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5871.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.457031 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.244141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6084.65625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6209.65625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6298.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.097656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6393.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6445.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.363281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.119141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6749.597656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6810.779297 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6883.679688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.466797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6956.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7017.859375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7084.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.033203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7177.820312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7205.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7257.703125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7352.966797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7453.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.222656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7554.585938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7651.998047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7679.78125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7770.943359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.035156 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7d072673eb">
+  <clipPath id="pc80f8d27e8">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="568.591094pt" height="386.202469pt" viewBox="0 0 568.591094 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.54125pt" height="386.202469pt" viewBox="0 0 570.54125 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 568.591094 386.202469 
-L 568.591094 0 
+L 570.54125 386.202469 
+L 570.54125 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.420547 104.1264 
-L 291.045547 104.1264 
-L 291.045547 74.7432 
-L 186.420547 74.7432 
+    <path d="M 187.395625 104.1264 
+L 292.020625 104.1264 
+L 292.020625 74.7432 
+L 187.395625 74.7432 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.045547 104.1264 
-L 395.670547 104.1264 
-L 395.670547 74.7432 
-L 291.045547 74.7432 
+    <path d="M 292.020625 104.1264 
+L 396.645625 104.1264 
+L 396.645625 74.7432 
+L 292.020625 74.7432 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.670547 104.1264 
-L 500.295547 104.1264 
-L 500.295547 74.7432 
-L 395.670547 74.7432 
+    <path d="M 396.645625 104.1264 
+L 501.270625 104.1264 
+L 501.270625 74.7432 
+L 396.645625 74.7432 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.420547 133.5096 
-L 291.045547 133.5096 
-L 291.045547 104.1264 
-L 186.420547 104.1264 
+    <path d="M 187.395625 133.5096 
+L 292.020625 133.5096 
+L 292.020625 104.1264 
+L 187.395625 104.1264 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.045547 133.5096 
-L 395.670547 133.5096 
-L 395.670547 104.1264 
-L 291.045547 104.1264 
+    <path d="M 292.020625 133.5096 
+L 396.645625 133.5096 
+L 396.645625 104.1264 
+L 292.020625 104.1264 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.670547 133.5096 
-L 500.295547 133.5096 
-L 500.295547 104.1264 
-L 395.670547 104.1264 
+    <path d="M 396.645625 133.5096 
+L 501.270625 133.5096 
+L 501.270625 104.1264 
+L 396.645625 104.1264 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.420547 162.8928 
-L 291.045547 162.8928 
-L 291.045547 133.5096 
-L 186.420547 133.5096 
+    <path d="M 187.395625 162.8928 
+L 292.020625 162.8928 
+L 292.020625 133.5096 
+L 187.395625 133.5096 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.045547 162.8928 
-L 395.670547 162.8928 
-L 395.670547 133.5096 
-L 291.045547 133.5096 
+    <path d="M 292.020625 162.8928 
+L 396.645625 162.8928 
+L 396.645625 133.5096 
+L 292.020625 133.5096 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.670547 162.8928 
-L 500.295547 162.8928 
-L 500.295547 133.5096 
-L 395.670547 133.5096 
+    <path d="M 396.645625 162.8928 
+L 501.270625 162.8928 
+L 501.270625 133.5096 
+L 396.645625 133.5096 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.420547 192.276 
-L 291.045547 192.276 
-L 291.045547 162.8928 
-L 186.420547 162.8928 
+    <path d="M 187.395625 192.276 
+L 292.020625 192.276 
+L 292.020625 162.8928 
+L 187.395625 162.8928 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.045547 192.276 
-L 395.670547 192.276 
-L 395.670547 162.8928 
-L 291.045547 162.8928 
+    <path d="M 292.020625 192.276 
+L 396.645625 192.276 
+L 396.645625 162.8928 
+L 292.020625 162.8928 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.670547 192.276 
-L 500.295547 192.276 
-L 500.295547 162.8928 
-L 395.670547 162.8928 
+    <path d="M 396.645625 192.276 
+L 501.270625 192.276 
+L 501.270625 162.8928 
+L 396.645625 162.8928 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.420547 221.6592 
-L 291.045547 221.6592 
-L 291.045547 192.276 
-L 186.420547 192.276 
+    <path d="M 187.395625 221.6592 
+L 292.020625 221.6592 
+L 292.020625 192.276 
+L 187.395625 192.276 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.045547 221.6592 
-L 395.670547 221.6592 
-L 395.670547 192.276 
-L 291.045547 192.276 
+    <path d="M 292.020625 221.6592 
+L 396.645625 221.6592 
+L 396.645625 192.276 
+L 292.020625 192.276 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.670547 221.6592 
-L 500.295547 221.6592 
-L 500.295547 192.276 
-L 395.670547 192.276 
+    <path d="M 396.645625 221.6592 
+L 501.270625 221.6592 
+L 501.270625 192.276 
+L 396.645625 192.276 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.420547 251.0424 
-L 291.045547 251.0424 
-L 291.045547 221.6592 
-L 186.420547 221.6592 
+    <path d="M 187.395625 251.0424 
+L 292.020625 251.0424 
+L 292.020625 221.6592 
+L 187.395625 221.6592 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.045547 251.0424 
-L 395.670547 251.0424 
-L 395.670547 221.6592 
-L 291.045547 221.6592 
+    <path d="M 292.020625 251.0424 
+L 396.645625 251.0424 
+L 396.645625 221.6592 
+L 292.020625 221.6592 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.670547 251.0424 
-L 500.295547 251.0424 
-L 500.295547 221.6592 
-L 395.670547 221.6592 
+    <path d="M 396.645625 251.0424 
+L 501.270625 251.0424 
+L 501.270625 221.6592 
+L 396.645625 221.6592 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.420547 280.4256 
-L 291.045547 280.4256 
-L 291.045547 251.0424 
-L 186.420547 251.0424 
+    <path d="M 187.395625 280.4256 
+L 292.020625 280.4256 
+L 292.020625 251.0424 
+L 187.395625 251.0424 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.045547 280.4256 
-L 395.670547 280.4256 
-L 395.670547 251.0424 
-L 291.045547 251.0424 
+    <path d="M 292.020625 280.4256 
+L 396.645625 280.4256 
+L 396.645625 251.0424 
+L 292.020625 251.0424 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fca55d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.670547 280.4256 
-L 500.295547 280.4256 
-L 500.295547 251.0424 
-L 395.670547 251.0424 
+    <path d="M 396.645625 280.4256 
+L 501.270625 280.4256 
+L 501.270625 251.0424 
+L 396.645625 251.0424 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.420547 309.8088 
-L 291.045547 309.8088 
-L 291.045547 280.4256 
-L 186.420547 280.4256 
+    <path d="M 187.395625 309.8088 
+L 292.020625 309.8088 
+L 292.020625 280.4256 
+L 187.395625 280.4256 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.045547 309.8088 
-L 395.670547 309.8088 
-L 395.670547 280.4256 
-L 291.045547 280.4256 
+    <path d="M 292.020625 309.8088 
+L 396.645625 309.8088 
+L 396.645625 280.4256 
+L 292.020625 280.4256 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.670547 309.8088 
-L 500.295547 309.8088 
-L 500.295547 280.4256 
-L 395.670547 280.4256 
+    <path d="M 396.645625 309.8088 
+L 501.270625 309.8088 
+L 501.270625 280.4256 
+L 396.645625 280.4256 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.420547 339.192 
-L 291.045547 339.192 
-L 291.045547 309.8088 
-L 186.420547 309.8088 
+    <path d="M 187.395625 339.192 
+L 292.020625 339.192 
+L 292.020625 309.8088 
+L 187.395625 309.8088 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.045547 339.192 
-L 395.670547 339.192 
-L 395.670547 309.8088 
-L 291.045547 309.8088 
+    <path d="M 292.020625 339.192 
+L 396.645625 339.192 
+L 396.645625 309.8088 
+L 292.020625 309.8088 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.670547 339.192 
-L 500.295547 339.192 
-L 500.295547 309.8088 
-L 395.670547 309.8088 
+    <path d="M 396.645625 339.192 
+L 501.270625 339.192 
+L 501.270625 309.8088 
+L 396.645625 309.8088 
 z
-" clip-path="url(#p2c645dc69c)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p387976e8a2)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.407813 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.382891 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.692031 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.667109 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.264141 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.239219 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.615859 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.590937 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.345547 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.320625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.281797 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(335.723047 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.698125 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.348047 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(109.983672 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.95875 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.281797 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.268047 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.348047 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.676797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(98.651875 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.281797 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.268047 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.348047 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(118.709297 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.684375 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.281797 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.268047 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.348047 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.246797 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(128.221875 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.281797 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.268047 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.348047 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(110.553047 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(111.528125 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(227.281797 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(338.268047 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(440.348047 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(441.323125 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.054922 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(98.03 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.325 -->
-    <g transform="translate(226.081172 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.05625 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1878,15 +1878,36 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 23 -->
-    <g transform="translate(337.791797 267.9415) scale(0.08 -0.08)">
+    <!-- 24 -->
+    <g transform="translate(338.766875 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 262 -->
-    <g transform="translate(439.633672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(440.60875 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-36" d="M 2316 2303 
 Q 2000 2303 1842 2098 
@@ -1926,7 +1947,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.169922 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(96.145 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1991,7 +2012,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.281797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2001,21 +2022,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.268047 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.243125 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(442.893047 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.868125 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.391172 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.36625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2026,7 +2047,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.281797 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.256875 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2036,13 +2057,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(340.813047 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.788125 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(443.983047 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.958125 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2058,7 +2079,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(150.897266 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.872344 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2172,7 +2193,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 3f1689c5  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-03T07:47:31Z  ·  Linux chungus x86_64  ·  commit 1c6bbdd6  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2359,110 +2380,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3107.080078 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3170.703125 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3234.326172 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3297.949219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3361.572266 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3416.552734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3480.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3511.962891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3543.75 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3575.537109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3607.324219 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3639.111328 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3666.894531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3728.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3789.697266 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3853.076172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3916.552734 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3955.416016 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4016.597656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4075.777344 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4137.300781 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4178.414062 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4212.105469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4239.888672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4301.412109 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4362.691406 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4426.070312 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4489.693359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4523.384766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4582.564453 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4646.1875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4677.974609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4741.597656 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4805.220703 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.007812 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4900.630859 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4936.714844 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4975.578125 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5030.558594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5094.181641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5125.96875 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5157.755859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5189.542969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5221.330078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5253.117188 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5292.326172 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5355.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5394.568359 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5455.75 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5519.128906 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5582.605469 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5645.984375 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5709.460938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5772.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5812.048828 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5843.835938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5927.625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5959.412109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6056.824219 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6118.347656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6181.824219 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6209.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6270.886719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6334.265625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6366.052734 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6418.152344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6481.53125 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6542.810547 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6606.287109 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6658.386719 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6721.765625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6782.947266 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6822.15625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6855.847656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6887.634766 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6928.748047 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6990.027344 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7029.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7057.019531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7118.201172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7149.988281 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7177.771484 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7229.871094 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7261.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7325.134766 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7386.658203 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.867188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7487.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7624.166016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7651.949219 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7715.328125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7743.111328 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7795.210938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7834.419922 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7862.203125 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3126.855469 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3253.955078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3317.431641 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3380.908203 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3444.384766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3508.007812 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3539.794922 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3571.582031 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3635.15625 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3666.943359 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3694.726562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3756.25 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3817.529297 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3880.908203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3944.384766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3983.248047 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4044.429688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4103.609375 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4165.132812 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4206.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4239.9375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4267.720703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4329.244141 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4390.523438 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4453.902344 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4517.525391 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4551.216797 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4610.396484 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4674.019531 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4705.806641 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4769.429688 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4833.052734 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4864.839844 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4928.462891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4964.546875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5003.410156 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5058.390625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5122.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5153.800781 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5185.587891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5249.162109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5280.949219 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5320.158203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5383.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5422.400391 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5483.582031 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5546.960938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5610.4375 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5673.816406 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5737.292969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5800.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5839.880859 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5871.667969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5955.457031 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5987.244141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6084.65625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6146.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6209.65625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6237.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6298.71875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6362.097656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6393.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6445.984375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6509.363281 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6570.642578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6634.119141 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6686.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6749.597656 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6810.779297 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6883.679688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6915.466797 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6956.580078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7017.859375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7057.068359 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7084.851562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7146.033203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7177.820312 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7205.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7257.703125 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7289.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7352.966797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7414.490234 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7453.699219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7515.222656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7554.585938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7651.998047 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7679.78125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7743.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7770.943359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7823.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7862.251953 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7890.035156 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2c645dc69c">
-   <rect x="81.795547" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p387976e8a2">
+   <rect x="82.770625" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -2,7 +2,7 @@
  "meta": {
   "date": "2026-07-03T07:47:31Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "3f1689c5",
+  "git_commit": "1c6bbdd6",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,7 +14,7 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 54.52,
+   "compress_mbps": 55.02,
    "decompress_mbps": 188.84
   },
   {
@@ -24,7 +24,7 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 42.14,
+   "compress_mbps": 42.78,
    "decompress_mbps": 214.46
   },
   {
@@ -34,7 +34,7 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 38.15,
+   "compress_mbps": 38.86,
    "decompress_mbps": 232.41
   },
   {
@@ -44,7 +44,7 @@
    "level": 4,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 28.86,
+   "compress_mbps": 29.55,
    "decompress_mbps": 234.53
   },
   {
@@ -54,7 +54,7 @@
    "level": 5,
    "out_size": 54437,
    "ratio": 0.3579,
-   "compress_mbps": 22.72,
+   "compress_mbps": 23.63,
    "decompress_mbps": 237.37
   },
   {
@@ -64,7 +64,7 @@
    "level": 6,
    "out_size": 54348,
    "ratio": 0.3573,
-   "compress_mbps": 20.37,
+   "compress_mbps": 20.95,
    "decompress_mbps": 244.44
   },
   {
@@ -74,7 +74,7 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 17.83,
+   "compress_mbps": 18.51,
    "decompress_mbps": 244.81
   },
   {
@@ -84,7 +84,7 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 15.4,
+   "compress_mbps": 16.04,
    "decompress_mbps": 246.17
   },
   {
@@ -104,7 +104,7 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 49.75,
+   "compress_mbps": 50.21,
    "decompress_mbps": 181.16
   },
   {
@@ -114,7 +114,7 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 38.76,
+   "compress_mbps": 39.35,
    "decompress_mbps": 196.7
   },
   {
@@ -124,7 +124,7 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 36.01,
+   "compress_mbps": 36.68,
    "decompress_mbps": 214.49
   },
   {
@@ -134,7 +134,7 @@
    "level": 4,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 26.99,
+   "compress_mbps": 27.63,
    "decompress_mbps": 217.91
   },
   {
@@ -144,7 +144,7 @@
    "level": 5,
    "out_size": 48891,
    "ratio": 0.3906,
-   "compress_mbps": 23.42,
+   "compress_mbps": 24.36,
    "decompress_mbps": 218.77
   },
   {
@@ -154,7 +154,7 @@
    "level": 6,
    "out_size": 48715,
    "ratio": 0.3892,
-   "compress_mbps": 19.59,
+   "compress_mbps": 20.15,
    "decompress_mbps": 222.75
   },
   {
@@ -164,7 +164,7 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 18.35,
+   "compress_mbps": 19.05,
    "decompress_mbps": 222.67
   },
   {
@@ -174,7 +174,7 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 15.84,
+   "compress_mbps": 16.49,
    "decompress_mbps": 222.66
   },
   {
@@ -194,7 +194,7 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 39.53,
+   "compress_mbps": 39.89,
    "decompress_mbps": 215.45
   },
   {
@@ -204,7 +204,7 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 34.89,
+   "compress_mbps": 35.42,
    "decompress_mbps": 221.09
   },
   {
@@ -214,7 +214,7 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 34.07,
+   "compress_mbps": 34.71,
    "decompress_mbps": 226.25
   },
   {
@@ -224,7 +224,7 @@
    "level": 4,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 30.75,
+   "compress_mbps": 31.48,
    "decompress_mbps": 233.5
   },
   {
@@ -234,7 +234,7 @@
    "level": 5,
    "out_size": 7932,
    "ratio": 0.3224,
-   "compress_mbps": 26.27,
+   "compress_mbps": 27.32,
    "decompress_mbps": 241.68
   },
   {
@@ -244,7 +244,7 @@
    "level": 6,
    "out_size": 7938,
    "ratio": 0.3226,
-   "compress_mbps": 22.84,
+   "compress_mbps": 23.5,
    "decompress_mbps": 243.0
   },
   {
@@ -254,7 +254,7 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 21.76,
+   "compress_mbps": 22.59,
    "decompress_mbps": 243.51
   },
   {
@@ -264,7 +264,7 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 16.63,
+   "compress_mbps": 17.32,
    "decompress_mbps": 243.52
   },
   {
@@ -284,7 +284,7 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 25.84,
+   "compress_mbps": 26.08,
    "decompress_mbps": 147.5
   },
   {
@@ -294,7 +294,7 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 24.1,
+   "compress_mbps": 24.47,
    "decompress_mbps": 149.97
   },
   {
@@ -304,7 +304,7 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 23.37,
+   "compress_mbps": 23.81,
    "decompress_mbps": 153.0
   },
   {
@@ -314,7 +314,7 @@
    "level": 4,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.58,
+   "compress_mbps": 22.09,
    "decompress_mbps": 155.39
   },
   {
@@ -324,7 +324,7 @@
    "level": 5,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 19.52,
+   "compress_mbps": 20.3,
    "decompress_mbps": 156.23
   },
   {
@@ -334,7 +334,7 @@
    "level": 6,
    "out_size": 3135,
    "ratio": 0.2812,
-   "compress_mbps": 17.83,
+   "compress_mbps": 18.34,
    "decompress_mbps": 157.2
   },
   {
@@ -344,7 +344,7 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 17.2,
+   "compress_mbps": 17.86,
    "decompress_mbps": 157.61
   },
   {
@@ -354,7 +354,7 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 11.62,
+   "compress_mbps": 12.1,
    "decompress_mbps": 156.67
   },
   {
@@ -374,7 +374,7 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 12.48,
+   "compress_mbps": 12.59,
    "decompress_mbps": 68.63
   },
   {
@@ -384,7 +384,7 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 11.96,
+   "compress_mbps": 12.14,
    "decompress_mbps": 69.1
   },
   {
@@ -394,7 +394,7 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 11.86,
+   "compress_mbps": 12.08,
    "decompress_mbps": 69.1
   },
   {
@@ -404,7 +404,7 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.6,
+   "compress_mbps": 11.88,
    "decompress_mbps": 69.71
   },
   {
@@ -414,7 +414,7 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.36,
+   "compress_mbps": 11.81,
    "decompress_mbps": 69.65
   },
   {
@@ -424,7 +424,7 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 10.28,
+   "compress_mbps": 10.57,
    "decompress_mbps": 70.0
   },
   {
@@ -434,7 +434,7 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 10.25,
+   "compress_mbps": 10.64,
    "decompress_mbps": 70.04
   },
   {
@@ -444,7 +444,7 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 5.99,
+   "compress_mbps": 6.24,
    "decompress_mbps": 69.78
   },
   {
@@ -464,7 +464,7 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 105.13,
+   "compress_mbps": 106.1,
    "decompress_mbps": 342.6
   },
   {
@@ -474,7 +474,7 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 78.37,
+   "compress_mbps": 79.57,
    "decompress_mbps": 370.89
   },
   {
@@ -484,7 +484,7 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 65.78,
+   "compress_mbps": 67.01,
    "decompress_mbps": 392.85
   },
   {
@@ -494,7 +494,7 @@
    "level": 4,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 60.25,
+   "compress_mbps": 61.68,
    "decompress_mbps": 412.31
   },
   {
@@ -504,7 +504,7 @@
    "level": 5,
    "out_size": 215530,
    "ratio": 0.2093,
-   "compress_mbps": 30.05,
+   "compress_mbps": 31.25,
    "decompress_mbps": 398.65
   },
   {
@@ -514,7 +514,7 @@
    "level": 6,
    "out_size": 201414,
    "ratio": 0.1956,
-   "compress_mbps": 20.12,
+   "compress_mbps": 20.7,
    "decompress_mbps": 411.72
   },
   {
@@ -524,7 +524,7 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 13.14,
+   "compress_mbps": 13.64,
    "decompress_mbps": 415.93
   },
   {
@@ -534,7 +534,7 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 8.38,
+   "compress_mbps": 8.73,
    "decompress_mbps": 422.69
   },
   {
@@ -554,7 +554,7 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 60.85,
+   "compress_mbps": 61.41,
    "decompress_mbps": 198.41
   },
   {
@@ -564,7 +564,7 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 46.09,
+   "compress_mbps": 46.79,
    "decompress_mbps": 213.77
   },
   {
@@ -574,7 +574,7 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 41.61,
+   "compress_mbps": 42.39,
    "decompress_mbps": 237.88
   },
   {
@@ -584,7 +584,7 @@
    "level": 4,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 31.04,
+   "compress_mbps": 31.78,
    "decompress_mbps": 241.32
   },
   {
@@ -594,7 +594,7 @@
    "level": 5,
    "out_size": 145321,
    "ratio": 0.3405,
-   "compress_mbps": 25.14,
+   "compress_mbps": 26.15,
    "decompress_mbps": 244.63
   },
   {
@@ -604,7 +604,7 @@
    "level": 6,
    "out_size": 145046,
    "ratio": 0.3399,
-   "compress_mbps": 22.05,
+   "compress_mbps": 22.68,
    "decompress_mbps": 249.28
   },
   {
@@ -614,7 +614,7 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 19.86,
+   "compress_mbps": 20.62,
    "decompress_mbps": 250.49
   },
   {
@@ -624,7 +624,7 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 16.98,
+   "compress_mbps": 17.68,
    "decompress_mbps": 250.9
   },
   {
@@ -644,7 +644,7 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 51.8,
+   "compress_mbps": 52.28,
    "decompress_mbps": 171.06
   },
   {
@@ -654,7 +654,7 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 39.22,
+   "compress_mbps": 39.82,
    "decompress_mbps": 190.62
   },
   {
@@ -664,7 +664,7 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 35.38,
+   "compress_mbps": 36.04,
    "decompress_mbps": 209.61
   },
   {
@@ -674,7 +674,7 @@
    "level": 4,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 24.41,
+   "compress_mbps": 24.99,
    "decompress_mbps": 212.96
   },
   {
@@ -684,7 +684,7 @@
    "level": 5,
    "out_size": 194902,
    "ratio": 0.4045,
-   "compress_mbps": 20.66,
+   "compress_mbps": 21.49,
    "decompress_mbps": 211.94
   },
   {
@@ -694,7 +694,7 @@
    "level": 6,
    "out_size": 195177,
    "ratio": 0.405,
-   "compress_mbps": 19.2,
+   "compress_mbps": 19.75,
    "decompress_mbps": 216.11
   },
   {
@@ -704,7 +704,7 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 17.05,
+   "compress_mbps": 17.7,
    "decompress_mbps": 216.16
   },
   {
@@ -714,7 +714,7 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 14.97,
+   "compress_mbps": 15.59,
    "decompress_mbps": 216.05
   },
   {
@@ -734,7 +734,7 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 160.88,
+   "compress_mbps": 162.36,
    "decompress_mbps": 470.03
   },
   {
@@ -744,7 +744,7 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 126.28,
+   "compress_mbps": 128.21,
    "decompress_mbps": 496.4
   },
   {
@@ -754,7 +754,7 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 111.56,
+   "compress_mbps": 113.65,
    "decompress_mbps": 538.29
   },
   {
@@ -764,7 +764,7 @@
    "level": 4,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 75.5,
+   "compress_mbps": 77.3,
    "decompress_mbps": 454.31
   },
   {
@@ -774,7 +774,7 @@
    "level": 5,
    "out_size": 54950,
    "ratio": 0.1071,
-   "compress_mbps": 50.59,
+   "compress_mbps": 52.61,
    "decompress_mbps": 481.02
   },
   {
@@ -784,7 +784,7 @@
    "level": 6,
    "out_size": 55259,
    "ratio": 0.1077,
-   "compress_mbps": 36.39,
+   "compress_mbps": 37.43,
    "decompress_mbps": 531.58
   },
   {
@@ -794,7 +794,7 @@
    "level": 7,
    "out_size": 53713,
    "ratio": 0.1047,
-   "compress_mbps": 26.6,
+   "compress_mbps": 27.62,
    "decompress_mbps": 567.71
   },
   {
@@ -804,7 +804,7 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 19.63,
+   "compress_mbps": 20.44,
    "decompress_mbps": 605.96
   },
   {
@@ -824,7 +824,7 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 29.38,
+   "compress_mbps": 29.65,
    "decompress_mbps": 182.6
   },
   {
@@ -834,7 +834,7 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 26.8,
+   "compress_mbps": 27.21,
    "decompress_mbps": 187.4
   },
   {
@@ -844,7 +844,7 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 26.08,
+   "compress_mbps": 26.57,
    "decompress_mbps": 191.06
   },
   {
@@ -854,7 +854,7 @@
    "level": 4,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 23.2,
+   "compress_mbps": 23.75,
    "decompress_mbps": 197.85
   },
   {
@@ -864,7 +864,7 @@
    "level": 5,
    "out_size": 13346,
    "ratio": 0.349,
-   "compress_mbps": 20.0,
+   "compress_mbps": 20.8,
    "decompress_mbps": 206.98
   },
   {
@@ -874,7 +874,7 @@
    "level": 6,
    "out_size": 13040,
    "ratio": 0.341,
-   "compress_mbps": 9.44,
+   "compress_mbps": 9.71,
    "decompress_mbps": 209.84
   },
   {
@@ -884,7 +884,7 @@
    "level": 7,
    "out_size": 13035,
    "ratio": 0.3409,
-   "compress_mbps": 8.54,
+   "compress_mbps": 8.87,
    "decompress_mbps": 211.64
   },
   {
@@ -894,7 +894,7 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 6.27,
+   "compress_mbps": 6.53,
    "decompress_mbps": 213.07
   },
   {
@@ -914,7 +914,7 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 13.95,
+   "compress_mbps": 14.08,
    "decompress_mbps": 74.76
   },
   {
@@ -924,7 +924,7 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 13.37,
+   "compress_mbps": 13.57,
    "decompress_mbps": 74.68
   },
   {
@@ -934,7 +934,7 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 13.34,
+   "compress_mbps": 13.59,
    "decompress_mbps": 74.83
   },
   {
@@ -944,7 +944,7 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 13.07,
+   "compress_mbps": 13.38,
    "decompress_mbps": 75.86
   },
   {
@@ -954,7 +954,7 @@
    "level": 5,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 12.93,
+   "compress_mbps": 13.45,
    "decompress_mbps": 75.6
   },
   {
@@ -964,7 +964,7 @@
    "level": 6,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 11.28,
+   "compress_mbps": 11.6,
    "decompress_mbps": 75.59
   },
   {
@@ -974,7 +974,7 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 11.27,
+   "compress_mbps": 11.7,
    "decompress_mbps": 75.35
   },
   {
@@ -984,7 +984,7 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 6.77,
+   "compress_mbps": 7.05,
    "decompress_mbps": 75.28
   },
   {
@@ -3974,7 +3974,7 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 55.21,
+   "compress_mbps": 55.67,
    "decompress_mbps": 174.44
   },
   {
@@ -3984,7 +3984,7 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 41.4,
+   "compress_mbps": 41.77,
    "decompress_mbps": 190.44
   },
   {
@@ -3994,7 +3994,7 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 37.08,
+   "compress_mbps": 37.57,
    "decompress_mbps": 211.4
   },
   {
@@ -4004,7 +4004,7 @@
    "level": 4,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 26.68,
+   "compress_mbps": 27.3,
    "decompress_mbps": 213.36
   },
   {
@@ -4014,7 +4014,7 @@
    "level": 5,
    "out_size": 3870984,
    "ratio": 0.3798,
-   "compress_mbps": 22.15,
+   "compress_mbps": 23.01,
    "decompress_mbps": 212.63
   },
   {
@@ -4024,7 +4024,7 @@
    "level": 6,
    "out_size": 3878499,
    "ratio": 0.3805,
-   "compress_mbps": 21.29,
+   "compress_mbps": 21.83,
    "decompress_mbps": 219.84
   },
   {
@@ -4034,7 +4034,7 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 18.43,
+   "compress_mbps": 19.09,
    "decompress_mbps": 220.24
   },
   {
@@ -4044,7 +4044,7 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 16.27,
+   "compress_mbps": 16.88,
    "decompress_mbps": 219.04
   },
   {
@@ -4064,7 +4064,7 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 69.79,
+   "compress_mbps": 70.37,
    "decompress_mbps": 190.77
   },
   {
@@ -4074,7 +4074,7 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 56.17,
+   "compress_mbps": 56.67,
    "decompress_mbps": 199.22
   },
   {
@@ -4084,7 +4084,7 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 52.12,
+   "compress_mbps": 52.81,
    "decompress_mbps": 205.46
   },
   {
@@ -4094,7 +4094,7 @@
    "level": 4,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 39.17,
+   "compress_mbps": 40.09,
    "decompress_mbps": 209.17
   },
   {
@@ -4104,7 +4104,7 @@
    "level": 5,
    "out_size": 20264932,
    "ratio": 0.3956,
-   "compress_mbps": 27.81,
+   "compress_mbps": 28.9,
    "decompress_mbps": 218.86
   },
   {
@@ -4114,7 +4114,7 @@
    "level": 6,
    "out_size": 19208910,
    "ratio": 0.375,
-   "compress_mbps": 16.18,
+   "compress_mbps": 16.59,
    "decompress_mbps": 222.71
   },
   {
@@ -4124,7 +4124,7 @@
    "level": 7,
    "out_size": 19177573,
    "ratio": 0.3744,
-   "compress_mbps": 12.92,
+   "compress_mbps": 13.38,
    "decompress_mbps": 222.09
   },
   {
@@ -4134,7 +4134,7 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 8.33,
+   "compress_mbps": 8.64,
    "decompress_mbps": 215.01
   },
   {
@@ -4154,7 +4154,7 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 67.65,
+   "compress_mbps": 68.21,
    "decompress_mbps": 206.01
   },
   {
@@ -4164,7 +4164,7 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 53.8,
+   "compress_mbps": 54.28,
    "decompress_mbps": 214.41
   },
   {
@@ -4174,7 +4174,7 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 46.83,
+   "compress_mbps": 47.45,
    "decompress_mbps": 224.61
   },
   {
@@ -4184,7 +4184,7 @@
    "level": 4,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 30.98,
+   "compress_mbps": 31.7,
    "decompress_mbps": 208.24
   },
   {
@@ -4194,7 +4194,7 @@
    "level": 5,
    "out_size": 3705174,
    "ratio": 0.3716,
-   "compress_mbps": 24.41,
+   "compress_mbps": 25.36,
    "decompress_mbps": 204.38
   },
   {
@@ -4204,7 +4204,7 @@
    "level": 6,
    "out_size": 3612809,
    "ratio": 0.3623,
-   "compress_mbps": 19.73,
+   "compress_mbps": 20.23,
    "decompress_mbps": 211.07
   },
   {
@@ -4214,7 +4214,7 @@
    "level": 7,
    "out_size": 3608980,
    "ratio": 0.362,
-   "compress_mbps": 17.02,
+   "compress_mbps": 17.63,
    "decompress_mbps": 212.35
   },
   {
@@ -4224,7 +4224,7 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 11.29,
+   "compress_mbps": 11.71,
    "decompress_mbps": 218.25
   },
   {
@@ -4244,7 +4244,7 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 200.96,
+   "compress_mbps": 202.63,
    "decompress_mbps": 601.26
   },
   {
@@ -4254,7 +4254,7 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 133.15,
+   "compress_mbps": 134.34,
    "decompress_mbps": 669.91
   },
   {
@@ -4264,7 +4264,7 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 114.56,
+   "compress_mbps": 116.09,
    "decompress_mbps": 746.36
   },
   {
@@ -4274,7 +4274,7 @@
    "level": 4,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 85.18,
+   "compress_mbps": 87.17,
    "decompress_mbps": 747.13
   },
   {
@@ -4284,7 +4284,7 @@
    "level": 5,
    "out_size": 3145121,
    "ratio": 0.0937,
-   "compress_mbps": 56.56,
+   "compress_mbps": 58.77,
    "decompress_mbps": 829.26
   },
   {
@@ -4294,7 +4294,7 @@
    "level": 6,
    "out_size": 3158854,
    "ratio": 0.0941,
-   "compress_mbps": 55.75,
+   "compress_mbps": 57.17,
    "decompress_mbps": 881.59
   },
   {
@@ -4304,7 +4304,7 @@
    "level": 7,
    "out_size": 3124878,
    "ratio": 0.0931,
-   "compress_mbps": 38.04,
+   "compress_mbps": 39.4,
    "decompress_mbps": 813.17
   },
   {
@@ -4314,7 +4314,7 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 29.37,
+   "compress_mbps": 30.47,
    "decompress_mbps": 908.42
   },
   {
@@ -4334,7 +4334,7 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 49.09,
+   "compress_mbps": 49.5,
    "decompress_mbps": 128.08
   },
   {
@@ -4344,7 +4344,7 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 40.76,
+   "compress_mbps": 41.12,
    "decompress_mbps": 132.16
   },
   {
@@ -4354,7 +4354,7 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 39.47,
+   "compress_mbps": 40.0,
    "decompress_mbps": 136.17
   },
   {
@@ -4364,7 +4364,7 @@
    "level": 4,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 31.82,
+   "compress_mbps": 32.56,
    "decompress_mbps": 144.05
   },
   {
@@ -4374,7 +4374,7 @@
    "level": 5,
    "out_size": 3233792,
    "ratio": 0.5256,
-   "compress_mbps": 28.47,
+   "compress_mbps": 29.58,
    "decompress_mbps": 149.19
   },
   {
@@ -4384,7 +4384,7 @@
    "level": 6,
    "out_size": 3168386,
    "ratio": 0.515,
-   "compress_mbps": 16.84,
+   "compress_mbps": 17.27,
    "decompress_mbps": 152.46
   },
   {
@@ -4394,7 +4394,7 @@
    "level": 7,
    "out_size": 3165783,
    "ratio": 0.5146,
-   "compress_mbps": 15.52,
+   "compress_mbps": 16.07,
    "decompress_mbps": 151.64
   },
   {
@@ -4404,7 +4404,7 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 9.34,
+   "compress_mbps": 9.69,
    "decompress_mbps": 153.45
   },
   {
@@ -4424,7 +4424,7 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 77.39,
+   "compress_mbps": 78.03,
    "decompress_mbps": 226.51
   },
   {
@@ -4434,7 +4434,7 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 59.85,
+   "compress_mbps": 60.38,
    "decompress_mbps": 235.9
   },
   {
@@ -4444,7 +4444,7 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 57.53,
+   "compress_mbps": 58.3,
    "decompress_mbps": 242.01
   },
   {
@@ -4454,7 +4454,7 @@
    "level": 4,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 51.16,
+   "compress_mbps": 52.36,
    "decompress_mbps": 255.48
   },
   {
@@ -4464,7 +4464,7 @@
    "level": 5,
    "out_size": 3707010,
    "ratio": 0.3676,
-   "compress_mbps": 47.74,
+   "compress_mbps": 49.6,
    "decompress_mbps": 257.14
   },
   {
@@ -4474,7 +4474,7 @@
    "level": 6,
    "out_size": 3707065,
    "ratio": 0.3676,
-   "compress_mbps": 35.74,
+   "compress_mbps": 36.65,
    "decompress_mbps": 266.68
   },
   {
@@ -4484,7 +4484,7 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 35.83,
+   "compress_mbps": 37.11,
    "decompress_mbps": 271.59
   },
   {
@@ -4494,7 +4494,7 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 18.33,
+   "compress_mbps": 19.02,
    "decompress_mbps": 271.7
   },
   {
@@ -4514,7 +4514,7 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 69.38,
+   "compress_mbps": 69.96,
    "decompress_mbps": 221.68
   },
   {
@@ -4524,7 +4524,7 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 49.41,
+   "compress_mbps": 49.85,
    "decompress_mbps": 236.01
   },
   {
@@ -4534,7 +4534,7 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 41.18,
+   "compress_mbps": 41.73,
    "decompress_mbps": 259.48
   },
   {
@@ -4544,7 +4544,7 @@
    "level": 4,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 25.84,
+   "compress_mbps": 26.44,
    "decompress_mbps": 263.01
   },
   {
@@ -4554,7 +4554,7 @@
    "level": 5,
    "out_size": 1874829,
    "ratio": 0.2829,
-   "compress_mbps": 15.82,
+   "compress_mbps": 16.44,
    "decompress_mbps": 262.62
   },
   {
@@ -4564,7 +4564,7 @@
    "level": 6,
    "out_size": 1867098,
    "ratio": 0.2817,
-   "compress_mbps": 18.53,
+   "compress_mbps": 19.0,
    "decompress_mbps": 278.32
   },
   {
@@ -4574,7 +4574,7 @@
    "level": 7,
    "out_size": 1843421,
    "ratio": 0.2782,
-   "compress_mbps": 12.55,
+   "compress_mbps": 13.0,
    "decompress_mbps": 282.13
   },
   {
@@ -4584,7 +4584,7 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 10.38,
+   "compress_mbps": 10.77,
    "decompress_mbps": 280.75
   },
   {
@@ -4604,7 +4604,7 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 94.48,
+   "compress_mbps": 95.26,
    "decompress_mbps": 292.53
   },
   {
@@ -4614,7 +4614,7 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 73.31,
+   "compress_mbps": 73.96,
    "decompress_mbps": 311.35
   },
   {
@@ -4624,7 +4624,7 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 66.5,
+   "compress_mbps": 67.39,
    "decompress_mbps": 322.99
   },
   {
@@ -4634,7 +4634,7 @@
    "level": 4,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 49.81,
+   "compress_mbps": 50.97,
    "decompress_mbps": 333.09
   },
   {
@@ -4644,7 +4644,7 @@
    "level": 5,
    "out_size": 5839944,
    "ratio": 0.2703,
-   "compress_mbps": 37.56,
+   "compress_mbps": 39.03,
    "decompress_mbps": 342.46
   },
   {
@@ -4654,7 +4654,7 @@
    "level": 6,
    "out_size": 5425813,
    "ratio": 0.2511,
-   "compress_mbps": 27.26,
+   "compress_mbps": 27.95,
    "decompress_mbps": 350.18
   },
   {
@@ -4664,7 +4664,7 @@
    "level": 7,
    "out_size": 5409983,
    "ratio": 0.2504,
-   "compress_mbps": 23.85,
+   "compress_mbps": 24.7,
    "decompress_mbps": 350.59
   },
   {
@@ -4674,7 +4674,7 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 17.77,
+   "compress_mbps": 18.44,
    "decompress_mbps": 353.58
   },
   {
@@ -4694,7 +4694,7 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 40.66,
+   "compress_mbps": 41.0,
    "decompress_mbps": 126.75
   },
   {
@@ -4704,7 +4704,7 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 35.09,
+   "compress_mbps": 35.4,
    "decompress_mbps": 130.84
   },
   {
@@ -4714,7 +4714,7 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 33.27,
+   "compress_mbps": 33.71,
    "decompress_mbps": 133.95
   },
   {
@@ -4724,7 +4724,7 @@
    "level": 4,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 27.21,
+   "compress_mbps": 27.85,
    "decompress_mbps": 137.63
   },
   {
@@ -4734,7 +4734,7 @@
    "level": 5,
    "out_size": 5496802,
    "ratio": 0.758,
-   "compress_mbps": 25.59,
+   "compress_mbps": 26.59,
    "decompress_mbps": 135.65
   },
   {
@@ -4744,7 +4744,7 @@
    "level": 6,
    "out_size": 5478405,
    "ratio": 0.7554,
-   "compress_mbps": 19.08,
+   "compress_mbps": 19.57,
    "decompress_mbps": 135.58
   },
   {
@@ -4754,7 +4754,7 @@
    "level": 7,
    "out_size": 5474648,
    "ratio": 0.7549,
-   "compress_mbps": 18.17,
+   "compress_mbps": 18.82,
    "decompress_mbps": 136.89
   },
   {
@@ -4764,7 +4764,7 @@
    "level": 8,
    "out_size": 5429363,
    "ratio": 0.7487,
-   "compress_mbps": 8.23,
+   "compress_mbps": 8.54,
    "decompress_mbps": 137.98
   },
   {
@@ -4784,7 +4784,7 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 70.95,
+   "compress_mbps": 71.54,
    "decompress_mbps": 224.96
   },
   {
@@ -4794,7 +4794,7 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 54.11,
+   "compress_mbps": 54.59,
    "decompress_mbps": 244.21
   },
   {
@@ -4804,7 +4804,7 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 50.2,
+   "compress_mbps": 50.87,
    "decompress_mbps": 262.7
   },
   {
@@ -4814,7 +4814,7 @@
    "level": 4,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 37.54,
+   "compress_mbps": 38.42,
    "decompress_mbps": 266.37
   },
   {
@@ -4824,7 +4824,7 @@
    "level": 5,
    "out_size": 12123671,
    "ratio": 0.2924,
-   "compress_mbps": 27.53,
+   "compress_mbps": 28.6,
    "decompress_mbps": 272.04
   },
   {
@@ -4834,7 +4834,7 @@
    "level": 6,
    "out_size": 12167341,
    "ratio": 0.2935,
-   "compress_mbps": 27.52,
+   "compress_mbps": 28.22,
    "decompress_mbps": 279.38
   },
   {
@@ -4844,7 +4844,7 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 22.74,
+   "compress_mbps": 23.55,
    "decompress_mbps": 280.46
   },
   {
@@ -4854,7 +4854,7 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 18.95,
+   "compress_mbps": 19.66,
    "decompress_mbps": 282.69
   },
   {
@@ -4874,7 +4874,7 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 38.82,
+   "compress_mbps": 39.14,
    "decompress_mbps": 124.74
   },
   {
@@ -4884,7 +4884,7 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 37.4,
+   "compress_mbps": 37.73,
    "decompress_mbps": 126.21
   },
   {
@@ -4894,7 +4894,7 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 37.18,
+   "compress_mbps": 37.68,
    "decompress_mbps": 126.86
   },
   {
@@ -4904,7 +4904,7 @@
    "level": 4,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 35.3,
+   "compress_mbps": 36.13,
    "decompress_mbps": 115.56
   },
   {
@@ -4914,7 +4914,7 @@
    "level": 5,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 35.06,
+   "compress_mbps": 36.43,
    "decompress_mbps": 115.82
   },
   {
@@ -4924,7 +4924,7 @@
    "level": 6,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 9.59,
+   "compress_mbps": 9.83,
    "decompress_mbps": 116.36
   },
   {
@@ -4934,7 +4934,7 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 9.56,
+   "compress_mbps": 9.9,
    "decompress_mbps": 118.39
   },
   {
@@ -4944,7 +4944,7 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 5.75,
+   "compress_mbps": 5.97,
    "decompress_mbps": 118.4
   },
   {
@@ -4964,7 +4964,7 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 150.14,
+   "compress_mbps": 151.39,
    "decompress_mbps": 435.7
   },
   {
@@ -4974,7 +4974,7 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 102.64,
+   "compress_mbps": 103.55,
    "decompress_mbps": 504.57
   },
   {
@@ -4984,7 +4984,7 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 94.35,
+   "compress_mbps": 95.61,
    "decompress_mbps": 561.39
   },
   {
@@ -4994,7 +4994,7 @@
    "level": 4,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 68.93,
+   "compress_mbps": 70.54,
    "decompress_mbps": 548.46
   },
   {
@@ -5004,7 +5004,7 @@
    "level": 5,
    "out_size": 710636,
    "ratio": 0.1329,
-   "compress_mbps": 49.91,
+   "compress_mbps": 51.86,
    "decompress_mbps": 602.4
   },
   {
@@ -5014,7 +5014,7 @@
    "level": 6,
    "out_size": 688375,
    "ratio": 0.1288,
-   "compress_mbps": 44.22,
+   "compress_mbps": 45.35,
    "decompress_mbps": 650.29
   },
   {
@@ -5024,7 +5024,7 @@
    "level": 7,
    "out_size": 676544,
    "ratio": 0.1266,
-   "compress_mbps": 35.66,
+   "compress_mbps": 36.93,
    "decompress_mbps": 659.32
   },
   {
@@ -5034,7 +5034,7 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 28.72,
+   "compress_mbps": 29.8,
    "decompress_mbps": 669.27
   },
   {


### PR DESCRIPTION
This PR ports the hot DEFLATE hash-chain walk `chainWalkPacked` to a `USize`-native twin `chainWalkPackedU`: the fuel counter, the best-length/best-position accumulator, and the `scan_end` prefilter's index arithmetic run on unboxed `USize` instead of tagged `Nat`, so the walk pays no per-step tag test/untag on its scalar arithmetic and reads the prefilter bytes through `ByteArray.uget` with no bounds branch. The chain link `cand` itself stays on the `Nat` `prev` ring — the `chainWinSize` docstring records that a de-boxed ring measured as a net conversion tax — so only the accumulators move to `USize`. `chainWalkPackedU` is proven equal to `chainWalkPacked` (`chainWalkPackedU_eq`), and the guarded wrapper `chainWalkGuardedPackedU` is proven unconditionally equal to `chainWalkGuardedPacked` (`chainWalkGuardedPackedU_eq`) behind one runtime addressability + accumulator-faithfulness check that falls back to the `Nat` walk, so the packed matchers `lz77ChainIterP`/`lz77ChainLazyIterP` switch to it with output unchanged by construction.

Closes #2741.

🤖 Prepared with Claude Code