### PR TITLE
perf(compress): drop the over-fit fixed-cadence split candidate at level 8

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1747,47 +1747,30 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
     else
       -- Levels 6–8 (and level 9/10 above the memory gate): base vs cross-block
       -- shared-window split at the observation-divergence boundaries (#2737),
-      -- **size-arbitrated** (#2753). Every candidate is *prepared* — sized to its
-      -- flushed byte count with its per-block trees captured (`deflateRawBasePPrep`
-      -- for the base, `deflateDynamicBlocksSharedAtSizedP` for each cut list) — and
-      -- only the winner is emitted, reusing the trees the sizing pass already
-      -- built, instead of emitting every candidate and discarding all but the
-      -- smallest via `pickSmaller`. `emitSmallerBy` selects by the same ⌈bits/8⌉
-      -- byte counts the emitted blocks flush (pinned by the `SizeHelpers`
-      -- conformance tests), so the winner and its bytes are identical to the
-      -- retired two/three-emit dispatch. The tree capture is what makes this a net
+      -- **size-arbitrated** (#2753). Both candidates are *prepared* — sized to
+      -- their flushed byte count with per-block trees captured
+      -- (`deflateRawBasePPrep` for the base, `deflateDynamicBlocksSharedAtSizedP`
+      -- for the cut list) — and only the winner is emitted, reusing the trees the
+      -- sizing pass already built, instead of emitting both and discarding the
+      -- larger via `pickSmaller`. The winner and its bytes are identical to the
+      -- retired emit-both dispatch. The tree capture is what makes this a net
       -- win: sizing a dynamic block otherwise costs a full frequency + Huffman
-      -- pass, so without reuse "size all + emit winner" would not beat "emit all"
-      -- (measured — Silesia L6-L7 +5-12% with reuse). No cuts ⇒ the split would be
-      -- a single dynamic block the base already sizes, so skip it entirely (every
-      -- input under ~2·splitMinBlockBytes takes this path).
+      -- pass, so without reuse "size both + emit winner" would not beat "emit
+      -- both" (measured — Silesia L6-L7 +5-12% with reuse). No cuts ⇒ the split
+      -- would be a single dynamic block the base already sizes, so skip it
+      -- entirely (every input under ~2·splitMinBlockBytes takes this path).
       let basePrep := deflateRawBasePPrep data ptokens
       let cuts := chooseSplitsHeuristicP ptokens
       -- `withObs`: the base, or the size-arbitrated smaller of base and the
       -- obs-divergence split — selected *eagerly* (the winning prep pair, tie →
       -- the split, matching `pickSmaller`), so the loser's captured per-block
-      -- trees are dropped now rather than held live through the L8 sizing below.
-      -- The winner's emit thunk stays unforced until the final selection.
+      -- trees are dropped now. The winner's emit thunk stays unforced until then.
       let withObs : Nat × (Unit → ByteArray) :=
         if cuts.isEmpty then basePrep
         else
           let obsPrep := deflateDynamicBlocksSharedAtSizedP data ptokens cuts
           if basePrep.1 < obsPrep.1 then basePrep else obsPrep
-      if 8 ≤ level then
-        -- Max-ratio split tier: also arbitrate the fixed-cadence partition. The
-        -- old L8 arbitration picked between the heuristic and cadence partitions
-        -- by exact bit sizing; deciding by the sized ⌈bits/8⌉ of the two split
-        -- candidates plus the base is that same quantity — never worse than the
-        -- retired sizing pass on any input, now at *one* emit instead of three.
-        -- Measured (Silesia): the divergence cuts alone lose only on sao
-        -- (+0.6pp, a statistically uniform star catalog the cadence handles
-        -- better); this candidate closes exactly that hole. L4–L7 skip it: they
-        -- had no split tier before, so there is nothing to not-regress, and the
-        -- divergence cuts already capture the mid-band win.
-        let fixedPrep := deflateDynamicBlocksSharedAtSizedP data ptokens
-          (fixedCadenceCuts sharedTokChunk ptokens.size)
-        emitSmallerBy withObs.1 withObs.2 fixedPrep.1 fixedPrep.2
-      else withObs.2 ()
+      withObs.2 ()
   else deflateRawBase data level
 
 end Zip.Native.Deflate

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -185,12 +185,9 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
             exact inflate_pickSmaller _ _ data maxOutputSize
               (inflate_deflateRawBase data level _ hsize)
               (inflate_deflateDynamicBlocksOptimal data sharedTokChunk _ hsize)
-          · split
-            · -- level 8: withObs vs the sized fixed-cadence partition
-              exact inflate_emitSmallerBy _ _ _ _ data maxOutputSize (hwithObs _ rfl)
-                (hsplit _)
-            · -- levels 6–7 (and 9/10 above the optimal-size gate)
-              exact hwithObs _ rfl
+          · -- levels 6–8 (and 9/10 above the optimal-size gate): one obs-split
+            -- candidate per tier, so `hwithObs` covers all three
+            exact hwithObs _ rfl
       · exact inflate_deflateRawBase data level _ hsize
 
 /-- Padding decomposition for the compressed-block dispatch. -/
@@ -322,14 +319,8 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
                 bits = contentBits ++ padding ∧ padding.length < 8)
               _ _ (deflateRawBase_pad data level)
               (deflateDynamicBlocksOptimal_pad data sharedTokChunk)
-          · split
-            · -- level 8: withObs vs the sized fixed-cadence partition
-              exact emitSmallerBy_bytesToBits
-                (P := fun bits => ∃ (contentBits padding : List Bool),
-                  bits = contentBits ++ padding ∧ padding.length < 8)
-                _ _ _ _ (hwithObs _ rfl) (hsplit _)
-            · -- levels 6–7 (and 9/10 above the optimal-size gate)
-              exact hwithObs _ rfl
+          · -- levels 6–8 (and 9/10 above the optimal-size gate)
+            exact hwithObs _ rfl
       · exact deflateRawBase_pad data level
 
 /-- `goR` short-remaining for a fixed-Huffman block over the lazy token stream —
@@ -538,15 +529,8 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
                   remaining.length < 8)
               _ _ (deflateRawBase_goR_pad data level)
               (deflateDynamicBlocksOptimal_goR_pad data sharedTokChunk)
-          · split
-            · -- level 8: withObs vs the sized fixed-cadence partition
-              exact emitSmallerBy_bytesToBits
-                (P := fun bits => ∃ remaining,
-                  Deflate.Spec.decode.goR bits [] = some (data.data.toList, remaining) ∧
-                    remaining.length < 8)
-                _ _ _ _ (hwithObs _ rfl) (hsplit _)
-            · -- levels 6–7 (and 9/10 above the optimal-size gate)
-              exact hwithObs _ rfl
+          · -- levels 6–8 (and 9/10 above the optimal-size gate)
+            exact hwithObs _ rfl
       · exact deflateRawBase_goR_pad data level
 
 end Zip.Native.Deflate

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p2e73d4ecf8)">
+   <g clip-path="url(#p917be839ff)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3Yz4rkZxmG4a6emmEYmkED+eMQRASzyj6LHIMbD8Qj8Cw8gkDAVbZBdOkuhxBUguAYYjNjxk5P2V1TP3fuA/fHa4rrOoKnKPjqrnd3+vZ32wU/LIeb6QXrHF5NL1hiu7+bnrDM7uk70xPWePh4esE6l5fTC9a4P0wvWGd3nt/Z9vL59IRlzvMbAwAYJLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL7ry6upzcscX86TE9Y5ic/+vn0hGWutvemJyyx++7F9IRl/vT6y+kJS7z/6J3pCcscT3fTE5a4eXO+7/7d6Tg9YYmPnv50esIyLlgAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2736z2fb9IgVXh9vpics8/bpyfSEdY530wvWuLmeXrDOux9ML1jiZrudnrDMub6Pb29X0xOWeX7xYnrCEs+u/zU9YRkXLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIjtr15eT29Y4mr/aHrCOoevpxcss918Oz1hjdNpesEyuyffTE9Y4pzfkKv90+kJazx6PL1gmWev76YnLLHd/mN6wjIuWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsf12/fX0Br6v02l6AfzP9ve/Tk9Y49L/zx8cbyP/R7wgAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENv/+p9/m96wxMvDm+kJy3zx/NX0hGU+/9XH0xOWeO/Jz6YnLPPhJ59OT1jil794a3rCMn95eZiewPf0+z/8eXrCEre//c30hGVcsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2O57+uE2PWOHN6Tg9YZnL3fl28YPD7fSENR7spxes892L6QVLnH78bHrCMtt2mp6wxIMzvhncb+f5m/bweJ6f6+LCBQsAICewAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+8u7w/SGJS4v99MT1vnmy+kFy2y3/56esMbxOL1gmd1b705PWOLy/m56wjoPH08vWOP6q+kFyzw8vJqesMR2c6Zv/oULFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT+C5bZjMUplQOfAAAAAElFTkSuQmCC" id="image29a62686aa" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3Yz4rkZxmG4a6emmEYmkED+eMQRASzyj6LHIMbD8Qj8Cw8gkDAVbZBdOkuhxBUguAYYjNjxk5P2V1TP3fuA/fHa4rrOoKnKPjqrnd3+vZ32wU/LIeb6QXrHF5NL1hiu7+bnrDM7uk70xPWePh4esE6l5fTC9a4P0wvWGd3nt/Z9vL59IRlzvMbAwAYJLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL7ry6upzcscX86TE9Y5ic/+vn0hGWutvemJyyx++7F9IRl/vT6y+kJS7z/6J3pCcscT3fTE5a4eXO+7/7d6Tg9YYmPnv50esIyLlgAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2736z2fb9IgVXh9vpics8/bpyfSEdY530wvWuLmeXrDOux9ML1jiZrudnrDMub6Pb29X0xOWeX7xYnrCEs+u/zU9YRkXLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIjtr15eT29Y4mr/aHrCOoevpxcss918Oz1hjdNpesEyuyffTE9Y4pzfkKv90+kJazx6PL1gmWev76YnLLHd/mN6wjIuWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsf12/fX0Br6v02l6AfzP9ve/Tk9Y49L/zx8cbyP/R7wgAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENv/+p9/m96wxMvDm+kJy3zx/NX0hGU+/9XH0xOWeO/Jz6YnLPPhJ59OT1jil794a3rCMn95eZiewPf0+z/8eXrCEre//c30hGVcsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2O57+uE2PWOHN6Tg9YZnL3fl28YPD7fSENR7spxes892L6QVLnH78bHrCMtt2mp6wxIMzvhncb+f5m/bweJ6f6+LCBQsAICewAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+8u7w/SGJS4v99MT1vnmy+kFy2y3/56esMbxOL1gmd1b705PWOLy/m56wjoPH08vWOP6q+kFyzw8vJqesMR2c6Zv/oULFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT+C5bZjMUplQOfAAAAAElFTkSuQmCC" id="image2606ec36c5" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mc323f99c19" d="M 0 0 
+       <path id="md5c4b01439" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc323f99c19" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mc323f99c19" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mc323f99c19" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc323f99c19" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mc323f99c19" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc323f99c19" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc323f99c19" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc323f99c19" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc323f99c19" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc323f99c19" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc323f99c19" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c4b01439" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="ma19ef3c722" d="M 0 0 
+       <path id="m814e2a20aa" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma19ef3c722" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m814e2a20aa" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#ma19ef3c722" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m814e2a20aa" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma19ef3c722" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m814e2a20aa" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#ma19ef3c722" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m814e2a20aa" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#ma19ef3c722" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m814e2a20aa" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#ma19ef3c722" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m814e2a20aa" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma19ef3c722" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m814e2a20aa" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#ma19ef3c722" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m814e2a20aa" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,8 +1303,36 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -16 -->
+    <!-- -17 -->
     <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- -11 -->
+    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -66 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1337,22 +1365,6 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- -11 -->
-    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -66 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -1445,49 +1457,15 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- -13 -->
+    <!-- -14 -->
     <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +3 -->
+    <!-- +2 -->
     <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1507,7 +1485,7 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1521,18 +1499,6 @@ z
    <g id="text_29">
     <!-- -71 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
@@ -1650,6 +1616,40 @@ z
    <g id="text_44">
     <!-- +303 -->
     <g transform="translate(184.87641 139.606222) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
@@ -2184,18 +2184,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image77258b6bd7" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image0d6a4fed3f" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m5c4552a6fa" d="M 0 0 
+       <path id="mfae2c67240" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5c4552a6fa" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfae2c67240" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2218,7 +2218,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m5c4552a6fa" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfae2c67240" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2232,7 +2232,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m5c4552a6fa" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfae2c67240" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2246,7 +2246,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m5c4552a6fa" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfae2c67240" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2259,7 +2259,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5c4552a6fa" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfae2c67240" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2272,7 +2272,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m5c4552a6fa" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfae2c67240" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2285,7 +2285,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m5c4552a6fa" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfae2c67240" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2946,8 +2946,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-03T22:49:18Z  ·  Linux chungus x86_64  ·  commit 2d0b6447  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.617109 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.688984 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3014,16 +3014,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3062,109 +3062,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3262.451172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.697266 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3453.320312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3516.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3548.730469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3580.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.304688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3644.091797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3675.878906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3703.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3765.185547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3826.464844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3889.84375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3953.320312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3992.183594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4053.365234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4174.068359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4215.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4248.873047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4276.65625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4338.179688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4399.458984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4462.837891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4526.460938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4560.152344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4682.955078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4714.742188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4778.365234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4841.988281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4873.775391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4937.398438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4973.482422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5012.345703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5067.326172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5130.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5162.736328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5194.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.310547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5258.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5289.884766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5329.09375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5392.472656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5431.335938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5492.517578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5555.896484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5619.373047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5682.751953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5746.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5809.607422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5848.816406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5880.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5964.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6093.591797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6155.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6218.591797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6246.375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6307.654297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6371.033203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6402.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6454.919922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6518.298828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6579.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6643.054688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6695.154297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6758.533203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6819.714844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6858.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6892.615234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6924.402344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6965.515625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7026.794922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7066.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7093.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7154.96875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7186.755859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7214.539062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7266.638672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7298.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7361.902344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7423.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7462.634766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7524.158203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7563.521484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.933594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7688.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7752.095703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7779.878906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7831.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7871.1875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7898.970703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p2e73d4ecf8">
+  <clipPath id="p917be839ff">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m2858f9eb21" d="M 0 0 
+       <path id="ma5bb635ab8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2858f9eb21" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5bb635ab8" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m2858f9eb21" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5bb635ab8" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m2858f9eb21" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5bb635ab8" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m2858f9eb21" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5bb635ab8" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2858f9eb21" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5bb635ab8" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m2858f9eb21" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5bb635ab8" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2858f9eb21" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5bb635ab8" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m3637839255" d="M 0 0 
+       <path id="m872fadba23" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3637839255" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m872fadba23" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3637839255" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m872fadba23" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3637839255" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m872fadba23" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m6e7d11f21a" d="M 0 0 
+       <path id="m6c16ce67cf" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m6e7d11f21a" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6c16ce67cf" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 163.267227) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 164.342865) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(105.541635 306.277139) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(105.541635 307.554784) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="mb8393857b3" d="M -2.5 2.5 
+     <path id="m0a1881a640" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p72cdef9915)">
-     <use xlink:href="#mb8393857b3" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8393857b3" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8393857b3" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8393857b3" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8393857b3" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8393857b3" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8393857b3" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8393857b3" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb8393857b3" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p93575b0a99)">
+     <use xlink:href="#m0a1881a640" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a1881a640" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a1881a640" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a1881a640" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a1881a640" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a1881a640" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a1881a640" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a1881a640" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0a1881a640" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.211803
 L 310.240844 102.355284 
 L 309.257387 102.498333 
 L 308.273931 102.64095 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.64095 
@@ -1853,7 +1853,7 @@ L 273.545396 115.495372
 L 272.773651 115.744903 
 L 272.001906 115.993127 
 L 271.230161 116.240058 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.240058 
@@ -1905,7 +1905,7 @@ L 221.171803 119.753456
 L 220.059395 119.828647 
 L 218.946988 119.90372 
 L 217.83458 119.978674 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 119.978674 
@@ -1957,7 +1957,7 @@ L 179.624997 137.397353
 L 178.775895 137.720164 
 L 177.926794 138.04079 
 L 177.077692 138.359262 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.359262 
@@ -2009,7 +2009,7 @@ L 163.767861 156.658214
 L 163.472087 156.994351 
 L 163.176313 157.328121 
 L 162.880539 157.659557 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.659557 
@@ -2061,7 +2061,7 @@ L 160.875139 164.650114
 L 160.830574 164.794326 
 L 160.78601 164.9381 
 L 160.741445 165.081439 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.081439 
@@ -2113,7 +2113,7 @@ L 154.390101 182.353217
 L 154.24896 182.673779 
 L 154.107819 182.992187 
 L 153.966678 183.30847 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.30847 
@@ -2165,26 +2165,26 @@ L 151.73818 193.734619
 L 151.688658 193.942139 
 L 151.639136 194.148754 
 L 151.589614 194.354473 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m91d66f7fc1" d="M 0 -2.5 
+     <path id="m397d01c602" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p72cdef9915)">
-     <use xlink:href="#m91d66f7fc1" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m91d66f7fc1" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m91d66f7fc1" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m91d66f7fc1" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m91d66f7fc1" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m91d66f7fc1" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m91d66f7fc1" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m91d66f7fc1" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m91d66f7fc1" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p93575b0a99)">
+     <use xlink:href="#m397d01c602" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m397d01c602" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m397d01c602" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m397d01c602" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m397d01c602" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m397d01c602" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m397d01c602" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m397d01c602" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m397d01c602" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.610561
 L 294.051648 97.995945 
 L 288.886486 98.37822 
 L 283.721324 98.757435 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 98.757435 
@@ -2289,7 +2289,7 @@ L 222.934499 119.784103
 L 221.583681 120.159977 
 L 220.232863 120.532893 
 L 218.882044 120.902897 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 120.902897 
@@ -2341,7 +2341,7 @@ L 189.411904 126.368029
 L 188.757012 126.482596 
 L 188.10212 126.596887 
 L 187.447228 126.710903 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 126.710903 
@@ -2393,7 +2393,7 @@ L 177.036521 137.569875
 L 176.805172 137.785045 
 L 176.573823 137.999242 
 L 176.342474 138.212475 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.212475 
@@ -2445,7 +2445,7 @@ L 163.884824 160.054818
 L 163.607987 160.442131 
 L 163.33115 160.826303 
 L 163.054314 161.207386 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.207386 
@@ -2497,7 +2497,7 @@ L 162.263275 168.244909
 L 162.245696 168.390018 
 L 162.228118 168.534683 
 L 162.210539 168.678909 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.678909 
@@ -2549,7 +2549,7 @@ L 159.485481 175.228819
 L 159.424925 175.364567 
 L 159.364368 175.499927 
 L 159.303811 175.634901 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.634901 
@@ -2601,30 +2601,30 @@ L 157.888296 179.180942
 L 157.85684 179.256806 
 L 157.825384 179.332549 
 L 157.793928 179.408171 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="mbec95f6a32" d="M -0 3.535534 
+     <path id="m6db7da3a18" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p72cdef9915)">
-     <use xlink:href="#mbec95f6a32" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbec95f6a32" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p93575b0a99)">
+     <use xlink:href="#m6db7da3a18" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6db7da3a18" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.99106
 L 205.766837 81.29344 
 L 204.771342 81.593904 
 L 203.775848 81.892474 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.892474 
@@ -2729,7 +2729,7 @@ L 188.032264 88.395253
 L 187.682406 88.530091 
 L 187.332549 88.664546 
 L 186.982691 88.798621 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.798621 
@@ -2781,7 +2781,7 @@ L 180.229518 90.954599
 L 180.079447 91.001413 
 L 179.929376 91.048181 
 L 179.779306 91.094902 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.094902 
@@ -2833,7 +2833,7 @@ L 158.995974 98.861987
 L 158.534122 99.02092 
 L 158.07227 99.179321 
 L 157.610419 99.337194 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.337194 
@@ -2885,7 +2885,7 @@ L 149.27802 107.306615
 L 149.092855 107.469343 
 L 148.907691 107.631514 
 L 148.722526 107.793132 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.793132 
@@ -2937,7 +2937,7 @@ L 144.65906 120.462338
 L 144.568761 120.708742 
 L 144.478462 120.95387 
 L 144.388162 121.197738 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.197738 
@@ -2989,7 +2989,7 @@ L 128.153555 143.293159
 L 127.792786 143.68398 
 L 127.432016 144.071604 
 L 127.071247 144.456083 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.456083 
@@ -3041,7 +3041,7 @@ L 124.653192 151.618794
 L 124.599457 151.76629 
 L 124.545723 151.913329 
 L 124.491988 152.059912 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.059912 
@@ -3093,7 +3093,7 @@ L 94.606058 205.368437
 L 93.941926 206.074323 
 L 93.277794 206.769849 
 L 92.613662 207.455314 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.455314 
@@ -3145,7 +3145,7 @@ L 87.677774 224.060225
 L 87.568088 224.37049 
 L 87.458402 224.678737 
 L 87.348715 224.984992 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 224.984992 
@@ -3197,23 +3197,23 @@ L 86.134388 240.678828
 L 86.107403 240.974786 
 L 86.080418 241.268907 
 L 86.053433 241.561213 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m082bb60af8" d="M -0 2.5 
+     <path id="m1989dbd046" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p72cdef9915)">
-     <use xlink:href="#m082bb60af8" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p93575b0a99)">
+     <use xlink:href="#m1989dbd046" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m75427197a3" d="M -0.833333 2.5 
+     <path id="m9285d4ef8e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p72cdef9915)">
-     <use xlink:href="#m75427197a3" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75427197a3" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75427197a3" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75427197a3" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75427197a3" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75427197a3" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75427197a3" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75427197a3" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75427197a3" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p93575b0a99)">
+     <use xlink:href="#m9285d4ef8e" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9285d4ef8e" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9285d4ef8e" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9285d4ef8e" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9285d4ef8e" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9285d4ef8e" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9285d4ef8e" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9285d4ef8e" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9285d4ef8e" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 180.888961
 L 282.301002 180.947904 
 L 280.549589 181.006774 
 L 278.798176 181.06557 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 181.06557 
@@ -3342,7 +3342,7 @@ L 252.902686 188.238912
 L 252.327231 188.386611 
 L 251.751776 188.53385 
 L 251.17632 188.680634 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 188.680634 
@@ -3394,7 +3394,7 @@ L 203.954921 186.473055
 L 202.905557 186.42281 
 L 201.856192 186.372512 
 L 200.806828 186.322161 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 186.322161 
@@ -3446,7 +3446,7 @@ L 171.740947 201.881696
 L 171.095038 202.175521 
 L 170.44913 202.467535 
 L 169.803221 202.757761 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 202.757761 
@@ -3498,7 +3498,7 @@ L 162.409549 210.675366
 L 162.245246 210.837123 
 L 162.080942 210.99833 
 L 161.916638 211.158991 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 211.158991 
@@ -3550,7 +3550,7 @@ L 158.898325 213.866476
 L 158.831251 213.92492 
 L 158.764178 213.983292 
 L 158.697104 214.041592 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 214.041592 
@@ -3602,7 +3602,7 @@ L 154.543684 229.493591
 L 154.451386 229.785704 
 L 154.359088 230.076027 
 L 154.26679 230.364582 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 230.364582 
@@ -3654,11 +3654,11 @@ L 153.16961 235.985723
 L 153.145228 236.103367 
 L 153.120846 236.220719 
 L 153.096464 236.337782 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m37475c66ef" d="M -1.25 2.5 
+     <path id="m73113e9463" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p72cdef9915)">
-     <use xlink:href="#m37475c66ef" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m37475c66ef" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m37475c66ef" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m37475c66ef" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m37475c66ef" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m37475c66ef" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m37475c66ef" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m37475c66ef" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m37475c66ef" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p93575b0a99)">
+     <use xlink:href="#m73113e9463" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m73113e9463" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m73113e9463" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m73113e9463" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m73113e9463" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m73113e9463" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m73113e9463" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m73113e9463" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m73113e9463" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 147.037933
 L 252.377414 147.089635 
 L 251.306944 147.141281 
 L 250.236474 147.192871 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 147.192871 
@@ -3787,7 +3787,7 @@ L 226.969772 152.467777
 L 226.452735 152.578579 
 L 225.935697 152.689122 
 L 225.418659 152.799409 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 152.799409 
@@ -3839,7 +3839,7 @@ L 213.147044 158.556257
 L 212.874341 158.676569 
 L 212.601639 158.796576 
 L 212.328936 158.91628 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 158.91628 
@@ -3891,7 +3891,7 @@ L 209.236323 156.954621
 L 209.167599 156.910092 
 L 209.098874 156.865522 
 L 209.030149 156.82091 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 156.82091 
@@ -3943,7 +3943,7 @@ L 198.265399 167.356927
 L 198.026182 167.566396 
 L 197.786966 167.774943 
 L 197.547749 167.982576 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 167.982576 
@@ -3995,7 +3995,7 @@ L 194.989815 169.398061
 L 194.932972 169.429041 
 L 194.876129 169.460001 
 L 194.819287 169.49094 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 169.49094 
@@ -4047,7 +4047,7 @@ L 193.228821 176.568565
 L 193.193478 176.714439 
 L 193.158134 176.859866 
 L 193.12279 177.004847 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 177.004847 
@@ -4099,11 +4099,11 @@ L 192.818243 181.564429
 L 192.811475 181.660932 
 L 192.804707 181.75724 
 L 192.79794 181.853352 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m01b93a6859" d="M 0 -2.5 
+     <path id="m02384afb76" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p72cdef9915)">
-     <use xlink:href="#m01b93a6859" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01b93a6859" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01b93a6859" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01b93a6859" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01b93a6859" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01b93a6859" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01b93a6859" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01b93a6859" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m01b93a6859" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p93575b0a99)">
+     <use xlink:href="#m02384afb76" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m02384afb76" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m02384afb76" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m02384afb76" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m02384afb76" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m02384afb76" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m02384afb76" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m02384afb76" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m02384afb76" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 117.963319
 L 206.45578 117.9566 
 L 206.45578 117.949879 
 L 206.45578 117.943158 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 117.943158 
@@ -4230,7 +4230,7 @@ L 206.45578 118.018397
 L 206.45578 118.020068 
 L 206.45578 118.021738 
 L 206.45578 118.023409 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.023409 
@@ -4282,7 +4282,7 @@ L 206.45578 118.009588
 L 206.45578 118.00928 
 L 206.45578 118.008973 
 L 206.45578 118.008666 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.008666 
@@ -4334,7 +4334,7 @@ L 173.935517 132.674231
 L 173.212844 132.953702 
 L 172.490172 133.231533 
 L 171.767499 133.507746 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 133.507746 
@@ -4386,7 +4386,7 @@ L 164.056872 143.78437
 L 163.885524 143.989231 
 L 163.714177 144.193211 
 L 163.54283 144.396316 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.396316 
@@ -4438,7 +4438,7 @@ L 160.385378 149.94789
 L 160.315212 150.064163 
 L 160.245047 150.180152 
 L 160.174881 150.295858 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 150.295858 
@@ -4490,7 +4490,7 @@ L 154.553946 167.637484
 L 154.429036 167.959116 
 L 154.304126 168.27858 
 L 154.179217 168.595905 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 168.595905 
@@ -4542,11 +4542,11 @@ L 152.549264 177.771325
 L 152.513043 177.956336 
 L 152.476822 178.140629 
 L 152.4406 178.324207 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m1b8fdf0a1b" d="M 0 -2.5 
+     <path id="m7261acafc5" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p72cdef9915)">
-     <use xlink:href="#m1b8fdf0a1b" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1b8fdf0a1b" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1b8fdf0a1b" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1b8fdf0a1b" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1b8fdf0a1b" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1b8fdf0a1b" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1b8fdf0a1b" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1b8fdf0a1b" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1b8fdf0a1b" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p93575b0a99)">
+     <use xlink:href="#m7261acafc5" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7261acafc5" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7261acafc5" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7261acafc5" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7261acafc5" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7261acafc5" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7261acafc5" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7261acafc5" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7261acafc5" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 174.939703
 L 592.834055 174.969152 
 L 592.450726 174.998584 
 L 592.067397 175.027997 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 175.027997 
@@ -4669,7 +4669,7 @@ L 538.386544 181.016797
 L 537.193636 181.14165 
 L 536.000728 181.266176 
 L 534.807821 181.390376 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 181.390376 
@@ -4721,7 +4721,7 @@ L 340.74006 177.010188
 L 336.427443 176.9081 
 L 332.114826 176.805792 
 L 327.802209 176.703263 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.703263 
@@ -4773,7 +4773,7 @@ L 279.085397 186.459613
 L 278.002801 186.655155 
 L 276.920205 186.849893 
 L 275.83761 187.043834 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 187.043834 
@@ -4825,7 +4825,7 @@ L 259.350398 198.484046
 L 258.984015 198.709377 
 L 258.617633 198.933642 
 L 258.25125 199.15685 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 199.15685 
@@ -4877,7 +4877,7 @@ L 256.869193 203.812849
 L 256.838481 203.911293 
 L 256.807768 204.009533 
 L 256.777056 204.107569 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 204.107569 
@@ -4929,7 +4929,7 @@ L 249.270304 217.480153
 L 249.103487 217.738369 
 L 248.93667 217.995185 
 L 248.769854 218.250617 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 218.250617 
@@ -4981,7 +4981,7 @@ L 246.421172 227.44791
 L 246.368979 227.633321 
 L 246.316786 227.818009 
 L 246.264594 228.00198 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="madc7f11b84" d="M 0 3.5 
+      <path id="md97273209d" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#madc7f11b84" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#md97273209d" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#mb8393857b3" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0a1881a640" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m91d66f7fc1" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m397d01c602" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#mbec95f6a32" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6db7da3a18" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m082bb60af8" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1989dbd046" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m75427197a3" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9285d4ef8e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m37475c66ef" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m73113e9463" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m01b93a6859" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m02384afb76" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m1b8fdf0a1b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7261acafc5" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p72cdef9915)">
-     <use xlink:href="#madc7f11b84" x="289.669676" y="168.267227" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#madc7f11b84" x="223.847406" y="177.342277" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#madc7f11b84" x="212.215046" y="180.645024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#madc7f11b84" x="186.58897" y="189.088269" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#madc7f11b84" x="169.057218" y="197.840024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#madc7f11b84" x="158.596848" y="209.599878" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#madc7f11b84" x="152.867313" y="214.710783" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#madc7f11b84" x="150.950891" y="229.132166" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#madc7f11b84" x="119.37967" y="286.095631" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#madc7f11b84" x="100.541635" y="311.277139" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p93575b0a99)">
+     <use xlink:href="#md97273209d" x="289.669676" y="169.342865" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md97273209d" x="223.847406" y="178.136767" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md97273209d" x="212.215046" y="181.34331" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md97273209d" x="186.58897" y="189.841488" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md97273209d" x="169.057218" y="198.556349" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md97273209d" x="158.596848" y="210.184521" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md97273209d" x="152.867313" y="215.135443" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md97273209d" x="150.950891" y="217.494763" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md97273209d" x="119.37967" y="287.785022" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#md97273209d" x="100.541635" y="312.554784" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 168.267227 
-L 288.298379 168.47515 
-L 286.927082 168.682165 
-L 285.555784 168.888279 
-L 284.184487 169.0935 
-L 282.81319 169.297837 
-L 281.441892 169.501296 
-L 280.070595 169.703886 
-L 278.699298 169.905613 
-L 277.328 170.106485 
-L 275.956703 170.306509 
-L 274.585406 170.505693 
-L 273.214109 170.704043 
-L 271.842811 170.901566 
-L 270.471514 171.098269 
-L 269.100217 171.294159 
-L 267.728919 171.489242 
-L 266.357622 171.683526 
-L 264.986325 171.877017 
-L 263.615028 172.06972 
-L 262.24373 172.261644 
-L 260.872433 172.452793 
-L 259.501136 172.643174 
-L 258.129838 172.832793 
-L 256.758541 173.021657 
-L 255.387244 173.209771 
-L 254.015947 173.397141 
-L 252.644649 173.583774 
-L 251.273352 173.769674 
-L 249.902055 173.954847 
-L 248.530757 174.1393 
-L 247.15946 174.323038 
-L 245.788163 174.506066 
-L 244.416866 174.68839 
-L 243.045568 174.870015 
-L 241.674271 175.050947 
-L 240.302974 175.231191 
-L 238.931676 175.410751 
-L 237.560379 175.589634 
-L 236.189082 175.767844 
-L 234.817784 175.945387 
-L 233.446487 176.122266 
-L 232.07519 176.298488 
-L 230.703893 176.474057 
-L 229.332595 176.648978 
-L 227.961298 176.823256 
-L 226.590001 176.996895 
-L 225.218703 177.169901 
-L 223.847406 177.342277 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 169.342865 
+L 288.298379 169.543745 
+L 286.927082 169.743778 
+L 285.555784 169.94297 
+L 284.184487 170.141328 
+L 282.81319 170.33886 
+L 281.441892 170.535571 
+L 280.070595 170.73147 
+L 278.699298 170.926562 
+L 277.328 171.120853 
+L 275.956703 171.314352 
+L 274.585406 171.507064 
+L 273.214109 171.698995 
+L 271.842811 171.890152 
+L 270.471514 172.080541 
+L 269.100217 172.270168 
+L 267.728919 172.45904 
+L 266.357622 172.647161 
+L 264.986325 172.834539 
+L 263.615028 173.021179 
+L 262.24373 173.207086 
+L 260.872433 173.392268 
+L 259.501136 173.576728 
+L 258.129838 173.760473 
+L 256.758541 173.943508 
+L 255.387244 174.125839 
+L 254.015947 174.307472 
+L 252.644649 174.488411 
+L 251.273352 174.668661 
+L 249.902055 174.848229 
+L 248.530757 175.027118 
+L 247.15946 175.205335 
+L 245.788163 175.382884 
+L 244.416866 175.559771 
+L 243.045568 175.736 
+L 241.674271 175.911575 
+L 240.302974 176.086503 
+L 238.931676 176.260787 
+L 237.560379 176.434433 
+L 236.189082 176.607445 
+L 234.817784 176.779827 
+L 233.446487 176.951585 
+L 232.07519 177.122722 
+L 230.703893 177.293243 
+L 229.332595 177.463154 
+L 227.961298 177.632457 
+L 226.590001 177.801157 
+L 225.218703 177.969259 
+L 223.847406 178.136767 
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 177.342277 
-L 223.605065 177.413485 
-L 223.362724 177.484586 
-L 223.120384 177.555581 
-L 222.878043 177.626469 
-L 222.635702 177.697252 
-L 222.393361 177.767929 
-L 222.15102 177.838501 
-L 221.908679 177.908968 
-L 221.666339 177.97933 
-L 221.423998 178.049588 
-L 221.181657 178.119742 
-L 220.939316 178.189793 
-L 220.696975 178.259739 
-L 220.454635 178.329583 
-L 220.212294 178.399324 
-L 219.969953 178.468963 
-L 219.727612 178.538499 
-L 219.485271 178.607933 
-L 219.24293 178.677266 
-L 219.00059 178.746498 
-L 218.758249 178.815629 
-L 218.515908 178.884658 
-L 218.273567 178.953588 
-L 218.031226 179.022417 
-L 217.788885 179.091147 
-L 217.546545 179.159777 
-L 217.304204 179.228307 
-L 217.061863 179.296739 
-L 216.819522 179.365072 
-L 216.577181 179.433307 
-L 216.33484 179.501444 
-L 216.0925 179.569482 
-L 215.850159 179.637424 
-L 215.607818 179.705268 
-L 215.365477 179.773015 
-L 215.123136 179.840665 
-L 214.880795 179.908219 
-L 214.638455 179.975676 
-L 214.396114 180.043038 
-L 214.153773 180.110304 
-L 213.911432 180.177475 
-L 213.669091 180.244551 
-L 213.42675 180.311532 
-L 213.18441 180.378418 
-L 212.942069 180.44521 
-L 212.699728 180.511908 
-L 212.457387 180.578513 
-L 212.215046 180.645024 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 178.136767 
+L 223.605065 178.205831 
+L 223.362724 178.274795 
+L 223.120384 178.343659 
+L 222.878043 178.412423 
+L 222.635702 178.481087 
+L 222.393361 178.549652 
+L 222.15102 178.618118 
+L 221.908679 178.686485 
+L 221.666339 178.754754 
+L 221.423998 178.822924 
+L 221.181657 178.890997 
+L 220.939316 178.958972 
+L 220.696975 179.026849 
+L 220.454635 179.094629 
+L 220.212294 179.162313 
+L 219.969953 179.2299 
+L 219.727612 179.297391 
+L 219.485271 179.364786 
+L 219.24293 179.432085 
+L 219.00059 179.499288 
+L 218.758249 179.566397 
+L 218.515908 179.633411 
+L 218.273567 179.70033 
+L 218.031226 179.767154 
+L 217.788885 179.833885 
+L 217.546545 179.900521 
+L 217.304204 179.967064 
+L 217.061863 180.033514 
+L 216.819522 180.099871 
+L 216.577181 180.166135 
+L 216.33484 180.232306 
+L 216.0925 180.298385 
+L 215.850159 180.364373 
+L 215.607818 180.430268 
+L 215.365477 180.496072 
+L 215.123136 180.561784 
+L 214.880795 180.627406 
+L 214.638455 180.692937 
+L 214.396114 180.758377 
+L 214.153773 180.823728 
+L 213.911432 180.888988 
+L 213.669091 180.954158 
+L 213.42675 181.019239 
+L 213.18441 181.084231 
+L 212.942069 181.149133 
+L 212.699728 181.213947 
+L 212.457387 181.278673 
+L 212.215046 181.34331 
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 180.645024 
-L 211.68117 180.837178 
-L 211.147293 181.028557 
-L 210.613417 181.219165 
-L 210.07954 181.409011 
-L 209.545663 181.598098 
-L 209.011787 181.786435 
-L 208.47791 181.974025 
-L 207.944034 182.160876 
-L 207.410157 182.346993 
-L 206.87628 182.532382 
-L 206.342404 182.717049 
-L 205.808527 182.900999 
-L 205.274651 183.084237 
-L 204.740774 183.26677 
-L 204.206897 183.448602 
-L 203.673021 183.629739 
-L 203.139144 183.810187 
-L 202.605268 183.98995 
-L 202.071391 184.169034 
-L 201.537515 184.347443 
-L 201.003638 184.525184 
-L 200.469761 184.70226 
-L 199.935885 184.878677 
-L 199.402008 185.054439 
-L 198.868132 185.229553 
-L 198.334255 185.404021 
-L 197.800378 185.577849 
-L 197.266502 185.751043 
-L 196.732625 185.923605 
-L 196.198749 186.095542 
-L 195.664872 186.266856 
-L 195.130995 186.437554 
-L 194.597119 186.607639 
-L 194.063242 186.777116 
-L 193.529366 186.945989 
-L 192.995489 187.114262 
-L 192.461612 187.28194 
-L 191.927736 187.449027 
-L 191.393859 187.615526 
-L 190.859983 187.781443 
-L 190.326106 187.94678 
-L 189.79223 188.111543 
-L 189.258353 188.275735 
-L 188.724476 188.43936 
-L 188.1906 188.602422 
-L 187.656723 188.764925 
-L 187.122847 188.926873 
-L 186.58897 189.088269 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 181.34331 
+L 211.68117 181.536827 
+L 211.147293 181.729557 
+L 210.613417 181.921507 
+L 210.07954 182.112683 
+L 209.545663 182.30309 
+L 209.011787 182.492735 
+L 208.47791 182.681624 
+L 207.944034 182.869764 
+L 207.410157 183.057159 
+L 206.87628 183.243817 
+L 206.342404 183.429742 
+L 205.808527 183.61494 
+L 205.274651 183.799417 
+L 204.740774 183.98318 
+L 204.206897 184.166232 
+L 203.673021 184.34858 
+L 203.139144 184.530229 
+L 202.605268 184.711184 
+L 202.071391 184.891451 
+L 201.537515 185.071034 
+L 201.003638 185.24994 
+L 200.469761 185.428173 
+L 199.935885 185.605738 
+L 199.402008 185.78264 
+L 198.868132 185.958885 
+L 198.334255 186.134476 
+L 197.800378 186.309419 
+L 197.266502 186.483719 
+L 196.732625 186.65738 
+L 196.198749 186.830406 
+L 195.664872 187.002804 
+L 195.130995 187.174576 
+L 194.597119 187.345728 
+L 194.063242 187.516264 
+L 193.529366 187.686189 
+L 192.995489 187.855506 
+L 192.461612 188.024221 
+L 191.927736 188.192337 
+L 191.393859 188.359859 
+L 190.859983 188.526791 
+L 190.326106 188.693136 
+L 189.79223 188.8589 
+L 189.258353 189.024086 
+L 188.724476 189.188699 
+L 188.1906 189.352741 
+L 187.656723 189.516218 
+L 187.122847 189.679132 
+L 186.58897 189.841488 
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 186.58897 189.088269 
-L 186.223725 189.288098 
-L 185.85848 189.487087 
-L 185.493235 189.685244 
-L 185.127991 189.882577 
-L 184.762746 190.079091 
-L 184.397501 190.274793 
-L 184.032256 190.469691 
-L 183.667011 190.66379 
-L 183.301766 190.857097 
-L 182.936522 191.04962 
-L 182.571277 191.241363 
-L 182.206032 191.432333 
-L 181.840787 191.622537 
-L 181.475542 191.811981 
-L 181.110297 192.00067 
-L 180.745053 192.188611 
-L 180.379808 192.37581 
-L 180.014563 192.562272 
-L 179.649318 192.748003 
-L 179.284073 192.933009 
-L 178.918828 193.117295 
-L 178.553584 193.300868 
-L 178.188339 193.483733 
-L 177.823094 193.665894 
-L 177.457849 193.847358 
-L 177.092604 194.02813 
-L 176.727359 194.208214 
-L 176.362115 194.387617 
-L 175.99687 194.566344 
-L 175.631625 194.744398 
-L 175.26638 194.921787 
-L 174.901135 195.098513 
-L 174.53589 195.274583 
-L 174.170645 195.450002 
-L 173.805401 195.624773 
-L 173.440156 195.798903 
-L 173.074911 195.972394 
-L 172.709666 196.145253 
-L 172.344421 196.317484 
-L 171.979176 196.489091 
-L 171.613932 196.660079 
-L 171.248687 196.830452 
-L 170.883442 197.000214 
-L 170.518197 197.169371 
-L 170.152952 197.337926 
-L 169.787707 197.505884 
-L 169.422463 197.673248 
-L 169.057218 197.840024 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.58897 189.841488 
+L 186.223725 190.040397 
+L 185.85848 190.238474 
+L 185.493235 190.435726 
+L 185.127991 190.632161 
+L 184.762746 190.827785 
+L 184.397501 191.022604 
+L 184.032256 191.216626 
+L 183.667011 191.409857 
+L 183.301766 191.602304 
+L 182.936522 191.793971 
+L 182.571277 191.984867 
+L 182.206032 192.174997 
+L 181.840787 192.364367 
+L 181.475542 192.552983 
+L 181.110297 192.740852 
+L 180.745053 192.927978 
+L 180.379808 193.114369 
+L 180.014563 193.30003 
+L 179.649318 193.484965 
+L 179.284073 193.669182 
+L 178.918828 193.852686 
+L 178.553584 194.035482 
+L 178.188339 194.217575 
+L 177.823094 194.398972 
+L 177.457849 194.579676 
+L 177.092604 194.759695 
+L 176.727359 194.939031 
+L 176.362115 195.117692 
+L 175.99687 195.295682 
+L 175.631625 195.473006 
+L 175.26638 195.649669 
+L 174.901135 195.825675 
+L 174.53589 196.00103 
+L 174.170645 196.175739 
+L 173.805401 196.349806 
+L 173.440156 196.523236 
+L 173.074911 196.696034 
+L 172.709666 196.868204 
+L 172.344421 197.03975 
+L 171.979176 197.210678 
+L 171.613932 197.380992 
+L 171.248687 197.550695 
+L 170.883442 197.719793 
+L 170.518197 197.88829 
+L 170.152952 198.05619 
+L 169.787707 198.223497 
+L 169.422463 198.390215 
+L 169.057218 198.556349 
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 169.057218 197.840024 
-L 168.839293 198.117285 
-L 168.621369 198.392934 
-L 168.403445 198.666989 
-L 168.18552 198.939468 
-L 167.967596 199.21039 
-L 167.749672 199.479771 
-L 167.531747 199.74763 
-L 167.313823 200.013983 
-L 167.095898 200.278847 
-L 166.877974 200.542239 
-L 166.66005 200.804176 
-L 166.442125 201.064672 
-L 166.224201 201.323745 
-L 166.006277 201.581408 
-L 165.788352 201.837679 
-L 165.570428 202.092571 
-L 165.352503 202.346099 
-L 165.134579 202.598278 
-L 164.916655 202.849122 
-L 164.69873 203.098646 
-L 164.480806 203.346862 
-L 164.262882 203.593785 
-L 164.044957 203.839428 
-L 163.827033 204.083805 
-L 163.609108 204.326927 
-L 163.391184 204.568809 
-L 163.17326 204.809462 
-L 162.955335 205.0489 
-L 162.737411 205.287134 
-L 162.519487 205.524176 
-L 162.301562 205.760038 
-L 162.083638 205.994732 
-L 161.865713 206.228269 
-L 161.647789 206.460662 
-L 161.429865 206.69192 
-L 161.21194 206.922055 
-L 160.994016 207.151078 
-L 160.776092 207.378999 
-L 160.558167 207.60583 
-L 160.340243 207.83158 
-L 160.122318 208.056259 
-L 159.904394 208.279879 
-L 159.68647 208.502448 
-L 159.468545 208.723976 
-L 159.250621 208.944474 
-L 159.032697 209.163951 
-L 158.814772 209.382415 
-L 158.596848 209.599878 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 169.057218 198.556349 
+L 168.839293 198.83012 
+L 168.621369 199.102319 
+L 168.403445 199.372963 
+L 168.18552 199.642069 
+L 167.967596 199.909657 
+L 167.749672 200.175742 
+L 167.531747 200.440341 
+L 167.313823 200.703471 
+L 167.095898 200.965148 
+L 166.877974 201.225388 
+L 166.66005 201.484206 
+L 166.442125 201.741619 
+L 166.224201 201.997641 
+L 166.006277 202.252287 
+L 165.788352 202.505572 
+L 165.570428 202.757511 
+L 165.352503 203.008117 
+L 165.134579 203.257405 
+L 164.916655 203.505389 
+L 164.69873 203.752081 
+L 164.480806 203.997496 
+L 164.262882 204.241647 
+L 164.044957 204.484546 
+L 163.827033 204.726206 
+L 163.609108 204.966641 
+L 163.391184 205.205861 
+L 163.17326 205.44388 
+L 162.955335 205.68071 
+L 162.737411 205.916362 
+L 162.519487 206.150848 
+L 162.301562 206.384179 
+L 162.083638 206.616367 
+L 161.865713 206.847423 
+L 161.647789 207.077358 
+L 161.429865 207.306182 
+L 161.21194 207.533907 
+L 160.994016 207.760543 
+L 160.776092 207.9861 
+L 160.558167 208.210589 
+L 160.340243 208.434019 
+L 160.122318 208.656401 
+L 159.904394 208.877744 
+L 159.68647 209.098058 
+L 159.468545 209.317352 
+L 159.250621 209.535637 
+L 159.032697 209.75292 
+L 158.814772 209.969212 
+L 158.596848 210.184521 
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 158.596848 209.599878 
-L 158.477483 209.712176 
-L 158.358117 209.824208 
-L 158.238752 209.935976 
-L 158.119387 210.047482 
-L 158.000021 210.158725 
-L 157.880656 210.269708 
-L 157.761291 210.380432 
-L 157.641925 210.490897 
-L 157.52256 210.601106 
-L 157.403195 210.711059 
-L 157.28383 210.820757 
-L 157.164464 210.930202 
-L 157.045099 211.039395 
-L 156.925734 211.148337 
-L 156.806368 211.257029 
-L 156.687003 211.365472 
-L 156.567638 211.473668 
-L 156.448272 211.581617 
-L 156.328907 211.689321 
-L 156.209542 211.796781 
-L 156.090177 211.903997 
-L 155.970811 212.010971 
-L 155.851446 212.117705 
-L 155.732081 212.224199 
-L 155.612715 212.330454 
-L 155.49335 212.436471 
-L 155.373985 212.542251 
-L 155.254619 212.647796 
-L 155.135254 212.753107 
-L 155.015889 212.858183 
-L 154.896524 212.963028 
-L 154.777158 213.067641 
-L 154.657793 213.172023 
-L 154.538428 213.276176 
-L 154.419062 213.380101 
-L 154.299697 213.483798 
-L 154.180332 213.587269 
-L 154.060966 213.690515 
-L 153.941601 213.793536 
-L 153.822236 213.896333 
-L 153.702871 213.998908 
-L 153.583505 214.101262 
-L 153.46414 214.203395 
-L 153.344775 214.305308 
-L 153.225409 214.407002 
-L 153.106044 214.508479 
-L 152.986679 214.609739 
-L 152.867313 214.710783 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.596848 210.184521 
+L 158.477483 210.293121 
+L 158.358117 210.401473 
+L 158.238752 210.509578 
+L 158.119387 210.617437 
+L 158.000021 210.725051 
+L 157.880656 210.832421 
+L 157.761291 210.939548 
+L 157.641925 211.046433 
+L 157.52256 211.153079 
+L 157.403195 211.259484 
+L 157.28383 211.365651 
+L 157.164464 211.471581 
+L 157.045099 211.577275 
+L 156.925734 211.682733 
+L 156.806368 211.787958 
+L 156.687003 211.892949 
+L 156.567638 211.997708 
+L 156.448272 212.102236 
+L 156.328907 212.206534 
+L 156.209542 212.310603 
+L 156.090177 212.414444 
+L 155.970811 212.518058 
+L 155.851446 212.621445 
+L 155.732081 212.724608 
+L 155.612715 212.827547 
+L 155.49335 212.930262 
+L 155.373985 213.032755 
+L 155.254619 213.135028 
+L 155.135254 213.237079 
+L 155.015889 213.338912 
+L 154.896524 213.440526 
+L 154.777158 213.541923 
+L 154.657793 213.643103 
+L 154.538428 213.744068 
+L 154.419062 213.844818 
+L 154.299697 213.945355 
+L 154.180332 214.045678 
+L 154.060966 214.14579 
+L 153.941601 214.24569 
+L 153.822236 214.345381 
+L 153.702871 214.444862 
+L 153.583505 214.544134 
+L 153.46414 214.6432 
+L 153.344775 214.742058 
+L 153.225409 214.840711 
+L 153.106044 214.939158 
+L 152.986679 215.037402 
+L 152.867313 215.135443 
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 152.867313 214.710783 
-L 152.827388 215.060662 
-L 152.787463 215.407977 
-L 152.747537 215.752766 
-L 152.707612 216.095063 
-L 152.667686 216.434906 
-L 152.627761 216.772329 
-L 152.587835 217.107367 
-L 152.54791 217.440052 
-L 152.507984 217.770418 
-L 152.468059 218.098497 
-L 152.428133 218.42432 
-L 152.388208 218.747919 
-L 152.348282 219.069322 
-L 152.308357 219.388561 
-L 152.268432 219.705663 
-L 152.228506 220.020657 
-L 152.188581 220.333572 
-L 152.148655 220.644434 
-L 152.10873 220.953269 
-L 152.068804 221.260106 
-L 152.028879 221.564968 
-L 151.988953 221.867881 
-L 151.949028 222.168871 
-L 151.909102 222.467961 
-L 151.869177 222.765175 
-L 151.829252 223.060536 
-L 151.789326 223.354069 
-L 151.749401 223.645794 
-L 151.709475 223.935734 
-L 151.66955 224.223911 
-L 151.629624 224.510346 
-L 151.589699 224.79506 
-L 151.549773 225.078074 
-L 151.509848 225.359408 
-L 151.469922 225.639081 
-L 151.429997 225.917114 
-L 151.390072 226.193525 
-L 151.350146 226.468332 
-L 151.310221 226.741556 
-L 151.270295 227.013213 
-L 151.23037 227.283322 
-L 151.190444 227.5519 
-L 151.150519 227.818964 
-L 151.110593 228.084532 
-L 151.070668 228.34862 
-L 151.030742 228.611244 
-L 150.990817 228.87242 
-L 150.950891 229.132166 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 152.867313 215.135443 
+L 152.827388 215.185812 
+L 152.787463 215.236129 
+L 152.747537 215.286392 
+L 152.707612 215.336602 
+L 152.667686 215.386758 
+L 152.627761 215.436862 
+L 152.587835 215.486912 
+L 152.54791 215.53691 
+L 152.507984 215.586855 
+L 152.468059 215.636748 
+L 152.428133 215.686588 
+L 152.388208 215.736376 
+L 152.348282 215.786111 
+L 152.308357 215.835795 
+L 152.268432 215.885426 
+L 152.228506 215.935005 
+L 152.188581 215.984533 
+L 152.148655 216.034009 
+L 152.10873 216.083433 
+L 152.068804 216.132806 
+L 152.028879 216.182127 
+L 151.988953 216.231397 
+L 151.949028 216.280616 
+L 151.909102 216.329784 
+L 151.869177 216.378901 
+L 151.829252 216.427967 
+L 151.789326 216.476982 
+L 151.749401 216.525947 
+L 151.709475 216.574861 
+L 151.66955 216.623724 
+L 151.629624 216.672538 
+L 151.589699 216.721301 
+L 151.549773 216.770014 
+L 151.509848 216.818677 
+L 151.469922 216.86729 
+L 151.429997 216.915853 
+L 151.390072 216.964366 
+L 151.350146 217.01283 
+L 151.310221 217.061245 
+L 151.270295 217.10961 
+L 151.23037 217.157925 
+L 151.190444 217.206192 
+L 151.150519 217.254409 
+L 151.110593 217.302577 
+L 151.070668 217.350697 
+L 151.030742 217.398767 
+L 150.990817 217.446789 
+L 150.950891 217.494763 
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 229.132166 
-L 150.293158 231.375503 
-L 149.635424 233.517427 
-L 148.97769 235.566709 
-L 148.319956 237.531034 
-L 147.662223 239.417165 
-L 147.004489 241.231091 
-L 146.346755 242.978137 
-L 145.689021 244.663058 
-L 145.031288 246.290124 
-L 144.373554 247.863174 
-L 143.71582 249.385681 
-L 143.058086 250.860791 
-L 142.400352 252.291368 
-L 141.742619 253.68002 
-L 141.084885 255.029136 
-L 140.427151 256.340905 
-L 139.769417 257.617338 
-L 139.111684 258.860291 
-L 138.45395 260.071473 
-L 137.796216 261.25247 
-L 137.138482 262.404749 
-L 136.480748 263.529673 
-L 135.823015 264.628512 
-L 135.165281 265.702447 
-L 134.507547 266.752583 
-L 133.849813 267.779952 
-L 133.19208 268.785519 
-L 132.534346 269.770192 
-L 131.876612 270.73482 
-L 131.218878 271.680203 
-L 130.561145 272.607095 
-L 129.903411 273.516205 
-L 129.245677 274.408203 
-L 128.587943 275.283719 
-L 127.930209 276.143354 
-L 127.272476 276.987672 
-L 126.614742 277.81721 
-L 125.957008 278.632477 
-L 125.299274 279.433954 
-L 124.641541 280.222102 
-L 123.983807 280.997356 
-L 123.326073 281.76013 
-L 122.668339 282.510822 
-L 122.010605 283.249807 
-L 121.352872 283.977444 
-L 120.695138 284.694078 
-L 120.037404 285.400036 
-L 119.37967 286.095631 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 150.950891 217.494763 
+L 150.293158 220.744669 
+L 149.635424 223.78593 
+L 148.97769 226.643728 
+L 148.319956 229.338943 
+L 147.662223 231.889084 
+L 147.004489 234.308972 
+L 146.346755 236.611271 
+L 145.689021 238.806879 
+L 145.031288 240.90525 
+L 144.373554 242.914632 
+L 143.71582 244.842266 
+L 143.058086 246.694545 
+L 142.400352 248.477139 
+L 141.742619 250.195103 
+L 141.084885 251.852959 
+L 140.427151 253.454771 
+L 139.769417 255.004205 
+L 139.111684 256.504578 
+L 138.45395 257.958903 
+L 137.796216 259.369921 
+L 137.138482 260.740137 
+L 136.480748 262.071846 
+L 135.823015 263.367151 
+L 135.165281 264.627992 
+L 134.507547 265.856153 
+L 133.849813 267.053287 
+L 133.19208 268.220923 
+L 132.534346 269.360479 
+L 131.876612 270.473275 
+L 131.218878 271.560538 
+L 130.561145 272.623414 
+L 129.903411 273.662973 
+L 129.245677 274.680216 
+L 128.587943 275.676081 
+L 127.930209 276.651448 
+L 127.272476 277.607144 
+L 126.614742 278.543947 
+L 125.957008 279.46259 
+L 125.299274 280.363762 
+L 124.641541 281.248116 
+L 123.983807 282.116269 
+L 123.326073 282.968803 
+L 122.668339 283.80627 
+L 122.010605 284.629194 
+L 121.352872 285.438071 
+L 120.695138 286.233373 
+L 120.037404 287.015548 
+L 119.37967 287.785022 
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 119.37967 286.095631 
-L 118.987211 286.782973 
-L 118.594752 287.460487 
-L 118.202293 288.128452 
-L 117.809834 288.787132 
-L 117.417375 289.436782 
-L 117.024916 290.077647 
-L 116.632457 290.70996 
-L 116.239998 291.333947 
-L 115.847539 291.949825 
-L 115.45508 292.557801 
-L 115.062621 293.158075 
-L 114.670162 293.750841 
-L 114.277703 294.336284 
-L 113.885243 294.914582 
-L 113.492784 295.485909 
-L 113.100325 296.050429 
-L 112.707866 296.608303 
-L 112.315407 297.159687 
-L 111.922948 297.704728 
-L 111.530489 298.243572 
-L 111.13803 298.776358 
-L 110.745571 299.30322 
-L 110.353112 299.824289 
-L 109.960653 300.339691 
-L 109.568194 300.849548 
-L 109.175735 301.353977 
-L 108.783276 301.853093 
-L 108.390817 302.347008 
-L 107.998358 302.835827 
-L 107.605898 303.319656 
-L 107.213439 303.798595 
-L 106.82098 304.272742 
-L 106.428521 304.742191 
-L 106.036062 305.207036 
-L 105.643603 305.667365 
-L 105.251144 306.123266 
-L 104.858685 306.574822 
-L 104.466226 307.022116 
-L 104.073767 307.465228 
-L 103.681308 307.904235 
-L 103.288849 308.339212 
-L 102.89639 308.770233 
-L 102.503931 309.197369 
-L 102.111472 309.620689 
-L 101.719013 310.040261 
-L 101.326553 310.456151 
-L 100.934094 310.868423 
-L 100.541635 311.277139 
-" clip-path="url(#p72cdef9915)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.37967 287.785022 
+L 118.987211 288.458041 
+L 118.594752 289.121634 
+L 118.202293 289.776064 
+L 117.809834 290.421579 
+L 117.417375 291.058419 
+L 117.024916 291.686814 
+L 116.632457 292.306985 
+L 116.239998 292.919145 
+L 115.847539 293.523498 
+L 115.45508 294.12024 
+L 115.062621 294.709562 
+L 114.670162 295.291644 
+L 114.277703 295.866664 
+L 113.885243 296.434789 
+L 113.492784 296.996185 
+L 113.100325 297.551007 
+L 112.707866 298.099409 
+L 112.315407 298.641537 
+L 111.922948 299.177533 
+L 111.530489 299.707534 
+L 111.13803 300.231673 
+L 110.745571 300.750079 
+L 110.353112 301.262874 
+L 109.960653 301.77018 
+L 109.568194 302.272113 
+L 109.175735 302.768785 
+L 108.783276 303.260305 
+L 108.390817 303.74678 
+L 107.998358 304.228311 
+L 107.605898 304.704999 
+L 107.213439 305.176939 
+L 106.82098 305.644226 
+L 106.428521 306.10695 
+L 106.036062 306.565199 
+L 105.643603 307.019059 
+L 105.251144 307.468614 
+L 104.858685 307.913944 
+L 104.466226 308.355128 
+L 104.073767 308.792242 
+L 103.681308 309.225362 
+L 103.288849 309.654558 
+L 102.89639 310.079903 
+L 102.503931 310.501463 
+L 102.111472 310.919307 
+L 101.719013 311.333498 
+L 101.326553 311.744101 
+L 100.934094 312.151176 
+L 100.541635 312.554784 
+" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-03T22:49:18Z  ·  Linux chungus x86_64  ·  commit 2d0b6447  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.617109 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.688984 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6416,16 +6416,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6464,109 +6464,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3262.451172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.697266 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3453.320312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3516.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3548.730469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3580.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.304688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3644.091797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3675.878906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3703.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3765.185547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3826.464844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3889.84375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3953.320312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3992.183594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4053.365234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4174.068359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4215.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4248.873047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4276.65625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4338.179688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4399.458984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4462.837891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4526.460938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4560.152344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4682.955078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4714.742188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4778.365234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4841.988281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4873.775391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4937.398438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4973.482422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5012.345703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5067.326172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5130.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5162.736328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5194.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.310547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5258.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5289.884766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5329.09375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5392.472656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5431.335938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5492.517578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5555.896484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5619.373047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5682.751953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5746.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5809.607422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5848.816406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5880.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5964.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6093.591797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6155.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6218.591797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6246.375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6307.654297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6371.033203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6402.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6454.919922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6518.298828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6579.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6643.054688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6695.154297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6758.533203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6819.714844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6858.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6892.615234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6924.402344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6965.515625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7026.794922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7066.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7093.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7154.96875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7186.755859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7214.539062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7266.638672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7298.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7361.902344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7423.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7462.634766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7524.158203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7563.521484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.933594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7688.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7752.095703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7779.878906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7831.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7871.1875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7898.970703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p72cdef9915">
+  <clipPath id="p93575b0a99">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p07fa8bb74e)">
+   <g clip-path="url(#pc82d8f76a5)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="imagef7a3c31e99" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="imageaf04dd4cc9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m8d8ef9a201" d="M 0 0 
+       <path id="m411f0e5819" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8d8ef9a201" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m8d8ef9a201" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m8d8ef9a201" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8d8ef9a201" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m8d8ef9a201" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8d8ef9a201" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m8d8ef9a201" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8d8ef9a201" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m8d8ef9a201" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8d8ef9a201" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m8d8ef9a201" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m411f0e5819" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mbfd3206e72" d="M 0 0 
+       <path id="mcaa80a7eee" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbfd3206e72" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcaa80a7eee" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mbfd3206e72" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcaa80a7eee" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mbfd3206e72" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcaa80a7eee" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mbfd3206e72" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcaa80a7eee" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mbfd3206e72" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcaa80a7eee" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mbfd3206e72" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcaa80a7eee" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mbfd3206e72" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcaa80a7eee" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mbfd3206e72" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcaa80a7eee" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image297b273e82" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image91dcc95c41" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="ma9c714c434" d="M 0 0 
+       <path id="m3d6300c706" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma9c714c434" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d6300c706" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#ma9c714c434" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d6300c706" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#ma9c714c434" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d6300c706" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#ma9c714c434" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d6300c706" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#ma9c714c434" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d6300c706" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#ma9c714c434" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d6300c706" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#ma9c714c434" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d6300c706" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#ma9c714c434" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d6300c706" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#ma9c714c434" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d6300c706" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-03T22:49:18Z  ·  Linux chungus x86_64  ·  commit 2d0b6447  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.617109 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(19.688984 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2950,16 +2950,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2998,109 +2998,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3262.451172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.697266 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3453.320312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3516.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3548.730469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3580.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.304688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3644.091797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3675.878906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3703.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3765.185547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3826.464844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3889.84375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3953.320312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3992.183594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4053.365234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4174.068359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4215.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4248.873047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4276.65625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4338.179688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4399.458984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4462.837891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4526.460938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4560.152344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4682.955078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4714.742188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4778.365234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4841.988281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4873.775391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4937.398438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4973.482422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5012.345703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5067.326172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5130.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5162.736328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5194.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.310547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5258.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5289.884766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5329.09375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5392.472656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5431.335938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5492.517578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5555.896484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5619.373047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5682.751953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5746.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5809.607422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5848.816406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5880.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5964.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6093.591797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6155.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6218.591797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6246.375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6307.654297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6371.033203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6402.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6454.919922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6518.298828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6579.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6643.054688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6695.154297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6758.533203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6819.714844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6858.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6892.615234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6924.402344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6965.515625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7026.794922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7066.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7093.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7154.96875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7186.755859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7214.539062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7266.638672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7298.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7361.902344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7423.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7462.634766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7524.158203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7563.521484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.933594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7688.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7752.095703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7779.878906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7831.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7871.1875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7898.970703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p07fa8bb74e">
+  <clipPath id="pc82d8f76a5">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="571.165781pt" height="386.202469pt" viewBox="0 0 571.165781 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.022031pt" height="386.202469pt" viewBox="0 0 569.022031 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 571.165781 386.202469 
-L 571.165781 0 
+L 569.022031 386.202469 
+L 569.022031 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.707891 104.1264 
-L 292.332891 104.1264 
-L 292.332891 74.7432 
-L 187.707891 74.7432 
+    <path d="M 186.636016 104.1264 
+L 291.261016 104.1264 
+L 291.261016 74.7432 
+L 186.636016 74.7432 
 z
-" clip-path="url(#p57013460e1)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.332891 104.1264 
-L 396.957891 104.1264 
-L 396.957891 74.7432 
-L 292.332891 74.7432 
+    <path d="M 291.261016 104.1264 
+L 395.886016 104.1264 
+L 395.886016 74.7432 
+L 291.261016 74.7432 
 z
-" clip-path="url(#p57013460e1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.957891 104.1264 
-L 501.582891 104.1264 
-L 501.582891 74.7432 
-L 396.957891 74.7432 
+    <path d="M 395.886016 104.1264 
+L 500.511016 104.1264 
+L 500.511016 74.7432 
+L 395.886016 74.7432 
 z
-" clip-path="url(#p57013460e1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.707891 133.5096 
-L 292.332891 133.5096 
-L 292.332891 104.1264 
-L 187.707891 104.1264 
+    <path d="M 186.636016 133.5096 
+L 291.261016 133.5096 
+L 291.261016 104.1264 
+L 186.636016 104.1264 
 z
-" clip-path="url(#p57013460e1)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.332891 133.5096 
-L 396.957891 133.5096 
-L 396.957891 104.1264 
-L 292.332891 104.1264 
+    <path d="M 291.261016 133.5096 
+L 395.886016 133.5096 
+L 395.886016 104.1264 
+L 291.261016 104.1264 
 z
-" clip-path="url(#p57013460e1)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.957891 133.5096 
-L 501.582891 133.5096 
-L 501.582891 104.1264 
-L 396.957891 104.1264 
+    <path d="M 395.886016 133.5096 
+L 500.511016 133.5096 
+L 500.511016 104.1264 
+L 395.886016 104.1264 
 z
-" clip-path="url(#p57013460e1)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.707891 162.8928 
-L 292.332891 162.8928 
-L 292.332891 133.5096 
-L 187.707891 133.5096 
+    <path d="M 186.636016 162.8928 
+L 291.261016 162.8928 
+L 291.261016 133.5096 
+L 186.636016 133.5096 
 z
-" clip-path="url(#p57013460e1)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.332891 162.8928 
-L 396.957891 162.8928 
-L 396.957891 133.5096 
-L 292.332891 133.5096 
+    <path d="M 291.261016 162.8928 
+L 395.886016 162.8928 
+L 395.886016 133.5096 
+L 291.261016 133.5096 
 z
-" clip-path="url(#p57013460e1)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.957891 162.8928 
-L 501.582891 162.8928 
-L 501.582891 133.5096 
-L 396.957891 133.5096 
+    <path d="M 395.886016 162.8928 
+L 500.511016 162.8928 
+L 500.511016 133.5096 
+L 395.886016 133.5096 
 z
-" clip-path="url(#p57013460e1)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.707891 192.276 
-L 292.332891 192.276 
-L 292.332891 162.8928 
-L 187.707891 162.8928 
+    <path d="M 186.636016 192.276 
+L 291.261016 192.276 
+L 291.261016 162.8928 
+L 186.636016 162.8928 
 z
-" clip-path="url(#p57013460e1)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.332891 192.276 
-L 396.957891 192.276 
-L 396.957891 162.8928 
-L 292.332891 162.8928 
+    <path d="M 291.261016 192.276 
+L 395.886016 192.276 
+L 395.886016 162.8928 
+L 291.261016 162.8928 
 z
-" clip-path="url(#p57013460e1)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.957891 192.276 
-L 501.582891 192.276 
-L 501.582891 162.8928 
-L 396.957891 162.8928 
+    <path d="M 395.886016 192.276 
+L 500.511016 192.276 
+L 500.511016 162.8928 
+L 395.886016 162.8928 
 z
-" clip-path="url(#p57013460e1)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.707891 221.6592 
-L 292.332891 221.6592 
-L 292.332891 192.276 
-L 187.707891 192.276 
+    <path d="M 186.636016 221.6592 
+L 291.261016 221.6592 
+L 291.261016 192.276 
+L 186.636016 192.276 
 z
-" clip-path="url(#p57013460e1)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.332891 221.6592 
-L 396.957891 221.6592 
-L 396.957891 192.276 
-L 292.332891 192.276 
+    <path d="M 291.261016 221.6592 
+L 395.886016 221.6592 
+L 395.886016 192.276 
+L 291.261016 192.276 
 z
-" clip-path="url(#p57013460e1)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.957891 221.6592 
-L 501.582891 221.6592 
-L 501.582891 192.276 
-L 396.957891 192.276 
+    <path d="M 395.886016 221.6592 
+L 500.511016 221.6592 
+L 500.511016 192.276 
+L 395.886016 192.276 
 z
-" clip-path="url(#p57013460e1)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.707891 251.0424 
-L 292.332891 251.0424 
-L 292.332891 221.6592 
-L 187.707891 221.6592 
+    <path d="M 186.636016 251.0424 
+L 291.261016 251.0424 
+L 291.261016 221.6592 
+L 186.636016 221.6592 
 z
-" clip-path="url(#p57013460e1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.332891 251.0424 
-L 396.957891 251.0424 
-L 396.957891 221.6592 
-L 292.332891 221.6592 
+    <path d="M 291.261016 251.0424 
+L 395.886016 251.0424 
+L 395.886016 221.6592 
+L 291.261016 221.6592 
 z
-" clip-path="url(#p57013460e1)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.957891 251.0424 
-L 501.582891 251.0424 
-L 501.582891 221.6592 
-L 396.957891 221.6592 
+    <path d="M 395.886016 251.0424 
+L 500.511016 251.0424 
+L 500.511016 221.6592 
+L 395.886016 221.6592 
 z
-" clip-path="url(#p57013460e1)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.707891 280.4256 
-L 292.332891 280.4256 
-L 292.332891 251.0424 
-L 187.707891 251.0424 
+    <path d="M 186.636016 280.4256 
+L 291.261016 280.4256 
+L 291.261016 251.0424 
+L 186.636016 251.0424 
 z
-" clip-path="url(#p57013460e1)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.332891 280.4256 
-L 396.957891 280.4256 
-L 396.957891 251.0424 
-L 292.332891 251.0424 
+    <path d="M 291.261016 280.4256 
+L 395.886016 280.4256 
+L 395.886016 251.0424 
+L 291.261016 251.0424 
 z
-" clip-path="url(#p57013460e1)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.957891 280.4256 
-L 501.582891 280.4256 
-L 501.582891 251.0424 
-L 396.957891 251.0424 
+    <path d="M 395.886016 280.4256 
+L 500.511016 280.4256 
+L 500.511016 251.0424 
+L 395.886016 251.0424 
 z
-" clip-path="url(#p57013460e1)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.707891 309.8088 
-L 292.332891 309.8088 
-L 292.332891 280.4256 
-L 187.707891 280.4256 
+    <path d="M 186.636016 309.8088 
+L 291.261016 309.8088 
+L 291.261016 280.4256 
+L 186.636016 280.4256 
 z
-" clip-path="url(#p57013460e1)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.332891 309.8088 
-L 396.957891 309.8088 
-L 396.957891 280.4256 
-L 292.332891 280.4256 
+    <path d="M 291.261016 309.8088 
+L 395.886016 309.8088 
+L 395.886016 280.4256 
+L 291.261016 280.4256 
 z
-" clip-path="url(#p57013460e1)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.957891 309.8088 
-L 501.582891 309.8088 
-L 501.582891 280.4256 
-L 396.957891 280.4256 
+    <path d="M 395.886016 309.8088 
+L 500.511016 309.8088 
+L 500.511016 280.4256 
+L 395.886016 280.4256 
 z
-" clip-path="url(#p57013460e1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.707891 339.192 
-L 292.332891 339.192 
-L 292.332891 309.8088 
-L 187.707891 309.8088 
+    <path d="M 186.636016 339.192 
+L 291.261016 339.192 
+L 291.261016 309.8088 
+L 186.636016 309.8088 
 z
-" clip-path="url(#p57013460e1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.332891 339.192 
-L 396.957891 339.192 
-L 396.957891 309.8088 
-L 292.332891 309.8088 
+    <path d="M 291.261016 339.192 
+L 395.886016 339.192 
+L 395.886016 309.8088 
+L 291.261016 309.8088 
 z
-" clip-path="url(#p57013460e1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.957891 339.192 
-L 501.582891 339.192 
-L 501.582891 309.8088 
-L 396.957891 309.8088 
+    <path d="M 395.886016 339.192 
+L 500.511016 339.192 
+L 500.511016 309.8088 
+L 395.886016 309.8088 
 z
-" clip-path="url(#p57013460e1)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p3855ef40a9)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.695156 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.623281 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.979375 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.9075 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.551484 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.479609 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.903203 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.831328 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.632891 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.561016 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.569141 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(337.010391 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.938516 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(441.635391 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.271016 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.199141 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.569141 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.555391 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(441.635391 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.534141 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(127.462266 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.569141 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.555391 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(441.635391 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(111.840391 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(110.768516 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(228.569141 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(339.555391 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(441.635391 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(119.996641 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(118.924766 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(228.569141 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(339.555391 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(441.635391 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- OCaml decompress -->
-    <g transform="translate(96.457266 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(95.385391 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1629,7 +1629,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.321 -->
-    <g transform="translate(228.569141 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1639,14 +1639,14 @@ z
    </g>
    <g id="text_27">
     <!-- 23 -->
-    <g transform="translate(339.555391 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 117 -->
-    <g transform="translate(441.635391 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1654,7 +1654,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.342266 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.270391 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1763,7 +1763,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.298 -->
-    <g transform="translate(227.368516 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.296641 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1894,7 +1894,7 @@ z
    </g>
    <g id="text_31">
     <!-- 18 -->
-    <g transform="translate(339.079141 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.007266 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1916,48 +1916,69 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 206 -->
-    <g transform="translate(440.921016 267.9415) scale(0.08 -0.08)">
+    <!-- 134 -->
+    <g transform="translate(439.849141 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
 z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(98.964141 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.892266 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2013,7 +2034,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(228.569141 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2023,21 +2044,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(339.555391 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(444.180391 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.108516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.678516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.606641 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2048,7 +2069,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.569141 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2058,13 +2079,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(342.100391 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.028516 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.270391 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.198516 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2080,7 +2101,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(135.091641 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(134.019766 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2219,6 +2240,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2263,7 +2314,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-03T22:49:18Z  ·  Linux chungus x86_64  ·  commit 2d0b6447  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2402,16 +2453,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2450,110 +2501,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3262.451172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.697266 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3453.320312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3516.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3548.730469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3580.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.304688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3644.091797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3675.878906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3703.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3765.185547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3826.464844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3889.84375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3953.320312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3992.183594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4053.365234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4174.068359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4215.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4248.873047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4276.65625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4338.179688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4399.458984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4462.837891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4526.460938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4560.152344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4682.955078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4714.742188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4778.365234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4841.988281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4873.775391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4937.398438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4973.482422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5012.345703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5067.326172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5130.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5162.736328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5194.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.310547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5258.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5289.884766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5329.09375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5392.472656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5431.335938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5492.517578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5555.896484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5619.373047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5682.751953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5746.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5809.607422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5848.816406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5880.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5964.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6093.591797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6155.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6218.591797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6246.375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6307.654297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6371.033203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6402.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6454.919922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6518.298828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6579.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6643.054688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6695.154297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6758.533203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6819.714844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6858.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6892.615234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6924.402344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6965.515625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7026.794922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7066.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7093.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7154.96875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7186.755859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7214.539062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7266.638672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7298.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7361.902344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7423.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7462.634766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7524.158203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7563.521484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.933594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7688.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7752.095703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7779.878906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7831.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7871.1875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7898.970703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p57013460e1">
-   <rect x="83.082891" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p3855ef40a9">
+   <rect x="82.011016" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p10f8c95f7d)">
+   <g clip-path="url(#p64180291ca)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7UlEQVR4nO3XsY5cZx2HYc/uZB0cW5jYrBWQLBpCBVIEVRruIEUug5KWnpKalp4boAJRISEEDQodlkkBjgIEm8i7s57lCqis7/2vj57nCn6jc85877c7fv6L61tbdng5vYDXcbyaXrDW7mR6wVpXl9ML1rpzf3rBWhcvphesdXo2vYDXsfX38+zO9IKlNn76AQBw0whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS+z8cnkxvWGp/cjo9Yanj9fX0hKXO751PT1jqyX/+Nj1hrY1fcd9/+/70hKUOt8+mJyz1x2efTE9Y6nsPvz09YamLs+P0hKV2uy+nJyy18eMBAICbRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPaP731resNS92+fT09Y6rOXn05PWOobX277jnT3wXenJyx1uttPT1jqeOs4PWGpr996OD1hqauHl9MTlnp05/H0hKUOx20/v3cut/3/su3THQCAG0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2u92227Q54d/Tk9Y6iund6cnLPXqwbvTE5b6+xd/mp6w1IvLl9MTlvr+134wPWGpy9PpBWv99/B8egKv4d8Xz6YnrHX7fHrBUtuuTwAAbhwBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAavfqtz++nh6x1PE4vQD+vxN3wDea/5c329a/v62/n57fG23jTw8AgJtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNo/+v1fpjcsdbLfdmM/++Sz6QlL/fxHH0xPWOqnv/vH9ISlfvj4q9MTlvrlb/46PWGpn3z8nekJS/3s10+nJyz10QfvTU9Y6ukXF9MTlvrwm+9MT1hq23UGAMCNI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUrvDq19dT49Y6fTqanrCWif76QVrXb2cXrDW2Z3pBWvtNn7HvT5OL1jr4Pt7o73a9vl32G37+3tr4/2y8dMBAICbRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDa73Ybb9DPn0wvWOve+fSCtZ4/m16w1u270wvWeuvt6QVrbf33/evT6QVrPXp/esFaFy+mFyy1f/rn6QlrPXhvesFSG69PAABuGgEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDqf9Aad6/FymREAAAAAElFTkSuQmCC" id="image08effed39b" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7UlEQVR4nO3XsY5cZx2HYc/uZB0cW5jYrBWQLBpCBVIEVRruIEUug5KWnpKalp4boAJRISEEDQodlkkBjgIEm8i7s57lCqis7/2vj57nCn6jc85877c7fv6L61tbdng5vYDXcbyaXrDW7mR6wVpXl9ML1rpzf3rBWhcvphesdXo2vYDXsfX38+zO9IKlNn76AQBw0whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS+z8cnkxvWGp/cjo9Yanj9fX0hKXO751PT1jqyX/+Nj1hrY1fcd9/+/70hKUOt8+mJyz1x2efTE9Y6nsPvz09YamLs+P0hKV2uy+nJyy18eMBAICbRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPaP731resNS92+fT09Y6rOXn05PWOobX277jnT3wXenJyx1uttPT1jqeOs4PWGpr996OD1hqauHl9MTlnp05/H0hKUOx20/v3cut/3/su3THQCAG0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2u92227Q54d/Tk9Y6iund6cnLPXqwbvTE5b6+xd/mp6w1IvLl9MTlvr+134wPWGpy9PpBWv99/B8egKv4d8Xz6YnrHX7fHrBUtuuTwAAbhwBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAavfqtz++nh6x1PE4vQD+vxN3wDea/5c329a/v62/n57fG23jTw8AgJtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNo/+v1fpjcsdbLfdmM/++Sz6QlL/fxHH0xPWOqnv/vH9ISlfvj4q9MTlvrlb/46PWGpn3z8nekJS/3s10+nJyz10QfvTU9Y6ukXF9MTlvrwm+9MT1hq23UGAMCNI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUrvDq19dT49Y6fTqanrCWif76QVrXb2cXrDW2Z3pBWvtNn7HvT5OL1jr4Pt7o73a9vl32G37+3tr4/2y8dMBAICbRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDa73Ybb9DPn0wvWOve+fSCtZ4/m16w1u270wvWeuvt6QVrbf33/evT6QVrPXp/esFaFy+mFyy1f/rn6QlrPXhvesFSG69PAABuGgEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDqf9Aad6/FymREAAAAAElFTkSuQmCC" id="image376915cd6d" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="macae89da47" d="M 0 0 
+       <path id="m9daf9c7cd5" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#macae89da47" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#macae89da47" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#macae89da47" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#macae89da47" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#macae89da47" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#macae89da47" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#macae89da47" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#macae89da47" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#macae89da47" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#macae89da47" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#macae89da47" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#macae89da47" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9daf9c7cd5" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mffd84d6d26" d="M 0 0 
+       <path id="m9e540e7528" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mffd84d6d26" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e540e7528" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mffd84d6d26" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e540e7528" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mffd84d6d26" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e540e7528" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mffd84d6d26" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e540e7528" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mffd84d6d26" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e540e7528" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mffd84d6d26" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e540e7528" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mffd84d6d26" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e540e7528" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mffd84d6d26" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9e540e7528" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +4 -->
+    <!-- +3 -->
     <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,6 +1156,47 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -49 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
 L 2419 1625 
@@ -1175,15 +1216,6 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -49 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
 Q 941 559 1184 500 
@@ -1306,40 +1338,6 @@ z
    <g id="text_25">
     <!-- -34 -->
     <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
@@ -1381,7 +1379,7 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- -16 -->
+    <!-- -15 -->
     <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
@@ -1398,6 +1396,67 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -49 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -3 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -21 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -72 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -42 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +6 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1429,88 +1488,6 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -50 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -4 -->
-    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -21 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- -73 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -42 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- +6 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
     </g>
@@ -1617,6 +1594,29 @@ z
    <g id="text_47">
     <!-- +305 -->
     <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
@@ -2195,18 +2195,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imageb9bd0ab03d" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagef37c5e82a7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mb09e62ed93" d="M 0 0 
+       <path id="mb4d1939c0a" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb09e62ed93" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4d1939c0a" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2229,7 +2229,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb09e62ed93" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4d1939c0a" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2243,7 +2243,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mb09e62ed93" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4d1939c0a" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2257,7 +2257,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb09e62ed93" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4d1939c0a" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2270,7 +2270,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mb09e62ed93" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4d1939c0a" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2283,7 +2283,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb09e62ed93" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4d1939c0a" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2296,7 +2296,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mb09e62ed93" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb4d1939c0a" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2912,8 +2912,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-03T22:49:18Z  ·  Linux chungus x86_64  ·  commit 2d0b6447  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.617109 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.688984 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3002,16 +3002,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3050,109 +3050,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3262.451172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.697266 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3453.320312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3516.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3548.730469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3580.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.304688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3644.091797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3675.878906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3703.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3765.185547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3826.464844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3889.84375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3953.320312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3992.183594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4053.365234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4174.068359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4215.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4248.873047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4276.65625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4338.179688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4399.458984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4462.837891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4526.460938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4560.152344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4682.955078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4714.742188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4778.365234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4841.988281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4873.775391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4937.398438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4973.482422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5012.345703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5067.326172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5130.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5162.736328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5194.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.310547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5258.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5289.884766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5329.09375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5392.472656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5431.335938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5492.517578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5555.896484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5619.373047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5682.751953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5746.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5809.607422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5848.816406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5880.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5964.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6093.591797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6155.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6218.591797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6246.375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6307.654297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6371.033203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6402.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6454.919922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6518.298828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6579.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6643.054688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6695.154297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6758.533203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6819.714844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6858.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6892.615234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6924.402344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6965.515625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7026.794922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7066.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7093.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7154.96875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7186.755859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7214.539062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7266.638672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7298.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7361.902344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7423.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7462.634766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7524.158203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7563.521484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.933594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7688.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7752.095703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7779.878906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7831.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7871.1875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7898.970703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p10f8c95f7d">
+  <clipPath id="p64180291ca">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m4425e4a2b8" d="M 0 0 
+       <path id="mb5a5bb871b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4425e4a2b8" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a5bb871b" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4425e4a2b8" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a5bb871b" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4425e4a2b8" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a5bb871b" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4425e4a2b8" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a5bb871b" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4425e4a2b8" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a5bb871b" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m4425e4a2b8" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a5bb871b" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m4425e4a2b8" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb5a5bb871b" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="ma644c0cc35" d="M 0 0 
+       <path id="m241e6564bf" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma644c0cc35" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m241e6564bf" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#ma644c0cc35" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m241e6564bf" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#ma644c0cc35" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m241e6564bf" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m845ac8d1dd" d="M 0 0 
+       <path id="m335ab5bc11" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m845ac8d1dd" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m335ab5bc11" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 127.474873) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 127.599674) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.149529 322.894785) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.149529 322.988146) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m4eea0d050a" d="M -2.5 2.5 
+     <path id="m6aa231fb8e" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0cdf9614cb)">
-     <use xlink:href="#m4eea0d050a" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4eea0d050a" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4eea0d050a" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4eea0d050a" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4eea0d050a" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4eea0d050a" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4eea0d050a" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4eea0d050a" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4eea0d050a" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38dff6dda8)">
+     <use xlink:href="#m6aa231fb8e" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6aa231fb8e" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6aa231fb8e" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6aa231fb8e" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6aa231fb8e" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6aa231fb8e" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6aa231fb8e" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6aa231fb8e" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6aa231fb8e" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 111.868554
 L 326.02264 111.96025 
 L 324.91204 112.051791 
 L 323.801439 112.143178 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 112.143178 
@@ -1807,7 +1807,7 @@ L 275.861725 127.410211
 L 274.796398 127.705019 
 L 273.731071 127.99823 
 L 272.665744 128.289861 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 128.289861 
@@ -1859,7 +1859,7 @@ L 237.512385 129.68632
 L 236.7312 129.716946 
 L 235.950014 129.747556 
 L 235.168828 129.778148 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 129.778148 
@@ -1911,7 +1911,7 @@ L 189.28705 148.994297
 L 188.267455 149.352551 
 L 187.24786 149.708449 
 L 186.228265 150.062022 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 150.062022 
@@ -1963,7 +1963,7 @@ L 160.048483 171.011997
 L 159.46671 171.396655 
 L 158.884937 171.778598 
 L 158.303164 172.157864 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 172.157864 
@@ -2015,7 +2015,7 @@ L 150.040398 181.598676
 L 149.856781 181.790851 
 L 149.673164 181.982345 
 L 149.489547 182.173164 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.173164 
@@ -2067,7 +2067,7 @@ L 141.121061 201.502451
 L 140.935095 201.862455 
 L 140.749129 202.220079 
 L 140.563162 202.575355 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.575355 
@@ -2119,26 +2119,26 @@ L 139.083497 208.86883
 L 139.050616 209.000699 
 L 139.017734 209.132247 
 L 138.984853 209.263476 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="mf152952544" d="M 0 -2.5 
+     <path id="me3b4a775c3" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0cdf9614cb)">
-     <use xlink:href="#mf152952544" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf152952544" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf152952544" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf152952544" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf152952544" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf152952544" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf152952544" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf152952544" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf152952544" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38dff6dda8)">
+     <use xlink:href="#me3b4a775c3" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b4a775c3" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b4a775c3" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b4a775c3" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b4a775c3" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b4a775c3" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b4a775c3" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b4a775c3" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me3b4a775c3" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.20247
 L 331.988718 100.690952 
 L 325.934838 101.175064 
 L 319.880958 101.654884 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.654884 
@@ -2243,7 +2243,7 @@ L 217.131235 128.404389
 L 214.847908 128.871381 
 L 212.564581 129.334377 
 L 210.281253 129.793447 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.793447 
@@ -2295,7 +2295,7 @@ L 197.161712 133.343265
 L 196.870166 133.419565 
 L 196.578621 133.495757 
 L 196.287076 133.571842 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.571842 
@@ -2347,7 +2347,7 @@ L 177.31896 146.664131
 L 176.897447 146.921938 
 L 176.475933 147.178523 
 L 176.054419 147.433896 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.433896 
@@ -2399,7 +2399,7 @@ L 153.654726 173.470231
 L 153.156955 173.927574 
 L 152.659184 174.381084 
 L 152.161413 174.830826 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.830826 
@@ -2451,7 +2451,7 @@ L 147.060283 185.961812
 L 146.946925 186.184927 
 L 146.833566 186.407126 
 L 146.720208 186.628416 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.628416 
@@ -2503,7 +2503,7 @@ L 144.164409 195.79469
 L 144.107613 195.981745 
 L 144.050817 196.168156 
 L 143.994022 196.353927 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.353927 
@@ -2555,30 +2555,30 @@ L 142.749036 200.0341
 L 142.72137 200.113105 
 L 142.693704 200.191995 
 L 142.666037 200.270771 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="mdd8b828e29" d="M -0 3.535534 
+     <path id="m38f07fca3b" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0cdf9614cb)">
-     <use xlink:href="#mdd8b828e29" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mdd8b828e29" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38dff6dda8)">
+     <use xlink:href="#m38f07fca3b" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m38f07fca3b" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.665392
 L 244.888911 79.95196 
 L 243.864032 80.237018 
 L 242.839153 80.520583 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.520583 
@@ -2683,7 +2683,7 @@ L 219.787941 85.73042
 L 219.275692 85.840684 
 L 218.763443 85.950723 
 L 218.251194 86.060539 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.060539 
@@ -2735,7 +2735,7 @@ L 199.092247 89.895187
 L 198.666492 89.97739 
 L 198.240738 90.059468 
 L 197.814984 90.141422 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.141422 
@@ -2787,7 +2787,7 @@ L 168.343148 98.26681
 L 167.688219 98.434213 
 L 167.033289 98.601101 
 L 166.378359 98.767475 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 98.767475 
@@ -2839,7 +2839,7 @@ L 147.11464 109.552827
 L 146.686557 109.769695 
 L 146.258475 109.985696 
 L 145.830392 110.20084 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.20084 
@@ -2891,7 +2891,7 @@ L 135.300472 124.91473
 L 135.066474 125.20027 
 L 134.832476 125.484312 
 L 134.598477 125.76687 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 125.76687 
@@ -2943,7 +2943,7 @@ L 124.734843 147.930147
 L 124.515652 148.332777 
 L 124.29646 148.732435 
 L 124.077268 149.129162 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.129162 
@@ -2995,7 +2995,7 @@ L 122.56387 156.732863
 L 122.530239 156.890271 
 L 122.496607 157.047223 
 L 122.462976 157.203722 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.203722 
@@ -3047,7 +3047,7 @@ L 83.602758 217.017639
 L 82.739198 217.816123 
 L 81.875637 218.602997 
 L 81.012077 219.378594 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 219.378594 
@@ -3099,7 +3099,7 @@ L 77.665842 237.784894
 L 77.591481 238.130517 
 L 77.517121 238.473948 
 L 77.44276 238.815213 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 238.815213 
@@ -3151,23 +3151,23 @@ L 76.984008 251.144668
 L 76.973814 251.389134 
 L 76.96362 251.6325 
 L 76.953425 251.874777 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m17348de420" d="M -0 2.5 
+     <path id="m1a753a509c" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0cdf9614cb)">
-     <use xlink:href="#m17348de420" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38dff6dda8)">
+     <use xlink:href="#m1a753a509c" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="mf35ef92df2" d="M -0.833333 2.5 
+     <path id="md2f24347e7" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0cdf9614cb)">
-     <use xlink:href="#mf35ef92df2" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf35ef92df2" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf35ef92df2" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf35ef92df2" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf35ef92df2" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf35ef92df2" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf35ef92df2" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf35ef92df2" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf35ef92df2" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38dff6dda8)">
+     <use xlink:href="#md2f24347e7" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md2f24347e7" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md2f24347e7" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md2f24347e7" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md2f24347e7" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md2f24347e7" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md2f24347e7" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md2f24347e7" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md2f24347e7" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 117.229073
 L 306.11717 117.494902 
 L 303.36982 117.759433 
 L 300.62247 118.022676 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 118.022676 
@@ -3296,7 +3296,7 @@ L 269.071051 125.234719
 L 268.369908 125.384559 
 L 267.668766 125.533985 
 L 266.967623 125.683 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 125.683 
@@ -3348,7 +3348,7 @@ L 228.598863 126.122913
 L 227.746224 126.132648 
 L 226.893585 126.142382 
 L 226.040946 126.152114 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 126.152114 
@@ -3400,7 +3400,7 @@ L 183.801673 143.118416
 L 182.863022 143.441102 
 L 181.924372 143.761876 
 L 180.985721 144.080759 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 144.080759 
@@ -3452,7 +3452,7 @@ L 165.475826 157.662961
 L 165.131161 157.929236 
 L 164.786497 158.194207 
 L 164.441833 158.457887 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 158.457887 
@@ -3504,7 +3504,7 @@ L 158.178848 166.505572
 L 158.03967 166.671493 
 L 157.900493 166.836907 
 L 157.761315 167.001817 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 167.001817 
@@ -3556,7 +3556,7 @@ L 151.674847 180.456413
 L 151.539592 180.720489 
 L 151.404337 180.983284 
 L 151.269082 181.244808 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 181.244808 
@@ -3608,11 +3608,11 @@ L 150.385962 186.640888
 L 150.366337 186.754896 
 L 150.346712 186.868665 
 L 150.327087 186.982195 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="mf47af60945" d="M -1.25 2.5 
+     <path id="m2e594971e5" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0cdf9614cb)">
-     <use xlink:href="#mf47af60945" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf47af60945" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf47af60945" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf47af60945" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf47af60945" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf47af60945" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf47af60945" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf47af60945" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf47af60945" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38dff6dda8)">
+     <use xlink:href="#m2e594971e5" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e594971e5" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e594971e5" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e594971e5" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e594971e5" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e594971e5" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e594971e5" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e594971e5" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e594971e5" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 141.492222
 L 276.351005 141.626293 
 L 274.857964 141.760033 
 L 273.364924 141.893443 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 141.893443 
@@ -3741,7 +3741,7 @@ L 242.760262 147.575596
 L 242.080158 147.695331 
 L 241.400055 147.814802 
 L 240.719951 147.934009 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 147.934009 
@@ -3793,7 +3793,7 @@ L 222.564351 152.930779
 L 222.160893 153.036743 
 L 221.757435 153.142499 
 L 221.353978 153.24805 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 153.24805 
@@ -3845,7 +3845,7 @@ L 208.018647 155.070715
 L 207.722306 155.110529 
 L 207.425965 155.150315 
 L 207.129625 155.190071 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 155.190071 
@@ -3897,7 +3897,7 @@ L 182.693853 166.038872
 L 182.150836 166.256889 
 L 181.607819 166.474032 
 L 181.064802 166.690306 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.690306 
@@ -3949,7 +3949,7 @@ L 179.393584 170.067361
 L 179.356445 170.140065 
 L 179.319307 170.21267 
 L 179.282169 170.285179 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.285179 
@@ -4001,7 +4001,7 @@ L 177.817012 175.338922
 L 177.784453 175.446037 
 L 177.751894 175.552941 
 L 177.719335 175.659634 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.659634 
@@ -4053,11 +4053,11 @@ L 177.648651 180.712426
 L 177.64708 180.819522 
 L 177.645509 180.926407 
 L 177.643939 181.03308 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m33eb56fc48" d="M 0 -2.5 
+     <path id="mdda079545e" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p0cdf9614cb)">
-     <use xlink:href="#m33eb56fc48" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m33eb56fc48" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m33eb56fc48" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m33eb56fc48" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m33eb56fc48" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m33eb56fc48" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m33eb56fc48" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m33eb56fc48" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m33eb56fc48" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p38dff6dda8)">
+     <use xlink:href="#mdda079545e" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdda079545e" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdda079545e" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdda079545e" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdda079545e" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdda079545e" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdda079545e" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdda079545e" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mdda079545e" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.101113
 L 226.871027 113.101614 
 L 226.871027 113.102116 
 L 226.871027 113.102618 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.102618 
@@ -4184,7 +4184,7 @@ L 226.871027 113.241886
 L 226.871027 113.244976 
 L 226.871027 113.248067 
 L 226.871027 113.251157 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.251157 
@@ -4236,7 +4236,7 @@ L 226.871027 113.165529
 L 226.871027 113.163625 
 L 226.871027 113.16172 
 L 226.871027 113.159816 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.159816 
@@ -4288,7 +4288,7 @@ L 180.837336 131.090576
 L 179.814365 131.428693 
 L 178.791394 131.764711 
 L 177.768423 132.098656 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.098656 
@@ -4340,7 +4340,7 @@ L 161.462117 144.555386
 L 161.099755 144.802091 
 L 160.737393 145.047676 
 L 160.37503 145.292152 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.292152 
@@ -4392,7 +4392,7 @@ L 154.394483 152.007915
 L 154.261581 152.148084 
 L 154.12868 152.287891 
 L 153.995779 152.427338 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.427338 
@@ -4444,7 +4444,7 @@ L 147.537442 166.80191
 L 147.393924 167.081716 
 L 147.250405 167.360084 
 L 147.106887 167.637027 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 167.637027 
@@ -4496,11 +4496,11 @@ L 145.948902 174.483819
 L 145.923169 174.626551 
 L 145.897436 174.768906 
 L 145.871703 174.910889 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m15f7e751a6" d="M 0 -2.5 
+     <path id="m940f081ffc" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p0cdf9614cb)">
-     <use xlink:href="#m15f7e751a6" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m15f7e751a6" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m15f7e751a6" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m15f7e751a6" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m15f7e751a6" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m15f7e751a6" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m15f7e751a6" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m15f7e751a6" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m15f7e751a6" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38dff6dda8)">
+     <use xlink:href="#m940f081ffc" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m940f081ffc" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m940f081ffc" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m940f081ffc" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m940f081ffc" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m940f081ffc" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m940f081ffc" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m940f081ffc" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m940f081ffc" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 176.312658
 L 529.583102 176.354957 
 L 528.363847 176.397222 
 L 527.144592 176.439455 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 176.439455 
@@ -4623,7 +4623,7 @@ L 461.70225 184.0537
 L 460.247976 184.211312 
 L 458.793701 184.368466 
 L 457.339427 184.525165 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 184.525165 
@@ -4675,7 +4675,7 @@ L 302.450749 179.565773
 L 299.008779 179.450234 
 L 295.566808 179.334447 
 L 292.124837 179.218412 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 179.218412 
@@ -4727,7 +4727,7 @@ L 246.191563 190.241103
 L 245.170823 190.462265 
 L 244.150084 190.682527 
 L 243.129344 190.901895 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.901895 
@@ -4779,7 +4779,7 @@ L 215.390639 204.06672
 L 214.774224 204.325785 
 L 214.157808 204.583617 
 L 213.541392 204.840226 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.840226 
@@ -4831,7 +4831,7 @@ L 205.113797 212.010949
 L 204.926517 212.159987 
 L 204.739237 212.308616 
 L 204.551957 212.456838 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.456838 
@@ -4883,7 +4883,7 @@ L 196.403329 227.996875
 L 196.222248 228.296222 
 L 196.041168 228.593923 
 L 195.860087 228.889995 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.889995 
@@ -4935,7 +4935,7 @@ L 194.134867 234.076634
 L 194.096529 234.18643 
 L 194.058191 234.296004 
 L 194.019853 234.405357 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m054caf7649" d="M 0 3.5 
+      <path id="m36bd3f3e0e" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m054caf7649" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m36bd3f3e0e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m4eea0d050a" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6aa231fb8e" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#mf152952544" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me3b4a775c3" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#mdd8b828e29" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m38f07fca3b" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m17348de420" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1a753a509c" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#mf35ef92df2" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md2f24347e7" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#mf47af60945" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2e594971e5" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m33eb56fc48" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mdda079545e" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m15f7e751a6" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m940f081ffc" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p0cdf9614cb)">
-     <use xlink:href="#m054caf7649" x="319.643112" y="132.474873" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m054caf7649" x="269.129958" y="146.947914" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m054caf7649" x="247.452898" y="151.643702" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m054caf7649" x="199.905291" y="166.323941" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m054caf7649" x="190.316224" y="178.375301" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m054caf7649" x="165.455859" y="195.755905" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m054caf7649" x="159.141659" y="204.048715" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m054caf7649" x="157.246106" y="225.28411" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m054caf7649" x="128.707405" y="298.538516" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m054caf7649" x="99.149529" y="327.894785" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p38dff6dda8)">
+     <use xlink:href="#m36bd3f3e0e" x="319.643112" y="132.599674" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36bd3f3e0e" x="269.129958" y="146.881872" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36bd3f3e0e" x="247.452898" y="151.513043" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36bd3f3e0e" x="199.905291" y="166.166926" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36bd3f3e0e" x="190.316224" y="178.363509" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36bd3f3e0e" x="165.455859" y="195.458865" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36bd3f3e0e" x="159.141659" y="203.826994" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36bd3f3e0e" x="158.180344" y="207.769828" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36bd3f3e0e" x="128.707405" y="299.239283" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36bd3f3e0e" x="99.149529" y="327.988146" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 132.474873 
-L 318.590755 132.819461 
-L 317.538397 133.16187 
-L 316.48604 133.502125 
-L 315.433682 133.840255 
-L 314.381325 134.176285 
-L 313.328968 134.510241 
-L 312.27661 134.84215 
-L 311.224253 135.172035 
-L 310.171896 135.499921 
-L 309.119538 135.825833 
-L 308.067181 136.149794 
-L 307.014823 136.471827 
-L 305.962466 136.791955 
-L 304.910109 137.110201 
-L 303.857751 137.426586 
-L 302.805394 137.741133 
-L 301.753037 138.053861 
-L 300.700679 138.364793 
-L 299.648322 138.673949 
-L 298.595965 138.981348 
-L 297.543607 139.287012 
-L 296.49125 139.590959 
-L 295.438892 139.893208 
-L 294.386535 140.193778 
-L 293.334178 140.492689 
-L 292.28182 140.789957 
-L 291.229463 141.085602 
-L 290.177106 141.37964 
-L 289.124748 141.672089 
-L 288.072391 141.962967 
-L 287.020033 142.252289 
-L 285.967676 142.540073 
-L 284.915319 142.826334 
-L 283.862961 143.11109 
-L 282.810604 143.394355 
-L 281.758247 143.676145 
-L 280.705889 143.956475 
-L 279.653532 144.235361 
-L 278.601175 144.512816 
-L 277.548817 144.788857 
-L 276.49646 145.063497 
-L 275.444102 145.33675 
-L 274.391745 145.60863 
-L 273.339388 145.879152 
-L 272.28703 146.148328 
-L 271.234673 146.416171 
-L 270.182316 146.682696 
-L 269.129958 146.947914 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 132.599674 
+L 318.590755 132.93911 
+L 317.538397 133.276429 
+L 316.48604 133.61166 
+L 315.433682 133.944826 
+L 314.381325 134.275954 
+L 313.328968 134.605068 
+L 312.27661 134.932193 
+L 311.224253 135.257352 
+L 310.171896 135.58057 
+L 309.119538 135.901868 
+L 308.067181 136.22127 
+L 307.014823 136.538799 
+L 305.962466 136.854475 
+L 304.910109 137.16832 
+L 303.857751 137.480356 
+L 302.805394 137.790603 
+L 301.753037 138.099081 
+L 300.700679 138.405811 
+L 299.648322 138.710813 
+L 298.595965 139.014105 
+L 297.543607 139.315707 
+L 296.49125 139.615637 
+L 295.438892 139.913914 
+L 294.386535 140.210557 
+L 293.334178 140.505582 
+L 292.28182 140.799007 
+L 291.229463 141.090851 
+L 290.177106 141.381128 
+L 289.124748 141.669858 
+L 288.072391 141.957054 
+L 287.020033 142.242735 
+L 285.967676 142.526916 
+L 284.915319 142.809612 
+L 283.862961 143.09084 
+L 282.810604 143.370613 
+L 281.758247 143.648948 
+L 280.705889 143.925858 
+L 279.653532 144.201359 
+L 278.601175 144.475464 
+L 277.548817 144.748188 
+L 276.49646 145.019544 
+L 275.444102 145.289547 
+L 274.391745 145.558209 
+L 273.339388 145.825544 
+L 272.28703 146.091565 
+L 271.234673 146.356285 
+L 270.182316 146.619716 
+L 269.129958 146.881872 
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 146.947914 
-L 268.678353 147.050016 
-L 268.226747 147.151926 
-L 267.775142 147.253645 
-L 267.323537 147.355172 
-L 266.871931 147.45651 
-L 266.420326 147.557658 
-L 265.96872 147.658617 
-L 265.517115 147.759389 
-L 265.065509 147.859973 
-L 264.613904 147.96037 
-L 264.162299 148.060582 
-L 263.710693 148.160608 
-L 263.259088 148.26045 
-L 262.807482 148.360108 
-L 262.355877 148.459583 
-L 261.904271 148.558875 
-L 261.452666 148.657986 
-L 261.001061 148.756915 
-L 260.549455 148.855664 
-L 260.09785 148.954233 
-L 259.646244 149.052623 
-L 259.194639 149.150834 
-L 258.743034 149.248867 
-L 258.291428 149.346723 
-L 257.839823 149.444402 
-L 257.388217 149.541906 
-L 256.936612 149.639234 
-L 256.485006 149.736387 
-L 256.033401 149.833366 
-L 255.581796 149.930172 
-L 255.13019 150.026805 
-L 254.678585 150.123266 
-L 254.226979 150.219555 
-L 253.775374 150.315673 
-L 253.323769 150.41162 
-L 252.872163 150.507398 
-L 252.420558 150.603007 
-L 251.968952 150.698447 
-L 251.517347 150.793719 
-L 251.065741 150.888823 
-L 250.614136 150.983761 
-L 250.162531 151.078533 
-L 249.710925 151.173138 
-L 249.25932 151.267579 
-L 248.807714 151.361855 
-L 248.356109 151.455967 
-L 247.904503 151.549916 
-L 247.452898 151.643702 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 146.881872 
+L 268.678353 146.982509 
+L 268.226747 147.08296 
+L 267.775142 147.183225 
+L 267.323537 147.283304 
+L 266.871931 147.383199 
+L 266.420326 147.482909 
+L 265.96872 147.582437 
+L 265.517115 147.681781 
+L 265.065509 147.780944 
+L 264.613904 147.879925 
+L 264.162299 147.978725 
+L 263.710693 148.077345 
+L 263.259088 148.175786 
+L 262.807482 148.274049 
+L 262.355877 148.372133 
+L 261.904271 148.47004 
+L 261.452666 148.567769 
+L 261.001061 148.665323 
+L 260.549455 148.762701 
+L 260.09785 148.859905 
+L 259.646244 148.956934 
+L 259.194639 149.053789 
+L 258.743034 149.150471 
+L 258.291428 149.246981 
+L 257.839823 149.343319 
+L 257.388217 149.439486 
+L 256.936612 149.535483 
+L 256.485006 149.631309 
+L 256.033401 149.726966 
+L 255.581796 149.822454 
+L 255.13019 149.917774 
+L 254.678585 150.012927 
+L 254.226979 150.107912 
+L 253.775374 150.202731 
+L 253.323769 150.297384 
+L 252.872163 150.391872 
+L 252.420558 150.486195 
+L 251.968952 150.580354 
+L 251.517347 150.67435 
+L 251.065741 150.768183 
+L 250.614136 150.861853 
+L 250.162531 150.955361 
+L 249.710925 151.048708 
+L 249.25932 151.141894 
+L 248.807714 151.234921 
+L 248.356109 151.327787 
+L 247.904503 151.420494 
+L 247.452898 151.513043 
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 151.643702 
-L 246.462323 151.993906 
-L 245.471748 152.341857 
-L 244.481173 152.687586 
-L 243.490597 153.03112 
-L 242.500022 153.372487 
-L 241.509447 153.711715 
-L 240.518872 154.048829 
-L 239.528297 154.383857 
-L 238.537722 154.716823 
-L 237.547147 155.047753 
-L 236.556571 155.376672 
-L 235.565996 155.703603 
-L 234.575421 156.028572 
-L 233.584846 156.351601 
-L 232.594271 156.672713 
-L 231.603696 156.991931 
-L 230.613121 157.309277 
-L 229.622545 157.624773 
-L 228.63197 157.938441 
-L 227.641395 158.250301 
-L 226.65082 158.560374 
-L 225.660245 158.868681 
-L 224.66967 159.175241 
-L 223.679095 159.480075 
-L 222.688519 159.783201 
-L 221.697944 160.084639 
-L 220.707369 160.384407 
-L 219.716794 160.682523 
-L 218.726219 160.979007 
-L 217.735644 161.273875 
-L 216.745069 161.567145 
-L 215.754493 161.858835 
-L 214.763918 162.148961 
-L 213.773343 162.437539 
-L 212.782768 162.724587 
-L 211.792193 163.010121 
-L 210.801618 163.294156 
-L 209.811043 163.576708 
-L 208.820467 163.857792 
-L 207.829892 164.137425 
-L 206.839317 164.415619 
-L 205.848742 164.692391 
-L 204.858167 164.967755 
-L 203.867592 165.241725 
-L 202.877017 165.514314 
-L 201.886441 165.785538 
-L 200.895866 166.055409 
-L 199.905291 166.323941 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 151.513043 
+L 246.462323 151.862531 
+L 245.471748 152.209777 
+L 244.481173 152.554808 
+L 243.490597 152.897654 
+L 242.500022 153.238342 
+L 241.509447 153.576898 
+L 240.518872 153.913349 
+L 239.528297 154.247722 
+L 238.537722 154.580041 
+L 237.547147 154.910332 
+L 236.556571 155.23862 
+L 235.565996 155.564928 
+L 234.575421 155.889281 
+L 233.584846 156.211701 
+L 232.594271 156.532211 
+L 231.603696 156.850835 
+L 230.613121 157.167594 
+L 229.622545 157.482509 
+L 228.63197 157.795603 
+L 227.641395 158.106895 
+L 226.65082 158.416407 
+L 225.660245 158.72416 
+L 224.66967 159.030172 
+L 223.679095 159.334463 
+L 222.688519 159.637053 
+L 221.697944 159.937961 
+L 220.707369 160.237204 
+L 219.716794 160.534802 
+L 218.726219 160.830773 
+L 217.735644 161.125134 
+L 216.745069 161.417902 
+L 215.754493 161.709095 
+L 214.763918 161.99873 
+L 213.773343 162.286823 
+L 212.782768 162.57339 
+L 211.792193 162.858448 
+L 210.801618 163.142012 
+L 209.811043 163.424098 
+L 208.820467 163.704722 
+L 207.829892 163.983898 
+L 206.839317 164.261641 
+L 205.848742 164.537966 
+L 204.858167 164.812887 
+L 203.867592 165.086419 
+L 202.877017 165.358575 
+L 201.886441 165.629369 
+L 200.895866 165.898815 
+L 199.905291 166.166926 
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 199.905291 166.323941 
-L 199.705519 166.604434 
-L 199.505747 166.88348 
-L 199.305974 167.161094 
-L 199.106202 167.437292 
-L 198.90643 167.712088 
-L 198.706658 167.985495 
-L 198.506885 168.257528 
-L 198.307113 168.5282 
-L 198.107341 168.797525 
-L 197.907569 169.065517 
-L 197.707797 169.332188 
-L 197.508024 169.597551 
-L 197.308252 169.86162 
-L 197.10848 170.124406 
-L 196.908708 170.385923 
-L 196.708935 170.646182 
-L 196.509163 170.905195 
-L 196.309391 171.162975 
-L 196.109619 171.419532 
-L 195.909846 171.674879 
-L 195.710074 171.929027 
-L 195.510302 172.181987 
-L 195.31053 172.43377 
-L 195.110758 172.684387 
-L 194.910985 172.933848 
-L 194.711213 173.182165 
-L 194.511441 173.429348 
-L 194.311669 173.675408 
-L 194.111896 173.920353 
-L 193.912124 174.164195 
-L 193.712352 174.406943 
-L 193.51258 174.648607 
-L 193.312807 174.889196 
-L 193.113035 175.128721 
-L 192.913263 175.367191 
-L 192.713491 175.604614 
-L 192.513719 175.841 
-L 192.313946 176.076358 
-L 192.114174 176.310697 
-L 191.914402 176.544026 
-L 191.71463 176.776353 
-L 191.514857 177.007687 
-L 191.315085 177.238036 
-L 191.115313 177.467409 
-L 190.915541 177.695814 
-L 190.715768 177.923259 
-L 190.515996 178.149752 
-L 190.316224 178.375301 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.905291 166.166926 
+L 199.705519 166.451184 
+L 199.505747 166.733957 
+L 199.305974 167.01526 
+L 199.106202 167.295108 
+L 198.90643 167.573516 
+L 198.706658 167.8505 
+L 198.506885 168.126073 
+L 198.307113 168.40025 
+L 198.107341 168.673045 
+L 197.907569 168.944472 
+L 197.707797 169.214545 
+L 197.508024 169.483276 
+L 197.308252 169.750679 
+L 197.10848 170.016768 
+L 196.908708 170.281555 
+L 196.708935 170.545052 
+L 196.509163 170.807273 
+L 196.309391 171.06823 
+L 196.109619 171.327934 
+L 195.909846 171.586397 
+L 195.710074 171.843633 
+L 195.510302 172.099651 
+L 195.31053 172.354464 
+L 195.110758 172.608083 
+L 194.910985 172.860519 
+L 194.711213 173.111782 
+L 194.511441 173.361885 
+L 194.311669 173.610837 
+L 194.111896 173.858649 
+L 193.912124 174.105332 
+L 193.712352 174.350895 
+L 193.51258 174.595349 
+L 193.312807 174.838703 
+L 193.113035 175.080969 
+L 192.913263 175.322154 
+L 192.713491 175.56227 
+L 192.513719 175.801325 
+L 192.313946 176.039328 
+L 192.114174 176.27629 
+L 191.914402 176.512218 
+L 191.71463 176.747123 
+L 191.514857 176.981012 
+L 191.315085 177.213895 
+L 191.115313 177.445779 
+L 190.915541 177.676675 
+L 190.715768 177.906589 
+L 190.515996 178.135531 
+L 190.316224 178.363509 
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 190.316224 178.375301 
-L 189.7983 178.800624 
-L 189.280375 179.222631 
-L 188.762451 179.641373 
-L 188.244527 180.056899 
-L 187.726603 180.469259 
-L 187.208678 180.878501 
-L 186.690754 181.284672 
-L 186.17283 181.687817 
-L 185.654906 182.087981 
-L 185.136981 182.485207 
-L 184.619057 182.87954 
-L 184.101133 183.27102 
-L 183.583208 183.659688 
-L 183.065284 184.045585 
-L 182.54736 184.428749 
-L 182.029436 184.80922 
-L 181.511511 185.187035 
-L 180.993587 185.56223 
-L 180.475663 185.934842 
-L 179.957739 186.304906 
-L 179.439814 186.672457 
-L 178.92189 187.037528 
-L 178.403966 187.400154 
-L 177.886041 187.760365 
-L 177.368117 188.118195 
-L 176.850193 188.473674 
-L 176.332269 188.826834 
-L 175.814344 189.177704 
-L 175.29642 189.526314 
-L 174.778496 189.872692 
-L 174.260572 190.216868 
-L 173.742647 190.558869 
-L 173.224723 190.898722 
-L 172.706799 191.236454 
-L 172.188874 191.572091 
-L 171.67095 191.90566 
-L 171.153026 192.237185 
-L 170.635102 192.566692 
-L 170.117177 192.894205 
-L 169.599253 193.219747 
-L 169.081329 193.543343 
-L 168.563404 193.865016 
-L 168.04548 194.184788 
-L 167.527556 194.502681 
-L 167.009632 194.818719 
-L 166.491707 195.132921 
-L 165.973783 195.445309 
-L 165.455859 195.755905 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 190.316224 178.363509 
+L 189.7983 178.780724 
+L 189.280375 179.194747 
+L 188.762451 179.605627 
+L 188.244527 180.013411 
+L 187.726603 180.418145 
+L 187.208678 180.819875 
+L 186.690754 181.218645 
+L 186.17283 181.614497 
+L 185.654906 182.007476 
+L 185.136981 182.397621 
+L 184.619057 182.784974 
+L 184.101133 183.169574 
+L 183.583208 183.55146 
+L 183.065284 183.93067 
+L 182.54736 184.307242 
+L 182.029436 184.681211 
+L 181.511511 185.052614 
+L 180.993587 185.421486 
+L 180.475663 185.78786 
+L 179.957739 186.15177 
+L 179.439814 186.51325 
+L 178.92189 186.872331 
+L 178.403966 187.229046 
+L 177.886041 187.583425 
+L 177.368117 187.935498 
+L 176.850193 188.285296 
+L 176.332269 188.632847 
+L 175.814344 188.97818 
+L 175.29642 189.321324 
+L 174.778496 189.662306 
+L 174.260572 190.001152 
+L 173.742647 190.337891 
+L 173.224723 190.672547 
+L 172.706799 191.005146 
+L 172.188874 191.335714 
+L 171.67095 191.664275 
+L 171.153026 191.990853 
+L 170.635102 192.315472 
+L 170.117177 192.638156 
+L 169.599253 192.958927 
+L 169.081329 193.277808 
+L 168.563404 193.594821 
+L 168.04548 193.909988 
+L 167.527556 194.22333 
+L 167.009632 194.534868 
+L 166.491707 194.844623 
+L 165.973783 195.152616 
+L 165.455859 195.458865 
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 165.455859 195.755905 
-L 165.324313 195.94229 
-L 165.192767 196.128036 
-L 165.061221 196.313146 
-L 164.929675 196.497625 
-L 164.79813 196.681478 
-L 164.666584 196.864708 
-L 164.535038 197.04732 
-L 164.403492 197.229317 
-L 164.271946 197.410705 
-L 164.1404 197.591487 
-L 164.008855 197.771667 
-L 163.877309 197.951248 
-L 163.745763 198.130236 
-L 163.614217 198.308634 
-L 163.482671 198.486446 
-L 163.351125 198.663676 
-L 163.21958 198.840327 
-L 163.088034 199.016403 
-L 162.956488 199.191908 
-L 162.824942 199.366846 
-L 162.693396 199.541221 
-L 162.56185 199.715035 
-L 162.430305 199.888293 
-L 162.298759 200.060997 
-L 162.167213 200.233153 
-L 162.035667 200.404763 
-L 161.904121 200.57583 
-L 161.772575 200.746358 
-L 161.64103 200.91635 
-L 161.509484 201.08581 
-L 161.377938 201.254742 
-L 161.246392 201.423147 
-L 161.114846 201.59103 
-L 160.9833 201.758394 
-L 160.851754 201.925242 
-L 160.720209 202.091577 
-L 160.588663 202.257402 
-L 160.457117 202.422721 
-L 160.325571 202.587537 
-L 160.194025 202.751852 
-L 160.062479 202.915669 
-L 159.930934 203.078993 
-L 159.799388 203.241824 
-L 159.667842 203.404168 
-L 159.536296 203.566025 
-L 159.40475 203.727401 
-L 159.273204 203.888296 
-L 159.141659 204.048715 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.455859 195.458865 
+L 165.324313 195.647074 
+L 165.192767 195.834631 
+L 165.061221 196.02154 
+L 164.929675 196.207806 
+L 164.79813 196.393433 
+L 164.666584 196.578426 
+L 164.535038 196.762788 
+L 164.403492 196.946524 
+L 164.271946 197.129639 
+L 164.1404 197.312136 
+L 164.008855 197.49402 
+L 163.877309 197.675295 
+L 163.745763 197.855964 
+L 163.614217 198.036032 
+L 163.482671 198.215503 
+L 163.351125 198.394381 
+L 163.21958 198.57267 
+L 163.088034 198.750373 
+L 162.956488 198.927495 
+L 162.824942 199.104038 
+L 162.693396 199.280008 
+L 162.56185 199.455407 
+L 162.430305 199.63024 
+L 162.298759 199.80451 
+L 162.167213 199.97822 
+L 162.035667 200.151375 
+L 161.904121 200.323977 
+L 161.772575 200.496031 
+L 161.64103 200.667539 
+L 161.509484 200.838506 
+L 161.377938 201.008934 
+L 161.246392 201.178827 
+L 161.114846 201.348189 
+L 160.9833 201.517022 
+L 160.851754 201.68533 
+L 160.720209 201.853116 
+L 160.588663 202.020384 
+L 160.457117 202.187136 
+L 160.325571 202.353376 
+L 160.194025 202.519107 
+L 160.062479 202.684332 
+L 159.930934 202.849054 
+L 159.799388 203.013276 
+L 159.667842 203.177001 
+L 159.536296 203.340233 
+L 159.40475 203.502974 
+L 159.273204 203.665227 
+L 159.141659 203.826994 
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 159.141659 204.048715 
-L 159.102168 204.587781 
-L 159.062677 205.121532 
-L 159.023187 205.650069 
-L 158.983696 206.173494 
-L 158.944205 206.691906 
-L 158.904715 207.205398 
-L 158.865224 207.714064 
-L 158.825733 208.217994 
-L 158.786243 208.717275 
-L 158.746752 209.211991 
-L 158.707261 209.702226 
-L 158.667771 210.18806 
-L 158.62828 210.669571 
-L 158.588789 211.146836 
-L 158.549299 211.619928 
-L 158.509808 212.088921 
-L 158.470317 212.553885 
-L 158.430827 213.014887 
-L 158.391336 213.471996 
-L 158.351845 213.925276 
-L 158.312355 214.374791 
-L 158.272864 214.820603 
-L 158.233373 215.262773 
-L 158.193882 215.701359 
-L 158.154392 216.13642 
-L 158.114901 216.56801 
-L 158.07541 216.996187 
-L 158.03592 217.421002 
-L 157.996429 217.842508 
-L 157.956938 218.260757 
-L 157.917448 218.675798 
-L 157.877957 219.08768 
-L 157.838466 219.496451 
-L 157.798976 219.902158 
-L 157.759485 220.304846 
-L 157.719994 220.70456 
-L 157.680504 221.101343 
-L 157.641013 221.495238 
-L 157.601522 221.886287 
-L 157.562032 222.274531 
-L 157.522541 222.660009 
-L 157.48305 223.042761 
-L 157.44356 223.422825 
-L 157.404069 223.800239 
-L 157.364578 224.175038 
-L 157.325088 224.54726 
-L 157.285597 224.916939 
-L 157.246106 225.28411 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.141659 203.826994 
+L 159.121631 203.912136 
+L 159.101604 203.997144 
+L 159.081576 204.082018 
+L 159.061549 204.16676 
+L 159.041522 204.251369 
+L 159.021494 204.335846 
+L 159.001467 204.420192 
+L 158.98144 204.504406 
+L 158.961412 204.588489 
+L 158.941385 204.672442 
+L 158.921357 204.756265 
+L 158.90133 204.839959 
+L 158.881303 204.923523 
+L 158.861275 205.006958 
+L 158.841248 205.090265 
+L 158.82122 205.173443 
+L 158.801193 205.256494 
+L 158.781166 205.339418 
+L 158.761138 205.422215 
+L 158.741111 205.504886 
+L 158.721084 205.58743 
+L 158.701056 205.669849 
+L 158.681029 205.752142 
+L 158.661001 205.83431 
+L 158.640974 205.916354 
+L 158.620947 205.998274 
+L 158.600919 206.08007 
+L 158.580892 206.161742 
+L 158.560865 206.243291 
+L 158.540837 206.324718 
+L 158.52081 206.406022 
+L 158.500782 206.487205 
+L 158.480755 206.568265 
+L 158.460728 206.649205 
+L 158.4407 206.730024 
+L 158.420673 206.810722 
+L 158.400645 206.8913 
+L 158.380618 206.971758 
+L 158.360591 207.052097 
+L 158.340563 207.132316 
+L 158.320536 207.212417 
+L 158.300509 207.2924 
+L 158.280481 207.372264 
+L 158.260454 207.452011 
+L 158.240426 207.53164 
+L 158.220399 207.611153 
+L 158.200372 207.690549 
+L 158.180344 207.769828 
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 157.246106 225.28411 
-L 156.65155 228.42829 
-L 156.056994 231.399785 
-L 155.462438 234.216582 
-L 154.867881 236.893993 
-L 154.273325 239.445165 
-L 153.678769 241.881468 
-L 153.084212 244.212803 
-L 152.489656 246.447841 
-L 151.8951 248.594224 
-L 151.300544 250.658718 
-L 150.705987 252.647341 
-L 150.111431 254.565473 
-L 149.516875 256.417942 
-L 148.922318 258.209094 
-L 148.327762 259.942858 
-L 147.733206 261.622799 
-L 147.13865 263.252158 
-L 146.544093 264.833891 
-L 145.949537 266.370705 
-L 145.354981 267.86508 
-L 144.760424 269.319297 
-L 144.165868 270.735458 
-L 143.571312 272.115504 
-L 142.976756 273.461232 
-L 142.382199 274.774307 
-L 141.787643 276.056276 
-L 141.193087 277.308579 
-L 140.598531 278.532558 
-L 140.003974 279.729466 
-L 139.409418 280.900474 
-L 138.814862 282.04668 
-L 138.220305 283.169113 
-L 137.625749 284.268738 
-L 137.031193 285.346464 
-L 136.436637 286.403146 
-L 135.84208 287.439591 
-L 135.247524 288.456559 
-L 134.652968 289.454769 
-L 134.058411 290.4349 
-L 133.463855 291.397595 
-L 132.869299 292.343464 
-L 132.274743 293.273085 
-L 131.680186 294.187006 
-L 131.08563 295.08575 
-L 130.491074 295.969812 
-L 129.896517 296.839664 
-L 129.301961 297.695756 
-L 128.707405 298.538516 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.180344 207.769828 
+L 157.566325 212.537386 
+L 156.952305 216.91874 
+L 156.338286 220.971799 
+L 155.724266 224.74235 
+L 155.110246 228.267223 
+L 154.496227 231.576484 
+L 153.882207 234.694997 
+L 153.268188 237.643559 
+L 152.654168 240.439739 
+L 152.040149 243.098517 
+L 151.426129 245.632767 
+L 150.812109 248.053633 
+L 150.19809 250.370828 
+L 149.58407 252.592868 
+L 148.970051 254.727261 
+L 148.356031 256.780659 
+L 147.742012 258.758986 
+L 147.127992 260.667537 
+L 146.513972 262.511068 
+L 145.899953 264.293862 
+L 145.285933 266.019795 
+L 144.671914 267.692383 
+L 144.057894 269.314823 
+L 143.443875 270.890035 
+L 142.829855 272.420693 
+L 142.215835 273.909246 
+L 141.601816 275.357949 
+L 140.987796 276.768881 
+L 140.373777 278.143961 
+L 139.759757 279.484967 
+L 139.145738 280.793545 
+L 138.531718 282.071227 
+L 137.917698 283.31944 
+L 137.303679 284.53951 
+L 136.689659 285.732681 
+L 136.07564 286.900111 
+L 135.46162 288.042889 
+L 134.847601 289.162034 
+L 134.233581 290.258504 
+L 133.619561 291.333199 
+L 133.005542 292.386968 
+L 132.391522 293.420609 
+L 131.777503 294.434878 
+L 131.163483 295.430486 
+L 130.549464 296.408109 
+L 129.935444 297.368385 
+L 129.321424 298.311919 
+L 128.707405 299.239283 
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 128.707405 298.538516 
-L 128.091616 299.344494 
-L 127.475827 300.138645 
-L 126.860038 300.921311 
-L 126.244249 301.692819 
-L 125.62846 302.453483 
-L 125.01267 303.203603 
-L 124.396881 303.943469 
-L 123.781092 304.673355 
-L 123.165303 305.393529 
-L 122.549514 306.104244 
-L 121.933725 306.805748 
-L 121.317936 307.498274 
-L 120.702147 308.18205 
-L 120.086358 308.857294 
-L 119.470569 309.524217 
-L 118.85478 310.183022 
-L 118.238991 310.833902 
-L 117.623201 311.477048 
-L 117.007412 312.11264 
-L 116.391623 312.740854 
-L 115.775834 313.361859 
-L 115.160045 313.975819 
-L 114.544256 314.582892 
-L 113.928467 315.183231 
-L 113.312678 315.776983 
-L 112.696889 316.364291 
-L 112.0811 316.945294 
-L 111.465311 317.520126 
-L 110.849522 318.088916 
-L 110.233733 318.65179 
-L 109.617943 319.208871 
-L 109.002154 319.760275 
-L 108.386365 320.306117 
-L 107.770576 320.846509 
-L 107.154787 321.381559 
-L 106.538998 321.91137 
-L 105.923209 322.436045 
-L 105.30742 322.955682 
-L 104.691631 323.470377 
-L 104.075842 323.980223 
-L 103.460053 324.48531 
-L 102.844264 324.985727 
-L 102.228474 325.48156 
-L 101.612685 325.97289 
-L 100.996896 326.4598 
-L 100.381107 326.942369 
-L 99.765318 327.420672 
-L 99.149529 327.894785 
-" clip-path="url(#p0cdf9614cb)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 128.707405 299.239283 
+L 128.091616 300.023931 
+L 127.475827 300.797365 
+L 126.860038 301.559901 
+L 126.244249 302.311842 
+L 125.62846 303.053479 
+L 125.01267 303.785089 
+L 124.396881 304.50694 
+L 123.781092 305.21929 
+L 123.165303 305.922385 
+L 122.549514 306.616463 
+L 121.933725 307.301751 
+L 121.317936 307.97847 
+L 120.702147 308.646832 
+L 120.086358 309.30704 
+L 119.470569 309.959291 
+L 118.85478 310.603775 
+L 118.238991 311.240673 
+L 117.623201 311.870164 
+L 117.007412 312.492416 
+L 116.391623 313.107595 
+L 115.775834 313.71586 
+L 115.160045 314.317364 
+L 114.544256 314.912256 
+L 113.928467 315.50068 
+L 113.312678 316.082774 
+L 112.696889 316.658675 
+L 112.0811 317.228511 
+L 111.465311 317.79241 
+L 110.849522 318.350493 
+L 110.233733 318.90288 
+L 109.617943 319.449686 
+L 109.002154 319.991023 
+L 108.386365 320.526998 
+L 107.770576 321.057716 
+L 107.154787 321.583281 
+L 106.538998 322.103791 
+L 105.923209 322.619343 
+L 105.30742 323.130029 
+L 104.691631 323.635941 
+L 104.075842 324.137168 
+L 103.460053 324.633795 
+L 102.844264 325.125906 
+L 102.228474 325.613582 
+L 101.612685 326.096903 
+L 100.996896 326.575946 
+L 100.381107 327.050786 
+L 99.765318 327.521496 
+L 99.149529 327.988146 
+" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-03T22:49:18Z  ·  Linux chungus x86_64  ·  commit 2d0b6447  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.617109 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.688984 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6328,16 +6328,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6376,109 +6376,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3262.451172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.697266 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3453.320312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3516.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3548.730469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3580.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.304688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3644.091797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3675.878906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3703.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3765.185547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3826.464844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3889.84375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3953.320312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3992.183594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4053.365234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4174.068359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4215.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4248.873047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4276.65625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4338.179688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4399.458984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4462.837891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4526.460938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4560.152344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4682.955078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4714.742188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4778.365234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4841.988281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4873.775391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4937.398438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4973.482422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5012.345703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5067.326172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5130.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5162.736328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5194.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.310547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5258.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5289.884766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5329.09375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5392.472656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5431.335938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5492.517578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5555.896484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5619.373047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5682.751953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5746.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5809.607422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5848.816406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5880.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5964.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6093.591797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6155.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6218.591797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6246.375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6307.654297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6371.033203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6402.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6454.919922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6518.298828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6579.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6643.054688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6695.154297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6758.533203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6819.714844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6858.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6892.615234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6924.402344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6965.515625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7026.794922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7066.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7093.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7154.96875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7186.755859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7214.539062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7266.638672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7298.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7361.902344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7423.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7462.634766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7524.158203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7563.521484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.933594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7688.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7752.095703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7779.878906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7831.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7871.1875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7898.970703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0cdf9614cb">
+  <clipPath id="p38dff6dda8">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m288a7caf1d" d="M 0 0 
+       <path id="m22305deb48" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m288a7caf1d" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m22305deb48" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m288a7caf1d" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m22305deb48" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m288a7caf1d" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m22305deb48" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m288a7caf1d" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m22305deb48" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m288a7caf1d" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m22305deb48" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m288a7caf1d" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m22305deb48" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m288a7caf1d" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m22305deb48" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 388.333941 
 L 637.2 388.333941 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m7b3d432854" d="M 0 0 
+       <path id="m5d80158a03" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7b3d432854" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d80158a03" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 264.064771 
 L 637.2 264.064771 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m7b3d432854" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d80158a03" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 264.064771
      <g id="line2d_19">
       <path d="M 49.078125 139.7956 
 L 637.2 139.7956 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7b3d432854" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5d80158a03" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.7956
      <g id="line2d_21">
       <path d="M 49.078125 407.583479 
 L 637.2 407.583479 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m50f3b454de" d="M 0 0 
+       <path id="mc8961334f7" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 400.376868 
 L 637.2 400.376868 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 400.376868
      <g id="line2d_25">
       <path d="M 49.078125 394.020186 
 L 637.2 394.020186 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 394.020186
      <g id="line2d_27">
       <path d="M 49.078125 350.925193 
 L 637.2 350.925193 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 350.925193
      <g id="line2d_29">
       <path d="M 49.078125 329.042478 
 L 637.2 329.042478 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 329.042478
      <g id="line2d_31">
       <path d="M 49.078125 313.516445 
 L 637.2 313.516445 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 313.516445
      <g id="line2d_33">
       <path d="M 49.078125 301.473518 
 L 637.2 301.473518 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 301.473518
      <g id="line2d_35">
       <path d="M 49.078125 291.633731 
 L 637.2 291.633731 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.633731
      <g id="line2d_37">
       <path d="M 49.078125 283.314309 
 L 637.2 283.314309 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.314309
      <g id="line2d_39">
       <path d="M 49.078125 276.107697 
 L 637.2 276.107697 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.107697
      <g id="line2d_41">
       <path d="M 49.078125 269.751016 
 L 637.2 269.751016 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.751016
      <g id="line2d_43">
       <path d="M 49.078125 226.656023 
 L 637.2 226.656023 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 226.656023
      <g id="line2d_45">
       <path d="M 49.078125 204.773308 
 L 637.2 204.773308 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 204.773308
      <g id="line2d_47">
       <path d="M 49.078125 189.247275 
 L 637.2 189.247275 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 189.247275
      <g id="line2d_49">
       <path d="M 49.078125 177.204348 
 L 637.2 177.204348 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.204348
      <g id="line2d_51">
       <path d="M 49.078125 167.36456 
 L 637.2 167.36456 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.36456
      <g id="line2d_53">
       <path d="M 49.078125 159.045138 
 L 637.2 159.045138 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.045138
      <g id="line2d_55">
       <path d="M 49.078125 151.838527 
 L 637.2 151.838527 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 151.838527
      <g id="line2d_57">
       <path d="M 49.078125 145.481845 
 L 637.2 145.481845 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.481845
      <g id="line2d_59">
       <path d="M 49.078125 102.386852 
 L 637.2 102.386852 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.386852
      <g id="line2d_61">
       <path d="M 49.078125 80.504138 
 L 637.2 80.504138 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 80.504138
      <g id="line2d_63">
       <path d="M 49.078125 64.978104 
 L 637.2 64.978104 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.978104
      <g id="line2d_65">
       <path d="M 49.078125 52.935177 
 L 637.2 52.935177 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m50f3b454de" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mc8961334f7" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pc72633b062)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p3484e9bc90)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m2b61cc24d7" d="M -2.5 2.5 
+     <path id="m5b6afb4182" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc72633b062)">
-     <use xlink:href="#m2b61cc24d7" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2b61cc24d7" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3484e9bc90)">
+     <use xlink:href="#m5b6afb4182" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b6afb4182" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="mafbc8a3c67" d="M 0 -2.5 
+     <path id="m59e107bad2" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc72633b062)">
-     <use xlink:href="#mafbc8a3c67" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mafbc8a3c67" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3484e9bc90)">
+     <use xlink:href="#m59e107bad2" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m59e107bad2" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m8711706955" d="M -0 3.535534 
+     <path id="m5bd634b558" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc72633b062)">
-     <use xlink:href="#m8711706955" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8711706955" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3484e9bc90)">
+     <use xlink:href="#m5bd634b558" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5bd634b558" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m63b7293adf" d="M -0.833333 2.5 
+     <path id="m6c390a7be6" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc72633b062)">
-     <use xlink:href="#m63b7293adf" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m63b7293adf" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3484e9bc90)">
+     <use xlink:href="#m6c390a7be6" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6c390a7be6" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="md71f8da8a7" d="M -1.25 2.5 
+     <path id="m6170ecf341" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc72633b062)">
-     <use xlink:href="#md71f8da8a7" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md71f8da8a7" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3484e9bc90)">
+     <use xlink:href="#m6170ecf341" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6170ecf341" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m000953b980" d="M 0 -2.5 
+     <path id="me9316f0d5d" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pc72633b062)">
-     <use xlink:href="#m000953b980" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m000953b980" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p3484e9bc90)">
+     <use xlink:href="#me9316f0d5d" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#me9316f0d5d" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m3a63b33390" d="M 0 -2.5 
+     <path id="macdb217ec3" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc72633b062)">
-     <use xlink:href="#m3a63b33390" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3a63b33390" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3484e9bc90)">
+     <use xlink:href="#macdb217ec3" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macdb217ec3" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="me9928d72bb" d="M 0 3.5 
+      <path id="m4e118e6710" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#me9928d72bb" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m4e118e6710" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m2b61cc24d7" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5b6afb4182" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#mafbc8a3c67" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m59e107bad2" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m8711706955" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5bd634b558" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m63b7293adf" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6c390a7be6" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#md71f8da8a7" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6170ecf341" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m000953b980" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#me9316f0d5d" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m3a63b33390" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#macdb217ec3" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pc72633b062)">
-     <use xlink:href="#me9928d72bb" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#me9928d72bb" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p3484e9bc90)">
+     <use xlink:href="#m4e118e6710" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m4e118e6710" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3153,7 +3153,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pc72633b062">
+  <clipPath id="p3484e9bc90">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.571865 308.04375 
 L 290.571865 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mbfb5d7bc1c" d="M 0 0 
+       <path id="mb16130aaf3" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbfb5d7bc1c" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb16130aaf3" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 446.931505 308.04375 
 L 446.931505 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mbfb5d7bc1c" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb16130aaf3" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.281168 308.04375 
 L 181.281168 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="mcb5ab4aac4" d="M 0 0 
+       <path id="m995cf27d35" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.814733 308.04375 
 L 208.814733 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.814733 56.7075
      <g id="line2d_9">
       <path d="M 228.350109 308.04375 
 L 228.350109 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.350109 56.7075
      <g id="line2d_11">
       <path d="M 243.502924 308.04375 
 L 243.502924 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.502924 56.7075
      <g id="line2d_13">
       <path d="M 255.883675 308.04375 
 L 255.883675 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 255.883675 56.7075
      <g id="line2d_15">
       <path d="M 266.351451 308.04375 
 L 266.351451 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.351451 56.7075
      <g id="line2d_17">
       <path d="M 275.419051 308.04375 
 L 275.419051 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.419051 56.7075
      <g id="line2d_19">
       <path d="M 283.417241 308.04375 
 L 283.417241 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.417241 56.7075
      <g id="line2d_21">
       <path d="M 337.640807 308.04375 
 L 337.640807 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.640807 56.7075
      <g id="line2d_23">
       <path d="M 365.174373 308.04375 
 L 365.174373 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.174373 56.7075
      <g id="line2d_25">
       <path d="M 384.709748 308.04375 
 L 384.709748 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 384.709748 56.7075
      <g id="line2d_27">
       <path d="M 399.862563 308.04375 
 L 399.862563 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 399.862563 56.7075
      <g id="line2d_29">
       <path d="M 412.243314 308.04375 
 L 412.243314 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.243314 56.7075
      <g id="line2d_31">
       <path d="M 422.71109 308.04375 
 L 422.71109 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 422.71109 56.7075
      <g id="line2d_33">
       <path d="M 431.77869 308.04375 
 L 431.77869 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 431.77869 56.7075
      <g id="line2d_35">
       <path d="M 439.77688 308.04375 
 L 439.77688 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 439.77688 56.7075
      <g id="line2d_37">
       <path d="M 494.000446 308.04375 
 L 494.000446 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.000446 56.7075
      <g id="line2d_39">
       <path d="M 521.534012 308.04375 
 L 521.534012 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 521.534012 56.7075
      <g id="line2d_41">
       <path d="M 541.069388 308.04375 
 L 541.069388 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.069388 56.7075
      <g id="line2d_43">
       <path d="M 556.222202 308.04375 
 L 556.222202 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mcb5ab4aac4" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m995cf27d35" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m60e8602ff4" d="M 0 0 
+       <path id="m3d1ccf1ab6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m60e8602ff4" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m60e8602ff4" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1118,7 +1118,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m60e8602ff4" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1185,7 +1185,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m60e8602ff4" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m60e8602ff4" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m60e8602ff4" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m60e8602ff4" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m60e8602ff4" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.513283 296.619375 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 167.187538 263.978304 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 190.461899 231.337232 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.409213 198.696161 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.370107 166.055089 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 238.951072 133.414018 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 246.772854 100.772946 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.62053 68.131875 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.351473 308.04375 
 L 542.351473 56.7075 
-" clip-path="url(#p5be6ad264c)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1890,7 +1890,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="mc5e27841e1" d="M 0 3 
+     <path id="m18045fe7f8" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1902,13 +1902,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p5be6ad264c)">
-     <use xlink:href="#mc5e27841e1" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pb2327ca0ee)">
+     <use xlink:href="#m18045fe7f8" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="mba22d448d9" d="M 0 3 
+     <path id="ma184c25b46" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1920,13 +1920,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p5be6ad264c)">
-     <use xlink:href="#mba22d448d9" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pb2327ca0ee)">
+     <use xlink:href="#ma184c25b46" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="meacaae6cca" d="M 0 3 
+     <path id="m80da58a543" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1938,13 +1938,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p5be6ad264c)">
-     <use xlink:href="#meacaae6cca" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pb2327ca0ee)">
+     <use xlink:href="#m80da58a543" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="mee9ca09b8f" d="M 0 5 
+     <path id="m861ade60c8" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1956,13 +1956,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p5be6ad264c)">
-     <use xlink:href="#mee9ca09b8f" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pb2327ca0ee)">
+     <use xlink:href="#m861ade60c8" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="mcd6f93ed7f" d="M 0 3 
+     <path id="mc563981b70" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1974,13 +1974,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p5be6ad264c)">
-     <use xlink:href="#mcd6f93ed7f" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pb2327ca0ee)">
+     <use xlink:href="#mc563981b70" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="med3dd479bb" d="M 0 3 
+     <path id="m4be366299e" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1992,13 +1992,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p5be6ad264c)">
-     <use xlink:href="#med3dd479bb" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pb2327ca0ee)">
+     <use xlink:href="#m4be366299e" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="ma769a35733" d="M 0 3 
+     <path id="m896ed526e6" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2010,13 +2010,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p5be6ad264c)">
-     <use xlink:href="#ma769a35733" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pb2327ca0ee)">
+     <use xlink:href="#m896ed526e6" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m4d2d5de088" d="M 0 3 
+     <path id="mc2b76e6f27" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2028,8 +2028,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p5be6ad264c)">
-     <use xlink:href="#m4d2d5de088" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pb2327ca0ee)">
+     <use xlink:href="#mc2b76e6f27" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2883,7 +2883,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p5be6ad264c">
+  <clipPath id="pb2327ca0ee">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p84ffbb8002)">
+   <g clip-path="url(#pd89ad64c7b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image5629e16879" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image70796ca170" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m77df1adee2" d="M 0 0 
+       <path id="m134e6dbd42" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m77df1adee2" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m77df1adee2" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m77df1adee2" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m77df1adee2" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m77df1adee2" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m77df1adee2" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m77df1adee2" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m77df1adee2" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m77df1adee2" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m77df1adee2" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m77df1adee2" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m77df1adee2" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m134e6dbd42" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m9497493b55" d="M 0 0 
+       <path id="m8fb3d4c7bc" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9497493b55" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9497493b55" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m9497493b55" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m9497493b55" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m9497493b55" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m9497493b55" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m9497493b55" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m9497493b55" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagebb80fd36d2" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageba9bd0f962" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m3f709aab40" d="M 0 0 
+       <path id="mb70a97b302" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3f709aab40" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb70a97b302" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3f709aab40" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb70a97b302" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3f709aab40" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb70a97b302" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3f709aab40" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb70a97b302" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m3f709aab40" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb70a97b302" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-03T22:49:18Z  ·  Linux chungus x86_64  ·  commit 2d0b6447  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.617109 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(46.688984 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2764,6 +2764,44 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-38" d="M 2034 2216 
@@ -2805,44 +2843,6 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-b7" d="M 684 2619 
-L 1344 2619 
-L 1344 1825 
-L 684 1825 
-L 684 2619 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-4c" d="M 628 4666 
-L 1259 4666 
-L 1259 531 
-L 3531 531 
-L 3531 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3b" d="M 750 3309 
 L 1409 3309 
 L 1409 2516 
@@ -2868,16 +2868,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2916,109 +2916,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3262.451172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.697266 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3453.320312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3516.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3548.730469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3580.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.304688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3644.091797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3675.878906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3703.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3765.185547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3826.464844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3889.84375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3953.320312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3992.183594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4053.365234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4174.068359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4215.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4248.873047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4276.65625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4338.179688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4399.458984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4462.837891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4526.460938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4560.152344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4682.955078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4714.742188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4778.365234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4841.988281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4873.775391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4937.398438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4973.482422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5012.345703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5067.326172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5130.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5162.736328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5194.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.310547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5258.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5289.884766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5329.09375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5392.472656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5431.335938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5492.517578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5555.896484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5619.373047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5682.751953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5746.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5809.607422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5848.816406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5880.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5964.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6093.591797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6155.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6218.591797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6246.375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6307.654297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6371.033203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6402.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6454.919922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6518.298828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6579.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6643.054688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6695.154297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6758.533203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6819.714844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6858.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6892.615234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6924.402344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6965.515625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7026.794922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7066.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7093.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7154.96875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7186.755859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7214.539062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7266.638672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7298.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7361.902344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7423.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7462.634766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7524.158203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7563.521484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.933594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7688.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7752.095703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7779.878906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7831.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7871.1875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7898.970703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p84ffbb8002">
+  <clipPath id="pd89ad64c7b">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="571.165781pt" height="386.202469pt" viewBox="0 0 571.165781 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.022031pt" height="386.202469pt" viewBox="0 0 569.022031 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 571.165781 386.202469 
-L 571.165781 0 
+L 569.022031 386.202469 
+L 569.022031 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.707891 104.1264 
-L 292.332891 104.1264 
-L 292.332891 74.7432 
-L 187.707891 74.7432 
+    <path d="M 186.636016 104.1264 
+L 291.261016 104.1264 
+L 291.261016 74.7432 
+L 186.636016 74.7432 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.332891 104.1264 
-L 396.957891 104.1264 
-L 396.957891 74.7432 
-L 292.332891 74.7432 
+    <path d="M 291.261016 104.1264 
+L 395.886016 104.1264 
+L 395.886016 74.7432 
+L 291.261016 74.7432 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.957891 104.1264 
-L 501.582891 104.1264 
-L 501.582891 74.7432 
-L 396.957891 74.7432 
+    <path d="M 395.886016 104.1264 
+L 500.511016 104.1264 
+L 500.511016 74.7432 
+L 395.886016 74.7432 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.707891 133.5096 
-L 292.332891 133.5096 
-L 292.332891 104.1264 
-L 187.707891 104.1264 
+    <path d="M 186.636016 133.5096 
+L 291.261016 133.5096 
+L 291.261016 104.1264 
+L 186.636016 104.1264 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.332891 133.5096 
-L 396.957891 133.5096 
-L 396.957891 104.1264 
-L 292.332891 104.1264 
+    <path d="M 291.261016 133.5096 
+L 395.886016 133.5096 
+L 395.886016 104.1264 
+L 291.261016 104.1264 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.957891 133.5096 
-L 501.582891 133.5096 
-L 501.582891 104.1264 
-L 396.957891 104.1264 
+    <path d="M 395.886016 133.5096 
+L 500.511016 133.5096 
+L 500.511016 104.1264 
+L 395.886016 104.1264 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.707891 162.8928 
-L 292.332891 162.8928 
-L 292.332891 133.5096 
-L 187.707891 133.5096 
+    <path d="M 186.636016 162.8928 
+L 291.261016 162.8928 
+L 291.261016 133.5096 
+L 186.636016 133.5096 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.332891 162.8928 
-L 396.957891 162.8928 
-L 396.957891 133.5096 
-L 292.332891 133.5096 
+    <path d="M 291.261016 162.8928 
+L 395.886016 162.8928 
+L 395.886016 133.5096 
+L 291.261016 133.5096 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.957891 162.8928 
-L 501.582891 162.8928 
-L 501.582891 133.5096 
-L 396.957891 133.5096 
+    <path d="M 395.886016 162.8928 
+L 500.511016 162.8928 
+L 500.511016 133.5096 
+L 395.886016 133.5096 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.707891 192.276 
-L 292.332891 192.276 
-L 292.332891 162.8928 
-L 187.707891 162.8928 
+    <path d="M 186.636016 192.276 
+L 291.261016 192.276 
+L 291.261016 162.8928 
+L 186.636016 162.8928 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.332891 192.276 
-L 396.957891 192.276 
-L 396.957891 162.8928 
-L 292.332891 162.8928 
+    <path d="M 291.261016 192.276 
+L 395.886016 192.276 
+L 395.886016 162.8928 
+L 291.261016 162.8928 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.957891 192.276 
-L 501.582891 192.276 
-L 501.582891 162.8928 
-L 396.957891 162.8928 
+    <path d="M 395.886016 192.276 
+L 500.511016 192.276 
+L 500.511016 162.8928 
+L 395.886016 162.8928 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.707891 221.6592 
-L 292.332891 221.6592 
-L 292.332891 192.276 
-L 187.707891 192.276 
+    <path d="M 186.636016 221.6592 
+L 291.261016 221.6592 
+L 291.261016 192.276 
+L 186.636016 192.276 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.332891 221.6592 
-L 396.957891 221.6592 
-L 396.957891 192.276 
-L 292.332891 192.276 
+    <path d="M 291.261016 221.6592 
+L 395.886016 221.6592 
+L 395.886016 192.276 
+L 291.261016 192.276 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.957891 221.6592 
-L 501.582891 221.6592 
-L 501.582891 192.276 
-L 396.957891 192.276 
+    <path d="M 395.886016 221.6592 
+L 500.511016 221.6592 
+L 500.511016 192.276 
+L 395.886016 192.276 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.707891 251.0424 
-L 292.332891 251.0424 
-L 292.332891 221.6592 
-L 187.707891 221.6592 
+    <path d="M 186.636016 251.0424 
+L 291.261016 251.0424 
+L 291.261016 221.6592 
+L 186.636016 221.6592 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.332891 251.0424 
-L 396.957891 251.0424 
-L 396.957891 221.6592 
-L 292.332891 221.6592 
+    <path d="M 291.261016 251.0424 
+L 395.886016 251.0424 
+L 395.886016 221.6592 
+L 291.261016 221.6592 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.957891 251.0424 
-L 501.582891 251.0424 
-L 501.582891 221.6592 
-L 396.957891 221.6592 
+    <path d="M 395.886016 251.0424 
+L 500.511016 251.0424 
+L 500.511016 221.6592 
+L 395.886016 221.6592 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.707891 280.4256 
-L 292.332891 280.4256 
-L 292.332891 251.0424 
-L 187.707891 251.0424 
+    <path d="M 186.636016 280.4256 
+L 291.261016 280.4256 
+L 291.261016 251.0424 
+L 186.636016 251.0424 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.332891 280.4256 
-L 396.957891 280.4256 
-L 396.957891 251.0424 
-L 292.332891 251.0424 
+    <path d="M 291.261016 280.4256 
+L 395.886016 280.4256 
+L 395.886016 251.0424 
+L 291.261016 251.0424 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.957891 280.4256 
-L 501.582891 280.4256 
-L 501.582891 251.0424 
-L 396.957891 251.0424 
+    <path d="M 395.886016 280.4256 
+L 500.511016 280.4256 
+L 500.511016 251.0424 
+L 395.886016 251.0424 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.707891 309.8088 
-L 292.332891 309.8088 
-L 292.332891 280.4256 
-L 187.707891 280.4256 
+    <path d="M 186.636016 309.8088 
+L 291.261016 309.8088 
+L 291.261016 280.4256 
+L 186.636016 280.4256 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.332891 309.8088 
-L 396.957891 309.8088 
-L 396.957891 280.4256 
-L 292.332891 280.4256 
+    <path d="M 291.261016 309.8088 
+L 395.886016 309.8088 
+L 395.886016 280.4256 
+L 291.261016 280.4256 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.957891 309.8088 
-L 501.582891 309.8088 
-L 501.582891 280.4256 
-L 396.957891 280.4256 
+    <path d="M 395.886016 309.8088 
+L 500.511016 309.8088 
+L 500.511016 280.4256 
+L 395.886016 280.4256 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.707891 339.192 
-L 292.332891 339.192 
-L 292.332891 309.8088 
-L 187.707891 309.8088 
+    <path d="M 186.636016 339.192 
+L 291.261016 339.192 
+L 291.261016 309.8088 
+L 186.636016 309.8088 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.332891 339.192 
-L 396.957891 339.192 
-L 396.957891 309.8088 
-L 292.332891 309.8088 
+    <path d="M 291.261016 339.192 
+L 395.886016 339.192 
+L 395.886016 309.8088 
+L 291.261016 309.8088 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.957891 339.192 
-L 501.582891 339.192 
-L 501.582891 309.8088 
-L 396.957891 309.8088 
+    <path d="M 395.886016 339.192 
+L 500.511016 339.192 
+L 500.511016 309.8088 
+L 395.886016 309.8088 
 z
-" clip-path="url(#pc7c5998ed1)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p114bb3719c)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.695156 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(119.623281 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.979375 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(226.9075 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.551484 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(305.479609 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.903203 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(403.831328 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.632891 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(115.561016 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.569141 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(337.010391 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(335.938516 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(441.635391 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.271016 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(110.199141 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.569141 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.555391 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(441.635391 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.964141 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(97.892266 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.569141 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(339.555391 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(441.635391 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.996641 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(118.924766 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.569141 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.555391 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(441.635391 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.534141 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(127.462266 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.569141 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(339.555391 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(441.635391 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.840391 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(110.768516 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.569141 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(339.555391 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(441.635391 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(440.563516 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.342266 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(97.270391 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.325 -->
-    <g transform="translate(227.368516 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(226.296641 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1879,7 +1879,7 @@ z
    </g>
    <g id="text_31">
     <!-- 24 -->
-    <g transform="translate(339.079141 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(338.007266 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-34" d="M 2356 3675 
 L 1038 1722 
@@ -1906,9 +1906,33 @@ z
     </g>
    </g>
    <g id="text_32">
-    <!-- 262 -->
-    <g transform="translate(440.921016 267.9415) scale(0.08 -0.08)">
+    <!-- 176 -->
+    <g transform="translate(439.849141 267.9415) scale(0.08 -0.08)">
      <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-36" d="M 2316 2303 
 Q 2000 2303 1842 2098 
 Q 1684 1894 1684 1484 
@@ -1940,14 +1964,14 @@ Q 3506 4644 3803 4544
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(96.457266 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(95.385391 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2012,7 +2036,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(228.569141 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2022,21 +2046,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(339.555391 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(338.483516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(444.180391 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.108516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.678516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(123.606641 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2047,7 +2071,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.569141 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(227.497266 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2057,13 +2081,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(342.100391 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(341.028516 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.270391 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(444.198516 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2079,7 +2103,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(152.184609 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(151.112734 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2193,7 +2217,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-03T22:49:18Z  ·  Linux chungus x86_64  ·  commit 2d0b6447  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2332,16 +2356,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
     <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2380,110 +2404,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3135.351562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3198.974609 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3262.451172 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.074219 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.697266 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3453.320312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3516.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3548.730469 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3580.517578 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.304688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3644.091797 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3675.878906 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3703.662109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3765.185547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3826.464844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3889.84375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3953.320312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3992.183594 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4053.365234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4112.544922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4174.068359 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4215.181641 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4248.873047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4276.65625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4338.179688 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4399.458984 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4462.837891 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4526.460938 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4560.152344 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4619.332031 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4682.955078 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4714.742188 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4778.365234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4841.988281 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4873.775391 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4937.398438 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4973.482422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5012.345703 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5067.326172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5130.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5162.736328 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5194.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.310547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5258.097656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5289.884766 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5329.09375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5392.472656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5431.335938 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5492.517578 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5555.896484 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5619.373047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5682.751953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5746.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5809.607422 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5848.816406 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5880.603516 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5964.392578 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6093.591797 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6155.115234 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6218.591797 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6246.375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6307.654297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6371.033203 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6402.820312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6454.919922 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6518.298828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6579.578125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6643.054688 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6695.154297 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6758.533203 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6819.714844 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6858.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6892.615234 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6924.402344 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6965.515625 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7026.794922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7066.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7093.787109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7154.96875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7186.755859 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7214.539062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7266.638672 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7298.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7361.902344 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7423.425781 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7462.634766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7524.158203 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7563.521484 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7660.933594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7688.716797 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7752.095703 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7779.878906 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7831.978516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7871.1875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7898.970703 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc7c5998ed1">
-   <rect x="83.082891" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p114bb3719c">
+   <rect x="82.011016" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-03T22:49:18Z",
+  "date": "2026-07-04T13:30:19Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "2d0b6447",
+  "git_commit": "df28a274",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 58.19,
-   "decompress_mbps": 188.77
+   "compress_mbps": 57.3,
+   "decompress_mbps": 108.85
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 44.0,
-   "decompress_mbps": 214.83
+   "compress_mbps": 43.78,
+   "decompress_mbps": 120.69
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 39.62,
-   "decompress_mbps": 232.4
+   "compress_mbps": 39.7,
+   "decompress_mbps": 131.45
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 29.87,
-   "decompress_mbps": 233.69
+   "compress_mbps": 29.8,
+   "decompress_mbps": 134.38
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54437,
    "ratio": 0.3579,
-   "compress_mbps": 23.87,
-   "decompress_mbps": 236.8
+   "compress_mbps": 23.84,
+   "decompress_mbps": 141.95
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54348,
    "ratio": 0.3573,
-   "compress_mbps": 21.33,
-   "decompress_mbps": 243.68
+   "compress_mbps": 21.29,
+   "decompress_mbps": 146.61
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 18.62,
-   "decompress_mbps": 245.79
+   "compress_mbps": 18.53,
+   "decompress_mbps": 147.06
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 16.01,
-   "decompress_mbps": 247.07
+   "compress_mbps": 18.1,
+   "decompress_mbps": 147.62
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 53082,
    "ratio": 0.349,
-   "compress_mbps": 3.3,
-   "decompress_mbps": 246.58
+   "compress_mbps": 3.2,
+   "decompress_mbps": 147.73
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 53.08,
-   "decompress_mbps": 180.84
+   "compress_mbps": 52.44,
+   "decompress_mbps": 102.53
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 40.42,
-   "decompress_mbps": 196.71
+   "compress_mbps": 40.77,
+   "decompress_mbps": 110.1
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 37.04,
-   "decompress_mbps": 214.73
+   "compress_mbps": 37.33,
+   "decompress_mbps": 119.09
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 28.01,
-   "decompress_mbps": 218.68
+   "compress_mbps": 27.66,
+   "decompress_mbps": 123.93
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48891,
    "ratio": 0.3906,
-   "compress_mbps": 24.25,
-   "decompress_mbps": 220.0
+   "compress_mbps": 24.22,
+   "decompress_mbps": 129.97
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48715,
    "ratio": 0.3892,
-   "compress_mbps": 20.26,
-   "decompress_mbps": 224.09
+   "compress_mbps": 20.21,
+   "decompress_mbps": 132.24
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 19.03,
-   "decompress_mbps": 224.01
+   "compress_mbps": 18.96,
+   "decompress_mbps": 133.14
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 16.35,
-   "decompress_mbps": 225.13
+   "compress_mbps": 18.97,
+   "decompress_mbps": 133.58
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 47620,
    "ratio": 0.3804,
-   "compress_mbps": 3.49,
-   "decompress_mbps": 225.01
+   "compress_mbps": 3.34,
+   "decompress_mbps": 133.38
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 40.62,
-   "decompress_mbps": 217.75
+   "compress_mbps": 39.36,
+   "decompress_mbps": 121.15
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 35.96,
-   "decompress_mbps": 223.83
+   "compress_mbps": 34.72,
+   "decompress_mbps": 125.37
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 35.19,
-   "decompress_mbps": 227.3
+   "compress_mbps": 34.07,
+   "decompress_mbps": 128.72
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 31.83,
-   "decompress_mbps": 235.77
+   "compress_mbps": 30.68,
+   "decompress_mbps": 134.29
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7932,
    "ratio": 0.3224,
-   "compress_mbps": 27.59,
-   "decompress_mbps": 242.26
+   "compress_mbps": 26.61,
+   "decompress_mbps": 138.51
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7938,
    "ratio": 0.3226,
-   "compress_mbps": 23.73,
-   "decompress_mbps": 243.35
+   "compress_mbps": 23.16,
+   "decompress_mbps": 139.91
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 22.86,
-   "decompress_mbps": 247.72
+   "compress_mbps": 22.3,
+   "decompress_mbps": 141.34
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 17.21,
-   "decompress_mbps": 246.58
+   "compress_mbps": 22.29,
+   "decompress_mbps": 141.21
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7806,
    "ratio": 0.3173,
-   "compress_mbps": 4.3,
-   "decompress_mbps": 247.52
+   "compress_mbps": 4.07,
+   "decompress_mbps": 141.51
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 26.86,
-   "decompress_mbps": 149.02
+   "compress_mbps": 25.43,
+   "decompress_mbps": 98.01
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 24.81,
-   "decompress_mbps": 151.06
+   "compress_mbps": 23.74,
+   "decompress_mbps": 100.87
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 24.17,
-   "decompress_mbps": 154.41
+   "compress_mbps": 23.19,
+   "decompress_mbps": 104.31
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 22.39,
-   "decompress_mbps": 156.02
+   "compress_mbps": 21.74,
+   "decompress_mbps": 106.55
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 20.69,
-   "decompress_mbps": 155.51
+   "compress_mbps": 20.04,
+   "decompress_mbps": 108.28
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3135,
    "ratio": 0.2812,
-   "compress_mbps": 18.75,
-   "decompress_mbps": 159.04
+   "compress_mbps": 18.27,
+   "decompress_mbps": 108.85
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 18.2,
-   "decompress_mbps": 159.64
+   "compress_mbps": 17.74,
+   "decompress_mbps": 109.47
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 12.01,
-   "decompress_mbps": 159.83
+   "compress_mbps": 17.75,
+   "decompress_mbps": 109.18
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3057,
    "ratio": 0.2742,
-   "compress_mbps": 4.26,
-   "decompress_mbps": 159.96
+   "compress_mbps": 4.09,
+   "decompress_mbps": 108.61
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 12.55,
-   "decompress_mbps": 69.54
+   "compress_mbps": 12.0,
+   "decompress_mbps": 55.4
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 12.04,
-   "decompress_mbps": 70.19
+   "compress_mbps": 11.55,
+   "decompress_mbps": 55.95
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 12.01,
-   "decompress_mbps": 69.89
+   "compress_mbps": 11.51,
+   "decompress_mbps": 56.21
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.75,
-   "decompress_mbps": 70.38
+   "compress_mbps": 11.27,
+   "decompress_mbps": 57.32
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.52,
-   "decompress_mbps": 70.52
+   "compress_mbps": 11.07,
+   "decompress_mbps": 57.72
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 10.5,
-   "decompress_mbps": 70.73
+   "compress_mbps": 10.09,
+   "decompress_mbps": 57.88
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 10.34,
-   "decompress_mbps": 70.89
+   "compress_mbps": 10.09,
+   "decompress_mbps": 57.94
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 5.92,
-   "decompress_mbps": 70.92
+   "compress_mbps": 10.08,
+   "decompress_mbps": 58.08
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 3.46,
-   "decompress_mbps": 70.99
+   "compress_mbps": 3.3,
+   "decompress_mbps": 58.11
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 114.67,
-   "decompress_mbps": 343.74
+   "compress_mbps": 114.16,
+   "decompress_mbps": 202.07
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 82.33,
-   "decompress_mbps": 369.95
+   "compress_mbps": 82.02,
+   "decompress_mbps": 217.31
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 71.15,
-   "decompress_mbps": 396.09
+   "compress_mbps": 70.64,
+   "decompress_mbps": 226.23
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 66.34,
-   "decompress_mbps": 416.42
+   "compress_mbps": 65.85,
+   "decompress_mbps": 233.37
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 215530,
    "ratio": 0.2093,
-   "compress_mbps": 37.63,
-   "decompress_mbps": 399.63
+   "compress_mbps": 37.45,
+   "decompress_mbps": 229.81
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 201414,
    "ratio": 0.1956,
-   "compress_mbps": 21.78,
-   "decompress_mbps": 413.15
+   "compress_mbps": 22.05,
+   "decompress_mbps": 235.92
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 15.73,
-   "decompress_mbps": 417.5
+   "compress_mbps": 15.95,
+   "decompress_mbps": 236.67
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 10.35,
-   "decompress_mbps": 423.73
+   "compress_mbps": 11.94,
+   "decompress_mbps": 241.47
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 183445,
    "ratio": 0.1781,
-   "compress_mbps": 2.91,
-   "decompress_mbps": 424.23
+   "compress_mbps": 2.86,
+   "decompress_mbps": 242.01
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 65.57,
-   "decompress_mbps": 199.18
+   "compress_mbps": 64.69,
+   "decompress_mbps": 116.61
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 48.5,
-   "decompress_mbps": 214.95
+   "compress_mbps": 48.17,
+   "decompress_mbps": 125.82
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 43.13,
-   "decompress_mbps": 239.22
+   "compress_mbps": 43.29,
+   "decompress_mbps": 137.89
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 32.52,
-   "decompress_mbps": 241.87
+   "compress_mbps": 32.65,
+   "decompress_mbps": 143.14
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145321,
    "ratio": 0.3405,
-   "compress_mbps": 26.4,
-   "decompress_mbps": 243.55
+   "compress_mbps": 26.44,
+   "decompress_mbps": 150.03
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145046,
    "ratio": 0.3399,
-   "compress_mbps": 23.05,
-   "decompress_mbps": 248.68
+   "compress_mbps": 22.88,
+   "decompress_mbps": 153.97
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 20.53,
-   "decompress_mbps": 249.54
+   "compress_mbps": 20.64,
+   "decompress_mbps": 154.65
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 17.63,
-   "decompress_mbps": 251.71
+   "compress_mbps": 20.38,
+   "decompress_mbps": 154.73
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 141031,
    "ratio": 0.3305,
-   "compress_mbps": 3.31,
-   "decompress_mbps": 251.64
+   "compress_mbps": 3.21,
+   "decompress_mbps": 155.19
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 55.97,
-   "decompress_mbps": 171.98
+   "compress_mbps": 55.18,
+   "decompress_mbps": 96.67
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 41.4,
-   "decompress_mbps": 191.3
+   "compress_mbps": 41.01,
+   "decompress_mbps": 105.23
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 37.09,
-   "decompress_mbps": 210.21
+   "compress_mbps": 36.84,
+   "decompress_mbps": 115.03
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 25.54,
-   "decompress_mbps": 213.11
+   "compress_mbps": 25.45,
+   "decompress_mbps": 118.86
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 194902,
    "ratio": 0.4045,
-   "compress_mbps": 21.56,
-   "decompress_mbps": 211.82
+   "compress_mbps": 21.41,
+   "decompress_mbps": 125.16
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 195177,
    "ratio": 0.405,
-   "compress_mbps": 20.02,
-   "decompress_mbps": 216.12
+   "compress_mbps": 19.84,
+   "decompress_mbps": 129.27
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 17.6,
-   "decompress_mbps": 216.05
+   "compress_mbps": 17.57,
+   "decompress_mbps": 129.34
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 15.4,
-   "decompress_mbps": 215.38
+   "compress_mbps": 17.5,
+   "decompress_mbps": 130.22
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 190711,
    "ratio": 0.3958,
-   "compress_mbps": 3.04,
-   "decompress_mbps": 216.61
+   "compress_mbps": 3.02,
+   "decompress_mbps": 129.94
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 168.42,
-   "decompress_mbps": 471.82
+   "compress_mbps": 166.39,
+   "decompress_mbps": 336.04
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 130.75,
-   "decompress_mbps": 494.14
+   "compress_mbps": 130.22,
+   "decompress_mbps": 351.05
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 115.71,
-   "decompress_mbps": 531.5
+   "compress_mbps": 115.43,
+   "decompress_mbps": 374.28
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 80.51,
-   "decompress_mbps": 457.35
+   "compress_mbps": 80.2,
+   "decompress_mbps": 347.1
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 54950,
    "ratio": 0.1071,
-   "compress_mbps": 56.29,
-   "decompress_mbps": 482.97
+   "compress_mbps": 56.42,
+   "decompress_mbps": 369.13
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55259,
    "ratio": 0.1077,
-   "compress_mbps": 38.13,
-   "decompress_mbps": 526.89
+   "compress_mbps": 37.94,
+   "decompress_mbps": 398.03
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53713,
    "ratio": 0.1047,
-   "compress_mbps": 29.21,
-   "decompress_mbps": 569.23
+   "compress_mbps": 29.17,
+   "decompress_mbps": 420.16
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 22.27,
-   "decompress_mbps": 610.12
+   "compress_mbps": 25.14,
+   "decompress_mbps": 449.74
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 52729,
    "ratio": 0.1027,
-   "compress_mbps": 5.08,
-   "decompress_mbps": 624.45
+   "compress_mbps": 4.86,
+   "decompress_mbps": 462.61
   },
   {
    "compressor": "native",
@@ -825,7 +825,7 @@
    "out_size": 14249,
    "ratio": 0.3726,
    "compress_mbps": 29.88,
-   "decompress_mbps": 181.87
+   "decompress_mbps": 111.99
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 27.51,
-   "decompress_mbps": 188.0
+   "compress_mbps": 27.43,
+   "decompress_mbps": 114.4
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 26.85,
-   "decompress_mbps": 191.86
+   "compress_mbps": 26.72,
+   "decompress_mbps": 116.17
   },
   {
    "compressor": "native",
@@ -855,7 +855,7 @@
    "out_size": 13366,
    "ratio": 0.3495,
    "compress_mbps": 24.43,
-   "decompress_mbps": 198.28
+   "decompress_mbps": 122.07
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13346,
    "ratio": 0.349,
-   "compress_mbps": 21.93,
-   "decompress_mbps": 208.19
+   "compress_mbps": 21.74,
+   "decompress_mbps": 128.56
   },
   {
    "compressor": "native",
@@ -875,7 +875,7 @@
    "out_size": 13040,
    "ratio": 0.341,
    "compress_mbps": 9.71,
-   "decompress_mbps": 212.36
+   "decompress_mbps": 130.6
   },
   {
    "compressor": "native",
@@ -885,7 +885,7 @@
    "out_size": 13035,
    "ratio": 0.3409,
    "compress_mbps": 9.08,
-   "decompress_mbps": 214.16
+   "decompress_mbps": 131.62
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 6.79,
-   "decompress_mbps": 215.16
+   "compress_mbps": 8.46,
+   "decompress_mbps": 133.11
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12522,
    "ratio": 0.3275,
-   "compress_mbps": 3.87,
-   "decompress_mbps": 217.02
+   "compress_mbps": 3.74,
+   "decompress_mbps": 134.73
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 14.0,
-   "decompress_mbps": 76.06
+   "compress_mbps": 13.36,
+   "decompress_mbps": 57.14
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 13.43,
-   "decompress_mbps": 75.87
+   "compress_mbps": 12.9,
+   "decompress_mbps": 57.56
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 13.37,
-   "decompress_mbps": 76.19
+   "compress_mbps": 12.87,
+   "decompress_mbps": 57.86
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 13.15,
-   "decompress_mbps": 76.81
+   "compress_mbps": 12.62,
+   "decompress_mbps": 59.16
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 13.01,
-   "decompress_mbps": 76.61
+   "compress_mbps": 12.51,
+   "decompress_mbps": 59.43
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 11.37,
-   "decompress_mbps": 76.67
+   "compress_mbps": 11.01,
+   "decompress_mbps": 59.47
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 11.35,
-   "decompress_mbps": 76.75
+   "compress_mbps": 11.0,
+   "decompress_mbps": 59.46
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 6.74,
-   "decompress_mbps": 76.62
+   "compress_mbps": 11.02,
+   "decompress_mbps": 59.43
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 3.95,
-   "decompress_mbps": 76.32
+   "compress_mbps": 3.79,
+   "decompress_mbps": 59.56
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 59.01,
-   "decompress_mbps": 176.05
+   "compress_mbps": 59.11,
+   "decompress_mbps": 101.62
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 43.37,
-   "decompress_mbps": 191.1
+   "compress_mbps": 43.35,
+   "decompress_mbps": 110.05
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 38.58,
-   "decompress_mbps": 211.76
+   "compress_mbps": 38.99,
+   "decompress_mbps": 120.46
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 27.84,
-   "decompress_mbps": 211.71
+   "compress_mbps": 27.58,
+   "decompress_mbps": 123.59
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3870984,
    "ratio": 0.3798,
-   "compress_mbps": 23.39,
-   "decompress_mbps": 212.39
+   "compress_mbps": 23.19,
+   "decompress_mbps": 130.18
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3878499,
    "ratio": 0.3805,
-   "compress_mbps": 22.1,
-   "decompress_mbps": 218.38
+   "compress_mbps": 21.97,
+   "decompress_mbps": 134.75
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 19.13,
-   "decompress_mbps": 219.66
+   "compress_mbps": 19.09,
+   "decompress_mbps": 135.91
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 16.72,
-   "decompress_mbps": 220.78
+   "compress_mbps": 18.75,
+   "decompress_mbps": 135.69
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3790404,
    "ratio": 0.3719,
-   "compress_mbps": 3.14,
-   "decompress_mbps": 226.58
+   "compress_mbps": 3.06,
+   "decompress_mbps": 137.76
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 74.24,
-   "decompress_mbps": 190.97
+   "compress_mbps": 74.27,
+   "decompress_mbps": 130.17
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 59.18,
-   "decompress_mbps": 199.45
+   "compress_mbps": 59.35,
+   "decompress_mbps": 136.93
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 55.73,
-   "decompress_mbps": 205.81
+   "compress_mbps": 55.91,
+   "decompress_mbps": 141.92
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 42.94,
-   "decompress_mbps": 210.13
+   "compress_mbps": 43.31,
+   "decompress_mbps": 148.83
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20264932,
    "ratio": 0.3956,
-   "compress_mbps": 31.82,
-   "decompress_mbps": 219.09
+   "compress_mbps": 32.14,
+   "decompress_mbps": 156.72
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 19208910,
    "ratio": 0.375,
-   "compress_mbps": 16.95,
-   "decompress_mbps": 223.37
+   "compress_mbps": 17.04,
+   "decompress_mbps": 160.85
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 19177573,
    "ratio": 0.3744,
-   "compress_mbps": 14.0,
-   "decompress_mbps": 218.92
+   "compress_mbps": 14.06,
+   "decompress_mbps": 160.9
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 8.97,
-   "decompress_mbps": 223.15
+   "compress_mbps": 12.3,
+   "decompress_mbps": 158.96
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18723512,
    "ratio": 0.3655,
-   "compress_mbps": 3.41,
-   "decompress_mbps": 224.92
+   "compress_mbps": 3.32,
+   "decompress_mbps": 161.55
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 72.76,
-   "decompress_mbps": 205.95
+   "compress_mbps": 72.29,
+   "decompress_mbps": 119.39
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 57.09,
-   "decompress_mbps": 213.87
+   "compress_mbps": 57.38,
+   "decompress_mbps": 125.28
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 49.47,
-   "decompress_mbps": 224.43
+   "compress_mbps": 49.43,
+   "decompress_mbps": 133.91
   },
   {
    "compressor": "native",
@@ -4185,7 +4185,7 @@
    "out_size": 3707604,
    "ratio": 0.3719,
    "compress_mbps": 32.71,
-   "decompress_mbps": 207.49
+   "decompress_mbps": 129.18
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3705174,
    "ratio": 0.3716,
-   "compress_mbps": 25.8,
-   "decompress_mbps": 203.83
+   "compress_mbps": 25.81,
+   "decompress_mbps": 135.54
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3612809,
    "ratio": 0.3623,
-   "compress_mbps": 20.49,
-   "decompress_mbps": 210.65
+   "compress_mbps": 20.51,
+   "decompress_mbps": 141.52
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3608980,
    "ratio": 0.362,
-   "compress_mbps": 17.83,
-   "decompress_mbps": 213.33
+   "compress_mbps": 17.79,
+   "decompress_mbps": 142.46
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 11.57,
-   "decompress_mbps": 218.05
+   "compress_mbps": 16.36,
+   "decompress_mbps": 145.67
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3598941,
    "ratio": 0.361,
-   "compress_mbps": 3.67,
-   "decompress_mbps": 228.62
+   "compress_mbps": 3.6,
+   "decompress_mbps": 149.87
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 213.21,
-   "decompress_mbps": 582.11
+   "compress_mbps": 214.0,
+   "decompress_mbps": 354.52
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 136.9,
-   "decompress_mbps": 672.74
+   "compress_mbps": 139.15,
+   "decompress_mbps": 399.48
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 117.91,
-   "decompress_mbps": 746.1
+   "compress_mbps": 117.88,
+   "decompress_mbps": 444.66
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 89.89,
-   "decompress_mbps": 750.55
+   "compress_mbps": 90.04,
+   "decompress_mbps": 429.32
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3145121,
    "ratio": 0.0937,
-   "compress_mbps": 61.36,
-   "decompress_mbps": 832.21
+   "compress_mbps": 61.62,
+   "decompress_mbps": 485.03
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3158854,
    "ratio": 0.0941,
-   "compress_mbps": 58.76,
-   "decompress_mbps": 883.2
+   "compress_mbps": 59.24,
+   "decompress_mbps": 558.58
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3124878,
    "ratio": 0.0931,
-   "compress_mbps": 41.62,
-   "decompress_mbps": 894.22
+   "compress_mbps": 41.96,
+   "decompress_mbps": 571.1
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 32.28,
-   "decompress_mbps": 912.68
+   "compress_mbps": 34.21,
+   "decompress_mbps": 591.92
   },
   {
    "compressor": "native",
@@ -4324,8 +4324,8 @@
    "level": 9,
    "out_size": 3083394,
    "ratio": 0.0919,
-   "compress_mbps": 3.13,
-   "decompress_mbps": 907.47
+   "compress_mbps": 3.11,
+   "decompress_mbps": 596.98
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 52.4,
-   "decompress_mbps": 128.1
+   "compress_mbps": 51.93,
+   "decompress_mbps": 90.53
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 43.32,
-   "decompress_mbps": 131.63
+   "compress_mbps": 42.93,
+   "decompress_mbps": 92.87
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 41.95,
-   "decompress_mbps": 136.65
+   "compress_mbps": 41.98,
+   "decompress_mbps": 95.43
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 33.81,
-   "decompress_mbps": 144.61
+   "compress_mbps": 34.07,
+   "decompress_mbps": 102.69
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3233792,
    "ratio": 0.5256,
-   "compress_mbps": 30.64,
-   "decompress_mbps": 149.0
+   "compress_mbps": 30.5,
+   "decompress_mbps": 107.48
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3168386,
    "ratio": 0.515,
-   "compress_mbps": 17.42,
-   "decompress_mbps": 152.06
+   "compress_mbps": 17.43,
+   "decompress_mbps": 108.86
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3165783,
    "ratio": 0.5146,
-   "compress_mbps": 16.27,
-   "decompress_mbps": 151.77
+   "compress_mbps": 16.46,
+   "decompress_mbps": 109.53
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 9.75,
-   "decompress_mbps": 152.3
+   "compress_mbps": 15.71,
+   "decompress_mbps": 110.18
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3055775,
    "ratio": 0.4967,
-   "compress_mbps": 3.84,
-   "decompress_mbps": 155.14
+   "compress_mbps": 3.77,
+   "decompress_mbps": 111.73
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 82.87,
-   "decompress_mbps": 228.3
+   "compress_mbps": 82.9,
+   "decompress_mbps": 149.59
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 62.5,
-   "decompress_mbps": 237.79
+   "compress_mbps": 62.23,
+   "decompress_mbps": 154.83
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 60.24,
-   "decompress_mbps": 242.96
+   "compress_mbps": 60.45,
+   "decompress_mbps": 158.63
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 53.62,
-   "decompress_mbps": 255.56
+   "compress_mbps": 53.54,
+   "decompress_mbps": 171.59
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3707010,
    "ratio": 0.3676,
-   "compress_mbps": 50.18,
-   "decompress_mbps": 258.28
+   "compress_mbps": 50.0,
+   "decompress_mbps": 177.14
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3707065,
    "ratio": 0.3676,
-   "compress_mbps": 36.79,
-   "decompress_mbps": 268.74
+   "compress_mbps": 36.92,
+   "decompress_mbps": 185.22
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 36.9,
-   "decompress_mbps": 271.54
+   "compress_mbps": 36.64,
+   "decompress_mbps": 187.1
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 18.49,
-   "decompress_mbps": 272.65
+   "compress_mbps": 36.84,
+   "decompress_mbps": 186.32
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3693258,
    "ratio": 0.3662,
-   "compress_mbps": 4.85,
-   "decompress_mbps": 267.67
+   "compress_mbps": 4.82,
+   "decompress_mbps": 192.65
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 74.83,
-   "decompress_mbps": 222.93
+   "compress_mbps": 73.16,
+   "decompress_mbps": 127.25
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 52.42,
-   "decompress_mbps": 238.04
+   "compress_mbps": 52.77,
+   "decompress_mbps": 138.98
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 43.74,
-   "decompress_mbps": 260.47
+   "compress_mbps": 43.78,
+   "decompress_mbps": 158.17
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 27.15,
-   "decompress_mbps": 264.66
+   "compress_mbps": 27.37,
+   "decompress_mbps": 157.53
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1874829,
    "ratio": 0.2829,
-   "compress_mbps": 16.53,
-   "decompress_mbps": 262.8
+   "compress_mbps": 16.61,
+   "decompress_mbps": 169.12
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1867098,
    "ratio": 0.2817,
-   "compress_mbps": 19.26,
-   "decompress_mbps": 276.48
+   "compress_mbps": 19.47,
+   "decompress_mbps": 180.04
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1843421,
    "ratio": 0.2782,
-   "compress_mbps": 13.04,
-   "decompress_mbps": 279.96
+   "compress_mbps": 13.16,
+   "decompress_mbps": 184.33
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 10.76,
-   "decompress_mbps": 280.0
+   "compress_mbps": 11.48,
+   "decompress_mbps": 185.97
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 1794155,
    "ratio": 0.2707,
-   "compress_mbps": 2.47,
-   "decompress_mbps": 293.77
+   "compress_mbps": 2.49,
+   "decompress_mbps": 188.0
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 101.33,
-   "decompress_mbps": 294.89
+   "compress_mbps": 101.71,
+   "decompress_mbps": 193.13
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 76.58,
-   "decompress_mbps": 312.86
+   "compress_mbps": 76.84,
+   "decompress_mbps": 204.55
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 69.32,
-   "decompress_mbps": 326.87
+   "compress_mbps": 69.98,
+   "decompress_mbps": 213.53
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 52.22,
-   "decompress_mbps": 335.41
+   "compress_mbps": 52.51,
+   "decompress_mbps": 223.54
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5839944,
    "ratio": 0.2703,
-   "compress_mbps": 40.18,
-   "decompress_mbps": 343.55
+   "compress_mbps": 40.41,
+   "decompress_mbps": 235.19
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5425813,
    "ratio": 0.2511,
-   "compress_mbps": 28.49,
-   "decompress_mbps": 348.03
+   "compress_mbps": 28.72,
+   "decompress_mbps": 240.15
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5409983,
    "ratio": 0.2504,
-   "compress_mbps": 25.2,
-   "decompress_mbps": 351.79
+   "compress_mbps": 25.39,
+   "decompress_mbps": 241.76
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 18.86,
-   "decompress_mbps": 355.89
+   "compress_mbps": 23.69,
+   "decompress_mbps": 243.69
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 9,
    "out_size": 5257833,
    "ratio": 0.2433,
-   "compress_mbps": 4.1,
-   "decompress_mbps": 346.39
+   "compress_mbps": 4.04,
+   "decompress_mbps": 239.51
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 43.62,
-   "decompress_mbps": 127.62
+   "compress_mbps": 44.08,
+   "decompress_mbps": 90.32
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 37.46,
-   "decompress_mbps": 131.64
+   "compress_mbps": 37.25,
+   "decompress_mbps": 93.21
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 35.57,
-   "decompress_mbps": 137.98
+   "compress_mbps": 35.15,
+   "decompress_mbps": 96.12
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 28.59,
-   "decompress_mbps": 138.57
+   "compress_mbps": 28.84,
+   "decompress_mbps": 100.47
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5496802,
    "ratio": 0.758,
-   "compress_mbps": 27.05,
-   "decompress_mbps": 140.07
+   "compress_mbps": 26.89,
+   "decompress_mbps": 102.16
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5478405,
    "ratio": 0.7554,
-   "compress_mbps": 19.77,
-   "decompress_mbps": 136.91
+   "compress_mbps": 19.88,
+   "decompress_mbps": 104.27
   },
   {
    "compressor": "native",
@@ -4754,18 +4754,18 @@
    "level": 7,
    "out_size": 5474648,
    "ratio": 0.7549,
-   "compress_mbps": 19.04,
-   "decompress_mbps": 134.4
+   "compress_mbps": 19.11,
+   "decompress_mbps": 104.36
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 8,
-   "out_size": 5429363,
-   "ratio": 0.7487,
-   "compress_mbps": 8.41,
-   "decompress_mbps": 135.6
+   "out_size": 5474139,
+   "ratio": 0.7549,
+   "compress_mbps": 18.98,
+   "decompress_mbps": 104.27
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5301868,
    "ratio": 0.7311,
-   "compress_mbps": 3.7,
-   "decompress_mbps": 138.28
+   "compress_mbps": 3.69,
+   "decompress_mbps": 105.65
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 75.49,
-   "decompress_mbps": 226.5
+   "compress_mbps": 75.48,
+   "decompress_mbps": 134.74
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 56.79,
-   "decompress_mbps": 245.66
+   "compress_mbps": 57.01,
+   "decompress_mbps": 145.55
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 52.18,
-   "decompress_mbps": 263.66
+   "compress_mbps": 52.56,
+   "decompress_mbps": 156.48
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 39.06,
-   "decompress_mbps": 268.55
+   "compress_mbps": 38.95,
+   "decompress_mbps": 163.62
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12123671,
    "ratio": 0.2924,
-   "compress_mbps": 29.01,
-   "decompress_mbps": 273.2
+   "compress_mbps": 28.95,
+   "decompress_mbps": 172.52
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12167341,
    "ratio": 0.2935,
-   "compress_mbps": 28.74,
-   "decompress_mbps": 278.89
+   "compress_mbps": 28.72,
+   "decompress_mbps": 177.15
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 23.69,
-   "decompress_mbps": 281.39
+   "compress_mbps": 23.79,
+   "decompress_mbps": 178.82
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 19.59,
-   "decompress_mbps": 282.19
+   "compress_mbps": 22.72,
+   "decompress_mbps": 179.76
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 9,
    "out_size": 11868997,
    "ratio": 0.2863,
-   "compress_mbps": 3.29,
-   "decompress_mbps": 282.1
+   "compress_mbps": 3.22,
+   "decompress_mbps": 179.3
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 41.28,
-   "decompress_mbps": 124.69
+   "compress_mbps": 41.02,
+   "decompress_mbps": 76.07
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 39.9,
-   "decompress_mbps": 126.86
+   "compress_mbps": 39.62,
+   "decompress_mbps": 76.86
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 39.74,
-   "decompress_mbps": 128.17
+   "compress_mbps": 39.8,
+   "decompress_mbps": 78.51
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 37.44,
-   "decompress_mbps": 115.34
+   "compress_mbps": 37.27,
+   "decompress_mbps": 78.04
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 37.4,
-   "decompress_mbps": 116.88
+   "compress_mbps": 37.32,
+   "decompress_mbps": 80.69
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 9.57,
-   "decompress_mbps": 118.82
+   "compress_mbps": 9.71,
+   "decompress_mbps": 81.65
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 9.55,
-   "decompress_mbps": 118.68
+   "compress_mbps": 9.58,
+   "decompress_mbps": 81.67
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 5.67,
-   "decompress_mbps": 118.6
+   "compress_mbps": 9.65,
+   "decompress_mbps": 81.82
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5949045,
    "ratio": 0.702,
-   "compress_mbps": 4.39,
-   "decompress_mbps": 120.52
+   "compress_mbps": 4.35,
+   "decompress_mbps": 82.41
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 160.73,
-   "decompress_mbps": 442.7
+   "compress_mbps": 160.16,
+   "decompress_mbps": 265.36
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 106.7,
-   "decompress_mbps": 509.77
+   "compress_mbps": 107.02,
+   "decompress_mbps": 297.06
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 98.35,
-   "decompress_mbps": 565.6
+   "compress_mbps": 98.82,
+   "decompress_mbps": 345.33
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 71.19,
-   "decompress_mbps": 556.68
+   "compress_mbps": 72.11,
+   "decompress_mbps": 327.96
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 710636,
    "ratio": 0.1329,
-   "compress_mbps": 52.62,
-   "decompress_mbps": 605.74
+   "compress_mbps": 52.85,
+   "decompress_mbps": 388.89
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 688375,
    "ratio": 0.1288,
-   "compress_mbps": 45.67,
-   "decompress_mbps": 651.48
+   "compress_mbps": 46.36,
+   "decompress_mbps": 399.42
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 676544,
    "ratio": 0.1266,
-   "compress_mbps": 37.08,
-   "decompress_mbps": 658.07
+   "compress_mbps": 37.41,
+   "decompress_mbps": 426.56
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 29.5,
-   "decompress_mbps": 661.72
+   "compress_mbps": 32.46,
+   "decompress_mbps": 413.38
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 9,
    "out_size": 669438,
    "ratio": 0.1252,
-   "compress_mbps": 4.02,
-   "decompress_mbps": 652.22
+   "compress_mbps": 3.97,
+   "decompress_mbps": 430.23
   },
   {
    "compressor": "zlib",
@@ -17264,7 +17264,7 @@
    "level": 10,
    "out_size": 52115,
    "ratio": 0.3427,
-   "compress_mbps": 1.85,
+   "compress_mbps": 1.8,
    "decompress_mbps": null
   },
   {
@@ -17274,7 +17274,7 @@
    "level": 10,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 2.11,
+   "compress_mbps": 2.05,
    "decompress_mbps": null
   },
   {
@@ -17284,7 +17284,7 @@
    "level": 10,
    "out_size": 7730,
    "ratio": 0.3142,
-   "compress_mbps": 2.6,
+   "compress_mbps": 2.5,
    "decompress_mbps": null
   },
   {
@@ -17294,7 +17294,7 @@
    "level": 10,
    "out_size": 3030,
    "ratio": 0.2717,
-   "compress_mbps": 2.5,
+   "compress_mbps": 2.42,
    "decompress_mbps": null
   },
   {
@@ -17304,7 +17304,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.18,
+   "compress_mbps": 2.1,
    "decompress_mbps": null
   },
   {
@@ -17314,7 +17314,7 @@
    "level": 10,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 1.28,
+   "compress_mbps": 1.27,
    "decompress_mbps": null
   },
   {
@@ -17324,7 +17324,7 @@
    "level": 10,
    "out_size": 138684,
    "ratio": 0.325,
-   "compress_mbps": 1.96,
+   "compress_mbps": 1.92,
    "decompress_mbps": null
   },
   {
@@ -17334,7 +17334,7 @@
    "level": 10,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.82,
+   "compress_mbps": 1.79,
    "decompress_mbps": null
   },
   {
@@ -17344,7 +17344,7 @@
    "level": 10,
    "out_size": 52368,
    "ratio": 0.102,
-   "compress_mbps": 3.31,
+   "compress_mbps": 3.22,
    "decompress_mbps": null
   },
   {
@@ -17354,7 +17354,7 @@
    "level": 10,
    "out_size": 12277,
    "ratio": 0.3211,
-   "compress_mbps": 2.28,
+   "compress_mbps": 2.23,
    "decompress_mbps": null
   },
   {
@@ -17364,7 +17364,7 @@
    "level": 10,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 2.52,
+   "compress_mbps": 2.43,
    "decompress_mbps": null
   },
   {
@@ -17374,7 +17374,7 @@
    "level": 10,
    "out_size": 3712353,
    "ratio": 0.3642,
-   "compress_mbps": 1.82,
+   "compress_mbps": 1.79,
    "decompress_mbps": null
   },
   {
@@ -17394,7 +17394,7 @@
    "level": 10,
    "out_size": 3523172,
    "ratio": 0.3534,
-   "compress_mbps": 1.9,
+   "compress_mbps": 1.91,
    "decompress_mbps": null
   },
   {
@@ -17414,7 +17414,7 @@
    "level": 10,
    "out_size": 3017814,
    "ratio": 0.4905,
-   "compress_mbps": 2.4,
+   "compress_mbps": 2.41,
    "decompress_mbps": null
   },
   {
@@ -17424,7 +17424,7 @@
    "level": 10,
    "out_size": 3647718,
    "ratio": 0.3617,
-   "compress_mbps": 2.79,
+   "compress_mbps": 2.8,
    "decompress_mbps": null
   },
   {
@@ -17434,7 +17434,7 @@
    "level": 10,
    "out_size": 1724649,
    "ratio": 0.2602,
-   "compress_mbps": 1.19,
+   "compress_mbps": 1.17,
    "decompress_mbps": null
   },
   {
@@ -17444,7 +17444,7 @@
    "level": 10,
    "out_size": 5179097,
    "ratio": 0.2397,
-   "compress_mbps": 2.28,
+   "compress_mbps": 2.26,
    "decompress_mbps": null
   },
   {
@@ -17454,7 +17454,7 @@
    "level": 10,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 2.57,
+   "compress_mbps": 2.6,
    "decompress_mbps": null
   },
   {
@@ -17474,7 +17474,7 @@
    "level": 10,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 3.44,
+   "compress_mbps": 3.43,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR removes the second (fixed-cadence) shared-window split candidate that level 8 alone arbitrated on top of the base and observation-divergence candidates, because it is over-fit to a single benchmark input. A per-file diff shows the candidate — a full extra frequency + Huffman sizing pass over the token stream cut at a fixed 8192-token cadence, computed on every input — changes the emitted bytes on exactly one Silesia file (a statistically uniform record catalog whose slow global drift the divergence heuristic never cuts), improving it 0.8% while costing a 1.1-2.1x level-8 compress slowdown on all twelve. Deciding a whole level's cost, on every input, from one file's 0.8% is the definition of over-fitting; the candidate and the corpus-specific comment justifying it both go.

With the tax gone, level 8 runs 1.44x faster on Silesia (1.37x Canterbury) at byte-identical output everywhere except that one file (+0.065% Silesia-total ratio), and moves from ~14% inside the achievable mixing frontier (dominated by a level-7/level-9 mix) to a genuine frontier vertex. Levels 6 and 7 are untouched — they never ran the second candidate.

A drift-detection hybrid that tried to keep the one-file win selectively was prototyped and measured to fail: neither the observation classes nor a finer byte-value head/tail histogram separate that input's benefit from the others, because the benefit is local structure visible only to the sizing pass itself, not to any cheap two-window statistic.

The roundtrip proof simplifies rather than churns: level 8's dispatch is now the same single obs-split emit as levels 6-7, so the `8 ≤ level` case split in `inflate_deflateRaw` / `deflateRaw_pad` / `deflateRaw_goR_pad` collapses to the shared `hwithObs` case.

Addresses the residual level-7/level-8 half of https://github.com/kim-em/lean-zip/issues/2698 (perf(explore): spread the per-level ladder — L4-6 and L7-8 collapse on the compress Pareto): the level-8 point is no longer wasted interior. Full separation of levels 7 and 8 remains bounded by the optimal-parse tier (they share a ratio ceiling), tracked by the DP-parser work.

🤖 Prepared with Claude Code