### PR TITLE
perf: batch BitWriter flushes to cut per-field FFI stores

### DIFF
--- a/Zip/Native/BitWriter.lean
+++ b/Zip/Native/BitWriter.lean
@@ -5,20 +5,32 @@ import Zip.Native.Wide
 
   DEFLATE (RFC 1951) packs bits LSB-first within each byte.
   This module provides a stateful writer that accumulates bits
-  into a partial byte, flushing complete bytes to a ByteArray.
+  into a wide pending buffer, flushing complete bytes to a ByteArray.
 
   Fields are packed in bulk: a whole `writeBits`/`writeHuffCode` field is
-  merged into a wide (`UInt64`) accumulator in one shift/OR, then whole bytes
-  are flushed in a short inner loop (`flushAcc`). This is byte-identical to a
-  bit-by-bit packer but avoids one loop iteration and one `ByteArray.push` per
-  bit — the dominant cost when emitting millions of literals.
+  merged into the 64-bit pending accumulator (`bitBuf`) in one shift/OR. Rather
+  than flush every completed byte immediately (one `pushUInt64LE` FFI store per
+  field — the dominant emit cost once the per-bit loop was removed, #2631), the
+  writer **holds up to 31 pending bits** and flushes whole bytes only when the
+  pending count reaches `flushThreshold` (32). One store then drains 4–7 bytes
+  at once, cutting the FFI store count on a literal-heavy stream ~4× (measured
+  ~+22-29% on the dynamic emit walk, ~+7-8% on full L1 — #2734). This is
+  byte-identical to flushing every field: `toBits` (hence `bitLength` and the
+  final `flush` output) depends only on the total bit sequence, not on when
+  whole bytes are drained to `data`.
 -/
 namespace Zip.Native
 
+/-- Pending-bit count at or above which whole bytes are drained to `data`.
+    Below it, bits stay in the `bitBuf` accumulator (batched). At most one field
+    (`≤ 25` bits) is added before the check, and the pre-check count is `< 32`,
+    so the accumulator never exceeds `31 + 25 = 56 < 64` bits. -/
+def flushThreshold : Nat := 32
+
 structure BitWriter where
   data : ByteArray
-  bitBuf : UInt8    -- partial byte being assembled
-  bitCount : UInt8  -- bits used in bitBuf (0-7)
+  bitBuf : UInt64   -- pending bits, LSB-first (0 ≤ bitCount valid low bits)
+  bitCount : UInt8  -- number of valid pending bits in bitBuf (0-31)
 
 namespace BitWriter
 
@@ -46,7 +58,7 @@ def flushAcc (data : ByteArray) (acc : UInt64) : Nat → BitWriter
     if total ≥ 8 then
       flushAcc (data.push acc.toUInt8) (acc >>> 8) (total - 8)
     else
-      ⟨data, acc.toUInt8, total.toUInt8⟩
+      ⟨data, acc, total.toUInt8⟩
   termination_by total => total
 
 /-- The byte-pushing half of `flushAcc`: push the low `k` whole bytes of
@@ -76,7 +88,8 @@ private theorem toUSize_toNat_of_le_8 {k : Nat} (h : k ≤ 8) : k.toUSize.toNat 
 /-- `flushBytes` through the wide store: one `pushUInt64LE` call (an 8-byte
     store into capacity slack plus a size bump, `c/bytearray_wide_ffi.c`)
     replaces the `k`-iteration per-byte push loop. The writers always take
-    the wide branch — `k = total / 8 ≤ (7 + 25) / 8 = 4` — but the guard
+    the wide branch — under batching the pending count is `< flushThreshold = 32`
+    before a field, so `k = total / 8 ≤ (31 + 25) / 8 = 7 ≤ 8` — but the guard
     keeps the function total on all inputs, falling back to the push loop.
     Kernel-measured 1.4× over the push loop on a synthetic L1-like field
     trace (`lake exe wide-store-bench`, issue #2631 step 0). -/
@@ -110,7 +123,7 @@ theorem flushBytesWide_eq (data : ByteArray) (acc : UInt64) (k : Nat) :
     and the leftover accumulator commute past each other. -/
 theorem flushAcc_eq (data : ByteArray) (acc : UInt64) (total : Nat) :
     flushAcc data acc total =
-      ⟨flushBytes data acc (total / 8), (dropBytes acc (total / 8)).toUInt8,
+      ⟨flushBytes data acc (total / 8), dropBytes acc (total / 8),
         (total % 8).toUInt8⟩ := by
   induction total using Nat.strongRecOn generalizing data acc with
   | _ total ih =>
@@ -125,6 +138,16 @@ theorem flushAcc_eq (data : ByteArray) (acc : UInt64) (total : Nat) :
       have hm : total % 8 = total := by omega
       rw [h8, hm, flushBytes, dropBytes]
 
+/-- Batched flush: drain whole bytes only when the pending count reaches
+    `flushThreshold`, else keep every bit in the accumulator. Reference form of
+    the flush cadence the production `writeBits`/`writeHuffCode` use (they call
+    `flushBytesWide`/`dropBytes` directly for ctor reuse; equal by
+    `writeBits_def`/`writeHuffCode_def`). Byte-identical to `flushAcc` in output
+    bits — only the split between `data` and the pending accumulator differs. -/
+def flushBatched (data : ByteArray) (acc : UInt64) (total : Nat) : BitWriter :=
+  if total ≥ flushThreshold then flushAcc data acc total
+  else ⟨data, acc, total.toUInt8⟩
+
 /-- Write `n` bits (n ≤ 25) from `val`, LSB first.
     Fixed-width fields in DEFLATE are packed LSB-first.
 
@@ -134,19 +157,24 @@ theorem flushAcc_eq (data : ByteArray) (acc : UInt64) (total : Nat) :
     flush loop) so ctor reuse updates `bw` in place — see `flushAcc`. -/
 def writeBits (bw : BitWriter) (n : Nat) (val : UInt32) : BitWriter :=
   let masked : UInt64 := val.toUInt64 % (1 <<< n.toUInt64)
-  let acc : UInt64 := bw.bitBuf.toUInt64 ||| (masked <<< bw.bitCount.toUInt64)
+  let acc : UInt64 := bw.bitBuf ||| (masked <<< bw.bitCount.toUInt64)
   let total := bw.bitCount.toNat + n
-  ⟨flushBytesWide bw.data acc (total / 8), (dropBytes acc (total / 8)).toUInt8,
-    (total % 8).toUInt8⟩
+  if total ≥ flushThreshold then
+    ⟨flushBytesWide bw.data acc (total / 8), dropBytes acc (total / 8), (total % 8).toUInt8⟩
+  else
+    ⟨bw.data, acc, total.toUInt8⟩
 
-/-- `writeBits` is `flushAcc` of the merged accumulator — the pre-#2739
-    defining equation, for the spec proofs. -/
+/-- `writeBits` is `flushBatched` of the merged accumulator — the defining
+    equation the spec proofs unfold to. -/
 theorem writeBits_def (bw : BitWriter) (n : Nat) (val : UInt32) :
     bw.writeBits n val =
-      flushAcc bw.data
-        (bw.bitBuf.toUInt64 ||| ((val.toUInt64 % (1 <<< n.toUInt64)) <<< bw.bitCount.toUInt64))
+      flushBatched bw.data
+        (bw.bitBuf ||| ((val.toUInt64 % (1 <<< n.toUInt64)) <<< bw.bitCount.toUInt64))
         (bw.bitCount.toNat + n) := by
-  rw [writeBits, flushBytesWide_eq, flushAcc_eq]
+  rw [writeBits, flushBatched]
+  split
+  · rw [flushBytesWide_eq, flushAcc_eq]
+  · rfl
 
 /-- Reverse all 16 bits of `x` (`bit i ↦ bit (15-i)`) with a branchless
     swap network — no per-bit loop. -/
@@ -166,25 +194,33 @@ def reverse16 (x : UInt16) : UInt16 :=
     yield `0` correctly, since `>>> 16` clears a 16-bit value.) -/
 def writeHuffCode (bw : BitWriter) (code : UInt16) (len : UInt8) : BitWriter :=
   let rev : UInt64 := (reverse16 code).toUInt64 >>> (16 - len.toUInt64)
-  let acc : UInt64 := bw.bitBuf.toUInt64 ||| (rev <<< bw.bitCount.toUInt64)
+  let acc : UInt64 := bw.bitBuf ||| (rev <<< bw.bitCount.toUInt64)
   let total := bw.bitCount.toNat + len.toNat
-  ⟨flushBytesWide bw.data acc (total / 8), (dropBytes acc (total / 8)).toUInt8,
-    (total % 8).toUInt8⟩
+  if total ≥ flushThreshold then
+    ⟨flushBytesWide bw.data acc (total / 8), dropBytes acc (total / 8), (total % 8).toUInt8⟩
+  else
+    ⟨bw.data, acc, total.toUInt8⟩
 
-/-- `writeHuffCode` is `flushAcc` of the merged accumulator — the pre-#2739
-    defining equation, for the spec proofs. -/
+/-- `writeHuffCode` is `flushBatched` of the merged accumulator — the defining
+    equation the spec proofs unfold to. -/
 theorem writeHuffCode_def (bw : BitWriter) (code : UInt16) (len : UInt8) :
     bw.writeHuffCode code len =
-      flushAcc bw.data
-        (bw.bitBuf.toUInt64 |||
+      flushBatched bw.data
+        (bw.bitBuf |||
           (((reverse16 code).toUInt64 >>> (16 - len.toUInt64)) <<< bw.bitCount.toUInt64))
         (bw.bitCount.toNat + len.toNat) := by
-  rw [writeHuffCode, flushBytesWide_eq, flushAcc_eq]
+  rw [writeHuffCode, flushBatched]
+  split
+  · rw [flushBytesWide_eq, flushAcc_eq]
+  · rfl
 
-/-- Flush any partial byte (pad with zeros). Returns the final ByteArray. -/
+/-- Flush all pending bits, padding the final partial byte with zeros. Drains
+    every whole pending byte (`bitCount` may hold up to 31 bits under batching),
+    then the final partial byte. Returns the final ByteArray. -/
 def flush (bw : BitWriter) : ByteArray :=
-  if bw.bitCount > 0 then bw.data.push bw.bitBuf
-  else bw.data
+  let r := flushAcc bw.data bw.bitBuf bw.bitCount.toNat
+  if r.bitCount > 0 then r.data.push r.bitBuf.toUInt8
+  else r.data
 
 end BitWriter
 end Zip.Native

--- a/Zip/Spec/BitWriterCorrect.lean
+++ b/Zip/Spec/BitWriterCorrect.lean
@@ -16,12 +16,16 @@ def toBits (bw : BitWriter) : List Bool :=
   bw.data.data.toList.flatMap Deflate.Spec.bytesToBits.byteToBits ++
   (List.range bw.bitCount.toNat).map (fun i => bw.bitBuf.toNat.testBit i)
 
-/-- Well-formedness: bitCount < 8, no stale bits above bitCount. -/
+/-- Well-formedness: at most `flushThreshold` (32) pending bits under batching,
+    with no stale bits above `bitCount`. -/
 def wf (bw : BitWriter) : Prop :=
-  bw.bitCount.toNat < 8 ∧ bw.bitBuf.toNat < 2 ^ bw.bitCount.toNat
+  bw.bitCount.toNat < 32 ∧ bw.bitBuf.toNat < 2 ^ bw.bitCount.toNat
 
 theorem empty_wf : empty.wf := by
-  constructor <;> simp only [empty, UInt8.toNat_zero, Nat.zero_lt_succ, Nat.pow_zero, Nat.lt_add_one]
+  refine ⟨?_, ?_⟩
+  · show (0 : UInt8).toNat < 32; simp only [UInt8.toNat_zero]; omega
+  · show (0 : UInt64).toNat < 2 ^ (0 : UInt8).toNat
+    simp only [UInt64.toNat_zero, UInt8.toNat_zero, Nat.pow_zero]; omega
 
 theorem empty_toBits : empty.toBits = [] := by
   simp only [toBits, empty, ByteArray.data_empty, Array.toList_empty, List.flatMap_nil,
@@ -182,20 +186,37 @@ private theorem flushAcc_spec (data : ByteArray) (acc : UInt64) (total : Nat)
       have htu : total.toUInt8.toNat = total := by
         simp only [Nat.toUInt8, UInt8.toNat_ofNat']
         rw [show (2 : Nat) ^ 8 = 256 from rfl]; omega
-      have hau : acc.toUInt8.toNat = acc.toNat := by
-        rw [UInt64.toNat_toUInt8]
-        exact Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le hacc
-          (Nat.pow_le_pow_right (by omega) (by omega)))
       refine ⟨?_, ?_, ?_⟩
       · simp only [toBits, htu]
-        congr 1
-        apply List.map_congr_left
-        intro i _
-        rw [hau]
-      · show total.toUInt8.toNat < 8
-        rw [htu]; exact htot
-      · show acc.toUInt8.toNat < 2 ^ total.toUInt8.toNat
-        rw [hau, htu]; exact hacc
+      · show total.toUInt8.toNat < 32
+        rw [htu]; omega
+      · show acc.toNat < 2 ^ total.toUInt8.toNat
+        rw [htu]; exact hacc
+
+/-- The batched flush lists the same bits as `flushAcc` (`data`-bits then the
+    `total` accumulator bits) and stays well-formed, whether it drained whole
+    bytes (`≥ flushThreshold`, via `flushAcc_spec`) or kept them pending
+    (`< flushThreshold`, so `bitCount = total < 32`). -/
+private theorem flushBatched_spec (data : ByteArray) (acc : UInt64) (total : Nat)
+    (hacc : acc.toNat < 2 ^ total) :
+    (flushBatched data acc total).toBits =
+      data.data.toList.flatMap Deflate.Spec.bytesToBits.byteToBits ++
+      (List.range total).map (fun i => acc.toNat.testBit i) ∧
+    (flushBatched data acc total).wf := by
+  unfold flushBatched
+  split
+  · exact flushAcc_spec data acc total hacc
+  · rename_i hlt
+    have htlt : total < 32 := by simp only [flushThreshold, ge_iff_le, Nat.not_le] at hlt; omega
+    have htu : total.toUInt8.toNat = total := by
+      simp only [Nat.toUInt8, UInt8.toNat_ofNat']
+      rw [show (2 : Nat) ^ 8 = 256 from rfl]; omega
+    refine ⟨?_, ?_, ?_⟩
+    · simp only [toBits, htu]
+    · show total.toUInt8.toNat < 32
+      rw [htu]; exact htlt
+    · show acc.toNat < 2 ^ total.toUInt8.toNat
+      rw [htu]; exact hacc
 
 /-! ## writeBits correspondence -/
 
@@ -223,9 +244,9 @@ private theorem writeBits_spec (bw : BitWriter) (n : Nat) (val : UInt32)
   have hmlt : val.toNat % 2 ^ n < 2 ^ n := Nat.mod_lt _ (Nat.two_pow_pos _)
   -- the accumulator as a Nat
   have hacc_nat :
-      (bw.bitBuf.toUInt64 ||| ((val.toUInt64 % (1 <<< n.toUInt64)) <<< bw.bitCount.toUInt64)).toNat
+      (bw.bitBuf ||| ((val.toUInt64 % (1 <<< n.toUInt64)) <<< bw.bitCount.toUInt64)).toNat
       = bw.bitBuf.toNat ||| ((val.toNat % 2 ^ n) <<< bw.bitCount.toNat) := by
-    rw [UInt64.toNat_or, UInt8.toNat_toUInt64, UInt64.toNat_shiftLeft, hmask, hbc64]
+    rw [UInt64.toNat_or, UInt64.toNat_shiftLeft, hmask, hbc64]
     congr 1
     apply Nat.mod_eq_of_lt
     rw [Nat.shiftLeft_eq]
@@ -235,11 +256,11 @@ private theorem writeBits_spec (bw : BitWriter) (n : Nat) (val : UInt32)
       _ = 2 ^ (n + bw.bitCount.toNat) := (Nat.pow_add 2 n _).symm
       _ ≤ 2 ^ 64 := Nat.pow_le_pow_right (by omega) (by omega)
   have haccbound :
-      (bw.bitBuf.toUInt64 ||| ((val.toUInt64 % (1 <<< n.toUInt64)) <<< bw.bitCount.toUInt64)).toNat
+      (bw.bitBuf ||| ((val.toUInt64 % (1 <<< n.toUInt64)) <<< bw.bitCount.toUInt64)).toNat
       < 2 ^ (bw.bitCount.toNat + n) := by
     rw [hacc_nat]
     exact or_shiftLeft_lt bw.bitBuf.toNat (val.toNat % 2 ^ n) bw.bitCount.toNat n hbuf hmlt
-  obtain ⟨hb, hw⟩ := flushAcc_spec bw.data _ (bw.bitCount.toNat + n) haccbound
+  obtain ⟨hb, hw⟩ := flushBatched_spec bw.data _ (bw.bitCount.toNat + n) haccbound
   refine ⟨?_, ?_⟩
   · -- toBits
     rw [writeBits_def]
@@ -335,11 +356,11 @@ private theorem writeHuffCode_spec (bw : BitWriter) (code : UInt16) (len : UInt8
     simp only [UInt8.toNat_toUInt64]; omega
   -- the accumulator as a Nat
   have hacc_nat :
-      (bw.bitBuf.toUInt64 |||
+      (bw.bitBuf |||
         (((reverse16 code).toUInt64 >>> (16 - len.toUInt64)) <<< bw.bitCount.toUInt64)).toNat
       = bw.bitBuf.toNat |||
         (((reverse16 code).toUInt64 >>> (16 - len.toUInt64)).toNat <<< bw.bitCount.toNat) := by
-    rw [UInt64.toNat_or, UInt8.toNat_toUInt64, UInt64.toNat_shiftLeft, hbc64]
+    rw [UInt64.toNat_or, UInt64.toNat_shiftLeft, hbc64]
     congr 1
     apply Nat.mod_eq_of_lt
     rw [Nat.shiftLeft_eq]
@@ -349,12 +370,12 @@ private theorem writeHuffCode_spec (bw : BitWriter) (code : UInt16) (len : UInt8
       _ = 2 ^ (len.toNat + bw.bitCount.toNat) := (Nat.pow_add 2 _ _).symm
       _ ≤ 2 ^ 64 := Nat.pow_le_pow_right (by omega) (by omega)
   have haccbound :
-      (bw.bitBuf.toUInt64 |||
+      (bw.bitBuf |||
         (((reverse16 code).toUInt64 >>> (16 - len.toUInt64)) <<< bw.bitCount.toUInt64)).toNat
       < 2 ^ (bw.bitCount.toNat + len.toNat) := by
     rw [hacc_nat]
     exact or_shiftLeft_lt bw.bitBuf.toNat _ bw.bitCount.toNat len.toNat hbuf hrev_lt
-  obtain ⟨hb, hw⟩ := flushAcc_spec bw.data _ (bw.bitCount.toNat + len.toNat) haccbound
+  obtain ⟨hb, hw⟩ := flushBatched_spec bw.data _ (bw.bitCount.toNat + len.toNat) haccbound
   refine ⟨?_, ?_⟩
   · rw [writeHuffCode_def]
     rw [hb, hacc_nat]
@@ -394,23 +415,58 @@ theorem flush_toBits (bw : BitWriter) (hwf : bw.wf) :
     Deflate.Spec.bytesToBits bw.flush =
     bw.toBits ++ List.replicate ((8 - bw.bitCount.toNat % 8) % 8) false := by
   obtain ⟨hbc_lt, hbuf_lt⟩ := hwf
+  -- `flush` first drains all whole pending bytes via `flushAcc` (which preserves
+  -- the bit sequence), leaving `< 8` pending, then pushes the final partial byte.
+  obtain ⟨hr_bits, _, hr_buf⟩ := flushAcc_spec bw.data bw.bitBuf bw.bitCount.toNat hbuf_lt
+  -- `flushAcc` preserves the bit sequence (defeq unfolds `bw.toBits`).
+  have hAtoB : (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).toBits = bw.toBits := hr_bits
+  have hr_bc8 : (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitCount.toNat
+      = bw.bitCount.toNat % 8 := by
+    rw [flushAcc_eq]
+    show ((bw.bitCount.toNat % 8).toUInt8).toNat = bw.bitCount.toNat % 8
+    simp only [Nat.toUInt8, UInt8.toNat_ofNat']
+    rw [show (2 : Nat) ^ 8 = 256 from rfl]; omega
+  have hbuf8 : (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitBuf.toUInt8.toNat
+      = (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitBuf.toNat := by
+    rw [UInt64.toNat_toUInt8]
+    exact Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le hr_buf
+      (by rw [hr_bc8]; exact Nat.pow_le_pow_right (by omega) (by omega)))
   unfold flush
-  by_cases hbc0 : bw.bitCount.toNat = 0
-  · -- bitCount = 0: no flush needed
-    have hcond : ¬(bw.bitCount > 0) := by show ¬(0 < bw.bitCount.toNat); omega
+  by_cases hbc0 : bw.bitCount.toNat % 8 = 0
+  · -- no residual partial byte
+    have hcond : ¬((flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitCount > 0) := by
+      show ¬(0 < (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitCount.toNat)
+      rw [hr_bc8]; omega
     rw [if_neg hcond]
-    simp only [hbc0, toBits, Deflate.Spec.bytesToBits, List.range_zero, List.map_nil,
-      List.append_nil, Nat.zero_mod, Nat.sub_zero, Nat.mod_self, List.replicate_zero]
-  · -- bitCount > 0: flush pushes bitBuf
-    have hcond : bw.bitCount > 0 := by show 0 < bw.bitCount.toNat; omega
+    have hrtb : Deflate.Spec.bytesToBits (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).data
+        = (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).toBits := by
+      simp only [toBits, hr_bc8, hbc0, List.range_zero, List.map_nil, List.append_nil,
+        Deflate.Spec.bytesToBits]
+    rw [hrtb, hAtoB, hbc0]
+    simp only [Nat.sub_zero, Nat.mod_self, List.replicate_zero, List.append_nil]
+  · -- push the final partial byte
+    have hcond : (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitCount > 0 := by
+      show 0 < (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitCount.toNat
+      rw [hr_bc8]; omega
     rw [if_pos hcond]
     simp only [Deflate.Spec.bytesToBits]
-    rw [flatMap_byteToBits_push]
-    simp only [toBits, List.append_assoc]
+    rw [flatMap_byteToBits_push,
+      byteToBits_split _ (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitCount.toNat
+        (by rw [hr_bc8]; omega) (by rw [hbuf8]; exact hr_buf)]
+    rw [← List.append_assoc]
+    have hmap : (List.range (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitCount.toNat).map
+          (fun i => (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitBuf.toUInt8.toNat.testBit i)
+        = (List.range (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitCount.toNat).map
+          (fun i => (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitBuf.toNat.testBit i) := by
+      apply List.map_congr_left; intro i _; rw [hbuf8]
+    rw [hmap,
+      show (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).data.data.toList.flatMap
+            Deflate.Spec.bytesToBits.byteToBits ++
+          (List.range (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitCount.toNat).map
+            (fun i => (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).bitBuf.toNat.testBit i)
+          = (flushAcc bw.data bw.bitBuf bw.bitCount.toNat).toBits from rfl,
+      hAtoB]
     congr 1
-    rw [byteToBits_split bw.bitBuf bw.bitCount.toNat (by omega) hbuf_lt]
-    congr 1
-    rw [Nat.mod_eq_of_lt hbc_lt,
-        Nat.mod_eq_of_lt (show 8 - bw.bitCount.toNat < 8 from by omega)]
+    rw [hr_bc8, Nat.mod_eq_of_lt (show 8 - bw.bitCount.toNat % 8 < 8 from by omega)]
 
 end Zip.Native.BitWriter

--- a/Zip/Spec/BlockSizeModel.lean
+++ b/Zip/Spec/BlockSizeModel.lean
@@ -55,17 +55,34 @@ theorem bitLength_writeHuffCode (bw : BitWriter) (code : UInt16) (len : UInt8)
   rw [← toBits_length, writeHuffCode_toBits bw code len hwf hlen, List.length_append,
     Huffman.Spec.natToBits_length, toBits_length]
 
+/-- `flushBytes` pushes exactly `k` bytes. -/
+theorem flushBytes_size (data : ByteArray) (acc : UInt64) (k : Nat) :
+    (flushBytes data acc k).size = data.size + k := by
+  induction k generalizing data acc with
+  | zero => simp only [flushBytes, Nat.add_zero]
+  | succ k ih => rw [flushBytes, ih, ByteArray.size_push]; omega
+
 /-- The flushed byte size of a (well-formed) writer is `⌈bitLength/8⌉`. `flush`
-    pushes one final partial byte iff `bitCount > 0`; since `bitCount < 8`, that
-    is exactly the ceiling division of the total bit count. -/
+    drains the `bitCount / 8` whole pending bytes (`flushBytes`), then pushes one
+    final partial byte iff `bitCount % 8 > 0` — exactly the ceiling division of
+    the total bit count. -/
 theorem flush_size (bw : BitWriter) (hwf : bw.wf) :
     bw.flush.size = (bw.bitLength + 7) / 8 := by
   obtain ⟨hbc_lt, _⟩ := hwf
   unfold flush bitLength
-  by_cases hbc0 : bw.bitCount.toNat = 0
-  · have hcond : ¬(bw.bitCount > 0) := by show ¬(0 < bw.bitCount.toNat); omega
-    rw [if_neg hcond, hbc0]; omega
-  · have hcond : bw.bitCount > 0 := by show 0 < bw.bitCount.toNat; omega
-    rw [if_pos hcond, ByteArray.size_push]; omega
+  rw [flushAcc_eq]
+  dsimp only
+  have hb8 : ((bw.bitCount.toNat % 8).toUInt8).toNat = bw.bitCount.toNat % 8 := by
+    simp only [Nat.toUInt8, UInt8.toNat_ofNat']; rw [show (2 : Nat) ^ 8 = 256 from rfl]; omega
+  have hz : (0 : UInt8).toNat = 0 := rfl
+  have hfb : (flushBytes bw.data bw.bitBuf (bw.bitCount.toNat / 8)).size
+      = bw.data.size + bw.bitCount.toNat / 8 := flushBytes_size _ _ _
+  by_cases hbc0 : bw.bitCount.toNat % 8 = 0
+  · have hcond : ¬((bw.bitCount.toNat % 8).toUInt8 > 0) := by
+      rw [gt_iff_lt, UInt8.lt_iff_toNat_lt, hb8, hz]; omega
+    rw [if_neg hcond, hfb]; omega
+  · have hcond : (bw.bitCount.toNat % 8).toUInt8 > 0 := by
+      rw [gt_iff_lt, UInt8.lt_iff_toNat_lt, hb8, hz]; omega
+    rw [if_pos hcond, ByteArray.size_push, hfb]; omega
 
 end Zip.Native.BitWriter

--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -424,7 +424,6 @@ theorem flush_toBits_aligned (bw : BitWriter) (hwf : bw.wf) :
       | nil => rfl
       | cons _ _ ih => simp only [List.map_cons, List.sum_cons, List.length_cons, ih]; omega
     rw [hsum]
-  have hbc : bw.bitCount.toNat < 8 := hwf.1
   congr 2
   omega
 

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p917be839ff)">
+   <g clip-path="url(#p0bb3862526)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3Yz4rkZxmG4a6emmEYmkED+eMQRASzyj6LHIMbD8Qj8Cw8gkDAVbZBdOkuhxBUguAYYjNjxk5P2V1TP3fuA/fHa4rrOoKnKPjqrnd3+vZ32wU/LIeb6QXrHF5NL1hiu7+bnrDM7uk70xPWePh4esE6l5fTC9a4P0wvWGd3nt/Z9vL59IRlzvMbAwAYJLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL7ry6upzcscX86TE9Y5ic/+vn0hGWutvemJyyx++7F9IRl/vT6y+kJS7z/6J3pCcscT3fTE5a4eXO+7/7d6Tg9YYmPnv50esIyLlgAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2736z2fb9IgVXh9vpics8/bpyfSEdY530wvWuLmeXrDOux9ML1jiZrudnrDMub6Pb29X0xOWeX7xYnrCEs+u/zU9YRkXLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIjtr15eT29Y4mr/aHrCOoevpxcss918Oz1hjdNpesEyuyffTE9Y4pzfkKv90+kJazx6PL1gmWev76YnLLHd/mN6wjIuWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsf12/fX0Br6v02l6AfzP9ve/Tk9Y49L/zx8cbyP/R7wgAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENv/+p9/m96wxMvDm+kJy3zx/NX0hGU+/9XH0xOWeO/Jz6YnLPPhJ59OT1jil794a3rCMn95eZiewPf0+z/8eXrCEre//c30hGVcsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2O57+uE2PWOHN6Tg9YZnL3fl28YPD7fSENR7spxes892L6QVLnH78bHrCMtt2mp6wxIMzvhncb+f5m/bweJ6f6+LCBQsAICewAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABi+8u7w/SGJS4v99MT1vnmy+kFy2y3/56esMbxOL1gmd1b705PWOLy/m56wjoPH08vWOP6q+kFyzw8vJqesMR2c6Zv/oULFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMT+C5bZjMUplQOfAAAAAElFTkSuQmCC" id="image2606ec36c5" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEUlEQVR4nO3YTYqc5xmG0a5WSRjRiPzgPxFCCCSjzDPIGjLxQrwC78IrMBg88tSEZJhZlmBiEwxRRNJIkdxutbtL9XnmueF6eezinBXczQdvX/Xsji8+2c74abm5ml6wzs3L6QVLbHe30xOW2T16a3rCGvffmF6wzvn59II17m6mF6yzO81vtj1/Mj1hmdP8YgAAgwQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBs/6+zy+kNS9wdb6YnLPPuz347PWGZi+2d6QlL7L55Nj1hmb+/+nx6whK/evDW9IRlDsfb6QlLXL0+3Xf/9niYnrDEHx/9enrCMi5YAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAENu9/PbTbXrECq8OV9MTlnnz+HB6wjqH2+kFa1xdTi9Y5+3fTy9Y4mq7np6wzKm+j29uF9MTlnly9mx6whKPL/8/PWEZFywAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCI7S+eX05vWOJi/2B6wjo3T6cXLLNdvZiesMbxOL1gmd3D/05PWOKU35CL/aPpCWs8eGN6wTKPX91OT1hiu/7P9IRlXLAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL77fLp9AZ+qONxegF8b/v3l9MT1jj3+/Mnx9vIj4gXBAAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL79//31fSGJZ7fvJ6esMw/nrycnrDMZ+/9aXrCEu88/M30hGX+8NHH0xOW+PPvfjE9YZkvnt9MT+AH+stf/zk9YYnrDz+YnrCMCxYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEdofj37bpESu8Ph6mJyxzvjvdLr53cz09YY17++kF63zzbHrBEsefP56esMy2HacnLHHvhG8Gd9tp/k+7fzjNv+vszAULACAnsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYvvzu9vpDUucn++nJ6zz9PPpBcts119PT1jjcJhesMzul+9OT1ji/IS/2XF/ou/j5VfTC5a5/+3V9IQltq9fTE9YxgULACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYt8B5rCNx4HWU/0AAAAASUVORK5CYII=" id="image87bbbd7571" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="md5c4b01439" d="M 0 0 
+       <path id="m660b9164a2" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md5c4b01439" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#md5c4b01439" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#md5c4b01439" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#md5c4b01439" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#md5c4b01439" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#md5c4b01439" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#md5c4b01439" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#md5c4b01439" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#md5c4b01439" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#md5c4b01439" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#md5c4b01439" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m660b9164a2" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m814e2a20aa" d="M 0 0 
+       <path id="mb72efb2b55" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m814e2a20aa" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb72efb2b55" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m814e2a20aa" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb72efb2b55" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m814e2a20aa" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb72efb2b55" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m814e2a20aa" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb72efb2b55" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m814e2a20aa" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb72efb2b55" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m814e2a20aa" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb72efb2b55" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m814e2a20aa" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb72efb2b55" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m814e2a20aa" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb72efb2b55" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,76 +1303,37 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -17 -->
+    <!-- -14 -->
     <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- -11 -->
-    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -66 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -88 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+    <!-- -8 -->
+    <g transform="translate(151.312096 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1416,56 +1377,94 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -65 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -87 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
-    <!-- -56 -->
+    <!-- -55 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -14 -->
+    <!-- -11 -->
     <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +2 -->
+    <!-- +5 -->
     <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1485,23 +1484,23 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -51 -->
+    <!-- -50 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -71 -->
+    <!-- -70 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -2184,18 +2183,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image0d6a4fed3f" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image401fbf585c" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mfae2c67240" d="M 0 0 
+       <path id="m7a8cb5c710" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfae2c67240" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8cb5c710" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2218,7 +2217,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mfae2c67240" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8cb5c710" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2232,7 +2231,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mfae2c67240" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8cb5c710" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2246,7 +2245,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mfae2c67240" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8cb5c710" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2259,7 +2258,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mfae2c67240" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8cb5c710" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2272,7 +2271,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mfae2c67240" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8cb5c710" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2285,7 +2284,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mfae2c67240" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7a8cb5c710" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2946,8 +2945,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-05T03:12:42Z  ·  Linux chungus x86_64  ·  commit 992547a3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.689297 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3014,16 +3013,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3062,109 +3061,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p917be839ff">
+  <clipPath id="p0bb3862526">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="ma5bb635ab8" d="M 0 0 
+       <path id="m1ede9dc558" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma5bb635ab8" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1ede9dc558" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma5bb635ab8" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1ede9dc558" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma5bb635ab8" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1ede9dc558" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma5bb635ab8" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1ede9dc558" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma5bb635ab8" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1ede9dc558" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#ma5bb635ab8" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1ede9dc558" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#ma5bb635ab8" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1ede9dc558" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.796763 
 L 637.2 347.796763 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m872fadba23" d="M 0 0 
+       <path id="m89543bab42" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m872fadba23" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m89543bab42" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.680056 
 L 637.2 238.680056 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m872fadba23" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m89543bab42" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.680056
      <g id="line2d_19">
       <path d="M 49.078125 129.563348 
 L 637.2 129.563348 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m872fadba23" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m89543bab42" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.563348
      <g id="line2d_21">
       <path d="M 49.078125 404.851571 
 L 637.2 404.851571 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m6c16ce67cf" d="M 0 0 
+       <path id="m0490a2ec7e" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.218667 
 L 637.2 391.218667 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.218667
      <g id="line2d_25">
       <path d="M 49.078125 380.644165 
 L 637.2 380.644165 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.644165
      <g id="line2d_27">
       <path d="M 49.078125 372.004168 
 L 637.2 372.004168 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 372.004168
      <g id="line2d_29">
       <path d="M 49.078125 364.699155 
 L 637.2 364.699155 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.699155
      <g id="line2d_31">
       <path d="M 49.078125 358.371265 
 L 637.2 358.371265 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.371265
      <g id="line2d_33">
       <path d="M 49.078125 352.78967 
 L 637.2 352.78967 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.78967
      <g id="line2d_35">
       <path d="M 49.078125 314.949361 
 L 637.2 314.949361 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.949361
      <g id="line2d_37">
       <path d="M 49.078125 295.734863 
 L 637.2 295.734863 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.734863
      <g id="line2d_39">
       <path d="M 49.078125 282.101959 
 L 637.2 282.101959 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.101959
      <g id="line2d_41">
       <path d="M 49.078125 271.527458 
 L 637.2 271.527458 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.527458
      <g id="line2d_43">
       <path d="M 49.078125 262.887461 
 L 637.2 262.887461 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.887461
      <g id="line2d_45">
       <path d="M 49.078125 255.582447 
 L 637.2 255.582447 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.582447
      <g id="line2d_47">
       <path d="M 49.078125 249.254557 
 L 637.2 249.254557 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.254557
      <g id="line2d_49">
       <path d="M 49.078125 243.672962 
 L 637.2 243.672962 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.672962
      <g id="line2d_51">
       <path d="M 49.078125 205.832653 
 L 637.2 205.832653 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.832653
      <g id="line2d_53">
       <path d="M 49.078125 186.618155 
 L 637.2 186.618155 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.618155
      <g id="line2d_55">
       <path d="M 49.078125 172.985251 
 L 637.2 172.985251 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.985251
      <g id="line2d_57">
       <path d="M 49.078125 162.41075 
 L 637.2 162.41075 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.41075
      <g id="line2d_59">
       <path d="M 49.078125 153.770753 
 L 637.2 153.770753 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.770753
      <g id="line2d_61">
       <path d="M 49.078125 146.46574 
 L 637.2 146.46574 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.46574
      <g id="line2d_63">
       <path d="M 49.078125 140.137849 
 L 637.2 140.137849 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.137849
      <g id="line2d_65">
       <path d="M 49.078125 134.556255 
 L 637.2 134.556255 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.556255
      <g id="line2d_67">
       <path d="M 49.078125 96.715946 
 L 637.2 96.715946 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.715946
      <g id="line2d_69">
       <path d="M 49.078125 77.501447 
 L 637.2 77.501447 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.501447
      <g id="line2d_71">
       <path d="M 49.078125 63.868544 
 L 637.2 63.868544 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.868544
      <g id="line2d_73">
       <path d="M 49.078125 53.294042 
 L 637.2 53.294042 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m6c16ce67cf" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m0490a2ec7e" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 164.342865) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 160.134715) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(105.541635 307.554784) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(105.541635 306.526975) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m0a1881a640" d="M -2.5 2.5 
+     <path id="m2627eb8669" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p93575b0a99)">
-     <use xlink:href="#m0a1881a640" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a1881a640" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a1881a640" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a1881a640" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a1881a640" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a1881a640" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a1881a640" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a1881a640" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0a1881a640" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38032c5e2b)">
+     <use xlink:href="#m2627eb8669" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2627eb8669" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2627eb8669" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2627eb8669" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2627eb8669" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2627eb8669" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2627eb8669" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2627eb8669" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2627eb8669" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.211803
 L 310.240844 102.355284 
 L 309.257387 102.498333 
 L 308.273931 102.64095 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.64095 
@@ -1853,7 +1853,7 @@ L 273.545396 115.495372
 L 272.773651 115.744903 
 L 272.001906 115.993127 
 L 271.230161 116.240058 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.240058 
@@ -1905,7 +1905,7 @@ L 221.171803 119.753456
 L 220.059395 119.828647 
 L 218.946988 119.90372 
 L 217.83458 119.978674 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 119.978674 
@@ -1957,7 +1957,7 @@ L 179.624997 137.397353
 L 178.775895 137.720164 
 L 177.926794 138.04079 
 L 177.077692 138.359262 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.359262 
@@ -2009,7 +2009,7 @@ L 163.767861 156.658214
 L 163.472087 156.994351 
 L 163.176313 157.328121 
 L 162.880539 157.659557 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.659557 
@@ -2061,7 +2061,7 @@ L 160.875139 164.650114
 L 160.830574 164.794326 
 L 160.78601 164.9381 
 L 160.741445 165.081439 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.081439 
@@ -2113,7 +2113,7 @@ L 154.390101 182.353217
 L 154.24896 182.673779 
 L 154.107819 182.992187 
 L 153.966678 183.30847 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.30847 
@@ -2165,26 +2165,26 @@ L 151.73818 193.734619
 L 151.688658 193.942139 
 L 151.639136 194.148754 
 L 151.589614 194.354473 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m397d01c602" d="M 0 -2.5 
+     <path id="m587e3213ab" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p93575b0a99)">
-     <use xlink:href="#m397d01c602" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m397d01c602" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m397d01c602" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m397d01c602" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m397d01c602" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m397d01c602" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m397d01c602" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m397d01c602" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m397d01c602" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38032c5e2b)">
+     <use xlink:href="#m587e3213ab" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m587e3213ab" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m587e3213ab" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m587e3213ab" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m587e3213ab" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m587e3213ab" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m587e3213ab" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m587e3213ab" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m587e3213ab" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.610561
 L 294.051648 97.995945 
 L 288.886486 98.37822 
 L 283.721324 98.757435 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 98.757435 
@@ -2289,7 +2289,7 @@ L 222.934499 119.784103
 L 221.583681 120.159977 
 L 220.232863 120.532893 
 L 218.882044 120.902897 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 120.902897 
@@ -2341,7 +2341,7 @@ L 189.411904 126.368029
 L 188.757012 126.482596 
 L 188.10212 126.596887 
 L 187.447228 126.710903 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 126.710903 
@@ -2393,7 +2393,7 @@ L 177.036521 137.569875
 L 176.805172 137.785045 
 L 176.573823 137.999242 
 L 176.342474 138.212475 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.212475 
@@ -2445,7 +2445,7 @@ L 163.884824 160.054818
 L 163.607987 160.442131 
 L 163.33115 160.826303 
 L 163.054314 161.207386 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.207386 
@@ -2497,7 +2497,7 @@ L 162.263275 168.244909
 L 162.245696 168.390018 
 L 162.228118 168.534683 
 L 162.210539 168.678909 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.678909 
@@ -2549,7 +2549,7 @@ L 159.485481 175.228819
 L 159.424925 175.364567 
 L 159.364368 175.499927 
 L 159.303811 175.634901 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.634901 
@@ -2601,30 +2601,30 @@ L 157.888296 179.180942
 L 157.85684 179.256806 
 L 157.825384 179.332549 
 L 157.793928 179.408171 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m6db7da3a18" d="M -0 3.535534 
+     <path id="m2388cb4a91" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p93575b0a99)">
-     <use xlink:href="#m6db7da3a18" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6db7da3a18" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38032c5e2b)">
+     <use xlink:href="#m2388cb4a91" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2388cb4a91" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.99106
 L 205.766837 81.29344 
 L 204.771342 81.593904 
 L 203.775848 81.892474 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.892474 
@@ -2729,7 +2729,7 @@ L 188.032264 88.395253
 L 187.682406 88.530091 
 L 187.332549 88.664546 
 L 186.982691 88.798621 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.798621 
@@ -2781,7 +2781,7 @@ L 180.229518 90.954599
 L 180.079447 91.001413 
 L 179.929376 91.048181 
 L 179.779306 91.094902 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.094902 
@@ -2833,7 +2833,7 @@ L 158.995974 98.861987
 L 158.534122 99.02092 
 L 158.07227 99.179321 
 L 157.610419 99.337194 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.337194 
@@ -2885,7 +2885,7 @@ L 149.27802 107.306615
 L 149.092855 107.469343 
 L 148.907691 107.631514 
 L 148.722526 107.793132 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.793132 
@@ -2937,7 +2937,7 @@ L 144.65906 120.462338
 L 144.568761 120.708742 
 L 144.478462 120.95387 
 L 144.388162 121.197738 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.197738 
@@ -2989,7 +2989,7 @@ L 128.153555 143.293159
 L 127.792786 143.68398 
 L 127.432016 144.071604 
 L 127.071247 144.456083 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.456083 
@@ -3041,7 +3041,7 @@ L 124.653192 151.618794
 L 124.599457 151.76629 
 L 124.545723 151.913329 
 L 124.491988 152.059912 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.059912 
@@ -3093,7 +3093,7 @@ L 94.606058 205.368437
 L 93.941926 206.074323 
 L 93.277794 206.769849 
 L 92.613662 207.455314 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.455314 
@@ -3145,7 +3145,7 @@ L 87.677774 224.060225
 L 87.568088 224.37049 
 L 87.458402 224.678737 
 L 87.348715 224.984992 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 224.984992 
@@ -3197,23 +3197,23 @@ L 86.134388 240.678828
 L 86.107403 240.974786 
 L 86.080418 241.268907 
 L 86.053433 241.561213 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m1989dbd046" d="M -0 2.5 
+     <path id="mcc10cbb15c" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p93575b0a99)">
-     <use xlink:href="#m1989dbd046" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38032c5e2b)">
+     <use xlink:href="#mcc10cbb15c" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m9285d4ef8e" d="M -0.833333 2.5 
+     <path id="m35b62b67b5" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p93575b0a99)">
-     <use xlink:href="#m9285d4ef8e" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9285d4ef8e" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9285d4ef8e" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9285d4ef8e" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9285d4ef8e" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9285d4ef8e" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9285d4ef8e" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9285d4ef8e" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9285d4ef8e" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38032c5e2b)">
+     <use xlink:href="#m35b62b67b5" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35b62b67b5" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35b62b67b5" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35b62b67b5" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35b62b67b5" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35b62b67b5" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35b62b67b5" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35b62b67b5" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35b62b67b5" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 180.888961
 L 282.301002 180.947904 
 L 280.549589 181.006774 
 L 278.798176 181.06557 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 181.06557 
@@ -3342,7 +3342,7 @@ L 252.902686 188.238912
 L 252.327231 188.386611 
 L 251.751776 188.53385 
 L 251.17632 188.680634 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 188.680634 
@@ -3394,7 +3394,7 @@ L 203.954921 186.473055
 L 202.905557 186.42281 
 L 201.856192 186.372512 
 L 200.806828 186.322161 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 186.322161 
@@ -3446,7 +3446,7 @@ L 171.740947 201.881696
 L 171.095038 202.175521 
 L 170.44913 202.467535 
 L 169.803221 202.757761 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 202.757761 
@@ -3498,7 +3498,7 @@ L 162.409549 210.675366
 L 162.245246 210.837123 
 L 162.080942 210.99833 
 L 161.916638 211.158991 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 211.158991 
@@ -3550,7 +3550,7 @@ L 158.898325 213.866476
 L 158.831251 213.92492 
 L 158.764178 213.983292 
 L 158.697104 214.041592 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 214.041592 
@@ -3602,7 +3602,7 @@ L 154.543684 229.493591
 L 154.451386 229.785704 
 L 154.359088 230.076027 
 L 154.26679 230.364582 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 230.364582 
@@ -3654,11 +3654,11 @@ L 153.16961 235.985723
 L 153.145228 236.103367 
 L 153.120846 236.220719 
 L 153.096464 236.337782 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m73113e9463" d="M -1.25 2.5 
+     <path id="mb284b0713f" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p93575b0a99)">
-     <use xlink:href="#m73113e9463" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m73113e9463" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m73113e9463" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m73113e9463" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m73113e9463" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m73113e9463" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m73113e9463" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m73113e9463" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m73113e9463" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38032c5e2b)">
+     <use xlink:href="#mb284b0713f" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb284b0713f" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb284b0713f" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb284b0713f" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb284b0713f" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb284b0713f" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb284b0713f" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb284b0713f" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb284b0713f" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 147.037933
 L 252.377414 147.089635 
 L 251.306944 147.141281 
 L 250.236474 147.192871 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 147.192871 
@@ -3787,7 +3787,7 @@ L 226.969772 152.467777
 L 226.452735 152.578579 
 L 225.935697 152.689122 
 L 225.418659 152.799409 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 152.799409 
@@ -3839,7 +3839,7 @@ L 213.147044 158.556257
 L 212.874341 158.676569 
 L 212.601639 158.796576 
 L 212.328936 158.91628 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 158.91628 
@@ -3891,7 +3891,7 @@ L 209.236323 156.954621
 L 209.167599 156.910092 
 L 209.098874 156.865522 
 L 209.030149 156.82091 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 156.82091 
@@ -3943,7 +3943,7 @@ L 198.265399 167.356927
 L 198.026182 167.566396 
 L 197.786966 167.774943 
 L 197.547749 167.982576 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 167.982576 
@@ -3995,7 +3995,7 @@ L 194.989815 169.398061
 L 194.932972 169.429041 
 L 194.876129 169.460001 
 L 194.819287 169.49094 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 169.49094 
@@ -4047,7 +4047,7 @@ L 193.228821 176.568565
 L 193.193478 176.714439 
 L 193.158134 176.859866 
 L 193.12279 177.004847 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 177.004847 
@@ -4099,11 +4099,11 @@ L 192.818243 181.564429
 L 192.811475 181.660932 
 L 192.804707 181.75724 
 L 192.79794 181.853352 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m02384afb76" d="M 0 -2.5 
+     <path id="m4c788e4fef" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p93575b0a99)">
-     <use xlink:href="#m02384afb76" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m02384afb76" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m02384afb76" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m02384afb76" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m02384afb76" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m02384afb76" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m02384afb76" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m02384afb76" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m02384afb76" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p38032c5e2b)">
+     <use xlink:href="#m4c788e4fef" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4c788e4fef" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4c788e4fef" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4c788e4fef" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4c788e4fef" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4c788e4fef" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4c788e4fef" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4c788e4fef" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4c788e4fef" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 117.963319
 L 206.45578 117.9566 
 L 206.45578 117.949879 
 L 206.45578 117.943158 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 117.943158 
@@ -4230,7 +4230,7 @@ L 206.45578 118.018397
 L 206.45578 118.020068 
 L 206.45578 118.021738 
 L 206.45578 118.023409 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.023409 
@@ -4282,7 +4282,7 @@ L 206.45578 118.009588
 L 206.45578 118.00928 
 L 206.45578 118.008973 
 L 206.45578 118.008666 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.008666 
@@ -4334,7 +4334,7 @@ L 173.935517 132.674231
 L 173.212844 132.953702 
 L 172.490172 133.231533 
 L 171.767499 133.507746 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 133.507746 
@@ -4386,7 +4386,7 @@ L 164.056872 143.78437
 L 163.885524 143.989231 
 L 163.714177 144.193211 
 L 163.54283 144.396316 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.396316 
@@ -4438,7 +4438,7 @@ L 160.385378 149.94789
 L 160.315212 150.064163 
 L 160.245047 150.180152 
 L 160.174881 150.295858 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 150.295858 
@@ -4490,7 +4490,7 @@ L 154.553946 167.637484
 L 154.429036 167.959116 
 L 154.304126 168.27858 
 L 154.179217 168.595905 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 168.595905 
@@ -4542,11 +4542,11 @@ L 152.549264 177.771325
 L 152.513043 177.956336 
 L 152.476822 178.140629 
 L 152.4406 178.324207 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m7261acafc5" d="M 0 -2.5 
+     <path id="m4009768be3" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p93575b0a99)">
-     <use xlink:href="#m7261acafc5" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7261acafc5" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7261acafc5" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7261acafc5" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7261acafc5" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7261acafc5" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7261acafc5" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7261acafc5" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7261acafc5" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p38032c5e2b)">
+     <use xlink:href="#m4009768be3" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4009768be3" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4009768be3" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4009768be3" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4009768be3" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4009768be3" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4009768be3" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4009768be3" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4009768be3" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 174.939703
 L 592.834055 174.969152 
 L 592.450726 174.998584 
 L 592.067397 175.027997 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 175.027997 
@@ -4669,7 +4669,7 @@ L 538.386544 181.016797
 L 537.193636 181.14165 
 L 536.000728 181.266176 
 L 534.807821 181.390376 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 181.390376 
@@ -4721,7 +4721,7 @@ L 340.74006 177.010188
 L 336.427443 176.9081 
 L 332.114826 176.805792 
 L 327.802209 176.703263 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.703263 
@@ -4773,7 +4773,7 @@ L 279.085397 186.459613
 L 278.002801 186.655155 
 L 276.920205 186.849893 
 L 275.83761 187.043834 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 187.043834 
@@ -4825,7 +4825,7 @@ L 259.350398 198.484046
 L 258.984015 198.709377 
 L 258.617633 198.933642 
 L 258.25125 199.15685 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 199.15685 
@@ -4877,7 +4877,7 @@ L 256.869193 203.812849
 L 256.838481 203.911293 
 L 256.807768 204.009533 
 L 256.777056 204.107569 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 204.107569 
@@ -4929,7 +4929,7 @@ L 249.270304 217.480153
 L 249.103487 217.738369 
 L 248.93667 217.995185 
 L 248.769854 218.250617 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 218.250617 
@@ -4981,7 +4981,7 @@ L 246.421172 227.44791
 L 246.368979 227.633321 
 L 246.316786 227.818009 
 L 246.264594 228.00198 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="md97273209d" d="M 0 3.5 
+      <path id="m798bba835e" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#md97273209d" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m798bba835e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m0a1881a640" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2627eb8669" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m397d01c602" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m587e3213ab" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m6db7da3a18" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2388cb4a91" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m1989dbd046" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcc10cbb15c" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m9285d4ef8e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m35b62b67b5" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m73113e9463" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb284b0713f" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m02384afb76" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m4c788e4fef" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m7261acafc5" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4009768be3" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p93575b0a99)">
-     <use xlink:href="#md97273209d" x="289.669676" y="169.342865" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md97273209d" x="223.847406" y="178.136767" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md97273209d" x="212.215046" y="181.34331" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md97273209d" x="186.58897" y="189.841488" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md97273209d" x="169.057218" y="198.556349" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md97273209d" x="158.596848" y="210.184521" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md97273209d" x="152.867313" y="215.135443" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md97273209d" x="150.950891" y="217.494763" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md97273209d" x="119.37967" y="287.785022" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#md97273209d" x="100.541635" y="312.554784" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p38032c5e2b)">
+     <use xlink:href="#m798bba835e" x="289.669676" y="165.134715" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m798bba835e" x="223.847406" y="174.908597" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m798bba835e" x="212.215046" y="178.376456" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m798bba835e" x="186.58897" y="187.245825" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m798bba835e" x="169.057218" y="196.284229" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m798bba835e" x="158.596848" y="208.330638" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m798bba835e" x="152.867313" y="213.396046" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m798bba835e" x="150.950891" y="215.752777" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m798bba835e" x="119.37967" y="285.99735" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m798bba835e" x="100.541635" y="311.526975" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 169.342865 
-L 288.298379 169.543745 
-L 286.927082 169.743778 
-L 285.555784 169.94297 
-L 284.184487 170.141328 
-L 282.81319 170.33886 
-L 281.441892 170.535571 
-L 280.070595 170.73147 
-L 278.699298 170.926562 
-L 277.328 171.120853 
-L 275.956703 171.314352 
-L 274.585406 171.507064 
-L 273.214109 171.698995 
-L 271.842811 171.890152 
-L 270.471514 172.080541 
-L 269.100217 172.270168 
-L 267.728919 172.45904 
-L 266.357622 172.647161 
-L 264.986325 172.834539 
-L 263.615028 173.021179 
-L 262.24373 173.207086 
-L 260.872433 173.392268 
-L 259.501136 173.576728 
-L 258.129838 173.760473 
-L 256.758541 173.943508 
-L 255.387244 174.125839 
-L 254.015947 174.307472 
-L 252.644649 174.488411 
-L 251.273352 174.668661 
-L 249.902055 174.848229 
-L 248.530757 175.027118 
-L 247.15946 175.205335 
-L 245.788163 175.382884 
-L 244.416866 175.559771 
-L 243.045568 175.736 
-L 241.674271 175.911575 
-L 240.302974 176.086503 
-L 238.931676 176.260787 
-L 237.560379 176.434433 
-L 236.189082 176.607445 
-L 234.817784 176.779827 
-L 233.446487 176.951585 
-L 232.07519 177.122722 
-L 230.703893 177.293243 
-L 229.332595 177.463154 
-L 227.961298 177.632457 
-L 226.590001 177.801157 
-L 225.218703 177.969259 
-L 223.847406 178.136767 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 165.134715 
+L 288.298379 165.360319 
+L 286.927082 165.584855 
+L 285.555784 165.808331 
+L 284.184487 166.030759 
+L 282.81319 166.252147 
+L 281.441892 166.472506 
+L 280.070595 166.691846 
+L 278.699298 166.910174 
+L 277.328 167.127501 
+L 275.956703 167.343837 
+L 274.585406 167.559189 
+L 273.214109 167.773567 
+L 271.842811 167.986979 
+L 270.471514 168.199435 
+L 269.100217 168.410942 
+L 267.728919 168.62151 
+L 266.357622 168.831146 
+L 264.986325 169.039858 
+L 263.615028 169.247656 
+L 262.24373 169.454546 
+L 260.872433 169.660537 
+L 259.501136 169.865637 
+L 258.129838 170.069853 
+L 256.758541 170.273192 
+L 255.387244 170.475663 
+L 254.015947 170.677272 
+L 252.644649 170.878027 
+L 251.273352 171.077935 
+L 249.902055 171.277004 
+L 248.530757 171.47524 
+L 247.15946 171.67265 
+L 245.788163 171.869241 
+L 244.416866 172.06502 
+L 243.045568 172.259993 
+L 241.674271 172.454167 
+L 240.302974 172.647549 
+L 238.931676 172.840145 
+L 237.560379 173.031962 
+L 236.189082 173.223005 
+L 234.817784 173.413281 
+L 233.446487 173.602797 
+L 232.07519 173.791557 
+L 230.703893 173.979568 
+L 229.332595 174.166837 
+L 227.961298 174.353368 
+L 226.590001 174.539168 
+L 225.218703 174.724243 
+L 223.847406 174.908597 
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 178.136767 
-L 223.605065 178.205831 
-L 223.362724 178.274795 
-L 223.120384 178.343659 
-L 222.878043 178.412423 
-L 222.635702 178.481087 
-L 222.393361 178.549652 
-L 222.15102 178.618118 
-L 221.908679 178.686485 
-L 221.666339 178.754754 
-L 221.423998 178.822924 
-L 221.181657 178.890997 
-L 220.939316 178.958972 
-L 220.696975 179.026849 
-L 220.454635 179.094629 
-L 220.212294 179.162313 
-L 219.969953 179.2299 
-L 219.727612 179.297391 
-L 219.485271 179.364786 
-L 219.24293 179.432085 
-L 219.00059 179.499288 
-L 218.758249 179.566397 
-L 218.515908 179.633411 
-L 218.273567 179.70033 
-L 218.031226 179.767154 
-L 217.788885 179.833885 
-L 217.546545 179.900521 
-L 217.304204 179.967064 
-L 217.061863 180.033514 
-L 216.819522 180.099871 
-L 216.577181 180.166135 
-L 216.33484 180.232306 
-L 216.0925 180.298385 
-L 215.850159 180.364373 
-L 215.607818 180.430268 
-L 215.365477 180.496072 
-L 215.123136 180.561784 
-L 214.880795 180.627406 
-L 214.638455 180.692937 
-L 214.396114 180.758377 
-L 214.153773 180.823728 
-L 213.911432 180.888988 
-L 213.669091 180.954158 
-L 213.42675 181.019239 
-L 213.18441 181.084231 
-L 212.942069 181.149133 
-L 212.699728 181.213947 
-L 212.457387 181.278673 
-L 212.215046 181.34331 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 174.908597 
+L 223.605065 174.983494 
+L 223.362724 175.058273 
+L 223.120384 175.132934 
+L 222.878043 175.207477 
+L 222.635702 175.281904 
+L 222.393361 175.356214 
+L 222.15102 175.430407 
+L 221.908679 175.504485 
+L 221.666339 175.578446 
+L 221.423998 175.652293 
+L 221.181657 175.726025 
+L 220.939316 175.799642 
+L 220.696975 175.873145 
+L 220.454635 175.946534 
+L 220.212294 176.01981 
+L 219.969953 176.092972 
+L 219.727612 176.166022 
+L 219.485271 176.238959 
+L 219.24293 176.311784 
+L 219.00059 176.384498 
+L 218.758249 176.4571 
+L 218.515908 176.529591 
+L 218.273567 176.601971 
+L 218.031226 176.674241 
+L 217.788885 176.746401 
+L 217.546545 176.818451 
+L 217.304204 176.890392 
+L 217.061863 176.962224 
+L 216.819522 177.033947 
+L 216.577181 177.105561 
+L 216.33484 177.177068 
+L 216.0925 177.248467 
+L 215.850159 177.319758 
+L 215.607818 177.390943 
+L 215.365477 177.46202 
+L 215.123136 177.532991 
+L 214.880795 177.603856 
+L 214.638455 177.674615 
+L 214.396114 177.745269 
+L 214.153773 177.815818 
+L 213.911432 177.886261 
+L 213.669091 177.9566 
+L 213.42675 178.026835 
+L 213.18441 178.096966 
+L 212.942069 178.166993 
+L 212.699728 178.236917 
+L 212.457387 178.306738 
+L 212.215046 178.376456 
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 181.34331 
-L 211.68117 181.536827 
-L 211.147293 181.729557 
-L 210.613417 181.921507 
-L 210.07954 182.112683 
-L 209.545663 182.30309 
-L 209.011787 182.492735 
-L 208.47791 182.681624 
-L 207.944034 182.869764 
-L 207.410157 183.057159 
-L 206.87628 183.243817 
-L 206.342404 183.429742 
-L 205.808527 183.61494 
-L 205.274651 183.799417 
-L 204.740774 183.98318 
-L 204.206897 184.166232 
-L 203.673021 184.34858 
-L 203.139144 184.530229 
-L 202.605268 184.711184 
-L 202.071391 184.891451 
-L 201.537515 185.071034 
-L 201.003638 185.24994 
-L 200.469761 185.428173 
-L 199.935885 185.605738 
-L 199.402008 185.78264 
-L 198.868132 185.958885 
-L 198.334255 186.134476 
-L 197.800378 186.309419 
-L 197.266502 186.483719 
-L 196.732625 186.65738 
-L 196.198749 186.830406 
-L 195.664872 187.002804 
-L 195.130995 187.174576 
-L 194.597119 187.345728 
-L 194.063242 187.516264 
-L 193.529366 187.686189 
-L 192.995489 187.855506 
-L 192.461612 188.024221 
-L 191.927736 188.192337 
-L 191.393859 188.359859 
-L 190.859983 188.526791 
-L 190.326106 188.693136 
-L 189.79223 188.8589 
-L 189.258353 189.024086 
-L 188.724476 189.188699 
-L 188.1906 189.352741 
-L 187.656723 189.516218 
-L 187.122847 189.679132 
-L 186.58897 189.841488 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 178.376456 
+L 211.68117 178.579223 
+L 211.147293 178.781126 
+L 210.613417 178.982173 
+L 210.07954 179.18237 
+L 209.545663 179.381725 
+L 209.011787 179.580245 
+L 208.47791 179.777937 
+L 207.944034 179.974807 
+L 207.410157 180.170863 
+L 206.87628 180.366111 
+L 206.342404 180.560558 
+L 205.808527 180.754211 
+L 205.274651 180.947075 
+L 204.740774 181.139158 
+L 204.206897 181.330465 
+L 203.673021 181.521003 
+L 203.139144 181.710778 
+L 202.605268 181.899796 
+L 202.071391 182.088063 
+L 201.537515 182.275585 
+L 201.003638 182.462368 
+L 200.469761 182.648417 
+L 199.935885 182.833739 
+L 199.402008 183.018339 
+L 198.868132 183.202223 
+L 198.334255 183.385396 
+L 197.800378 183.567864 
+L 197.266502 183.749632 
+L 196.732625 183.930705 
+L 196.198749 184.111089 
+L 195.664872 184.290789 
+L 195.130995 184.46981 
+L 194.597119 184.648158 
+L 194.063242 184.825836 
+L 193.529366 185.002851 
+L 192.995489 185.179208 
+L 192.461612 185.35491 
+L 191.927736 185.529963 
+L 191.393859 185.704372 
+L 190.859983 185.878142 
+L 190.326106 186.051277 
+L 189.79223 186.223781 
+L 189.258353 186.39566 
+L 188.724476 186.566917 
+L 188.1906 186.737558 
+L 187.656723 186.907587 
+L 187.122847 187.077008 
+L 186.58897 187.245825 
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 186.58897 189.841488 
-L 186.223725 190.040397 
-L 185.85848 190.238474 
-L 185.493235 190.435726 
-L 185.127991 190.632161 
-L 184.762746 190.827785 
-L 184.397501 191.022604 
-L 184.032256 191.216626 
-L 183.667011 191.409857 
-L 183.301766 191.602304 
-L 182.936522 191.793971 
-L 182.571277 191.984867 
-L 182.206032 192.174997 
-L 181.840787 192.364367 
-L 181.475542 192.552983 
-L 181.110297 192.740852 
-L 180.745053 192.927978 
-L 180.379808 193.114369 
-L 180.014563 193.30003 
-L 179.649318 193.484965 
-L 179.284073 193.669182 
-L 178.918828 193.852686 
-L 178.553584 194.035482 
-L 178.188339 194.217575 
-L 177.823094 194.398972 
-L 177.457849 194.579676 
-L 177.092604 194.759695 
-L 176.727359 194.939031 
-L 176.362115 195.117692 
-L 175.99687 195.295682 
-L 175.631625 195.473006 
-L 175.26638 195.649669 
-L 174.901135 195.825675 
-L 174.53589 196.00103 
-L 174.170645 196.175739 
-L 173.805401 196.349806 
-L 173.440156 196.523236 
-L 173.074911 196.696034 
-L 172.709666 196.868204 
-L 172.344421 197.03975 
-L 171.979176 197.210678 
-L 171.613932 197.380992 
-L 171.248687 197.550695 
-L 170.883442 197.719793 
-L 170.518197 197.88829 
-L 170.152952 198.05619 
-L 169.787707 198.223497 
-L 169.422463 198.390215 
-L 169.057218 198.556349 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.58897 187.245825 
+L 186.223725 187.452828 
+L 185.85848 187.65893 
+L 185.493235 187.86414 
+L 185.127991 188.068465 
+L 184.762746 188.271913 
+L 184.397501 188.474491 
+L 184.032256 188.676207 
+L 183.667011 188.877068 
+L 183.301766 189.077081 
+L 182.936522 189.276253 
+L 182.571277 189.474592 
+L 182.206032 189.672104 
+L 181.840787 189.868797 
+L 181.475542 190.064676 
+L 181.110297 190.259749 
+L 180.745053 190.454022 
+L 180.379808 190.647503 
+L 180.014563 190.840196 
+L 179.649318 191.032109 
+L 179.284073 191.223248 
+L 178.918828 191.413619 
+L 178.553584 191.603229 
+L 178.188339 191.792082 
+L 177.823094 191.980186 
+L 177.457849 192.167547 
+L 177.092604 192.35417 
+L 176.727359 192.54006 
+L 176.362115 192.725224 
+L 175.99687 192.909668 
+L 175.631625 193.093396 
+L 175.26638 193.276415 
+L 174.901135 193.45873 
+L 174.53589 193.640346 
+L 174.170645 193.821268 
+L 173.805401 194.001503 
+L 173.440156 194.181055 
+L 173.074911 194.359929 
+L 172.709666 194.53813 
+L 172.344421 194.715663 
+L 171.979176 194.892535 
+L 171.613932 195.068748 
+L 171.248687 195.244308 
+L 170.883442 195.419221 
+L 170.518197 195.59349 
+L 170.152952 195.767121 
+L 169.787707 195.940118 
+L 169.422463 196.112486 
+L 169.057218 196.284229 
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 169.057218 198.556349 
-L 168.839293 198.83012 
-L 168.621369 199.102319 
-L 168.403445 199.372963 
-L 168.18552 199.642069 
-L 167.967596 199.909657 
-L 167.749672 200.175742 
-L 167.531747 200.440341 
-L 167.313823 200.703471 
-L 167.095898 200.965148 
-L 166.877974 201.225388 
-L 166.66005 201.484206 
-L 166.442125 201.741619 
-L 166.224201 201.997641 
-L 166.006277 202.252287 
-L 165.788352 202.505572 
-L 165.570428 202.757511 
-L 165.352503 203.008117 
-L 165.134579 203.257405 
-L 164.916655 203.505389 
-L 164.69873 203.752081 
-L 164.480806 203.997496 
-L 164.262882 204.241647 
-L 164.044957 204.484546 
-L 163.827033 204.726206 
-L 163.609108 204.966641 
-L 163.391184 205.205861 
-L 163.17326 205.44388 
-L 162.955335 205.68071 
-L 162.737411 205.916362 
-L 162.519487 206.150848 
-L 162.301562 206.384179 
-L 162.083638 206.616367 
-L 161.865713 206.847423 
-L 161.647789 207.077358 
-L 161.429865 207.306182 
-L 161.21194 207.533907 
-L 160.994016 207.760543 
-L 160.776092 207.9861 
-L 160.558167 208.210589 
-L 160.340243 208.434019 
-L 160.122318 208.656401 
-L 159.904394 208.877744 
-L 159.68647 209.098058 
-L 159.468545 209.317352 
-L 159.250621 209.535637 
-L 159.032697 209.75292 
-L 158.814772 209.969212 
-L 158.596848 210.184521 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 169.057218 196.284229 
+L 168.839293 196.56912 
+L 168.621369 196.852308 
+L 168.403445 197.133814 
+L 168.18552 197.413658 
+L 167.967596 197.691859 
+L 167.749672 197.968436 
+L 167.531747 198.243409 
+L 167.313823 198.516795 
+L 167.095898 198.788613 
+L 166.877974 199.058881 
+L 166.66005 199.327616 
+L 166.442125 199.594836 
+L 166.224201 199.860557 
+L 166.006277 200.124797 
+L 165.788352 200.387571 
+L 165.570428 200.648897 
+L 165.352503 200.908789 
+L 165.134579 201.167264 
+L 164.916655 201.424336 
+L 164.69873 201.680022 
+L 164.480806 201.934335 
+L 164.262882 202.187291 
+L 164.044957 202.438903 
+L 163.827033 202.689187 
+L 163.609108 202.938156 
+L 163.391184 203.185824 
+L 163.17326 203.432204 
+L 162.955335 203.67731 
+L 162.737411 203.921154 
+L 162.519487 204.163751 
+L 162.301562 204.405111 
+L 162.083638 204.645249 
+L 161.865713 204.884176 
+L 161.647789 205.121904 
+L 161.429865 205.358445 
+L 161.21194 205.593812 
+L 160.994016 205.828016 
+L 160.776092 206.061067 
+L 160.558167 206.292979 
+L 160.340243 206.52376 
+L 160.122318 206.753424 
+L 159.904394 206.981979 
+L 159.68647 207.209438 
+L 159.468545 207.43581 
+L 159.250621 207.661106 
+L 159.032697 207.885336 
+L 158.814772 208.10851 
+L 158.596848 208.330638 
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 158.596848 210.184521 
-L 158.477483 210.293121 
-L 158.358117 210.401473 
-L 158.238752 210.509578 
-L 158.119387 210.617437 
-L 158.000021 210.725051 
-L 157.880656 210.832421 
-L 157.761291 210.939548 
-L 157.641925 211.046433 
-L 157.52256 211.153079 
-L 157.403195 211.259484 
-L 157.28383 211.365651 
-L 157.164464 211.471581 
-L 157.045099 211.577275 
-L 156.925734 211.682733 
-L 156.806368 211.787958 
-L 156.687003 211.892949 
-L 156.567638 211.997708 
-L 156.448272 212.102236 
-L 156.328907 212.206534 
-L 156.209542 212.310603 
-L 156.090177 212.414444 
-L 155.970811 212.518058 
-L 155.851446 212.621445 
-L 155.732081 212.724608 
-L 155.612715 212.827547 
-L 155.49335 212.930262 
-L 155.373985 213.032755 
-L 155.254619 213.135028 
-L 155.135254 213.237079 
-L 155.015889 213.338912 
-L 154.896524 213.440526 
-L 154.777158 213.541923 
-L 154.657793 213.643103 
-L 154.538428 213.744068 
-L 154.419062 213.844818 
-L 154.299697 213.945355 
-L 154.180332 214.045678 
-L 154.060966 214.14579 
-L 153.941601 214.24569 
-L 153.822236 214.345381 
-L 153.702871 214.444862 
-L 153.583505 214.544134 
-L 153.46414 214.6432 
-L 153.344775 214.742058 
-L 153.225409 214.840711 
-L 153.106044 214.939158 
-L 152.986679 215.037402 
-L 152.867313 215.135443 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.596848 208.330638 
+L 158.477483 208.441883 
+L 158.358117 208.552867 
+L 158.238752 208.663593 
+L 158.119387 208.77406 
+L 158.000021 208.88427 
+L 157.880656 208.994225 
+L 157.761291 209.103925 
+L 157.641925 209.213371 
+L 157.52256 209.322566 
+L 157.403195 209.431509 
+L 157.28383 209.540203 
+L 157.164464 209.648648 
+L 157.045099 209.756845 
+L 156.925734 209.864796 
+L 156.806368 209.972501 
+L 156.687003 210.079962 
+L 156.567638 210.18718 
+L 156.448272 210.294156 
+L 156.328907 210.400891 
+L 156.209542 210.507387 
+L 156.090177 210.613643 
+L 155.970811 210.719662 
+L 155.851446 210.825444 
+L 155.732081 210.93099 
+L 155.612715 211.036302 
+L 155.49335 211.14138 
+L 155.373985 211.246226 
+L 155.254619 211.350841 
+L 155.135254 211.455225 
+L 155.015889 211.559379 
+L 154.896524 211.663305 
+L 154.777158 211.767004 
+L 154.657793 211.870476 
+L 154.538428 211.973723 
+L 154.419062 212.076746 
+L 154.299697 212.179545 
+L 154.180332 212.282121 
+L 154.060966 212.384476 
+L 153.941601 212.48661 
+L 153.822236 212.588525 
+L 153.702871 212.690221 
+L 153.583505 212.791699 
+L 153.46414 212.89296 
+L 153.344775 212.994005 
+L 153.225409 213.094836 
+L 153.106044 213.195452 
+L 152.986679 213.295855 
+L 152.867313 213.396046 
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 152.867313 215.135443 
-L 152.827388 215.185812 
-L 152.787463 215.236129 
-L 152.747537 215.286392 
-L 152.707612 215.336602 
-L 152.667686 215.386758 
-L 152.627761 215.436862 
-L 152.587835 215.486912 
-L 152.54791 215.53691 
-L 152.507984 215.586855 
-L 152.468059 215.636748 
-L 152.428133 215.686588 
-L 152.388208 215.736376 
-L 152.348282 215.786111 
-L 152.308357 215.835795 
-L 152.268432 215.885426 
-L 152.228506 215.935005 
-L 152.188581 215.984533 
-L 152.148655 216.034009 
-L 152.10873 216.083433 
-L 152.068804 216.132806 
-L 152.028879 216.182127 
-L 151.988953 216.231397 
-L 151.949028 216.280616 
-L 151.909102 216.329784 
-L 151.869177 216.378901 
-L 151.829252 216.427967 
-L 151.789326 216.476982 
-L 151.749401 216.525947 
-L 151.709475 216.574861 
-L 151.66955 216.623724 
-L 151.629624 216.672538 
-L 151.589699 216.721301 
-L 151.549773 216.770014 
-L 151.509848 216.818677 
-L 151.469922 216.86729 
-L 151.429997 216.915853 
-L 151.390072 216.964366 
-L 151.350146 217.01283 
-L 151.310221 217.061245 
-L 151.270295 217.10961 
-L 151.23037 217.157925 
-L 151.190444 217.206192 
-L 151.150519 217.254409 
-L 151.110593 217.302577 
-L 151.070668 217.350697 
-L 151.030742 217.398767 
-L 150.990817 217.446789 
-L 150.950891 217.494763 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 152.867313 213.396046 
+L 152.827388 213.446359 
+L 152.787463 213.496619 
+L 152.747537 213.546826 
+L 152.707612 213.596979 
+L 152.667686 213.64708 
+L 152.627761 213.697127 
+L 152.587835 213.747122 
+L 152.54791 213.797064 
+L 152.507984 213.846953 
+L 152.468059 213.89679 
+L 152.428133 213.946575 
+L 152.388208 213.996307 
+L 152.348282 214.045988 
+L 152.308357 214.095616 
+L 152.268432 214.145192 
+L 152.228506 214.194717 
+L 152.188581 214.24419 
+L 152.148655 214.293611 
+L 152.10873 214.34298 
+L 152.068804 214.392299 
+L 152.028879 214.441566 
+L 151.988953 214.490782 
+L 151.949028 214.539947 
+L 151.909102 214.589061 
+L 151.869177 214.638124 
+L 151.829252 214.687136 
+L 151.789326 214.736097 
+L 151.749401 214.785009 
+L 151.709475 214.833869 
+L 151.66955 214.88268 
+L 151.629624 214.93144 
+L 151.589699 214.98015 
+L 151.549773 215.02881 
+L 151.509848 215.07742 
+L 151.469922 215.12598 
+L 151.429997 215.174491 
+L 151.390072 215.222952 
+L 151.350146 215.271363 
+L 151.310221 215.319725 
+L 151.270295 215.368038 
+L 151.23037 215.416302 
+L 151.190444 215.464516 
+L 151.150519 215.512681 
+L 151.110593 215.560798 
+L 151.070668 215.608866 
+L 151.030742 215.656885 
+L 150.990817 215.704855 
+L 150.950891 215.752777 
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 217.494763 
-L 150.293158 220.744669 
-L 149.635424 223.78593 
-L 148.97769 226.643728 
-L 148.319956 229.338943 
-L 147.662223 231.889084 
-L 147.004489 234.308972 
-L 146.346755 236.611271 
-L 145.689021 238.806879 
-L 145.031288 240.90525 
-L 144.373554 242.914632 
-L 143.71582 244.842266 
-L 143.058086 246.694545 
-L 142.400352 248.477139 
-L 141.742619 250.195103 
-L 141.084885 251.852959 
-L 140.427151 253.454771 
-L 139.769417 255.004205 
-L 139.111684 256.504578 
-L 138.45395 257.958903 
-L 137.796216 259.369921 
-L 137.138482 260.740137 
-L 136.480748 262.071846 
-L 135.823015 263.367151 
-L 135.165281 264.627992 
-L 134.507547 265.856153 
-L 133.849813 267.053287 
-L 133.19208 268.220923 
-L 132.534346 269.360479 
-L 131.876612 270.473275 
-L 131.218878 271.560538 
-L 130.561145 272.623414 
-L 129.903411 273.662973 
-L 129.245677 274.680216 
-L 128.587943 275.676081 
-L 127.930209 276.651448 
-L 127.272476 277.607144 
-L 126.614742 278.543947 
-L 125.957008 279.46259 
-L 125.299274 280.363762 
-L 124.641541 281.248116 
-L 123.983807 282.116269 
-L 123.326073 282.968803 
-L 122.668339 283.80627 
-L 122.010605 284.629194 
-L 121.352872 285.438071 
-L 120.695138 286.233373 
-L 120.037404 287.015548 
-L 119.37967 287.785022 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 150.950891 215.752777 
+L 150.293158 218.998768 
+L 149.635424 222.036601 
+L 148.97769 224.891371 
+L 148.319956 227.583893 
+L 147.662223 230.131623 
+L 147.004489 232.549341 
+L 146.346755 234.849674 
+L 145.689021 237.043495 
+L 145.031288 239.140233 
+L 144.373554 241.148118 
+L 143.71582 243.074375 
+L 143.058086 244.925381 
+L 142.400352 246.706798 
+L 141.742619 248.423667 
+L 141.084885 250.080504 
+L 140.427151 251.681364 
+L 139.769417 253.229908 
+L 139.111684 254.729447 
+L 138.45395 256.182987 
+L 137.796216 257.593267 
+L 137.138482 258.962787 
+L 136.480748 260.293838 
+L 135.823015 261.588521 
+L 135.165281 262.848772 
+L 134.507547 264.076374 
+L 133.849813 265.272977 
+L 133.19208 266.440107 
+L 132.534346 267.579182 
+L 131.876612 268.691518 
+L 131.218878 269.778343 
+L 130.561145 270.8408 
+L 129.903411 271.879958 
+L 129.245677 272.896817 
+L 128.587943 273.892315 
+L 127.930209 274.867329 
+L 127.272476 275.822686 
+L 126.614742 276.759164 
+L 125.957008 277.677493 
+L 125.299274 278.578364 
+L 124.641541 279.462428 
+L 123.983807 280.330301 
+L 123.326073 281.182566 
+L 122.668339 282.019773 
+L 122.010605 282.842446 
+L 121.352872 283.651081 
+L 120.695138 284.446148 
+L 120.037404 285.228096 
+L 119.37967 285.99735 
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 119.37967 287.785022 
-L 118.987211 288.458041 
-L 118.594752 289.121634 
-L 118.202293 289.776064 
-L 117.809834 290.421579 
-L 117.417375 291.058419 
-L 117.024916 291.686814 
-L 116.632457 292.306985 
-L 116.239998 292.919145 
-L 115.847539 293.523498 
-L 115.45508 294.12024 
-L 115.062621 294.709562 
-L 114.670162 295.291644 
-L 114.277703 295.866664 
-L 113.885243 296.434789 
-L 113.492784 296.996185 
-L 113.100325 297.551007 
-L 112.707866 298.099409 
-L 112.315407 298.641537 
-L 111.922948 299.177533 
-L 111.530489 299.707534 
-L 111.13803 300.231673 
-L 110.745571 300.750079 
-L 110.353112 301.262874 
-L 109.960653 301.77018 
-L 109.568194 302.272113 
-L 109.175735 302.768785 
-L 108.783276 303.260305 
-L 108.390817 303.74678 
-L 107.998358 304.228311 
-L 107.605898 304.704999 
-L 107.213439 305.176939 
-L 106.82098 305.644226 
-L 106.428521 306.10695 
-L 106.036062 306.565199 
-L 105.643603 307.019059 
-L 105.251144 307.468614 
-L 104.858685 307.913944 
-L 104.466226 308.355128 
-L 104.073767 308.792242 
-L 103.681308 309.225362 
-L 103.288849 309.654558 
-L 102.89639 310.079903 
-L 102.503931 310.501463 
-L 102.111472 310.919307 
-L 101.719013 311.333498 
-L 101.326553 311.744101 
-L 100.934094 312.151176 
-L 100.541635 312.554784 
-" clip-path="url(#p93575b0a99)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 119.37967 285.99735 
+L 118.987211 286.696896 
+L 118.594752 287.386265 
+L 118.202293 288.06575 
+L 117.809834 288.735629 
+L 117.417375 289.39617 
+L 117.024916 290.047631 
+L 116.632457 290.690258 
+L 116.239998 291.324287 
+L 115.847539 291.949944 
+L 115.45508 292.567449 
+L 115.062621 293.177011 
+L 114.670162 293.778831 
+L 114.277703 294.373104 
+L 113.885243 294.960017 
+L 113.492784 295.53975 
+L 113.100325 296.112477 
+L 112.707866 296.678364 
+L 112.315407 297.237573 
+L 111.922948 297.79026 
+L 111.530489 298.336576 
+L 111.13803 298.876665 
+L 110.745571 299.410668 
+L 110.353112 299.938721 
+L 109.960653 300.460954 
+L 109.568194 300.977495 
+L 109.175735 301.488466 
+L 108.783276 301.993987 
+L 108.390817 302.494171 
+L 107.998358 302.989132 
+L 107.605898 303.478976 
+L 107.213439 303.963808 
+L 106.82098 304.44373 
+L 106.428521 304.918841 
+L 106.036062 305.389236 
+L 105.643603 305.855007 
+L 105.251144 306.316244 
+L 104.858685 306.773036 
+L 104.466226 307.225467 
+L 104.073767 307.673619 
+L 103.681308 308.117572 
+L 103.288849 308.557405 
+L 102.89639 308.993193 
+L 102.503931 309.42501 
+L 102.111472 309.852928 
+L 101.719013 310.277017 
+L 101.326553 310.697343 
+L 100.934094 311.113975 
+L 100.541635 311.526975 
+" clip-path="url(#p38032c5e2b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-05T03:12:42Z  ·  Linux chungus x86_64  ·  commit 992547a3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.689297 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6265,6 +6265,31 @@ L 1172 0
 L 2766 4134 
 L 525 4134 
 L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
@@ -6289,36 +6314,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6378,6 +6373,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6416,16 +6441,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6464,109 +6489,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p93575b0a99">
+  <clipPath id="p38032c5e2b">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pc82d8f76a5)">
+   <g clip-path="url(#paeef9231e1)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="imageaf04dd4cc9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="imagee40fef0399" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m411f0e5819" d="M 0 0 
+       <path id="m559eba2892" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m411f0e5819" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m411f0e5819" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m411f0e5819" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m411f0e5819" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m411f0e5819" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m411f0e5819" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m411f0e5819" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m411f0e5819" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m411f0e5819" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m411f0e5819" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m411f0e5819" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m559eba2892" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="mcaa80a7eee" d="M 0 0 
+       <path id="mba68f69e1e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcaa80a7eee" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba68f69e1e" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mcaa80a7eee" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba68f69e1e" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mcaa80a7eee" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba68f69e1e" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mcaa80a7eee" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba68f69e1e" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mcaa80a7eee" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba68f69e1e" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mcaa80a7eee" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba68f69e1e" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mcaa80a7eee" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba68f69e1e" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mcaa80a7eee" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mba68f69e1e" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image91dcc95c41" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image436539d016" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m3d6300c706" d="M 0 0 
+       <path id="m1daa786346" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3d6300c706" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1daa786346" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m3d6300c706" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1daa786346" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3d6300c706" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1daa786346" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3d6300c706" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1daa786346" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3d6300c706" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1daa786346" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m3d6300c706" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1daa786346" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m3d6300c706" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1daa786346" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m3d6300c706" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1daa786346" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m3d6300c706" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1daa786346" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(19.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-05T03:12:42Z  ·  Linux chungus x86_64  ·  commit 992547a3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(18.689297 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2950,16 +2950,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2998,109 +2998,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc82d8f76a5">
+  <clipPath id="paeef9231e1">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.022031pt" height="386.202469pt" viewBox="0 0 569.022031 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="571.021406pt" height="386.202469pt" viewBox="0 0 571.021406 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 569.022031 386.202469 
-L 569.022031 0 
+L 571.021406 386.202469 
+L 571.021406 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.636016 104.1264 
-L 291.261016 104.1264 
-L 291.261016 74.7432 
-L 186.636016 74.7432 
+    <path d="M 187.635703 104.1264 
+L 292.260703 104.1264 
+L 292.260703 74.7432 
+L 187.635703 74.7432 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.261016 104.1264 
-L 395.886016 104.1264 
-L 395.886016 74.7432 
-L 291.261016 74.7432 
+    <path d="M 292.260703 104.1264 
+L 396.885703 104.1264 
+L 396.885703 74.7432 
+L 292.260703 74.7432 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.886016 104.1264 
-L 500.511016 104.1264 
-L 500.511016 74.7432 
-L 395.886016 74.7432 
+    <path d="M 396.885703 104.1264 
+L 501.510703 104.1264 
+L 501.510703 74.7432 
+L 396.885703 74.7432 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.636016 133.5096 
-L 291.261016 133.5096 
-L 291.261016 104.1264 
-L 186.636016 104.1264 
+    <path d="M 187.635703 133.5096 
+L 292.260703 133.5096 
+L 292.260703 104.1264 
+L 187.635703 104.1264 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.261016 133.5096 
-L 395.886016 133.5096 
-L 395.886016 104.1264 
-L 291.261016 104.1264 
+    <path d="M 292.260703 133.5096 
+L 396.885703 133.5096 
+L 396.885703 104.1264 
+L 292.260703 104.1264 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.886016 133.5096 
-L 500.511016 133.5096 
-L 500.511016 104.1264 
-L 395.886016 104.1264 
+    <path d="M 396.885703 133.5096 
+L 501.510703 133.5096 
+L 501.510703 104.1264 
+L 396.885703 104.1264 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.636016 162.8928 
-L 291.261016 162.8928 
-L 291.261016 133.5096 
-L 186.636016 133.5096 
+    <path d="M 187.635703 162.8928 
+L 292.260703 162.8928 
+L 292.260703 133.5096 
+L 187.635703 133.5096 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.261016 162.8928 
-L 395.886016 162.8928 
-L 395.886016 133.5096 
-L 291.261016 133.5096 
+    <path d="M 292.260703 162.8928 
+L 396.885703 162.8928 
+L 396.885703 133.5096 
+L 292.260703 133.5096 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.886016 162.8928 
-L 500.511016 162.8928 
-L 500.511016 133.5096 
-L 395.886016 133.5096 
+    <path d="M 396.885703 162.8928 
+L 501.510703 162.8928 
+L 501.510703 133.5096 
+L 396.885703 133.5096 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.636016 192.276 
-L 291.261016 192.276 
-L 291.261016 162.8928 
-L 186.636016 162.8928 
+    <path d="M 187.635703 192.276 
+L 292.260703 192.276 
+L 292.260703 162.8928 
+L 187.635703 162.8928 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.261016 192.276 
-L 395.886016 192.276 
-L 395.886016 162.8928 
-L 291.261016 162.8928 
+    <path d="M 292.260703 192.276 
+L 396.885703 192.276 
+L 396.885703 162.8928 
+L 292.260703 162.8928 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.886016 192.276 
-L 500.511016 192.276 
-L 500.511016 162.8928 
-L 395.886016 162.8928 
+    <path d="M 396.885703 192.276 
+L 501.510703 192.276 
+L 501.510703 162.8928 
+L 396.885703 162.8928 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.636016 221.6592 
-L 291.261016 221.6592 
-L 291.261016 192.276 
-L 186.636016 192.276 
+    <path d="M 187.635703 221.6592 
+L 292.260703 221.6592 
+L 292.260703 192.276 
+L 187.635703 192.276 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.261016 221.6592 
-L 395.886016 221.6592 
-L 395.886016 192.276 
-L 291.261016 192.276 
+    <path d="M 292.260703 221.6592 
+L 396.885703 221.6592 
+L 396.885703 192.276 
+L 292.260703 192.276 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.886016 221.6592 
-L 500.511016 221.6592 
-L 500.511016 192.276 
-L 395.886016 192.276 
+    <path d="M 396.885703 221.6592 
+L 501.510703 221.6592 
+L 501.510703 192.276 
+L 396.885703 192.276 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.636016 251.0424 
-L 291.261016 251.0424 
-L 291.261016 221.6592 
-L 186.636016 221.6592 
+    <path d="M 187.635703 251.0424 
+L 292.260703 251.0424 
+L 292.260703 221.6592 
+L 187.635703 221.6592 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.261016 251.0424 
-L 395.886016 251.0424 
-L 395.886016 221.6592 
-L 291.261016 221.6592 
+    <path d="M 292.260703 251.0424 
+L 396.885703 251.0424 
+L 396.885703 221.6592 
+L 292.260703 221.6592 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.886016 251.0424 
-L 500.511016 251.0424 
-L 500.511016 221.6592 
-L 395.886016 221.6592 
+    <path d="M 396.885703 251.0424 
+L 501.510703 251.0424 
+L 501.510703 221.6592 
+L 396.885703 221.6592 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.636016 280.4256 
-L 291.261016 280.4256 
-L 291.261016 251.0424 
-L 186.636016 251.0424 
+    <path d="M 187.635703 280.4256 
+L 292.260703 280.4256 
+L 292.260703 251.0424 
+L 187.635703 251.0424 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.261016 280.4256 
-L 395.886016 280.4256 
-L 395.886016 251.0424 
-L 291.261016 251.0424 
+    <path d="M 292.260703 280.4256 
+L 396.885703 280.4256 
+L 396.885703 251.0424 
+L 292.260703 251.0424 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.886016 280.4256 
-L 500.511016 280.4256 
-L 500.511016 251.0424 
-L 395.886016 251.0424 
+    <path d="M 396.885703 280.4256 
+L 501.510703 280.4256 
+L 501.510703 251.0424 
+L 396.885703 251.0424 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.636016 309.8088 
-L 291.261016 309.8088 
-L 291.261016 280.4256 
-L 186.636016 280.4256 
+    <path d="M 187.635703 309.8088 
+L 292.260703 309.8088 
+L 292.260703 280.4256 
+L 187.635703 280.4256 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.261016 309.8088 
-L 395.886016 309.8088 
-L 395.886016 280.4256 
-L 291.261016 280.4256 
+    <path d="M 292.260703 309.8088 
+L 396.885703 309.8088 
+L 396.885703 280.4256 
+L 292.260703 280.4256 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.886016 309.8088 
-L 500.511016 309.8088 
-L 500.511016 280.4256 
-L 395.886016 280.4256 
+    <path d="M 396.885703 309.8088 
+L 501.510703 309.8088 
+L 501.510703 280.4256 
+L 396.885703 280.4256 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.636016 339.192 
-L 291.261016 339.192 
-L 291.261016 309.8088 
-L 186.636016 309.8088 
+    <path d="M 187.635703 339.192 
+L 292.260703 339.192 
+L 292.260703 309.8088 
+L 187.635703 309.8088 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.261016 339.192 
-L 395.886016 339.192 
-L 395.886016 309.8088 
-L 291.261016 309.8088 
+    <path d="M 292.260703 339.192 
+L 396.885703 339.192 
+L 396.885703 309.8088 
+L 292.260703 309.8088 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.886016 339.192 
-L 500.511016 339.192 
-L 500.511016 309.8088 
-L 395.886016 309.8088 
+    <path d="M 396.885703 339.192 
+L 501.510703 339.192 
+L 501.510703 309.8088 
+L 396.885703 309.8088 
 z
-" clip-path="url(#p3855ef40a9)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p4ebe5693cb)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.623281 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.622969 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.9075 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.907188 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.479609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.479297 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.831328 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.831016 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.561016 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.560703 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(227.497266 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(335.938516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.938203 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(440.563516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.199141 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(111.198828 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(338.483516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 281 -->
-    <g transform="translate(440.563516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(127.462266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(128.461953 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(338.483516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 700 -->
-    <g transform="translate(440.563516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- miniz_oxide -->
-    <g transform="translate(110.768516 179.68065) scale(0.08 -0.08)">
+    <g transform="translate(111.768203 179.68065) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
@@ -1369,7 +1369,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1379,14 +1379,14 @@ z
    </g>
    <g id="text_19">
     <!-- 51 -->
-    <g transform="translate(338.483516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 730 -->
-    <g transform="translate(440.563516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1394,7 +1394,7 @@ z
    </g>
    <g id="text_21">
     <!-- JS fflate -->
-    <g transform="translate(118.924766 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(119.924453 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1454,7 +1454,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.307 -->
-    <g transform="translate(227.497266 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1464,7 +1464,7 @@ z
    </g>
    <g id="text_23">
     <!-- 44 -->
-    <g transform="translate(338.483516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1492,7 +1492,7 @@ z
    </g>
    <g id="text_24">
     <!-- 119 -->
-    <g transform="translate(440.563516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1500,7 +1500,7 @@ z
    </g>
    <g id="text_25">
     <!-- OCaml decompress -->
-    <g transform="translate(95.385391 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(96.385078 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1629,7 +1629,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.321 -->
-    <g transform="translate(227.497266 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1639,14 +1639,14 @@ z
    </g>
    <g id="text_27">
     <!-- 23 -->
-    <g transform="translate(338.483516 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 117 -->
-    <g transform="translate(440.563516 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1654,7 +1654,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.270391 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(98.270078 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1763,7 +1763,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.298 -->
-    <g transform="translate(226.296641 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.296328 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1893,8 +1893,8 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 18 -->
-    <g transform="translate(338.007266 267.9415) scale(0.08 -0.08)">
+    <!-- 19 -->
+    <g transform="translate(339.006953 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1912,73 +1912,52 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 134 -->
-    <g transform="translate(439.849141 267.9415) scale(0.08 -0.08)">
+    <!-- 206 -->
+    <g transform="translate(440.848828 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
-Q 3453 2394 3698 2092 
-Q 3944 1791 3944 1325 
-Q 3944 631 3412 270 
-Q 2881 -91 1863 -91 
-Q 1503 -91 1142 -33 
-Q 781 25 428 141 
-L 428 1069 
-Q 766 900 1098 814 
-Q 1431 728 1753 728 
-Q 2231 728 2486 893 
-Q 2741 1059 2741 1369 
-Q 2741 1688 2480 1852 
-Q 2219 2016 1709 2016 
-L 1228 2016 
-L 1228 2791 
-L 1734 2791 
-Q 2188 2791 2409 2933 
-Q 2631 3075 2631 3366 
-Q 2631 3634 2415 3781 
-Q 2200 3928 1806 3928 
-Q 1516 3928 1219 3862 
-Q 922 3797 628 3669 
-L 628 4550 
-Q 984 4650 1334 4700 
-Q 1684 4750 2022 4750 
-Q 2931 4750 3382 4451 
-Q 3834 4153 3834 3553 
-Q 3834 3144 3618 2883 
-Q 3403 2622 2981 2516 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
 z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- Go compress/flate -->
-    <g transform="translate(97.892266 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.891953 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -2034,7 +2013,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.299 -->
-    <g transform="translate(227.497266 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2044,21 +2023,21 @@ z
    </g>
    <g id="text_35">
     <!-- 18 -->
-    <g transform="translate(338.483516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 88 -->
-    <g transform="translate(443.108516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(444.108203 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.606641 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.606328 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2069,7 +2048,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(227.497266 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2079,13 +2058,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.028516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(342.028203 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.198516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(445.198203 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2101,7 +2080,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.019766 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(135.019453 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2240,36 +2219,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2314,7 +2263,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-05T03:12:42Z  ·  Linux chungus x86_64  ·  commit 992547a3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2453,16 +2402,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2501,110 +2450,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3855ef40a9">
-   <rect x="82.011016" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p4ebe5693cb">
+   <rect x="83.010703" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p64180291ca)">
+   <g clip-path="url(#p9cc9955f7d)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7UlEQVR4nO3XsY5cZx2HYc/uZB0cW5jYrBWQLBpCBVIEVRruIEUug5KWnpKalp4boAJRISEEDQodlkkBjgIEm8i7s57lCqis7/2vj57nCn6jc85877c7fv6L61tbdng5vYDXcbyaXrDW7mR6wVpXl9ML1rpzf3rBWhcvphesdXo2vYDXsfX38+zO9IKlNn76AQBw0whQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABS+z8cnkxvWGp/cjo9Yanj9fX0hKXO751PT1jqyX/+Nj1hrY1fcd9/+/70hKUOt8+mJyz1x2efTE9Y6nsPvz09YamLs+P0hKV2uy+nJyy18eMBAICbRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApPaP731resNS92+fT09Y6rOXn05PWOobX277jnT3wXenJyx1uttPT1jqeOs4PWGpr996OD1hqauHl9MTlnp05/H0hKUOx20/v3cut/3/su3THQCAG0eAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2u92227Q54d/Tk9Y6iund6cnLPXqwbvTE5b6+xd/mp6w1IvLl9MTlvr+134wPWGpy9PpBWv99/B8egKv4d8Xz6YnrHX7fHrBUtuuTwAAbhwBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAavfqtz++nh6x1PE4vQD+vxN3wDea/5c329a/v62/n57fG23jTw8AgJtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNo/+v1fpjcsdbLfdmM/++Sz6QlL/fxHH0xPWOqnv/vH9ISlfvj4q9MTlvrlb/46PWGpn3z8nekJS/3s10+nJyz10QfvTU9Y6ukXF9MTlvrwm+9MT1hq23UGAMCNI0ABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUrvDq19dT49Y6fTqanrCWif76QVrXb2cXrDW2Z3pBWvtNn7HvT5OL1jr4Pt7o73a9vl32G37+3tr4/2y8dMBAICbRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDa73Ybb9DPn0wvWOve+fSCtZ4/m16w1u270wvWeuvt6QVrbf33/evT6QVrPXp/esFaFy+mFyy1f/rn6QlrPXhvesFSG69PAABuGgEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDqf9Aad6/FymREAAAAAElFTkSuQmCC" id="image376915cd6d" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7klEQVR4nO3Yv46cZx2GYc/uZB0chzixcRKQLBoITSJFoUqTM6DgMChp6Smpaek5ASoQFRJCIFGELsZQEEeJEpxY9s56liOgst77t/50XUfwjL4/7/3N7vj5by6vbdnhyfQCnsfxYnrBWruT6QVrXZxPL1jrxq3pBWs9/Xp6wVqnZ9MLeB5bvz/PbkwvWGrjpx8AAFeNAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILX/y+H+9Ial9ien0xOWOl5eTk9Y6u6rd6cnLHX/v/+anrDWxj9xf/jyrekJSx2un01PWOqvDz+enrDUe3d+MD1hqadnx+kJS+12j6cnLLXx4wEAgKtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9vde/f70hqVuXb87PWGpz578e3rCUt99vO1vpJu3352esNTpbj89YanjteP0hKW+c+3O9ISlLu6cT09Y6s0b96YnLHU4bvv6vXK+7ffLtk93AACuHAEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqv9ttu0EfHb6YnrDUt05vTk9Y6tntN6YnLPWfr/42PWGpr8+fTE9Y6oPXfzw9Yanz0+kFa31zeDQ9gefw5dOH0xPWun53esFS265PAACuHAEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBq9+yPP7+cHrHU8Ti9AP6/E9+ALzTvlxfb1p+/rd+frt8LbeNXDwCAq0aAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQ2r/5539Mb1jqZL/txn748WfTE5b69c/en56w1C//9On0hKU+uvfa9ISlfvuHT6YnLPWLn74zPWGpX/3+wfSEpX7y/tvTE5Z68NXT6QlLffi9V6YnLLXtOgMA4MoRoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp3eHZ7y6nR6x0enExPWGtk/30grUunkwvWOvsxvSCtXYb/8a9PE4vWOvg+XuhPdv2+XfYbfv5e2nj/bLx0wEAgKtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNpPD1ju8/vTC9b69lvTC9Z69HB6wVrXb04vWOull6cXrLX13/fFg+kFa731o+kFa50/nl6w1P6ff5+esNbtt6cXLOUfUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAIDU/wCzCneuE5lvXwAAAABJRU5ErkJggg==" id="image50af06f8f7" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m9daf9c7cd5" d="M 0 0 
+       <path id="m6b30816205" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9daf9c7cd5" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6b30816205" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m9e540e7528" d="M 0 0 
+       <path id="m15a80d7cd9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9e540e7528" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15a80d7cd9" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m9e540e7528" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15a80d7cd9" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m9e540e7528" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15a80d7cd9" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m9e540e7528" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15a80d7cd9" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m9e540e7528" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15a80d7cd9" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m9e540e7528" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15a80d7cd9" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m9e540e7528" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15a80d7cd9" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m9e540e7528" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m15a80d7cd9" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +3 -->
+    <!-- +7 -->
     <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1156,45 +1156,23 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -49 -->
+    <!-- -48 -->
     <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
@@ -1216,80 +1194,6 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -22 -->
-    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -48 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1335,53 +1239,34 @@ z
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_25">
-    <!-- -34 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -25 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+   <g id="text_23">
+    <!-- -21 -->
+    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -15 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
 L 1825 4091 
@@ -1398,48 +1283,134 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -47 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -32 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -23 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- -13 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- -49 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -3 -->
+    <!-- -1 -->
     <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -21 -->
+    <!-- -19 -->
     <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
     <!-- -72 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
@@ -1510,6 +1481,33 @@ z
    <g id="text_36">
     <!-- -15 -->
     <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
@@ -2195,18 +2193,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagef37c5e82a7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image8462ef113e" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mb4d1939c0a" d="M 0 0 
+       <path id="mf627eea196" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb4d1939c0a" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf627eea196" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2229,7 +2227,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb4d1939c0a" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf627eea196" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2243,7 +2241,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mb4d1939c0a" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf627eea196" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2257,7 +2255,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb4d1939c0a" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf627eea196" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2270,7 +2268,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mb4d1939c0a" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf627eea196" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2283,7 +2281,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb4d1939c0a" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf627eea196" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2296,7 +2294,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mb4d1939c0a" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf627eea196" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2912,8 +2910,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-05T03:12:42Z  ·  Linux chungus x86_64  ·  commit 992547a3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.689297 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3002,16 +3000,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3050,109 +3048,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p64180291ca">
+  <clipPath id="p9cc9955f7d">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mb5a5bb871b" d="M 0 0 
+       <path id="mb0bd1c5838" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb5a5bb871b" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0bd1c5838" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb5a5bb871b" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0bd1c5838" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb5a5bb871b" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0bd1c5838" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb5a5bb871b" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0bd1c5838" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb5a5bb871b" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0bd1c5838" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb5a5bb871b" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0bd1c5838" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb5a5bb871b" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0bd1c5838" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.088255 
 L 637.2 368.088255 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m241e6564bf" d="M 0 0 
+       <path id="m9c85bc5789" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m241e6564bf" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c85bc5789" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.475737 
 L 637.2 243.475737 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m241e6564bf" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c85bc5789" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.475737
      <g id="line2d_19">
       <path d="M 49.078125 118.863219 
 L 637.2 118.863219 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m241e6564bf" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9c85bc5789" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.863219
      <g id="line2d_21">
       <path d="M 49.078125 405.600361 
 L 637.2 405.600361 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m335ab5bc11" d="M 0 0 
+       <path id="mdd111b00af" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733387 
 L 637.2 395.733387 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733387
      <g id="line2d_25">
       <path d="M 49.078125 387.390979 
 L 637.2 387.390979 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.390979
      <g id="line2d_27">
       <path d="M 49.078125 380.164456 
 L 637.2 380.164456 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.164456
      <g id="line2d_29">
       <path d="M 49.078125 373.790211 
 L 637.2 373.790211 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.790211
      <g id="line2d_31">
       <path d="M 49.078125 330.57615 
 L 637.2 330.57615 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.57615
      <g id="line2d_33">
       <path d="M 49.078125 308.632974 
 L 637.2 308.632974 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.632974
      <g id="line2d_35">
       <path d="M 49.078125 293.064044 
 L 637.2 293.064044 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.064044
      <g id="line2d_37">
       <path d="M 49.078125 280.987843 
 L 637.2 280.987843 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.987843
      <g id="line2d_39">
       <path d="M 49.078125 271.120868 
 L 637.2 271.120868 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.120868
      <g id="line2d_41">
       <path d="M 49.078125 262.77846 
 L 637.2 262.77846 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.77846
      <g id="line2d_43">
       <path d="M 49.078125 255.551938 
 L 637.2 255.551938 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.551938
      <g id="line2d_45">
       <path d="M 49.078125 249.177693 
 L 637.2 249.177693 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.177693
      <g id="line2d_47">
       <path d="M 49.078125 205.963631 
 L 637.2 205.963631 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.963631
      <g id="line2d_49">
       <path d="M 49.078125 184.020456 
 L 637.2 184.020456 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 184.020456
      <g id="line2d_51">
       <path d="M 49.078125 168.451525 
 L 637.2 168.451525 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.451525
      <g id="line2d_53">
       <path d="M 49.078125 156.375325 
 L 637.2 156.375325 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.375325
      <g id="line2d_55">
       <path d="M 49.078125 146.50835 
 L 637.2 146.50835 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.50835
      <g id="line2d_57">
       <path d="M 49.078125 138.165942 
 L 637.2 138.165942 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.165942
      <g id="line2d_59">
       <path d="M 49.078125 130.93942 
 L 637.2 130.93942 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.93942
      <g id="line2d_61">
       <path d="M 49.078125 124.565175 
 L 637.2 124.565175 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.565175
      <g id="line2d_63">
       <path d="M 49.078125 81.351113 
 L 637.2 81.351113 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.351113
      <g id="line2d_65">
       <path d="M 49.078125 59.407938 
 L 637.2 59.407938 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m335ab5bc11" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdd111b00af" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 127.599674) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 122.852422) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.149529 322.988146) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.149529 322.941172) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m6aa231fb8e" d="M -2.5 2.5 
+     <path id="m3b5681f79c" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p38dff6dda8)">
-     <use xlink:href="#m6aa231fb8e" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6aa231fb8e" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6aa231fb8e" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6aa231fb8e" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6aa231fb8e" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6aa231fb8e" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6aa231fb8e" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6aa231fb8e" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6aa231fb8e" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc10a72b880)">
+     <use xlink:href="#m3b5681f79c" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b5681f79c" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b5681f79c" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b5681f79c" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b5681f79c" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b5681f79c" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b5681f79c" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b5681f79c" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3b5681f79c" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 111.868554
 L 326.02264 111.96025 
 L 324.91204 112.051791 
 L 323.801439 112.143178 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 112.143178 
@@ -1807,7 +1807,7 @@ L 275.861725 127.410211
 L 274.796398 127.705019 
 L 273.731071 127.99823 
 L 272.665744 128.289861 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 128.289861 
@@ -1859,7 +1859,7 @@ L 237.512385 129.68632
 L 236.7312 129.716946 
 L 235.950014 129.747556 
 L 235.168828 129.778148 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 129.778148 
@@ -1911,7 +1911,7 @@ L 189.28705 148.994297
 L 188.267455 149.352551 
 L 187.24786 149.708449 
 L 186.228265 150.062022 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 150.062022 
@@ -1963,7 +1963,7 @@ L 160.048483 171.011997
 L 159.46671 171.396655 
 L 158.884937 171.778598 
 L 158.303164 172.157864 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 172.157864 
@@ -2015,7 +2015,7 @@ L 150.040398 181.598676
 L 149.856781 181.790851 
 L 149.673164 181.982345 
 L 149.489547 182.173164 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.173164 
@@ -2067,7 +2067,7 @@ L 141.121061 201.502451
 L 140.935095 201.862455 
 L 140.749129 202.220079 
 L 140.563162 202.575355 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.575355 
@@ -2119,26 +2119,26 @@ L 139.083497 208.86883
 L 139.050616 209.000699 
 L 139.017734 209.132247 
 L 138.984853 209.263476 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="me3b4a775c3" d="M 0 -2.5 
+     <path id="m60a723ac56" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p38dff6dda8)">
-     <use xlink:href="#me3b4a775c3" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b4a775c3" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b4a775c3" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b4a775c3" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b4a775c3" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b4a775c3" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b4a775c3" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b4a775c3" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me3b4a775c3" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc10a72b880)">
+     <use xlink:href="#m60a723ac56" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m60a723ac56" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m60a723ac56" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m60a723ac56" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m60a723ac56" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m60a723ac56" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m60a723ac56" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m60a723ac56" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m60a723ac56" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.20247
 L 331.988718 100.690952 
 L 325.934838 101.175064 
 L 319.880958 101.654884 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.654884 
@@ -2243,7 +2243,7 @@ L 217.131235 128.404389
 L 214.847908 128.871381 
 L 212.564581 129.334377 
 L 210.281253 129.793447 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.793447 
@@ -2295,7 +2295,7 @@ L 197.161712 133.343265
 L 196.870166 133.419565 
 L 196.578621 133.495757 
 L 196.287076 133.571842 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.571842 
@@ -2347,7 +2347,7 @@ L 177.31896 146.664131
 L 176.897447 146.921938 
 L 176.475933 147.178523 
 L 176.054419 147.433896 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.433896 
@@ -2399,7 +2399,7 @@ L 153.654726 173.470231
 L 153.156955 173.927574 
 L 152.659184 174.381084 
 L 152.161413 174.830826 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.830826 
@@ -2451,7 +2451,7 @@ L 147.060283 185.961812
 L 146.946925 186.184927 
 L 146.833566 186.407126 
 L 146.720208 186.628416 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.628416 
@@ -2503,7 +2503,7 @@ L 144.164409 195.79469
 L 144.107613 195.981745 
 L 144.050817 196.168156 
 L 143.994022 196.353927 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.353927 
@@ -2555,30 +2555,30 @@ L 142.749036 200.0341
 L 142.72137 200.113105 
 L 142.693704 200.191995 
 L 142.666037 200.270771 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m38f07fca3b" d="M -0 3.535534 
+     <path id="m0b88ad2f0c" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p38dff6dda8)">
-     <use xlink:href="#m38f07fca3b" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m38f07fca3b" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc10a72b880)">
+     <use xlink:href="#m0b88ad2f0c" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0b88ad2f0c" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.665392
 L 244.888911 79.95196 
 L 243.864032 80.237018 
 L 242.839153 80.520583 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.520583 
@@ -2683,7 +2683,7 @@ L 219.787941 85.73042
 L 219.275692 85.840684 
 L 218.763443 85.950723 
 L 218.251194 86.060539 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.060539 
@@ -2735,7 +2735,7 @@ L 199.092247 89.895187
 L 198.666492 89.97739 
 L 198.240738 90.059468 
 L 197.814984 90.141422 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.141422 
@@ -2787,7 +2787,7 @@ L 168.343148 98.26681
 L 167.688219 98.434213 
 L 167.033289 98.601101 
 L 166.378359 98.767475 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 98.767475 
@@ -2839,7 +2839,7 @@ L 147.11464 109.552827
 L 146.686557 109.769695 
 L 146.258475 109.985696 
 L 145.830392 110.20084 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.20084 
@@ -2891,7 +2891,7 @@ L 135.300472 124.91473
 L 135.066474 125.20027 
 L 134.832476 125.484312 
 L 134.598477 125.76687 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 125.76687 
@@ -2943,7 +2943,7 @@ L 124.734843 147.930147
 L 124.515652 148.332777 
 L 124.29646 148.732435 
 L 124.077268 149.129162 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.129162 
@@ -2995,7 +2995,7 @@ L 122.56387 156.732863
 L 122.530239 156.890271 
 L 122.496607 157.047223 
 L 122.462976 157.203722 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.203722 
@@ -3047,7 +3047,7 @@ L 83.602758 217.017639
 L 82.739198 217.816123 
 L 81.875637 218.602997 
 L 81.012077 219.378594 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 219.378594 
@@ -3099,7 +3099,7 @@ L 77.665842 237.784894
 L 77.591481 238.130517 
 L 77.517121 238.473948 
 L 77.44276 238.815213 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 238.815213 
@@ -3151,23 +3151,23 @@ L 76.984008 251.144668
 L 76.973814 251.389134 
 L 76.96362 251.6325 
 L 76.953425 251.874777 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m1a753a509c" d="M -0 2.5 
+     <path id="m317fea0982" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p38dff6dda8)">
-     <use xlink:href="#m1a753a509c" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc10a72b880)">
+     <use xlink:href="#m317fea0982" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="md2f24347e7" d="M -0.833333 2.5 
+     <path id="m6afcad57c9" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p38dff6dda8)">
-     <use xlink:href="#md2f24347e7" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md2f24347e7" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md2f24347e7" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md2f24347e7" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md2f24347e7" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md2f24347e7" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md2f24347e7" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md2f24347e7" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md2f24347e7" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc10a72b880)">
+     <use xlink:href="#m6afcad57c9" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6afcad57c9" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6afcad57c9" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6afcad57c9" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6afcad57c9" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6afcad57c9" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6afcad57c9" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6afcad57c9" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6afcad57c9" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 117.229073
 L 306.11717 117.494902 
 L 303.36982 117.759433 
 L 300.62247 118.022676 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 118.022676 
@@ -3296,7 +3296,7 @@ L 269.071051 125.234719
 L 268.369908 125.384559 
 L 267.668766 125.533985 
 L 266.967623 125.683 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 125.683 
@@ -3348,7 +3348,7 @@ L 228.598863 126.122913
 L 227.746224 126.132648 
 L 226.893585 126.142382 
 L 226.040946 126.152114 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 126.152114 
@@ -3400,7 +3400,7 @@ L 183.801673 143.118416
 L 182.863022 143.441102 
 L 181.924372 143.761876 
 L 180.985721 144.080759 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 144.080759 
@@ -3452,7 +3452,7 @@ L 165.475826 157.662961
 L 165.131161 157.929236 
 L 164.786497 158.194207 
 L 164.441833 158.457887 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 158.457887 
@@ -3504,7 +3504,7 @@ L 158.178848 166.505572
 L 158.03967 166.671493 
 L 157.900493 166.836907 
 L 157.761315 167.001817 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 167.001817 
@@ -3556,7 +3556,7 @@ L 151.674847 180.456413
 L 151.539592 180.720489 
 L 151.404337 180.983284 
 L 151.269082 181.244808 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 181.244808 
@@ -3608,11 +3608,11 @@ L 150.385962 186.640888
 L 150.366337 186.754896 
 L 150.346712 186.868665 
 L 150.327087 186.982195 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m2e594971e5" d="M -1.25 2.5 
+     <path id="ma043a0ae35" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p38dff6dda8)">
-     <use xlink:href="#m2e594971e5" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e594971e5" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e594971e5" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e594971e5" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e594971e5" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e594971e5" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e594971e5" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e594971e5" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e594971e5" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc10a72b880)">
+     <use xlink:href="#ma043a0ae35" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma043a0ae35" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma043a0ae35" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma043a0ae35" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma043a0ae35" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma043a0ae35" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma043a0ae35" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma043a0ae35" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma043a0ae35" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 141.492222
 L 276.351005 141.626293 
 L 274.857964 141.760033 
 L 273.364924 141.893443 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 141.893443 
@@ -3741,7 +3741,7 @@ L 242.760262 147.575596
 L 242.080158 147.695331 
 L 241.400055 147.814802 
 L 240.719951 147.934009 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 147.934009 
@@ -3793,7 +3793,7 @@ L 222.564351 152.930779
 L 222.160893 153.036743 
 L 221.757435 153.142499 
 L 221.353978 153.24805 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 153.24805 
@@ -3845,7 +3845,7 @@ L 208.018647 155.070715
 L 207.722306 155.110529 
 L 207.425965 155.150315 
 L 207.129625 155.190071 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 155.190071 
@@ -3897,7 +3897,7 @@ L 182.693853 166.038872
 L 182.150836 166.256889 
 L 181.607819 166.474032 
 L 181.064802 166.690306 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.690306 
@@ -3949,7 +3949,7 @@ L 179.393584 170.067361
 L 179.356445 170.140065 
 L 179.319307 170.21267 
 L 179.282169 170.285179 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.285179 
@@ -4001,7 +4001,7 @@ L 177.817012 175.338922
 L 177.784453 175.446037 
 L 177.751894 175.552941 
 L 177.719335 175.659634 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.659634 
@@ -4053,11 +4053,11 @@ L 177.648651 180.712426
 L 177.64708 180.819522 
 L 177.645509 180.926407 
 L 177.643939 181.03308 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mdda079545e" d="M 0 -2.5 
+     <path id="m36d6c11f60" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p38dff6dda8)">
-     <use xlink:href="#mdda079545e" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdda079545e" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdda079545e" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdda079545e" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdda079545e" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdda079545e" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdda079545e" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdda079545e" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mdda079545e" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pc10a72b880)">
+     <use xlink:href="#m36d6c11f60" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m36d6c11f60" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m36d6c11f60" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m36d6c11f60" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m36d6c11f60" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m36d6c11f60" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m36d6c11f60" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m36d6c11f60" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m36d6c11f60" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.101113
 L 226.871027 113.101614 
 L 226.871027 113.102116 
 L 226.871027 113.102618 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.102618 
@@ -4184,7 +4184,7 @@ L 226.871027 113.241886
 L 226.871027 113.244976 
 L 226.871027 113.248067 
 L 226.871027 113.251157 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.251157 
@@ -4236,7 +4236,7 @@ L 226.871027 113.165529
 L 226.871027 113.163625 
 L 226.871027 113.16172 
 L 226.871027 113.159816 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.159816 
@@ -4288,7 +4288,7 @@ L 180.837336 131.090576
 L 179.814365 131.428693 
 L 178.791394 131.764711 
 L 177.768423 132.098656 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.098656 
@@ -4340,7 +4340,7 @@ L 161.462117 144.555386
 L 161.099755 144.802091 
 L 160.737393 145.047676 
 L 160.37503 145.292152 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.292152 
@@ -4392,7 +4392,7 @@ L 154.394483 152.007915
 L 154.261581 152.148084 
 L 154.12868 152.287891 
 L 153.995779 152.427338 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.427338 
@@ -4444,7 +4444,7 @@ L 147.537442 166.80191
 L 147.393924 167.081716 
 L 147.250405 167.360084 
 L 147.106887 167.637027 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 167.637027 
@@ -4496,11 +4496,11 @@ L 145.948902 174.483819
 L 145.923169 174.626551 
 L 145.897436 174.768906 
 L 145.871703 174.910889 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m940f081ffc" d="M 0 -2.5 
+     <path id="mca8a872d8f" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p38dff6dda8)">
-     <use xlink:href="#m940f081ffc" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940f081ffc" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940f081ffc" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940f081ffc" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940f081ffc" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940f081ffc" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940f081ffc" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940f081ffc" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m940f081ffc" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pc10a72b880)">
+     <use xlink:href="#mca8a872d8f" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca8a872d8f" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca8a872d8f" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca8a872d8f" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca8a872d8f" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca8a872d8f" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca8a872d8f" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca8a872d8f" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mca8a872d8f" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 176.312658
 L 529.583102 176.354957 
 L 528.363847 176.397222 
 L 527.144592 176.439455 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 176.439455 
@@ -4623,7 +4623,7 @@ L 461.70225 184.0537
 L 460.247976 184.211312 
 L 458.793701 184.368466 
 L 457.339427 184.525165 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 184.525165 
@@ -4675,7 +4675,7 @@ L 302.450749 179.565773
 L 299.008779 179.450234 
 L 295.566808 179.334447 
 L 292.124837 179.218412 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 179.218412 
@@ -4727,7 +4727,7 @@ L 246.191563 190.241103
 L 245.170823 190.462265 
 L 244.150084 190.682527 
 L 243.129344 190.901895 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.901895 
@@ -4779,7 +4779,7 @@ L 215.390639 204.06672
 L 214.774224 204.325785 
 L 214.157808 204.583617 
 L 213.541392 204.840226 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.840226 
@@ -4831,7 +4831,7 @@ L 205.113797 212.010949
 L 204.926517 212.159987 
 L 204.739237 212.308616 
 L 204.551957 212.456838 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.456838 
@@ -4883,7 +4883,7 @@ L 196.403329 227.996875
 L 196.222248 228.296222 
 L 196.041168 228.593923 
 L 195.860087 228.889995 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.889995 
@@ -4935,7 +4935,7 @@ L 194.134867 234.076634
 L 194.096529 234.18643 
 L 194.058191 234.296004 
 L 194.019853 234.405357 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m36bd3f3e0e" d="M 0 3.5 
+      <path id="m9d8fc0dd86" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m36bd3f3e0e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m9d8fc0dd86" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m6aa231fb8e" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3b5681f79c" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#me3b4a775c3" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m60a723ac56" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m38f07fca3b" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0b88ad2f0c" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m1a753a509c" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m317fea0982" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#md2f24347e7" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6afcad57c9" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m2e594971e5" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma043a0ae35" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mdda079545e" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m36d6c11f60" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m940f081ffc" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mca8a872d8f" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p38dff6dda8)">
-     <use xlink:href="#m36bd3f3e0e" x="319.643112" y="132.599674" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36bd3f3e0e" x="269.129958" y="146.881872" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36bd3f3e0e" x="247.452898" y="151.513043" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36bd3f3e0e" x="199.905291" y="166.166926" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36bd3f3e0e" x="190.316224" y="178.363509" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36bd3f3e0e" x="165.455859" y="195.458865" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36bd3f3e0e" x="159.141659" y="203.826994" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36bd3f3e0e" x="158.180344" y="207.769828" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36bd3f3e0e" x="128.707405" y="299.239283" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36bd3f3e0e" x="99.149529" y="327.988146" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pc10a72b880)">
+     <use xlink:href="#m9d8fc0dd86" x="319.643112" y="127.852422" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9d8fc0dd86" x="269.129958" y="143.805013" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9d8fc0dd86" x="247.452898" y="148.851395" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9d8fc0dd86" x="199.905291" y="164.38653" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9d8fc0dd86" x="190.316224" y="176.916085" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9d8fc0dd86" x="165.455859" y="194.361902" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9d8fc0dd86" x="159.141659" y="202.809166" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9d8fc0dd86" x="158.180344" y="206.732528" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9d8fc0dd86" x="128.707405" y="298.618827" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m9d8fc0dd86" x="99.149529" y="327.941172" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 132.599674 
-L 318.590755 132.93911 
-L 317.538397 133.276429 
-L 316.48604 133.61166 
-L 315.433682 133.944826 
-L 314.381325 134.275954 
-L 313.328968 134.605068 
-L 312.27661 134.932193 
-L 311.224253 135.257352 
-L 310.171896 135.58057 
-L 309.119538 135.901868 
-L 308.067181 136.22127 
-L 307.014823 136.538799 
-L 305.962466 136.854475 
-L 304.910109 137.16832 
-L 303.857751 137.480356 
-L 302.805394 137.790603 
-L 301.753037 138.099081 
-L 300.700679 138.405811 
-L 299.648322 138.710813 
-L 298.595965 139.014105 
-L 297.543607 139.315707 
-L 296.49125 139.615637 
-L 295.438892 139.913914 
-L 294.386535 140.210557 
-L 293.334178 140.505582 
-L 292.28182 140.799007 
-L 291.229463 141.090851 
-L 290.177106 141.381128 
-L 289.124748 141.669858 
-L 288.072391 141.957054 
-L 287.020033 142.242735 
-L 285.967676 142.526916 
-L 284.915319 142.809612 
-L 283.862961 143.09084 
-L 282.810604 143.370613 
-L 281.758247 143.648948 
-L 280.705889 143.925858 
-L 279.653532 144.201359 
-L 278.601175 144.475464 
-L 277.548817 144.748188 
-L 276.49646 145.019544 
-L 275.444102 145.289547 
-L 274.391745 145.558209 
-L 273.339388 145.825544 
-L 272.28703 146.091565 
-L 271.234673 146.356285 
-L 270.182316 146.619716 
-L 269.129958 146.881872 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 127.852422 
+L 318.590755 128.237566 
+L 317.538397 128.619989 
+L 316.48604 128.999729 
+L 315.433682 129.376822 
+L 314.381325 129.751306 
+L 313.328968 130.123217 
+L 312.27661 130.492589 
+L 311.224253 130.859457 
+L 310.171896 131.223855 
+L 309.119538 131.585816 
+L 308.067181 131.945372 
+L 307.014823 132.302555 
+L 305.962466 132.657396 
+L 304.910109 133.009925 
+L 303.857751 133.360173 
+L 302.805394 133.708169 
+L 301.753037 134.053941 
+L 300.700679 134.397518 
+L 299.648322 134.738928 
+L 298.595965 135.078197 
+L 297.543607 135.415353 
+L 296.49125 135.750421 
+L 295.438892 136.083427 
+L 294.386535 136.414397 
+L 293.334178 136.743355 
+L 292.28182 137.070326 
+L 291.229463 137.395333 
+L 290.177106 137.7184 
+L 289.124748 138.03955 
+L 288.072391 138.358805 
+L 287.020033 138.676188 
+L 285.967676 138.99172 
+L 284.915319 139.305423 
+L 283.862961 139.617319 
+L 282.810604 139.927427 
+L 281.758247 140.235768 
+L 280.705889 140.542363 
+L 279.653532 140.84723 
+L 278.601175 141.15039 
+L 277.548817 141.451861 
+L 276.49646 141.751661 
+L 275.444102 142.04981 
+L 274.391745 142.346326 
+L 273.339388 142.641226 
+L 272.28703 142.934527 
+L 271.234673 143.226248 
+L 270.182316 143.516404 
+L 269.129958 143.805013 
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 146.881872 
-L 268.678353 146.982509 
-L 268.226747 147.08296 
-L 267.775142 147.183225 
-L 267.323537 147.283304 
-L 266.871931 147.383199 
-L 266.420326 147.482909 
-L 265.96872 147.582437 
-L 265.517115 147.681781 
-L 265.065509 147.780944 
-L 264.613904 147.879925 
-L 264.162299 147.978725 
-L 263.710693 148.077345 
-L 263.259088 148.175786 
-L 262.807482 148.274049 
-L 262.355877 148.372133 
-L 261.904271 148.47004 
-L 261.452666 148.567769 
-L 261.001061 148.665323 
-L 260.549455 148.762701 
-L 260.09785 148.859905 
-L 259.646244 148.956934 
-L 259.194639 149.053789 
-L 258.743034 149.150471 
-L 258.291428 149.246981 
-L 257.839823 149.343319 
-L 257.388217 149.439486 
-L 256.936612 149.535483 
-L 256.485006 149.631309 
-L 256.033401 149.726966 
-L 255.581796 149.822454 
-L 255.13019 149.917774 
-L 254.678585 150.012927 
-L 254.226979 150.107912 
-L 253.775374 150.202731 
-L 253.323769 150.297384 
-L 252.872163 150.391872 
-L 252.420558 150.486195 
-L 251.968952 150.580354 
-L 251.517347 150.67435 
-L 251.065741 150.768183 
-L 250.614136 150.861853 
-L 250.162531 150.955361 
-L 249.710925 151.048708 
-L 249.25932 151.141894 
-L 248.807714 151.234921 
-L 248.356109 151.327787 
-L 247.904503 151.420494 
-L 247.452898 151.513043 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 143.805013 
+L 268.678353 143.915092 
+L 268.226747 144.024947 
+L 267.775142 144.134579 
+L 267.323537 144.24399 
+L 266.871931 144.35318 
+L 266.420326 144.462151 
+L 265.96872 144.570902 
+L 265.517115 144.679435 
+L 265.065509 144.787751 
+L 264.613904 144.895851 
+L 264.162299 145.003735 
+L 263.710693 145.111405 
+L 263.259088 145.21886 
+L 262.807482 145.326103 
+L 262.355877 145.433134 
+L 261.904271 145.539953 
+L 261.452666 145.646562 
+L 261.001061 145.752962 
+L 260.549455 145.859153 
+L 260.09785 145.965135 
+L 259.646244 146.070911 
+L 259.194639 146.17648 
+L 258.743034 146.281844 
+L 258.291428 146.387003 
+L 257.839823 146.491958 
+L 257.388217 146.59671 
+L 256.936612 146.701259 
+L 256.485006 146.805607 
+L 256.033401 146.909754 
+L 255.581796 147.013701 
+L 255.13019 147.117449 
+L 254.678585 147.220998 
+L 254.226979 147.32435 
+L 253.775374 147.427504 
+L 253.323769 147.530463 
+L 252.872163 147.633225 
+L 252.420558 147.735793 
+L 251.968952 147.838167 
+L 251.517347 147.940348 
+L 251.065741 148.042336 
+L 250.614136 148.144133 
+L 250.162531 148.245738 
+L 249.710925 148.347153 
+L 249.25932 148.448378 
+L 248.807714 148.549414 
+L 248.356109 148.650262 
+L 247.904503 148.750922 
+L 247.452898 148.851395 
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 151.513043 
-L 246.462323 151.862531 
-L 245.471748 152.209777 
-L 244.481173 152.554808 
-L 243.490597 152.897654 
-L 242.500022 153.238342 
-L 241.509447 153.576898 
-L 240.518872 153.913349 
-L 239.528297 154.247722 
-L 238.537722 154.580041 
-L 237.547147 154.910332 
-L 236.556571 155.23862 
-L 235.565996 155.564928 
-L 234.575421 155.889281 
-L 233.584846 156.211701 
-L 232.594271 156.532211 
-L 231.603696 156.850835 
-L 230.613121 157.167594 
-L 229.622545 157.482509 
-L 228.63197 157.795603 
-L 227.641395 158.106895 
-L 226.65082 158.416407 
-L 225.660245 158.72416 
-L 224.66967 159.030172 
-L 223.679095 159.334463 
-L 222.688519 159.637053 
-L 221.697944 159.937961 
-L 220.707369 160.237204 
-L 219.716794 160.534802 
-L 218.726219 160.830773 
-L 217.735644 161.125134 
-L 216.745069 161.417902 
-L 215.754493 161.709095 
-L 214.763918 161.99873 
-L 213.773343 162.286823 
-L 212.782768 162.57339 
-L 211.792193 162.858448 
-L 210.801618 163.142012 
-L 209.811043 163.424098 
-L 208.820467 163.704722 
-L 207.829892 163.983898 
-L 206.839317 164.261641 
-L 205.848742 164.537966 
-L 204.858167 164.812887 
-L 203.867592 165.086419 
-L 202.877017 165.358575 
-L 201.886441 165.629369 
-L 200.895866 165.898815 
-L 199.905291 166.166926 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 148.851395 
+L 246.462323 149.224987 
+L 245.471748 149.596018 
+L 244.481173 149.964523 
+L 243.490597 150.330535 
+L 242.500022 150.694088 
+L 241.509447 151.055216 
+L 240.518872 151.413949 
+L 239.528297 151.77032 
+L 238.537722 152.12436 
+L 237.547147 152.476099 
+L 236.556571 152.825567 
+L 235.565996 153.172792 
+L 234.575421 153.517804 
+L 233.584846 153.86063 
+L 232.594271 154.201298 
+L 231.603696 154.539835 
+L 230.613121 154.876268 
+L 229.622545 155.210622 
+L 228.63197 155.542923 
+L 227.641395 155.873196 
+L 226.65082 156.201466 
+L 225.660245 156.527756 
+L 224.66967 156.852091 
+L 223.679095 157.174494 
+L 222.688519 157.494987 
+L 221.697944 157.813594 
+L 220.707369 158.130336 
+L 219.716794 158.445235 
+L 218.726219 158.758312 
+L 217.735644 159.069588 
+L 216.745069 159.379085 
+L 215.754493 159.686821 
+L 214.763918 159.992817 
+L 213.773343 160.297093 
+L 212.782768 160.599668 
+L 211.792193 160.900561 
+L 210.801618 161.199789 
+L 209.811043 161.497373 
+L 208.820467 161.793329 
+L 207.829892 162.087675 
+L 206.839317 162.380429 
+L 205.848742 162.671608 
+L 204.858167 162.961229 
+L 203.867592 163.249308 
+L 202.877017 163.535861 
+L 201.886441 163.820906 
+L 200.895866 164.104457 
+L 199.905291 164.38653 
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 199.905291 166.166926 
-L 199.705519 166.451184 
-L 199.505747 166.733957 
-L 199.305974 167.01526 
-L 199.106202 167.295108 
-L 198.90643 167.573516 
-L 198.706658 167.8505 
-L 198.506885 168.126073 
-L 198.307113 168.40025 
-L 198.107341 168.673045 
-L 197.907569 168.944472 
-L 197.707797 169.214545 
-L 197.508024 169.483276 
-L 197.308252 169.750679 
-L 197.10848 170.016768 
-L 196.908708 170.281555 
-L 196.708935 170.545052 
-L 196.509163 170.807273 
-L 196.309391 171.06823 
-L 196.109619 171.327934 
-L 195.909846 171.586397 
-L 195.710074 171.843633 
-L 195.510302 172.099651 
-L 195.31053 172.354464 
-L 195.110758 172.608083 
-L 194.910985 172.860519 
-L 194.711213 173.111782 
-L 194.511441 173.361885 
-L 194.311669 173.610837 
-L 194.111896 173.858649 
-L 193.912124 174.105332 
-L 193.712352 174.350895 
-L 193.51258 174.595349 
-L 193.312807 174.838703 
-L 193.113035 175.080969 
-L 192.913263 175.322154 
-L 192.713491 175.56227 
-L 192.513719 175.801325 
-L 192.313946 176.039328 
-L 192.114174 176.27629 
-L 191.914402 176.512218 
-L 191.71463 176.747123 
-L 191.514857 176.981012 
-L 191.315085 177.213895 
-L 191.115313 177.445779 
-L 190.915541 177.676675 
-L 190.715768 177.906589 
-L 190.515996 178.135531 
-L 190.316224 178.363509 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.905291 164.38653 
+L 199.705519 164.679458 
+L 199.505747 164.97081 
+L 199.305974 165.260602 
+L 199.106202 165.54885 
+L 198.90643 165.835571 
+L 198.706658 166.120781 
+L 198.506885 166.404496 
+L 198.307113 166.686731 
+L 198.107341 166.967502 
+L 197.907569 167.246824 
+L 197.707797 167.524711 
+L 197.508024 167.801179 
+L 197.308252 168.076242 
+L 197.10848 168.349914 
+L 196.908708 168.622208 
+L 196.708935 168.89314 
+L 196.509163 169.162722 
+L 196.309391 169.430968 
+L 196.109619 169.69789 
+L 195.909846 169.963503 
+L 195.710074 170.227819 
+L 195.510302 170.490849 
+L 195.31053 170.752608 
+L 195.110758 171.013106 
+L 194.910985 171.272357 
+L 194.711213 171.530372 
+L 194.511441 171.787162 
+L 194.311669 172.04274 
+L 194.111896 172.297116 
+L 193.912124 172.550303 
+L 193.712352 172.80231 
+L 193.51258 173.053149 
+L 193.312807 173.302831 
+L 193.113035 173.551367 
+L 192.913263 173.798766 
+L 192.713491 174.045039 
+L 192.513719 174.290197 
+L 192.313946 174.534249 
+L 192.114174 174.777206 
+L 191.914402 175.019076 
+L 191.71463 175.259871 
+L 191.514857 175.499599 
+L 191.315085 175.738269 
+L 191.115313 175.975892 
+L 190.915541 176.212476 
+L 190.715768 176.44803 
+L 190.515996 176.682563 
+L 190.316224 176.916085 
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 190.316224 178.363509 
-L 189.7983 178.780724 
-L 189.280375 179.194747 
-L 188.762451 179.605627 
-L 188.244527 180.013411 
-L 187.726603 180.418145 
-L 187.208678 180.819875 
-L 186.690754 181.218645 
-L 186.17283 181.614497 
-L 185.654906 182.007476 
-L 185.136981 182.397621 
-L 184.619057 182.784974 
-L 184.101133 183.169574 
-L 183.583208 183.55146 
-L 183.065284 183.93067 
-L 182.54736 184.307242 
-L 182.029436 184.681211 
-L 181.511511 185.052614 
-L 180.993587 185.421486 
-L 180.475663 185.78786 
-L 179.957739 186.15177 
-L 179.439814 186.51325 
-L 178.92189 186.872331 
-L 178.403966 187.229046 
-L 177.886041 187.583425 
-L 177.368117 187.935498 
-L 176.850193 188.285296 
-L 176.332269 188.632847 
-L 175.814344 188.97818 
-L 175.29642 189.321324 
-L 174.778496 189.662306 
-L 174.260572 190.001152 
-L 173.742647 190.337891 
-L 173.224723 190.672547 
-L 172.706799 191.005146 
-L 172.188874 191.335714 
-L 171.67095 191.664275 
-L 171.153026 191.990853 
-L 170.635102 192.315472 
-L 170.117177 192.638156 
-L 169.599253 192.958927 
-L 169.081329 193.277808 
-L 168.563404 193.594821 
-L 168.04548 193.909988 
-L 167.527556 194.22333 
-L 167.009632 194.534868 
-L 166.491707 194.844623 
-L 165.973783 195.152616 
-L 165.455859 195.458865 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 190.316224 176.916085 
+L 189.7983 177.343268 
+L 189.280375 177.767105 
+L 188.762451 178.187649 
+L 188.244527 178.60495 
+L 187.726603 179.019058 
+L 187.208678 179.430022 
+L 186.690754 179.837888 
+L 186.17283 180.242703 
+L 185.654906 180.644512 
+L 185.136981 181.043361 
+L 184.619057 181.439291 
+L 184.101133 181.832345 
+L 183.583208 182.222566 
+L 183.065284 182.609993 
+L 182.54736 182.994666 
+L 182.029436 183.376624 
+L 181.511511 183.755906 
+L 180.993587 184.132547 
+L 180.475663 184.506586 
+L 179.957739 184.878057 
+L 179.439814 185.246996 
+L 178.92189 185.613436 
+L 178.403966 185.977412 
+L 177.886041 186.338956 
+L 177.368117 186.698102 
+L 176.850193 187.054879 
+L 176.332269 187.40932 
+L 175.814344 187.761454 
+L 175.29642 188.111312 
+L 174.778496 188.458923 
+L 174.260572 188.804316 
+L 173.742647 189.147518 
+L 173.224723 189.488557 
+L 172.706799 189.82746 
+L 172.188874 190.164255 
+L 171.67095 190.498966 
+L 171.153026 190.83162 
+L 170.635102 191.162242 
+L 170.117177 191.490856 
+L 169.599253 191.817487 
+L 169.081329 192.142158 
+L 168.563404 192.464894 
+L 168.04548 192.785716 
+L 167.527556 193.104647 
+L 167.009632 193.421709 
+L 166.491707 193.736925 
+L 165.973783 194.050316 
+L 165.455859 194.361902 
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 165.455859 195.458865 
-L 165.324313 195.647074 
-L 165.192767 195.834631 
-L 165.061221 196.02154 
-L 164.929675 196.207806 
-L 164.79813 196.393433 
-L 164.666584 196.578426 
-L 164.535038 196.762788 
-L 164.403492 196.946524 
-L 164.271946 197.129639 
-L 164.1404 197.312136 
-L 164.008855 197.49402 
-L 163.877309 197.675295 
-L 163.745763 197.855964 
-L 163.614217 198.036032 
-L 163.482671 198.215503 
-L 163.351125 198.394381 
-L 163.21958 198.57267 
-L 163.088034 198.750373 
-L 162.956488 198.927495 
-L 162.824942 199.104038 
-L 162.693396 199.280008 
-L 162.56185 199.455407 
-L 162.430305 199.63024 
-L 162.298759 199.80451 
-L 162.167213 199.97822 
-L 162.035667 200.151375 
-L 161.904121 200.323977 
-L 161.772575 200.496031 
-L 161.64103 200.667539 
-L 161.509484 200.838506 
-L 161.377938 201.008934 
-L 161.246392 201.178827 
-L 161.114846 201.348189 
-L 160.9833 201.517022 
-L 160.851754 201.68533 
-L 160.720209 201.853116 
-L 160.588663 202.020384 
-L 160.457117 202.187136 
-L 160.325571 202.353376 
-L 160.194025 202.519107 
-L 160.062479 202.684332 
-L 159.930934 202.849054 
-L 159.799388 203.013276 
-L 159.667842 203.177001 
-L 159.536296 203.340233 
-L 159.40475 203.502974 
-L 159.273204 203.665227 
-L 159.141659 203.826994 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.455859 194.361902 
+L 165.324313 194.55203 
+L 165.192767 194.741493 
+L 165.061221 194.930295 
+L 164.929675 195.11844 
+L 164.79813 195.305933 
+L 164.666584 195.49278 
+L 164.535038 195.678983 
+L 164.403492 195.864548 
+L 164.271946 196.049478 
+L 164.1404 196.233779 
+L 164.008855 196.417454 
+L 163.877309 196.600509 
+L 163.745763 196.782946 
+L 163.614217 196.96477 
+L 163.482671 197.145985 
+L 163.351125 197.326595 
+L 163.21958 197.506605 
+L 163.088034 197.686018 
+L 162.956488 197.864838 
+L 162.824942 198.043069 
+L 162.693396 198.220716 
+L 162.56185 198.39778 
+L 162.430305 198.574268 
+L 162.298759 198.750182 
+L 162.167213 198.925526 
+L 162.035667 199.100303 
+L 161.904121 199.274518 
+L 161.772575 199.448174 
+L 161.64103 199.621275 
+L 161.509484 199.793823 
+L 161.377938 199.965823 
+L 161.246392 200.137279 
+L 161.114846 200.308192 
+L 160.9833 200.478568 
+L 160.851754 200.648409 
+L 160.720209 200.817719 
+L 160.588663 200.9865 
+L 160.457117 201.154757 
+L 160.325571 201.322493 
+L 160.194025 201.48971 
+L 160.062479 201.656412 
+L 159.930934 201.822602 
+L 159.799388 201.988283 
+L 159.667842 202.153459 
+L 159.536296 202.318132 
+L 159.40475 202.482305 
+L 159.273204 202.645982 
+L 159.141659 202.809166 
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 159.141659 203.826994 
-L 159.121631 203.912136 
-L 159.101604 203.997144 
-L 159.081576 204.082018 
-L 159.061549 204.16676 
-L 159.041522 204.251369 
-L 159.021494 204.335846 
-L 159.001467 204.420192 
-L 158.98144 204.504406 
-L 158.961412 204.588489 
-L 158.941385 204.672442 
-L 158.921357 204.756265 
-L 158.90133 204.839959 
-L 158.881303 204.923523 
-L 158.861275 205.006958 
-L 158.841248 205.090265 
-L 158.82122 205.173443 
-L 158.801193 205.256494 
-L 158.781166 205.339418 
-L 158.761138 205.422215 
-L 158.741111 205.504886 
-L 158.721084 205.58743 
-L 158.701056 205.669849 
-L 158.681029 205.752142 
-L 158.661001 205.83431 
-L 158.640974 205.916354 
-L 158.620947 205.998274 
-L 158.600919 206.08007 
-L 158.580892 206.161742 
-L 158.560865 206.243291 
-L 158.540837 206.324718 
-L 158.52081 206.406022 
-L 158.500782 206.487205 
-L 158.480755 206.568265 
-L 158.460728 206.649205 
-L 158.4407 206.730024 
-L 158.420673 206.810722 
-L 158.400645 206.8913 
-L 158.380618 206.971758 
-L 158.360591 207.052097 
-L 158.340563 207.132316 
-L 158.320536 207.212417 
-L 158.300509 207.2924 
-L 158.280481 207.372264 
-L 158.260454 207.452011 
-L 158.240426 207.53164 
-L 158.220399 207.611153 
-L 158.200372 207.690549 
-L 158.180344 207.769828 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.141659 202.809166 
+L 159.121631 202.893872 
+L 159.101604 202.978446 
+L 159.081576 203.062887 
+L 159.061549 203.147198 
+L 159.041522 203.231377 
+L 159.021494 203.315425 
+L 159.001467 203.399343 
+L 158.98144 203.483131 
+L 158.961412 203.56679 
+L 158.941385 203.650319 
+L 158.921357 203.73372 
+L 158.90133 203.816992 
+L 158.881303 203.900137 
+L 158.861275 203.983153 
+L 158.841248 204.066043 
+L 158.82122 204.148806 
+L 158.801193 204.231443 
+L 158.781166 204.313953 
+L 158.761138 204.396338 
+L 158.741111 204.478598 
+L 158.721084 204.560733 
+L 158.701056 204.642744 
+L 158.681029 204.72463 
+L 158.661001 204.806393 
+L 158.640974 204.888032 
+L 158.620947 204.969548 
+L 158.600919 205.050942 
+L 158.580892 205.132214 
+L 158.560865 205.213363 
+L 158.540837 205.294392 
+L 158.52081 205.375299 
+L 158.500782 205.456085 
+L 158.480755 205.536751 
+L 158.460728 205.617296 
+L 158.4407 205.697723 
+L 158.420673 205.778029 
+L 158.400645 205.858217 
+L 158.380618 205.938286 
+L 158.360591 206.018237 
+L 158.340563 206.09807 
+L 158.320536 206.177785 
+L 158.300509 206.257383 
+L 158.280481 206.336864 
+L 158.260454 206.416229 
+L 158.240426 206.495477 
+L 158.220399 206.57461 
+L 158.200372 206.653627 
+L 158.180344 206.732528 
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 158.180344 207.769828 
-L 157.566325 212.537386 
-L 156.952305 216.91874 
-L 156.338286 220.971799 
-L 155.724266 224.74235 
-L 155.110246 228.267223 
-L 154.496227 231.576484 
-L 153.882207 234.694997 
-L 153.268188 237.643559 
-L 152.654168 240.439739 
-L 152.040149 243.098517 
-L 151.426129 245.632767 
-L 150.812109 248.053633 
-L 150.19809 250.370828 
-L 149.58407 252.592868 
-L 148.970051 254.727261 
-L 148.356031 256.780659 
-L 147.742012 258.758986 
-L 147.127992 260.667537 
-L 146.513972 262.511068 
-L 145.899953 264.293862 
-L 145.285933 266.019795 
-L 144.671914 267.692383 
-L 144.057894 269.314823 
-L 143.443875 270.890035 
-L 142.829855 272.420693 
-L 142.215835 273.909246 
-L 141.601816 275.357949 
-L 140.987796 276.768881 
-L 140.373777 278.143961 
-L 139.759757 279.484967 
-L 139.145738 280.793545 
-L 138.531718 282.071227 
-L 137.917698 283.31944 
-L 137.303679 284.53951 
-L 136.689659 285.732681 
-L 136.07564 286.900111 
-L 135.46162 288.042889 
-L 134.847601 289.162034 
-L 134.233581 290.258504 
-L 133.619561 291.333199 
-L 133.005542 292.386968 
-L 132.391522 293.420609 
-L 131.777503 294.434878 
-L 131.163483 295.430486 
-L 130.549464 296.408109 
-L 129.935444 297.368385 
-L 129.321424 298.311919 
-L 128.707405 299.239283 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.180344 206.732528 
+L 157.566325 211.543338 
+L 156.952305 215.96119 
+L 156.338286 220.04546 
+L 155.724266 223.843006 
+L 155.110246 227.391459 
+L 154.496227 230.721494 
+L 153.882207 233.858448 
+L 153.268188 236.823489 
+L 152.654168 239.634486 
+L 152.040149 242.306656 
+L 151.426129 244.853069 
+L 150.812109 247.285032 
+L 150.19809 249.612392 
+L 149.58407 251.843777 
+L 148.970051 253.986791 
+L 148.356031 256.048167 
+L 147.742012 258.033898 
+L 147.127992 259.94934 
+L 146.513972 261.799298 
+L 145.899953 263.588103 
+L 145.285933 265.319669 
+L 144.671914 266.997545 
+L 144.057894 268.624961 
+L 143.443875 270.204864 
+L 142.829855 271.73995 
+L 142.215835 273.232691 
+L 141.601816 274.685361 
+L 140.987796 276.100055 
+L 140.373777 277.478708 
+L 139.759757 278.82311 
+L 139.145738 280.134924 
+L 138.531718 281.41569 
+L 137.917698 282.666846 
+L 137.303679 283.889729 
+L 136.689659 285.085588 
+L 136.07564 286.255593 
+L 135.46162 287.400837 
+L 134.847601 288.522348 
+L 134.233581 289.621088 
+L 133.619561 290.697964 
+L 133.005542 291.753829 
+L 132.391522 292.789488 
+L 131.777503 293.805699 
+L 131.163483 294.80318 
+L 130.549464 295.782607 
+L 129.935444 296.744624 
+L 129.321424 297.689838 
+L 128.707405 298.618827 
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 128.707405 299.239283 
-L 128.091616 300.023931 
-L 127.475827 300.797365 
-L 126.860038 301.559901 
-L 126.244249 302.311842 
-L 125.62846 303.053479 
-L 125.01267 303.785089 
-L 124.396881 304.50694 
-L 123.781092 305.21929 
-L 123.165303 305.922385 
-L 122.549514 306.616463 
-L 121.933725 307.301751 
-L 121.317936 307.97847 
-L 120.702147 308.646832 
-L 120.086358 309.30704 
-L 119.470569 309.959291 
-L 118.85478 310.603775 
-L 118.238991 311.240673 
-L 117.623201 311.870164 
-L 117.007412 312.492416 
-L 116.391623 313.107595 
-L 115.775834 313.71586 
-L 115.160045 314.317364 
-L 114.544256 314.912256 
-L 113.928467 315.50068 
-L 113.312678 316.082774 
-L 112.696889 316.658675 
-L 112.0811 317.228511 
-L 111.465311 317.79241 
-L 110.849522 318.350493 
-L 110.233733 318.90288 
-L 109.617943 319.449686 
-L 109.002154 319.991023 
-L 108.386365 320.526998 
-L 107.770576 321.057716 
-L 107.154787 321.583281 
-L 106.538998 322.103791 
-L 105.923209 322.619343 
-L 105.30742 323.130029 
-L 104.691631 323.635941 
-L 104.075842 324.137168 
-L 103.460053 324.633795 
-L 102.844264 325.125906 
-L 102.228474 325.613582 
-L 101.612685 326.096903 
-L 100.996896 326.575946 
-L 100.381107 327.050786 
-L 99.765318 327.521496 
-L 99.149529 327.988146 
-" clip-path="url(#p38dff6dda8)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 128.707405 298.618827 
+L 128.091616 299.423608 
+L 127.475827 300.216596 
+L 126.860038 300.998133 
+L 126.244249 301.768544 
+L 125.62846 302.528141 
+L 125.01267 303.277224 
+L 124.396881 304.01608 
+L 123.781092 304.744984 
+L 123.165303 305.464202 
+L 122.549514 306.173986 
+L 121.933725 306.874582 
+L 121.317936 307.566224 
+L 120.702147 308.249138 
+L 120.086358 308.923542 
+L 119.470569 309.589645 
+L 118.85478 310.247649 
+L 118.238991 310.897749 
+L 117.623201 311.540132 
+L 117.007412 312.174979 
+L 116.391623 312.802465 
+L 115.775834 313.422759 
+L 115.160045 314.036024 
+L 114.544256 314.642417 
+L 113.928467 315.242091 
+L 113.312678 315.835193 
+L 112.696889 316.421866 
+L 112.0811 317.002246 
+L 111.465311 317.576469 
+L 110.849522 318.144662 
+L 110.233733 318.706952 
+L 109.617943 319.26346 
+L 109.002154 319.814303 
+L 108.386365 320.359596 
+L 107.770576 320.89945 
+L 107.154787 321.433971 
+L 106.538998 321.963265 
+L 105.923209 322.487432 
+L 105.30742 323.006571 
+L 104.691631 323.520777 
+L 104.075842 324.030144 
+L 103.460053 324.534761 
+L 102.844264 325.034716 
+L 102.228474 325.530095 
+L 101.612685 326.020981 
+L 100.996896 326.507453 
+L 100.381107 326.989592 
+L 99.765318 327.467474 
+L 99.149529 327.941172 
+" clip-path="url(#pc10a72b880)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-05T03:12:42Z  ·  Linux chungus x86_64  ·  commit 992547a3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.689297 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6177,6 +6177,31 @@ L 1172 0
 L 2766 4134 
 L 525 4134 
 L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
@@ -6201,36 +6226,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6290,6 +6285,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6328,16 +6353,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6376,109 +6401,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p38dff6dda8">
+  <clipPath id="pc10a72b880">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m22305deb48" d="M 0 0 
+       <path id="m5ae47a64f4" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m22305deb48" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ae47a64f4" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m22305deb48" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ae47a64f4" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m22305deb48" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ae47a64f4" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m22305deb48" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ae47a64f4" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m22305deb48" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ae47a64f4" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m22305deb48" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ae47a64f4" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m22305deb48" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5ae47a64f4" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 388.333941 
 L 637.2 388.333941 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m5d80158a03" d="M 0 0 
+       <path id="md0cdf4ad34" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5d80158a03" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md0cdf4ad34" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 264.064771 
 L 637.2 264.064771 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5d80158a03" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md0cdf4ad34" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 264.064771
      <g id="line2d_19">
       <path d="M 49.078125 139.7956 
 L 637.2 139.7956 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m5d80158a03" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md0cdf4ad34" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.7956
      <g id="line2d_21">
       <path d="M 49.078125 407.583479 
 L 637.2 407.583479 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mc8961334f7" d="M 0 0 
+       <path id="m87dd659997" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 400.376868 
 L 637.2 400.376868 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 400.376868
      <g id="line2d_25">
       <path d="M 49.078125 394.020186 
 L 637.2 394.020186 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 394.020186
      <g id="line2d_27">
       <path d="M 49.078125 350.925193 
 L 637.2 350.925193 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 350.925193
      <g id="line2d_29">
       <path d="M 49.078125 329.042478 
 L 637.2 329.042478 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 329.042478
      <g id="line2d_31">
       <path d="M 49.078125 313.516445 
 L 637.2 313.516445 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 313.516445
      <g id="line2d_33">
       <path d="M 49.078125 301.473518 
 L 637.2 301.473518 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 301.473518
      <g id="line2d_35">
       <path d="M 49.078125 291.633731 
 L 637.2 291.633731 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 291.633731
      <g id="line2d_37">
       <path d="M 49.078125 283.314309 
 L 637.2 283.314309 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 283.314309
      <g id="line2d_39">
       <path d="M 49.078125 276.107697 
 L 637.2 276.107697 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 276.107697
      <g id="line2d_41">
       <path d="M 49.078125 269.751016 
 L 637.2 269.751016 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 269.751016
      <g id="line2d_43">
       <path d="M 49.078125 226.656023 
 L 637.2 226.656023 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 226.656023
      <g id="line2d_45">
       <path d="M 49.078125 204.773308 
 L 637.2 204.773308 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 204.773308
      <g id="line2d_47">
       <path d="M 49.078125 189.247275 
 L 637.2 189.247275 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 189.247275
      <g id="line2d_49">
       <path d="M 49.078125 177.204348 
 L 637.2 177.204348 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.204348
      <g id="line2d_51">
       <path d="M 49.078125 167.36456 
 L 637.2 167.36456 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.36456
      <g id="line2d_53">
       <path d="M 49.078125 159.045138 
 L 637.2 159.045138 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.045138
      <g id="line2d_55">
       <path d="M 49.078125 151.838527 
 L 637.2 151.838527 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 151.838527
      <g id="line2d_57">
       <path d="M 49.078125 145.481845 
 L 637.2 145.481845 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.481845
      <g id="line2d_59">
       <path d="M 49.078125 102.386852 
 L 637.2 102.386852 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.386852
      <g id="line2d_61">
       <path d="M 49.078125 80.504138 
 L 637.2 80.504138 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 80.504138
      <g id="line2d_63">
       <path d="M 49.078125 64.978104 
 L 637.2 64.978104 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.978104
      <g id="line2d_65">
       <path d="M 49.078125 52.935177 
 L 637.2 52.935177 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mc8961334f7" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m87dd659997" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p3484e9bc90)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p6219f7c106)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m5b6afb4182" d="M -2.5 2.5 
+     <path id="m8f970b933a" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3484e9bc90)">
-     <use xlink:href="#m5b6afb4182" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b6afb4182" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6219f7c106)">
+     <use xlink:href="#m8f970b933a" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8f970b933a" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m59e107bad2" d="M 0 -2.5 
+     <path id="m1306a2ff0d" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3484e9bc90)">
-     <use xlink:href="#m59e107bad2" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m59e107bad2" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6219f7c106)">
+     <use xlink:href="#m1306a2ff0d" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1306a2ff0d" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m5bd634b558" d="M -0 3.535534 
+     <path id="m7dffaabeb2" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3484e9bc90)">
-     <use xlink:href="#m5bd634b558" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5bd634b558" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6219f7c106)">
+     <use xlink:href="#m7dffaabeb2" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7dffaabeb2" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m6c390a7be6" d="M -0.833333 2.5 
+     <path id="m64f76e5e7e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3484e9bc90)">
-     <use xlink:href="#m6c390a7be6" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6c390a7be6" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6219f7c106)">
+     <use xlink:href="#m64f76e5e7e" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m64f76e5e7e" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m6170ecf341" d="M -1.25 2.5 
+     <path id="md793971399" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3484e9bc90)">
-     <use xlink:href="#m6170ecf341" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6170ecf341" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6219f7c106)">
+     <use xlink:href="#md793971399" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md793971399" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="me9316f0d5d" d="M 0 -2.5 
+     <path id="mbc5824d955" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p3484e9bc90)">
-     <use xlink:href="#me9316f0d5d" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#me9316f0d5d" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p6219f7c106)">
+     <use xlink:href="#mbc5824d955" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc5824d955" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="macdb217ec3" d="M 0 -2.5 
+     <path id="m3d1ccc68e0" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3484e9bc90)">
-     <use xlink:href="#macdb217ec3" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#macdb217ec3" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p6219f7c106)">
+     <use xlink:href="#m3d1ccc68e0" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d1ccc68e0" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m4e118e6710" d="M 0 3.5 
+      <path id="mb27bf6d8d5" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m4e118e6710" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mb27bf6d8d5" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m5b6afb4182" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8f970b933a" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m59e107bad2" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1306a2ff0d" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m5bd634b558" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7dffaabeb2" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m6c390a7be6" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m64f76e5e7e" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m6170ecf341" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md793971399" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#me9316f0d5d" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mbc5824d955" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#macdb217ec3" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3d1ccc68e0" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p3484e9bc90)">
-     <use xlink:href="#m4e118e6710" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m4e118e6710" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p6219f7c106)">
+     <use xlink:href="#mb27bf6d8d5" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mb27bf6d8d5" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3153,7 +3153,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p3484e9bc90">
+  <clipPath id="p6219f7c106">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.571865 308.04375 
 L 290.571865 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mb16130aaf3" d="M 0 0 
+       <path id="m734393cbda" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb16130aaf3" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m734393cbda" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 446.931505 308.04375 
 L 446.931505 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb16130aaf3" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m734393cbda" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.281168 308.04375 
 L 181.281168 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m995cf27d35" d="M 0 0 
+       <path id="m6613a79e38" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m995cf27d35" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.814733 308.04375 
 L 208.814733 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m995cf27d35" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.814733 56.7075
      <g id="line2d_9">
       <path d="M 228.350109 308.04375 
 L 228.350109 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m995cf27d35" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.350109 56.7075
      <g id="line2d_11">
       <path d="M 243.502924 308.04375 
 L 243.502924 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m995cf27d35" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.502924 56.7075
      <g id="line2d_13">
       <path d="M 255.883675 308.04375 
 L 255.883675 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m995cf27d35" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 255.883675 56.7075
      <g id="line2d_15">
       <path d="M 266.351451 308.04375 
 L 266.351451 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m995cf27d35" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.351451 56.7075
      <g id="line2d_17">
       <path d="M 275.419051 308.04375 
 L 275.419051 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m995cf27d35" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.419051 56.7075
      <g id="line2d_19">
       <path d="M 283.417241 308.04375 
 L 283.417241 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m995cf27d35" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.417241 56.7075
      <g id="line2d_21">
       <path d="M 337.640807 308.04375 
 L 337.640807 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m995cf27d35" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.640807 56.7075
      <g id="line2d_23">
       <path d="M 365.174373 308.04375 
 L 365.174373 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m995cf27d35" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.174373 56.7075
      <g id="line2d_25">
       <path d="M 384.709748 308.04375 
 L 384.709748 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m995cf27d35" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 384.709748 56.7075
      <g id="line2d_27">
       <path d="M 399.862563 308.04375 
 L 399.862563 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m995cf27d35" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 399.862563 56.7075
      <g id="line2d_29">
       <path d="M 412.243314 308.04375 
 L 412.243314 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m995cf27d35" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.243314 56.7075
      <g id="line2d_31">
       <path d="M 422.71109 308.04375 
 L 422.71109 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m995cf27d35" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 422.71109 56.7075
      <g id="line2d_33">
       <path d="M 431.77869 308.04375 
 L 431.77869 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m995cf27d35" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 431.77869 56.7075
      <g id="line2d_35">
       <path d="M 439.77688 308.04375 
 L 439.77688 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m995cf27d35" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 439.77688 56.7075
      <g id="line2d_37">
       <path d="M 494.000446 308.04375 
 L 494.000446 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m995cf27d35" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.000446 56.7075
      <g id="line2d_39">
       <path d="M 521.534012 308.04375 
 L 521.534012 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m995cf27d35" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 521.534012 56.7075
      <g id="line2d_41">
       <path d="M 541.069388 308.04375 
 L 541.069388 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m995cf27d35" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.069388 56.7075
      <g id="line2d_43">
       <path d="M 556.222202 308.04375 
 L 556.222202 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m995cf27d35" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m6613a79e38" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m3d1ccf1ab6" d="M 0 0 
+       <path id="m2f30a8814a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f30a8814a" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f30a8814a" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1118,7 +1118,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f30a8814a" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1185,7 +1185,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f30a8814a" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f30a8814a" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f30a8814a" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f30a8814a" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m3d1ccf1ab6" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2f30a8814a" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.513283 296.619375 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 167.187538 263.978304 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 190.461899 231.337232 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 208.409213 198.696161 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.370107 166.055089 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 238.951072 133.414018 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 246.772854 100.772946 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.62053 68.131875 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.351473 308.04375 
 L 542.351473 56.7075 
-" clip-path="url(#pb2327ca0ee)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pbf9ac8bbe7)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1890,7 +1890,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m18045fe7f8" d="M 0 3 
+     <path id="m5911ba52b4" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1902,13 +1902,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pb2327ca0ee)">
-     <use xlink:href="#m18045fe7f8" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#pbf9ac8bbe7)">
+     <use xlink:href="#m5911ba52b4" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="ma184c25b46" d="M 0 3 
+     <path id="m8bac149617" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1920,13 +1920,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#pb2327ca0ee)">
-     <use xlink:href="#ma184c25b46" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#pbf9ac8bbe7)">
+     <use xlink:href="#m8bac149617" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m80da58a543" d="M 0 3 
+     <path id="m3558db4cf4" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1938,13 +1938,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pb2327ca0ee)">
-     <use xlink:href="#m80da58a543" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#pbf9ac8bbe7)">
+     <use xlink:href="#m3558db4cf4" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m861ade60c8" d="M 0 5 
+     <path id="mbe770e11a4" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1956,13 +1956,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pb2327ca0ee)">
-     <use xlink:href="#m861ade60c8" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#pbf9ac8bbe7)">
+     <use xlink:href="#mbe770e11a4" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="mc563981b70" d="M 0 3 
+     <path id="mcff7ce9e75" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1974,13 +1974,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pb2327ca0ee)">
-     <use xlink:href="#mc563981b70" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#pbf9ac8bbe7)">
+     <use xlink:href="#mcff7ce9e75" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m4be366299e" d="M 0 3 
+     <path id="mf1629fdba5" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1992,13 +1992,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pb2327ca0ee)">
-     <use xlink:href="#m4be366299e" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#pbf9ac8bbe7)">
+     <use xlink:href="#mf1629fdba5" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m896ed526e6" d="M 0 3 
+     <path id="mdf368a3ab1" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2010,13 +2010,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pb2327ca0ee)">
-     <use xlink:href="#m896ed526e6" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#pbf9ac8bbe7)">
+     <use xlink:href="#mdf368a3ab1" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="mc2b76e6f27" d="M 0 3 
+     <path id="m0dc75ef315" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2028,8 +2028,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pb2327ca0ee)">
-     <use xlink:href="#mc2b76e6f27" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#pbf9ac8bbe7)">
+     <use xlink:href="#m0dc75ef315" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2883,7 +2883,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pb2327ca0ee">
+  <clipPath id="pbf9ac8bbe7">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pd89ad64c7b)">
+   <g clip-path="url(#pf0fbf30c51)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image70796ca170" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="imageafc72dc6f0" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m134e6dbd42" d="M 0 0 
+       <path id="md16479778b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m134e6dbd42" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m134e6dbd42" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m134e6dbd42" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m134e6dbd42" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m134e6dbd42" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m134e6dbd42" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m134e6dbd42" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m134e6dbd42" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m134e6dbd42" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m134e6dbd42" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m134e6dbd42" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m134e6dbd42" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md16479778b" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m8fb3d4c7bc" d="M 0 0 
+       <path id="m8ed35d801a" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ed35d801a" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ed35d801a" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ed35d801a" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ed35d801a" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ed35d801a" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ed35d801a" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ed35d801a" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m8fb3d4c7bc" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8ed35d801a" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imageba9bd0f962" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagefc4f906a2a" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mb70a97b302" d="M 0 0 
+       <path id="me4fa570737" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb70a97b302" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me4fa570737" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mb70a97b302" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me4fa570737" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mb70a97b302" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me4fa570737" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb70a97b302" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me4fa570737" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mb70a97b302" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me4fa570737" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.688984 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-05T03:12:42Z  ·  Linux chungus x86_64  ·  commit 992547a3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(45.689297 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2868,16 +2868,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2916,109 +2916,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pd89ad64c7b">
+  <clipPath id="pf0fbf30c51">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="569.022031pt" height="386.202469pt" viewBox="0 0 569.022031 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="571.021406pt" height="386.202469pt" viewBox="0 0 571.021406 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 569.022031 386.202469 
-L 569.022031 0 
+L 571.021406 386.202469 
+L 571.021406 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 186.636016 104.1264 
-L 291.261016 104.1264 
-L 291.261016 74.7432 
-L 186.636016 74.7432 
+    <path d="M 187.635703 104.1264 
+L 292.260703 104.1264 
+L 292.260703 74.7432 
+L 187.635703 74.7432 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 291.261016 104.1264 
-L 395.886016 104.1264 
-L 395.886016 74.7432 
-L 291.261016 74.7432 
+    <path d="M 292.260703 104.1264 
+L 396.885703 104.1264 
+L 396.885703 74.7432 
+L 292.260703 74.7432 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 395.886016 104.1264 
-L 500.511016 104.1264 
-L 500.511016 74.7432 
-L 395.886016 74.7432 
+    <path d="M 396.885703 104.1264 
+L 501.510703 104.1264 
+L 501.510703 74.7432 
+L 396.885703 74.7432 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 186.636016 133.5096 
-L 291.261016 133.5096 
-L 291.261016 104.1264 
-L 186.636016 104.1264 
+    <path d="M 187.635703 133.5096 
+L 292.260703 133.5096 
+L 292.260703 104.1264 
+L 187.635703 104.1264 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 291.261016 133.5096 
-L 395.886016 133.5096 
-L 395.886016 104.1264 
-L 291.261016 104.1264 
+    <path d="M 292.260703 133.5096 
+L 396.885703 133.5096 
+L 396.885703 104.1264 
+L 292.260703 104.1264 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 395.886016 133.5096 
-L 500.511016 133.5096 
-L 500.511016 104.1264 
-L 395.886016 104.1264 
+    <path d="M 396.885703 133.5096 
+L 501.510703 133.5096 
+L 501.510703 104.1264 
+L 396.885703 104.1264 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 186.636016 162.8928 
-L 291.261016 162.8928 
-L 291.261016 133.5096 
-L 186.636016 133.5096 
+    <path d="M 187.635703 162.8928 
+L 292.260703 162.8928 
+L 292.260703 133.5096 
+L 187.635703 133.5096 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 291.261016 162.8928 
-L 395.886016 162.8928 
-L 395.886016 133.5096 
-L 291.261016 133.5096 
+    <path d="M 292.260703 162.8928 
+L 396.885703 162.8928 
+L 396.885703 133.5096 
+L 292.260703 133.5096 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 395.886016 162.8928 
-L 500.511016 162.8928 
-L 500.511016 133.5096 
-L 395.886016 133.5096 
+    <path d="M 396.885703 162.8928 
+L 501.510703 162.8928 
+L 501.510703 133.5096 
+L 396.885703 133.5096 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 186.636016 192.276 
-L 291.261016 192.276 
-L 291.261016 162.8928 
-L 186.636016 162.8928 
+    <path d="M 187.635703 192.276 
+L 292.260703 192.276 
+L 292.260703 162.8928 
+L 187.635703 162.8928 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 291.261016 192.276 
-L 395.886016 192.276 
-L 395.886016 162.8928 
-L 291.261016 162.8928 
+    <path d="M 292.260703 192.276 
+L 396.885703 192.276 
+L 396.885703 162.8928 
+L 292.260703 162.8928 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 395.886016 192.276 
-L 500.511016 192.276 
-L 500.511016 162.8928 
-L 395.886016 162.8928 
+    <path d="M 396.885703 192.276 
+L 501.510703 192.276 
+L 501.510703 162.8928 
+L 396.885703 162.8928 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 186.636016 221.6592 
-L 291.261016 221.6592 
-L 291.261016 192.276 
-L 186.636016 192.276 
+    <path d="M 187.635703 221.6592 
+L 292.260703 221.6592 
+L 292.260703 192.276 
+L 187.635703 192.276 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 291.261016 221.6592 
-L 395.886016 221.6592 
-L 395.886016 192.276 
-L 291.261016 192.276 
+    <path d="M 292.260703 221.6592 
+L 396.885703 221.6592 
+L 396.885703 192.276 
+L 292.260703 192.276 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 395.886016 221.6592 
-L 500.511016 221.6592 
-L 500.511016 192.276 
-L 395.886016 192.276 
+    <path d="M 396.885703 221.6592 
+L 501.510703 221.6592 
+L 501.510703 192.276 
+L 396.885703 192.276 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 186.636016 251.0424 
-L 291.261016 251.0424 
-L 291.261016 221.6592 
-L 186.636016 221.6592 
+    <path d="M 187.635703 251.0424 
+L 292.260703 251.0424 
+L 292.260703 221.6592 
+L 187.635703 221.6592 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 291.261016 251.0424 
-L 395.886016 251.0424 
-L 395.886016 221.6592 
-L 291.261016 221.6592 
+    <path d="M 292.260703 251.0424 
+L 396.885703 251.0424 
+L 396.885703 221.6592 
+L 292.260703 221.6592 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 395.886016 251.0424 
-L 500.511016 251.0424 
-L 500.511016 221.6592 
-L 395.886016 221.6592 
+    <path d="M 396.885703 251.0424 
+L 501.510703 251.0424 
+L 501.510703 221.6592 
+L 396.885703 221.6592 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 186.636016 280.4256 
-L 291.261016 280.4256 
-L 291.261016 251.0424 
-L 186.636016 251.0424 
+    <path d="M 187.635703 280.4256 
+L 292.260703 280.4256 
+L 292.260703 251.0424 
+L 187.635703 251.0424 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 291.261016 280.4256 
-L 395.886016 280.4256 
-L 395.886016 251.0424 
-L 291.261016 251.0424 
+    <path d="M 292.260703 280.4256 
+L 396.885703 280.4256 
+L 396.885703 251.0424 
+L 292.260703 251.0424 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fca85e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fcaa5f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 395.886016 280.4256 
-L 500.511016 280.4256 
-L 500.511016 251.0424 
-L 395.886016 251.0424 
+    <path d="M 396.885703 280.4256 
+L 501.510703 280.4256 
+L 501.510703 251.0424 
+L 396.885703 251.0424 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 186.636016 309.8088 
-L 291.261016 309.8088 
-L 291.261016 280.4256 
-L 186.636016 280.4256 
+    <path d="M 187.635703 309.8088 
+L 292.260703 309.8088 
+L 292.260703 280.4256 
+L 187.635703 280.4256 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 291.261016 309.8088 
-L 395.886016 309.8088 
-L 395.886016 280.4256 
-L 291.261016 280.4256 
+    <path d="M 292.260703 309.8088 
+L 396.885703 309.8088 
+L 396.885703 280.4256 
+L 292.260703 280.4256 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 395.886016 309.8088 
-L 500.511016 309.8088 
-L 500.511016 280.4256 
-L 395.886016 280.4256 
+    <path d="M 396.885703 309.8088 
+L 501.510703 309.8088 
+L 501.510703 280.4256 
+L 396.885703 280.4256 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 186.636016 339.192 
-L 291.261016 339.192 
-L 291.261016 309.8088 
-L 186.636016 309.8088 
+    <path d="M 187.635703 339.192 
+L 292.260703 339.192 
+L 292.260703 309.8088 
+L 187.635703 309.8088 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 291.261016 339.192 
-L 395.886016 339.192 
-L 395.886016 309.8088 
-L 291.261016 309.8088 
+    <path d="M 292.260703 339.192 
+L 396.885703 339.192 
+L 396.885703 309.8088 
+L 292.260703 309.8088 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 395.886016 339.192 
-L 500.511016 339.192 
-L 500.511016 309.8088 
-L 395.886016 309.8088 
+    <path d="M 396.885703 339.192 
+L 501.510703 339.192 
+L 501.510703 309.8088 
+L 396.885703 309.8088 
 z
-" clip-path="url(#p114bb3719c)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p472d9718aa)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(119.623281 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(120.622969 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(226.9075 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(227.907188 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(305.479609 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(306.479297 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(403.831328 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(404.831016 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(115.561016 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(116.560703 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(227.497266 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(335.938516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(336.938203 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 878 -->
-    <g transform="translate(440.563516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1001,7 +1001,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(110.199141 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(111.198828 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1100,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(227.497266 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1131,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(338.483516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1170,7 +1170,7 @@ z
    </g>
    <g id="text_12">
     <!-- 311 -->
-    <g transform="translate(440.563516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1178,7 +1178,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(97.892266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(98.891953 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,7 +1349,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(227.497266 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1386,14 +1386,14 @@ z
    </g>
    <g id="text_15">
     <!-- 48 -->
-    <g transform="translate(338.483516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 180 -->
-    <g transform="translate(440.563516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1401,7 +1401,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(118.924766 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(119.924453 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1461,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(227.497266 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,14 +1503,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(338.483516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 205 -->
-    <g transform="translate(440.563516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1518,7 +1518,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(127.462266 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(128.461953 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1542,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(227.497266 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1552,14 +1552,14 @@ z
    </g>
    <g id="text_23">
     <!-- 37 -->
-    <g transform="translate(338.483516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 451 -->
-    <g transform="translate(440.563516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
@@ -1567,7 +1567,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(110.768516 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(111.768203 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1626,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(227.497266 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,14 +1636,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(338.483516 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 532 -->
-    <g transform="translate(440.563516 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(441.563203 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1651,7 +1651,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(97.270391 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(98.270078 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1760,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.325 -->
-    <g transform="translate(226.296641 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(227.296328 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1878,61 +1878,16 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 24 -->
-    <g transform="translate(338.007266 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 25 -->
+    <g transform="translate(339.006953 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 176 -->
-    <g transform="translate(439.849141 267.9415) scale(0.08 -0.08)">
+    <!-- 262 -->
+    <g transform="translate(440.848828 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-36" d="M 2316 2303 
 Q 2000 2303 1842 2098 
 Q 1684 1894 1684 1484 
@@ -1964,14 +1919,14 @@ Q 3506 4644 3803 4544
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(95.385391 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(96.385078 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2036,7 +1991,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(227.497266 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2046,21 +2001,21 @@ z
    </g>
    <g id="text_35">
     <!-- 20 -->
-    <g transform="translate(338.483516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(339.483203 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 68 -->
-    <g transform="translate(443.108516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(444.108203 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(123.606641 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(124.606328 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2071,7 +2026,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(227.497266 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(228.496953 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2081,13 +2036,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.028516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(342.028203 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(444.198516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(445.198203 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2103,7 +2058,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(151.112734 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(152.112422 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2217,7 +2172,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-04T13:30:19Z  ·  Linux chungus x86_64  ·  commit df28a274  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-05T03:12:42Z  ·  Linux chungus x86_64  ·  commit 992547a3  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2356,16 +2311,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
     <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2404,110 +2359,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3071.728516 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3106.933594 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3170.556641 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3234.179688 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3295.458984 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3359.082031 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3422.705078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3486.328125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3518.115234 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3549.902344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3581.689453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3613.476562 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3645.263672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3673.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3734.570312 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3795.849609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3859.228516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3922.705078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3961.568359 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4022.75 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4081.929688 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4143.453125 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4184.566406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4218.257812 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4246.041016 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4307.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4368.84375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4432.222656 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4495.845703 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4529.537109 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4588.716797 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4652.339844 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4684.126953 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4747.75 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4811.373047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4843.160156 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4906.783203 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4942.867188 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4981.730469 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5036.710938 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5100.333984 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5132.121094 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5163.908203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5195.695312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5227.482422 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5259.269531 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5298.478516 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5361.857422 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5400.720703 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5461.902344 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5525.28125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5588.757812 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5652.136719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5715.613281 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5778.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5818.201172 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5849.988281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5933.777344 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5965.564453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6062.976562 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6124.5 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6187.976562 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6215.759766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6277.039062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6340.417969 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6372.205078 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6424.304688 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6487.683594 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6548.962891 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6612.439453 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6664.539062 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6727.917969 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6789.099609 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6828.308594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6862 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6893.787109 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6934.900391 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6996.179688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7035.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7063.171875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7124.353516 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7156.140625 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7183.923828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7236.023438 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7267.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7331.287109 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7392.810547 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7432.019531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7493.542969 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7532.90625 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7630.318359 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7658.101562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7721.480469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7749.263672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7801.363281 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7840.572266 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7868.355469 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3008.251953 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3451.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3514.892578 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3546.679688 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3578.466797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3642.041016 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3673.828125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3701.611328 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3763.134766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3824.414062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3887.792969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3990.132812 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4051.314453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4110.494141 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4172.017578 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4213.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4246.822266 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4274.605469 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4336.128906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4397.408203 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4460.787109 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4524.410156 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4558.101562 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4617.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4680.904297 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4712.691406 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4776.314453 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4839.9375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4871.724609 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4935.347656 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4971.431641 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5010.294922 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5065.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5128.898438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5160.685547 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5192.472656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.259766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5256.046875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5287.833984 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5327.042969 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5390.421875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5429.285156 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5490.466797 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5553.845703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5680.701172 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5807.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5846.765625 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5878.552734 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5962.341797 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5994.128906 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6091.541016 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6153.064453 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6244.324219 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6305.603516 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6368.982422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6400.769531 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6452.869141 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6516.248047 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6577.527344 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6693.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6756.482422 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6817.664062 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6856.873047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6890.564453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6922.351562 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6963.464844 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7024.744141 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7063.953125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7091.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7184.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7212.488281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7264.587891 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7296.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7421.375 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7460.583984 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7522.107422 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7561.470703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7658.882812 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7686.666016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7750.044922 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7777.828125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7829.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7869.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7896.919922 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p114bb3719c">
-   <rect x="82.011016" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p472d9718aa">
+   <rect x="83.010703" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-04T13:30:19Z",
+  "date": "2026-07-05T03:12:42Z",
   "machine": "Linux chungus x86_64",
-  "git_commit": "df28a274",
+  "git_commit": "992547a3",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 57.3,
-   "decompress_mbps": 108.85
+   "compress_mbps": 63.44,
+   "decompress_mbps": 188.3
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 43.78,
-   "decompress_mbps": 120.69
+   "compress_mbps": 46.89,
+   "decompress_mbps": 214.65
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 39.7,
-   "decompress_mbps": 131.45
+   "compress_mbps": 41.82,
+   "decompress_mbps": 233.14
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 29.8,
-   "decompress_mbps": 134.38
+   "compress_mbps": 31.16,
+   "decompress_mbps": 235.5
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54437,
    "ratio": 0.3579,
-   "compress_mbps": 23.84,
-   "decompress_mbps": 141.95
+   "compress_mbps": 24.62,
+   "decompress_mbps": 239.29
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54348,
    "ratio": 0.3573,
-   "compress_mbps": 21.29,
-   "decompress_mbps": 146.61
+   "compress_mbps": 21.93,
+   "decompress_mbps": 245.31
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 18.53,
-   "decompress_mbps": 147.06
+   "compress_mbps": 19.09,
+   "decompress_mbps": 245.98
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 18.1,
-   "decompress_mbps": 147.62
+   "compress_mbps": 18.58,
+   "decompress_mbps": 246.23
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 53082,
    "ratio": 0.349,
-   "compress_mbps": 3.2,
-   "decompress_mbps": 147.73
+   "compress_mbps": 3.31,
+   "decompress_mbps": 245.99
   },
   {
    "compressor": "native",
@@ -104,8 +104,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 52.44,
-   "decompress_mbps": 102.53
+   "compress_mbps": 58.06,
+   "decompress_mbps": 181.49
   },
   {
    "compressor": "native",
@@ -114,8 +114,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 40.77,
-   "decompress_mbps": 110.1
+   "compress_mbps": 43.82,
+   "decompress_mbps": 196.48
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 37.33,
-   "decompress_mbps": 119.09
+   "compress_mbps": 39.88,
+   "decompress_mbps": 214.75
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 4,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 27.66,
-   "decompress_mbps": 123.93
+   "compress_mbps": 29.2,
+   "decompress_mbps": 218.56
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 5,
    "out_size": 48891,
    "ratio": 0.3906,
-   "compress_mbps": 24.22,
-   "decompress_mbps": 129.97
+   "compress_mbps": 25.3,
+   "decompress_mbps": 219.9
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 6,
    "out_size": 48715,
    "ratio": 0.3892,
-   "compress_mbps": 20.21,
-   "decompress_mbps": 132.24
+   "compress_mbps": 20.97,
+   "decompress_mbps": 223.18
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 18.96,
-   "decompress_mbps": 133.14
+   "compress_mbps": 19.63,
+   "decompress_mbps": 223.4
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 18.97,
-   "decompress_mbps": 133.58
+   "compress_mbps": 19.64,
+   "decompress_mbps": 223.89
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 9,
    "out_size": 47620,
    "ratio": 0.3804,
-   "compress_mbps": 3.34,
-   "decompress_mbps": 133.38
+   "compress_mbps": 3.46,
+   "decompress_mbps": 224.03
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 39.36,
-   "decompress_mbps": 121.15
+   "compress_mbps": 43.5,
+   "decompress_mbps": 213.95
   },
   {
    "compressor": "native",
@@ -204,8 +204,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 34.72,
-   "decompress_mbps": 125.37
+   "compress_mbps": 37.99,
+   "decompress_mbps": 222.12
   },
   {
    "compressor": "native",
@@ -214,8 +214,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 34.07,
-   "decompress_mbps": 128.72
+   "compress_mbps": 36.93,
+   "decompress_mbps": 227.9
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 4,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 30.68,
-   "decompress_mbps": 134.29
+   "compress_mbps": 33.05,
+   "decompress_mbps": 234.18
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 5,
    "out_size": 7932,
    "ratio": 0.3224,
-   "compress_mbps": 26.61,
-   "decompress_mbps": 138.51
+   "compress_mbps": 28.36,
+   "decompress_mbps": 241.32
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 6,
    "out_size": 7938,
    "ratio": 0.3226,
-   "compress_mbps": 23.16,
-   "decompress_mbps": 139.91
+   "compress_mbps": 24.31,
+   "decompress_mbps": 242.83
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 22.3,
-   "decompress_mbps": 141.34
+   "compress_mbps": 23.32,
+   "decompress_mbps": 245.63
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 22.29,
-   "decompress_mbps": 141.21
+   "compress_mbps": 23.34,
+   "decompress_mbps": 245.78
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 9,
    "out_size": 7806,
    "ratio": 0.3173,
-   "compress_mbps": 4.07,
-   "decompress_mbps": 141.51
+   "compress_mbps": 4.27,
+   "decompress_mbps": 246.62
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 25.43,
-   "decompress_mbps": 98.01
+   "compress_mbps": 27.42,
+   "decompress_mbps": 148.16
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 23.74,
-   "decompress_mbps": 100.87
+   "compress_mbps": 25.39,
+   "decompress_mbps": 150.69
   },
   {
    "compressor": "native",
@@ -304,8 +304,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 23.19,
-   "decompress_mbps": 104.31
+   "compress_mbps": 25.01,
+   "decompress_mbps": 153.58
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 4,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 21.74,
-   "decompress_mbps": 106.55
+   "compress_mbps": 23.3,
+   "decompress_mbps": 156.13
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 5,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 20.04,
-   "decompress_mbps": 108.28
+   "compress_mbps": 21.37,
+   "decompress_mbps": 157.55
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 6,
    "out_size": 3135,
    "ratio": 0.2812,
-   "compress_mbps": 18.27,
-   "decompress_mbps": 108.85
+   "compress_mbps": 19.27,
+   "decompress_mbps": 158.05
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 17.74,
-   "decompress_mbps": 109.47
+   "compress_mbps": 18.76,
+   "decompress_mbps": 158.11
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 17.75,
-   "decompress_mbps": 109.18
+   "compress_mbps": 18.73,
+   "decompress_mbps": 158.68
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 9,
    "out_size": 3057,
    "ratio": 0.2742,
-   "compress_mbps": 4.09,
-   "decompress_mbps": 108.61
+   "compress_mbps": 4.3,
+   "decompress_mbps": 158.34
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 12.0,
-   "decompress_mbps": 55.4
+   "compress_mbps": 12.94,
+   "decompress_mbps": 69.04
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 11.55,
-   "decompress_mbps": 55.95
+   "compress_mbps": 12.44,
+   "decompress_mbps": 69.71
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 11.51,
-   "decompress_mbps": 56.21
+   "compress_mbps": 12.35,
+   "decompress_mbps": 69.81
   },
   {
    "compressor": "native",
@@ -404,8 +404,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 11.27,
-   "decompress_mbps": 57.32
+   "compress_mbps": 12.14,
+   "decompress_mbps": 70.14
   },
   {
    "compressor": "native",
@@ -414,8 +414,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 11.07,
-   "decompress_mbps": 57.72
+   "compress_mbps": 11.89,
+   "decompress_mbps": 70.23
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 10.09,
-   "decompress_mbps": 57.88
+   "compress_mbps": 10.76,
+   "decompress_mbps": 70.57
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 10.09,
-   "decompress_mbps": 57.94
+   "compress_mbps": 10.75,
+   "decompress_mbps": 70.31
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 10.08,
-   "decompress_mbps": 58.08
+   "compress_mbps": 10.77,
+   "decompress_mbps": 70.52
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 3.3,
-   "decompress_mbps": 58.11
+   "compress_mbps": 3.55,
+   "decompress_mbps": 70.52
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 114.16,
-   "decompress_mbps": 202.07
+   "compress_mbps": 123.55,
+   "decompress_mbps": 343.13
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 82.02,
-   "decompress_mbps": 217.31
+   "compress_mbps": 86.77,
+   "decompress_mbps": 373.13
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 70.64,
-   "decompress_mbps": 226.23
+   "compress_mbps": 74.45,
+   "decompress_mbps": 395.47
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 4,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 65.85,
-   "decompress_mbps": 233.37
+   "compress_mbps": 68.93,
+   "decompress_mbps": 415.33
   },
   {
    "compressor": "native",
@@ -504,8 +504,8 @@
    "level": 5,
    "out_size": 215530,
    "ratio": 0.2093,
-   "compress_mbps": 37.45,
-   "decompress_mbps": 229.81
+   "compress_mbps": 39.29,
+   "decompress_mbps": 399.16
   },
   {
    "compressor": "native",
@@ -514,8 +514,8 @@
    "level": 6,
    "out_size": 201414,
    "ratio": 0.1956,
-   "compress_mbps": 22.05,
-   "decompress_mbps": 235.92
+   "compress_mbps": 22.57,
+   "decompress_mbps": 411.57
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 15.95,
-   "decompress_mbps": 236.67
+   "compress_mbps": 16.22,
+   "decompress_mbps": 415.58
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 11.94,
-   "decompress_mbps": 241.47
+   "compress_mbps": 12.21,
+   "decompress_mbps": 421.35
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 9,
    "out_size": 183445,
    "ratio": 0.1781,
-   "compress_mbps": 2.86,
-   "decompress_mbps": 242.01
+   "compress_mbps": 2.87,
+   "decompress_mbps": 422.88
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 64.69,
-   "decompress_mbps": 116.61
+   "compress_mbps": 71.96,
+   "decompress_mbps": 198.47
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 48.17,
-   "decompress_mbps": 125.82
+   "compress_mbps": 51.61,
+   "decompress_mbps": 214.33
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 43.29,
-   "decompress_mbps": 137.89
+   "compress_mbps": 46.04,
+   "decompress_mbps": 239.0
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 4,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 32.65,
-   "decompress_mbps": 143.14
+   "compress_mbps": 34.19,
+   "decompress_mbps": 242.58
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 5,
    "out_size": 145321,
    "ratio": 0.3405,
-   "compress_mbps": 26.44,
-   "decompress_mbps": 150.03
+   "compress_mbps": 27.38,
+   "decompress_mbps": 245.3
   },
   {
    "compressor": "native",
@@ -604,8 +604,8 @@
    "level": 6,
    "out_size": 145046,
    "ratio": 0.3399,
-   "compress_mbps": 22.88,
-   "decompress_mbps": 153.97
+   "compress_mbps": 23.64,
+   "decompress_mbps": 250.66
   },
   {
    "compressor": "native",
@@ -614,8 +614,8 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 20.64,
-   "decompress_mbps": 154.65
+   "compress_mbps": 21.25,
+   "decompress_mbps": 251.33
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 20.38,
-   "decompress_mbps": 154.73
+   "compress_mbps": 20.89,
+   "decompress_mbps": 252.07
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 9,
    "out_size": 141031,
    "ratio": 0.3305,
-   "compress_mbps": 3.21,
-   "decompress_mbps": 155.19
+   "compress_mbps": 3.32,
+   "decompress_mbps": 251.31
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 55.18,
-   "decompress_mbps": 96.67
+   "compress_mbps": 61.13,
+   "decompress_mbps": 171.66
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 41.01,
-   "decompress_mbps": 105.23
+   "compress_mbps": 43.84,
+   "decompress_mbps": 191.13
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 36.84,
-   "decompress_mbps": 115.03
+   "compress_mbps": 39.06,
+   "decompress_mbps": 209.71
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 4,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 25.45,
-   "decompress_mbps": 118.86
+   "compress_mbps": 26.64,
+   "decompress_mbps": 212.79
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 5,
    "out_size": 194902,
    "ratio": 0.4045,
-   "compress_mbps": 21.41,
-   "decompress_mbps": 125.16
+   "compress_mbps": 22.19,
+   "decompress_mbps": 211.69
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 6,
    "out_size": 195177,
    "ratio": 0.405,
-   "compress_mbps": 19.84,
-   "decompress_mbps": 129.27
+   "compress_mbps": 20.51,
+   "decompress_mbps": 215.6
   },
   {
    "compressor": "native",
@@ -704,8 +704,8 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 17.57,
-   "decompress_mbps": 129.34
+   "compress_mbps": 18.16,
+   "decompress_mbps": 216.05
   },
   {
    "compressor": "native",
@@ -714,8 +714,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 17.5,
-   "decompress_mbps": 130.22
+   "compress_mbps": 18.14,
+   "decompress_mbps": 216.57
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 9,
    "out_size": 190711,
    "ratio": 0.3958,
-   "compress_mbps": 3.02,
-   "decompress_mbps": 129.94
+   "compress_mbps": 3.09,
+   "decompress_mbps": 216.42
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 166.39,
-   "decompress_mbps": 336.04
+   "compress_mbps": 183.05,
+   "decompress_mbps": 473.83
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 130.22,
-   "decompress_mbps": 351.05
+   "compress_mbps": 139.19,
+   "decompress_mbps": 498.15
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 115.43,
-   "decompress_mbps": 374.28
+   "compress_mbps": 121.53,
+   "decompress_mbps": 539.04
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 4,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 80.2,
-   "decompress_mbps": 347.1
+   "compress_mbps": 83.19,
+   "decompress_mbps": 461.77
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 5,
    "out_size": 54950,
    "ratio": 0.1071,
-   "compress_mbps": 56.42,
-   "decompress_mbps": 369.13
+   "compress_mbps": 57.74,
+   "decompress_mbps": 491.16
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 6,
    "out_size": 55259,
    "ratio": 0.1077,
-   "compress_mbps": 37.94,
-   "decompress_mbps": 398.03
+   "compress_mbps": 39.06,
+   "decompress_mbps": 533.48
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 7,
    "out_size": 53713,
    "ratio": 0.1047,
-   "compress_mbps": 29.17,
-   "decompress_mbps": 420.16
+   "compress_mbps": 29.77,
+   "decompress_mbps": 571.35
   },
   {
    "compressor": "native",
@@ -804,8 +804,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 25.14,
-   "decompress_mbps": 449.74
+   "compress_mbps": 25.63,
+   "decompress_mbps": 609.24
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 9,
    "out_size": 52729,
    "ratio": 0.1027,
-   "compress_mbps": 4.86,
-   "decompress_mbps": 462.61
+   "compress_mbps": 4.93,
+   "decompress_mbps": 623.09
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 29.88,
-   "decompress_mbps": 111.99
+   "compress_mbps": 31.66,
+   "decompress_mbps": 183.77
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 27.43,
-   "decompress_mbps": 114.4
+   "compress_mbps": 28.68,
+   "decompress_mbps": 187.86
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 26.72,
-   "decompress_mbps": 116.17
+   "compress_mbps": 27.93,
+   "decompress_mbps": 191.22
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 4,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 24.43,
-   "decompress_mbps": 122.07
+   "compress_mbps": 25.27,
+   "decompress_mbps": 198.67
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 5,
    "out_size": 13346,
    "ratio": 0.349,
-   "compress_mbps": 21.74,
-   "decompress_mbps": 128.56
+   "compress_mbps": 22.53,
+   "decompress_mbps": 207.61
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 6,
    "out_size": 13040,
    "ratio": 0.341,
-   "compress_mbps": 9.71,
-   "decompress_mbps": 130.6
+   "compress_mbps": 9.91,
+   "decompress_mbps": 211.6
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 7,
    "out_size": 13035,
    "ratio": 0.3409,
-   "compress_mbps": 9.08,
-   "decompress_mbps": 131.62
+   "compress_mbps": 9.25,
+   "decompress_mbps": 213.75
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 8.46,
-   "decompress_mbps": 133.11
+   "compress_mbps": 8.62,
+   "decompress_mbps": 215.48
   },
   {
    "compressor": "native",
@@ -904,8 +904,8 @@
    "level": 9,
    "out_size": 12522,
    "ratio": 0.3275,
-   "compress_mbps": 3.74,
-   "decompress_mbps": 134.73
+   "compress_mbps": 3.86,
+   "decompress_mbps": 217.58
   },
   {
    "compressor": "native",
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 13.36,
-   "decompress_mbps": 57.14
+   "compress_mbps": 14.49,
+   "decompress_mbps": 75.85
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 12.9,
-   "decompress_mbps": 57.56
+   "compress_mbps": 13.89,
+   "decompress_mbps": 75.61
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 12.87,
-   "decompress_mbps": 57.86
+   "compress_mbps": 13.88,
+   "decompress_mbps": 75.73
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 12.62,
-   "decompress_mbps": 59.16
+   "compress_mbps": 13.64,
+   "decompress_mbps": 76.56
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 12.51,
-   "decompress_mbps": 59.43
+   "compress_mbps": 13.48,
+   "decompress_mbps": 76.39
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 11.01,
-   "decompress_mbps": 59.47
+   "compress_mbps": 11.68,
+   "decompress_mbps": 76.41
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 11.0,
-   "decompress_mbps": 59.46
+   "compress_mbps": 11.65,
+   "decompress_mbps": 76.36
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 11.02,
-   "decompress_mbps": 59.43
+   "compress_mbps": 11.66,
+   "decompress_mbps": 76.52
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 3.79,
-   "decompress_mbps": 59.56
+   "compress_mbps": 4.06,
+   "decompress_mbps": 76.17
   },
   {
    "compressor": "zlib",
@@ -3974,8 +3974,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 59.11,
-   "decompress_mbps": 101.62
+   "compress_mbps": 64.71,
+   "decompress_mbps": 175.57
   },
   {
    "compressor": "native",
@@ -3984,8 +3984,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 43.35,
-   "decompress_mbps": 110.05
+   "compress_mbps": 46.52,
+   "decompress_mbps": 190.04
   },
   {
    "compressor": "native",
@@ -3994,8 +3994,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 38.99,
-   "decompress_mbps": 120.46
+   "compress_mbps": 40.74,
+   "decompress_mbps": 210.89
   },
   {
    "compressor": "native",
@@ -4004,8 +4004,8 @@
    "level": 4,
    "out_size": 3882303,
    "ratio": 0.3809,
-   "compress_mbps": 27.58,
-   "decompress_mbps": 123.59
+   "compress_mbps": 28.81,
+   "decompress_mbps": 210.62
   },
   {
    "compressor": "native",
@@ -4014,8 +4014,8 @@
    "level": 5,
    "out_size": 3870984,
    "ratio": 0.3798,
-   "compress_mbps": 23.19,
-   "decompress_mbps": 130.18
+   "compress_mbps": 24.06,
+   "decompress_mbps": 211.65
   },
   {
    "compressor": "native",
@@ -4024,8 +4024,8 @@
    "level": 6,
    "out_size": 3878499,
    "ratio": 0.3805,
-   "compress_mbps": 21.97,
-   "decompress_mbps": 134.75
+   "compress_mbps": 22.71,
+   "decompress_mbps": 218.96
   },
   {
    "compressor": "native",
@@ -4034,8 +4034,8 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 19.09,
-   "decompress_mbps": 135.91
+   "compress_mbps": 19.58,
+   "decompress_mbps": 219.24
   },
   {
    "compressor": "native",
@@ -4044,8 +4044,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 18.75,
-   "decompress_mbps": 135.69
+   "compress_mbps": 19.43,
+   "decompress_mbps": 218.96
   },
   {
    "compressor": "native",
@@ -4054,8 +4054,8 @@
    "level": 9,
    "out_size": 3790404,
    "ratio": 0.3719,
-   "compress_mbps": 3.06,
-   "decompress_mbps": 137.76
+   "compress_mbps": 3.09,
+   "decompress_mbps": 227.56
   },
   {
    "compressor": "native",
@@ -4064,8 +4064,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 74.27,
-   "decompress_mbps": 130.17
+   "compress_mbps": 80.4,
+   "decompress_mbps": 191.35
   },
   {
    "compressor": "native",
@@ -4074,8 +4074,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 59.35,
-   "decompress_mbps": 136.93
+   "compress_mbps": 63.0,
+   "decompress_mbps": 199.42
   },
   {
    "compressor": "native",
@@ -4084,8 +4084,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 55.91,
-   "decompress_mbps": 141.92
+   "compress_mbps": 58.71,
+   "decompress_mbps": 205.71
   },
   {
    "compressor": "native",
@@ -4094,8 +4094,8 @@
    "level": 4,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 43.31,
-   "decompress_mbps": 148.83
+   "compress_mbps": 44.48,
+   "decompress_mbps": 209.33
   },
   {
    "compressor": "native",
@@ -4104,8 +4104,8 @@
    "level": 5,
    "out_size": 20264932,
    "ratio": 0.3956,
-   "compress_mbps": 32.14,
-   "decompress_mbps": 156.72
+   "compress_mbps": 32.77,
+   "decompress_mbps": 218.15
   },
   {
    "compressor": "native",
@@ -4114,8 +4114,8 @@
    "level": 6,
    "out_size": 19208910,
    "ratio": 0.375,
-   "compress_mbps": 17.04,
-   "decompress_mbps": 160.85
+   "compress_mbps": 17.39,
+   "decompress_mbps": 222.01
   },
   {
    "compressor": "native",
@@ -4124,8 +4124,8 @@
    "level": 7,
    "out_size": 19177573,
    "ratio": 0.3744,
-   "compress_mbps": 14.06,
-   "decompress_mbps": 160.9
+   "compress_mbps": 14.26,
+   "decompress_mbps": 223.29
   },
   {
    "compressor": "native",
@@ -4134,8 +4134,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 12.3,
-   "decompress_mbps": 158.96
+   "compress_mbps": 12.45,
+   "decompress_mbps": 217.93
   },
   {
    "compressor": "native",
@@ -4144,8 +4144,8 @@
    "level": 9,
    "out_size": 18723512,
    "ratio": 0.3655,
-   "compress_mbps": 3.32,
-   "decompress_mbps": 161.55
+   "compress_mbps": 3.31,
+   "decompress_mbps": 222.59
   },
   {
    "compressor": "native",
@@ -4154,8 +4154,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 72.29,
-   "decompress_mbps": 119.39
+   "compress_mbps": 79.3,
+   "decompress_mbps": 204.01
   },
   {
    "compressor": "native",
@@ -4164,8 +4164,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 57.38,
-   "decompress_mbps": 125.28
+   "compress_mbps": 60.78,
+   "decompress_mbps": 212.24
   },
   {
    "compressor": "native",
@@ -4174,8 +4174,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 49.43,
-   "decompress_mbps": 133.91
+   "compress_mbps": 52.27,
+   "decompress_mbps": 223.1
   },
   {
    "compressor": "native",
@@ -4184,8 +4184,8 @@
    "level": 4,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 32.71,
-   "decompress_mbps": 129.18
+   "compress_mbps": 33.75,
+   "decompress_mbps": 207.28
   },
   {
    "compressor": "native",
@@ -4194,8 +4194,8 @@
    "level": 5,
    "out_size": 3705174,
    "ratio": 0.3716,
-   "compress_mbps": 25.81,
-   "decompress_mbps": 135.54
+   "compress_mbps": 26.32,
+   "decompress_mbps": 203.56
   },
   {
    "compressor": "native",
@@ -4204,8 +4204,8 @@
    "level": 6,
    "out_size": 3612809,
    "ratio": 0.3623,
-   "compress_mbps": 20.51,
-   "decompress_mbps": 141.52
+   "compress_mbps": 20.88,
+   "decompress_mbps": 209.97
   },
   {
    "compressor": "native",
@@ -4214,8 +4214,8 @@
    "level": 7,
    "out_size": 3608980,
    "ratio": 0.362,
-   "compress_mbps": 17.79,
-   "decompress_mbps": 142.46
+   "compress_mbps": 18.14,
+   "decompress_mbps": 212.12
   },
   {
    "compressor": "native",
@@ -4224,8 +4224,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 16.36,
-   "decompress_mbps": 145.67
+   "compress_mbps": 16.62,
+   "decompress_mbps": 216.64
   },
   {
    "compressor": "native",
@@ -4234,8 +4234,8 @@
    "level": 9,
    "out_size": 3598941,
    "ratio": 0.361,
-   "compress_mbps": 3.6,
-   "decompress_mbps": 149.87
+   "compress_mbps": 3.69,
+   "decompress_mbps": 220.72
   },
   {
    "compressor": "native",
@@ -4244,8 +4244,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 214.0,
-   "decompress_mbps": 354.52
+   "compress_mbps": 233.94,
+   "decompress_mbps": 603.71
   },
   {
    "compressor": "native",
@@ -4254,8 +4254,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 139.15,
-   "decompress_mbps": 399.48
+   "compress_mbps": 146.11,
+   "decompress_mbps": 674.18
   },
   {
    "compressor": "native",
@@ -4264,8 +4264,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 117.88,
-   "decompress_mbps": 444.66
+   "compress_mbps": 123.99,
+   "decompress_mbps": 745.14
   },
   {
    "compressor": "native",
@@ -4274,8 +4274,8 @@
    "level": 4,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 90.04,
-   "decompress_mbps": 429.32
+   "compress_mbps": 92.79,
+   "decompress_mbps": 741.57
   },
   {
    "compressor": "native",
@@ -4284,8 +4284,8 @@
    "level": 5,
    "out_size": 3145121,
    "ratio": 0.0937,
-   "compress_mbps": 61.62,
-   "decompress_mbps": 485.03
+   "compress_mbps": 62.84,
+   "decompress_mbps": 755.43
   },
   {
    "compressor": "native",
@@ -4294,8 +4294,8 @@
    "level": 6,
    "out_size": 3158854,
    "ratio": 0.0941,
-   "compress_mbps": 59.24,
-   "decompress_mbps": 558.58
+   "compress_mbps": 60.24,
+   "decompress_mbps": 871.94
   },
   {
    "compressor": "native",
@@ -4304,8 +4304,8 @@
    "level": 7,
    "out_size": 3124878,
    "ratio": 0.0931,
-   "compress_mbps": 41.96,
-   "decompress_mbps": 571.1
+   "compress_mbps": 42.45,
+   "decompress_mbps": 894.35
   },
   {
    "compressor": "native",
@@ -4314,8 +4314,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 34.21,
-   "decompress_mbps": 591.92
+   "compress_mbps": 34.67,
+   "decompress_mbps": 899.98
   },
   {
    "compressor": "native",
@@ -4324,8 +4324,8 @@
    "level": 9,
    "out_size": 3083394,
    "ratio": 0.0919,
-   "compress_mbps": 3.11,
-   "decompress_mbps": 596.98
+   "compress_mbps": 3.1,
+   "decompress_mbps": 807.45
   },
   {
    "compressor": "native",
@@ -4334,8 +4334,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 51.93,
-   "decompress_mbps": 90.53
+   "compress_mbps": 56.22,
+   "decompress_mbps": 129.03
   },
   {
    "compressor": "native",
@@ -4344,8 +4344,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 42.93,
-   "decompress_mbps": 92.87
+   "compress_mbps": 46.09,
+   "decompress_mbps": 131.94
   },
   {
    "compressor": "native",
@@ -4354,8 +4354,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 41.98,
-   "decompress_mbps": 95.43
+   "compress_mbps": 44.52,
+   "decompress_mbps": 135.46
   },
   {
    "compressor": "native",
@@ -4364,8 +4364,8 @@
    "level": 4,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 34.07,
-   "decompress_mbps": 102.69
+   "compress_mbps": 35.56,
+   "decompress_mbps": 144.13
   },
   {
    "compressor": "native",
@@ -4374,8 +4374,8 @@
    "level": 5,
    "out_size": 3233792,
    "ratio": 0.5256,
-   "compress_mbps": 30.5,
-   "decompress_mbps": 107.48
+   "compress_mbps": 31.83,
+   "decompress_mbps": 147.19
   },
   {
    "compressor": "native",
@@ -4384,8 +4384,8 @@
    "level": 6,
    "out_size": 3168386,
    "ratio": 0.515,
-   "compress_mbps": 17.43,
-   "decompress_mbps": 108.86
+   "compress_mbps": 17.96,
+   "decompress_mbps": 151.89
   },
   {
    "compressor": "native",
@@ -4394,8 +4394,8 @@
    "level": 7,
    "out_size": 3165783,
    "ratio": 0.5146,
-   "compress_mbps": 16.46,
-   "decompress_mbps": 109.53
+   "compress_mbps": 16.35,
+   "decompress_mbps": 151.22
   },
   {
    "compressor": "native",
@@ -4404,8 +4404,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 15.71,
-   "decompress_mbps": 110.18
+   "compress_mbps": 15.95,
+   "decompress_mbps": 153.23
   },
   {
    "compressor": "native",
@@ -4414,8 +4414,8 @@
    "level": 9,
    "out_size": 3055775,
    "ratio": 0.4967,
-   "compress_mbps": 3.77,
-   "decompress_mbps": 111.73
+   "compress_mbps": 3.91,
+   "decompress_mbps": 155.73
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 82.9,
-   "decompress_mbps": 149.59
+   "compress_mbps": 89.97,
+   "decompress_mbps": 228.07
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 62.23,
-   "decompress_mbps": 154.83
+   "compress_mbps": 66.7,
+   "decompress_mbps": 237.4
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 60.45,
-   "decompress_mbps": 158.63
+   "compress_mbps": 63.92,
+   "decompress_mbps": 243.81
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 4,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 53.54,
-   "decompress_mbps": 171.59
+   "compress_mbps": 55.92,
+   "decompress_mbps": 255.15
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 5,
    "out_size": 3707010,
    "ratio": 0.3676,
-   "compress_mbps": 50.0,
-   "decompress_mbps": 177.14
+   "compress_mbps": 52.1,
+   "decompress_mbps": 258.26
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 6,
    "out_size": 3707065,
    "ratio": 0.3676,
-   "compress_mbps": 36.92,
-   "decompress_mbps": 185.22
+   "compress_mbps": 37.8,
+   "decompress_mbps": 268.34
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 36.64,
-   "decompress_mbps": 187.1
+   "compress_mbps": 38.08,
+   "decompress_mbps": 269.52
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 36.84,
-   "decompress_mbps": 186.32
+   "compress_mbps": 37.98,
+   "decompress_mbps": 270.81
   },
   {
    "compressor": "native",
@@ -4504,8 +4504,8 @@
    "level": 9,
    "out_size": 3693258,
    "ratio": 0.3662,
-   "compress_mbps": 4.82,
-   "decompress_mbps": 192.65
+   "compress_mbps": 4.91,
+   "decompress_mbps": 264.8
   },
   {
    "compressor": "native",
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 73.16,
-   "decompress_mbps": 127.25
+   "compress_mbps": 83.73,
+   "decompress_mbps": 219.85
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 52.77,
-   "decompress_mbps": 138.98
+   "compress_mbps": 54.71,
+   "decompress_mbps": 234.37
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 43.78,
-   "decompress_mbps": 158.17
+   "compress_mbps": 45.8,
+   "decompress_mbps": 255.1
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 27.37,
-   "decompress_mbps": 157.53
+   "compress_mbps": 28.11,
+   "decompress_mbps": 259.07
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 1874829,
    "ratio": 0.2829,
-   "compress_mbps": 16.61,
-   "decompress_mbps": 169.12
+   "compress_mbps": 16.92,
+   "decompress_mbps": 259.06
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 1867098,
    "ratio": 0.2817,
-   "compress_mbps": 19.47,
-   "decompress_mbps": 180.04
+   "compress_mbps": 19.82,
+   "decompress_mbps": 273.17
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 1843421,
    "ratio": 0.2782,
-   "compress_mbps": 13.16,
-   "decompress_mbps": 184.33
+   "compress_mbps": 13.3,
+   "decompress_mbps": 276.72
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 11.48,
-   "decompress_mbps": 185.97
+   "compress_mbps": 11.6,
+   "decompress_mbps": 278.57
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 1794155,
    "ratio": 0.2707,
-   "compress_mbps": 2.49,
-   "decompress_mbps": 188.0
+   "compress_mbps": 2.51,
+   "decompress_mbps": 285.82
   },
   {
    "compressor": "native",
@@ -4604,8 +4604,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 101.71,
-   "decompress_mbps": 193.13
+   "compress_mbps": 109.89,
+   "decompress_mbps": 295.4
   },
   {
    "compressor": "native",
@@ -4614,8 +4614,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 76.84,
-   "decompress_mbps": 204.55
+   "compress_mbps": 80.94,
+   "decompress_mbps": 314.13
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 69.98,
-   "decompress_mbps": 213.53
+   "compress_mbps": 73.6,
+   "decompress_mbps": 325.37
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 4,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 52.51,
-   "decompress_mbps": 223.54
+   "compress_mbps": 53.88,
+   "decompress_mbps": 335.33
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 5,
    "out_size": 5839944,
    "ratio": 0.2703,
-   "compress_mbps": 40.41,
-   "decompress_mbps": 235.19
+   "compress_mbps": 41.15,
+   "decompress_mbps": 343.96
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 6,
    "out_size": 5425813,
    "ratio": 0.2511,
-   "compress_mbps": 28.72,
-   "decompress_mbps": 240.15
+   "compress_mbps": 29.06,
+   "decompress_mbps": 348.94
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 7,
    "out_size": 5409983,
    "ratio": 0.2504,
-   "compress_mbps": 25.39,
-   "decompress_mbps": 241.76
+   "compress_mbps": 25.92,
+   "decompress_mbps": 351.03
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 23.69,
-   "decompress_mbps": 243.69
+   "compress_mbps": 24.11,
+   "decompress_mbps": 357.05
   },
   {
    "compressor": "native",
@@ -4685,7 +4685,7 @@
    "out_size": 5257833,
    "ratio": 0.2433,
    "compress_mbps": 4.04,
-   "decompress_mbps": 239.51
+   "decompress_mbps": 356.47
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 44.08,
-   "decompress_mbps": 90.32
+   "compress_mbps": 47.29,
+   "decompress_mbps": 128.14
   },
   {
    "compressor": "native",
@@ -4704,8 +4704,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 37.25,
-   "decompress_mbps": 93.21
+   "compress_mbps": 39.64,
+   "decompress_mbps": 133.11
   },
   {
    "compressor": "native",
@@ -4714,8 +4714,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 35.15,
-   "decompress_mbps": 96.12
+   "compress_mbps": 37.24,
+   "decompress_mbps": 135.98
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 4,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 28.84,
-   "decompress_mbps": 100.47
+   "compress_mbps": 29.83,
+   "decompress_mbps": 138.98
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 5,
    "out_size": 5496802,
    "ratio": 0.758,
-   "compress_mbps": 26.89,
-   "decompress_mbps": 102.16
+   "compress_mbps": 27.83,
+   "decompress_mbps": 138.35
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 6,
    "out_size": 5478405,
    "ratio": 0.7554,
-   "compress_mbps": 19.88,
-   "decompress_mbps": 104.27
+   "compress_mbps": 20.39,
+   "decompress_mbps": 137.35
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 7,
    "out_size": 5474648,
    "ratio": 0.7549,
-   "compress_mbps": 19.11,
-   "decompress_mbps": 104.36
+   "compress_mbps": 19.59,
+   "decompress_mbps": 140.92
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 8,
    "out_size": 5474139,
    "ratio": 0.7549,
-   "compress_mbps": 18.98,
-   "decompress_mbps": 104.27
+   "compress_mbps": 19.26,
+   "decompress_mbps": 136.3
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 9,
    "out_size": 5301868,
    "ratio": 0.7311,
-   "compress_mbps": 3.69,
-   "decompress_mbps": 105.65
+   "compress_mbps": 3.68,
+   "decompress_mbps": 138.57
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 75.48,
-   "decompress_mbps": 134.74
+   "compress_mbps": 83.85,
+   "decompress_mbps": 224.07
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 57.01,
-   "decompress_mbps": 145.55
+   "compress_mbps": 60.71,
+   "decompress_mbps": 244.12
   },
   {
    "compressor": "native",
@@ -4804,8 +4804,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 52.56,
-   "decompress_mbps": 156.48
+   "compress_mbps": 55.83,
+   "decompress_mbps": 262.79
   },
   {
    "compressor": "native",
@@ -4814,8 +4814,8 @@
    "level": 4,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 38.95,
-   "decompress_mbps": 163.62
+   "compress_mbps": 40.49,
+   "decompress_mbps": 267.9
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 5,
    "out_size": 12123671,
    "ratio": 0.2924,
-   "compress_mbps": 28.95,
-   "decompress_mbps": 172.52
+   "compress_mbps": 29.82,
+   "decompress_mbps": 272.6
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 6,
    "out_size": 12167341,
    "ratio": 0.2935,
-   "compress_mbps": 28.72,
-   "decompress_mbps": 177.15
+   "compress_mbps": 29.69,
+   "decompress_mbps": 279.58
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 23.79,
-   "decompress_mbps": 178.82
+   "compress_mbps": 24.35,
+   "decompress_mbps": 281.01
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 22.72,
-   "decompress_mbps": 179.76
+   "compress_mbps": 23.31,
+   "decompress_mbps": 281.27
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 9,
    "out_size": 11868997,
    "ratio": 0.2863,
-   "compress_mbps": 3.22,
-   "decompress_mbps": 179.3
+   "compress_mbps": 3.31,
+   "decompress_mbps": 281.58
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 41.02,
-   "decompress_mbps": 76.07
+   "compress_mbps": 43.43,
+   "decompress_mbps": 124.77
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 39.62,
-   "decompress_mbps": 76.86
+   "compress_mbps": 41.58,
+   "decompress_mbps": 125.4
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 39.8,
-   "decompress_mbps": 78.51
+   "compress_mbps": 41.05,
+   "decompress_mbps": 128.58
   },
   {
    "compressor": "native",
@@ -4904,8 +4904,8 @@
    "level": 4,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 37.27,
-   "decompress_mbps": 78.04
+   "compress_mbps": 38.37,
+   "decompress_mbps": 115.99
   },
   {
    "compressor": "native",
@@ -4914,8 +4914,8 @@
    "level": 5,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 37.32,
-   "decompress_mbps": 80.69
+   "compress_mbps": 38.1,
+   "decompress_mbps": 117.04
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 6,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 9.71,
-   "decompress_mbps": 81.65
+   "compress_mbps": 9.84,
+   "decompress_mbps": 117.99
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 9.58,
-   "decompress_mbps": 81.67
+   "compress_mbps": 9.85,
+   "decompress_mbps": 118.36
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 9.65,
-   "decompress_mbps": 81.82
+   "compress_mbps": 9.89,
+   "decompress_mbps": 118.33
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 9,
    "out_size": 5949045,
    "ratio": 0.702,
-   "compress_mbps": 4.35,
-   "decompress_mbps": 82.41
+   "compress_mbps": 4.49,
+   "decompress_mbps": 119.81
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 160.16,
-   "decompress_mbps": 265.36
+   "compress_mbps": 176.14,
+   "decompress_mbps": 422.6
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 107.02,
-   "decompress_mbps": 297.06
+   "compress_mbps": 111.81,
+   "decompress_mbps": 464.93
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 98.82,
-   "decompress_mbps": 345.33
+   "compress_mbps": 102.02,
+   "decompress_mbps": 519.45
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 4,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 72.11,
-   "decompress_mbps": 327.96
+   "compress_mbps": 73.77,
+   "decompress_mbps": 512.27
   },
   {
    "compressor": "native",
@@ -5004,8 +5004,8 @@
    "level": 5,
    "out_size": 710636,
    "ratio": 0.1329,
-   "compress_mbps": 52.85,
-   "decompress_mbps": 388.89
+   "compress_mbps": 53.94,
+   "decompress_mbps": 547.71
   },
   {
    "compressor": "native",
@@ -5014,8 +5014,8 @@
    "level": 6,
    "out_size": 688375,
    "ratio": 0.1288,
-   "compress_mbps": 46.36,
-   "decompress_mbps": 399.42
+   "compress_mbps": 46.37,
+   "decompress_mbps": 656.88
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 7,
    "out_size": 676544,
    "ratio": 0.1266,
-   "compress_mbps": 37.41,
-   "decompress_mbps": 426.56
+   "compress_mbps": 38.02,
+   "decompress_mbps": 658.76
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 32.46,
-   "decompress_mbps": 413.38
+   "compress_mbps": 32.94,
+   "decompress_mbps": 662.58
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 9,
    "out_size": 669438,
    "ratio": 0.1252,
-   "compress_mbps": 3.97,
-   "decompress_mbps": 430.23
+   "compress_mbps": 3.93,
+   "decompress_mbps": 654.12
   },
   {
    "compressor": "zlib",
@@ -17264,7 +17264,7 @@
    "level": 10,
    "out_size": 52115,
    "ratio": 0.3427,
-   "compress_mbps": 1.8,
+   "compress_mbps": 1.85,
    "decompress_mbps": null
   },
   {
@@ -17274,7 +17274,7 @@
    "level": 10,
    "out_size": 46881,
    "ratio": 0.3745,
-   "compress_mbps": 2.05,
+   "compress_mbps": 2.13,
    "decompress_mbps": null
   },
   {
@@ -17284,7 +17284,7 @@
    "level": 10,
    "out_size": 7730,
    "ratio": 0.3142,
-   "compress_mbps": 2.5,
+   "compress_mbps": 2.59,
    "decompress_mbps": null
   },
   {
@@ -17294,7 +17294,7 @@
    "level": 10,
    "out_size": 3030,
    "ratio": 0.2717,
-   "compress_mbps": 2.42,
+   "compress_mbps": 2.51,
    "decompress_mbps": null
   },
   {
@@ -17304,7 +17304,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.1,
+   "compress_mbps": 2.2,
    "decompress_mbps": null
   },
   {
@@ -17314,7 +17314,7 @@
    "level": 10,
    "out_size": 178311,
    "ratio": 0.1732,
-   "compress_mbps": 1.27,
+   "compress_mbps": 1.23,
    "decompress_mbps": null
   },
   {
@@ -17324,7 +17324,7 @@
    "level": 10,
    "out_size": 138684,
    "ratio": 0.325,
-   "compress_mbps": 1.92,
+   "compress_mbps": 1.96,
    "decompress_mbps": null
   },
   {
@@ -17334,7 +17334,7 @@
    "level": 10,
    "out_size": 186472,
    "ratio": 0.387,
-   "compress_mbps": 1.79,
+   "compress_mbps": 1.82,
    "decompress_mbps": null
   },
   {
@@ -17354,7 +17354,7 @@
    "level": 10,
    "out_size": 12277,
    "ratio": 0.3211,
-   "compress_mbps": 2.23,
+   "compress_mbps": 2.25,
    "decompress_mbps": null
   },
   {
@@ -17364,7 +17364,7 @@
    "level": 10,
    "out_size": 1696,
    "ratio": 0.4012,
-   "compress_mbps": 2.43,
+   "compress_mbps": 2.53,
    "decompress_mbps": null
   },
   {
@@ -17374,7 +17374,7 @@
    "level": 10,
    "out_size": 3712353,
    "ratio": 0.3642,
-   "compress_mbps": 1.79,
+   "compress_mbps": 1.82,
    "decompress_mbps": null
   },
   {
@@ -17384,7 +17384,7 @@
    "level": 10,
    "out_size": 18524576,
    "ratio": 0.3617,
-   "compress_mbps": 1.84,
+   "compress_mbps": 1.83,
    "decompress_mbps": null
   },
   {
@@ -17404,7 +17404,7 @@
    "level": 10,
    "out_size": 2930422,
    "ratio": 0.0873,
-   "compress_mbps": 1.71,
+   "compress_mbps": 1.68,
    "decompress_mbps": null
   },
   {
@@ -17414,7 +17414,7 @@
    "level": 10,
    "out_size": 3017814,
    "ratio": 0.4905,
-   "compress_mbps": 2.41,
+   "compress_mbps": 2.42,
    "decompress_mbps": null
   },
   {
@@ -17424,7 +17424,7 @@
    "level": 10,
    "out_size": 3647718,
    "ratio": 0.3617,
-   "compress_mbps": 2.8,
+   "compress_mbps": 2.78,
    "decompress_mbps": null
   },
   {
@@ -17444,7 +17444,7 @@
    "level": 10,
    "out_size": 5179097,
    "ratio": 0.2397,
-   "compress_mbps": 2.26,
+   "compress_mbps": 2.24,
    "decompress_mbps": null
   },
   {
@@ -17454,7 +17454,7 @@
    "level": 10,
    "out_size": 5261135,
    "ratio": 0.7255,
-   "compress_mbps": 2.6,
+   "compress_mbps": 2.59,
    "decompress_mbps": null
   },
   {
@@ -17464,7 +17464,7 @@
    "level": 10,
    "out_size": 11640134,
    "ratio": 0.2808,
-   "compress_mbps": 1.64,
+   "compress_mbps": 1.65,
    "decompress_mbps": null
   },
   {
@@ -17474,7 +17474,7 @@
    "level": 10,
    "out_size": 5825680,
    "ratio": 0.6875,
-   "compress_mbps": 3.43,
+   "compress_mbps": 3.55,
    "decompress_mbps": null
   },
   {
@@ -17484,7 +17484,7 @@
    "level": 10,
    "out_size": 643958,
    "ratio": 0.1205,
-   "compress_mbps": 2.59,
+   "compress_mbps": 2.57,
    "decompress_mbps": null
   }
  ]


### PR DESCRIPTION
This PR widens the DEFLATE `BitWriter` to hold up to 31 pending bits in a `UInt64` accumulator and flush whole bytes only when 32 or more accumulate, instead of storing every completed byte immediately. The old writer made one `pushUInt64LE` FFI store per bit-field, which — now that the per-bit loop is gone (#2631) — is the dominant emit cost on a literal-heavy stream. Batching drains 4-7 bytes in a single store, cutting the FFI store count roughly 4x. On Silesia at level 1 this measures +26-38% on the dynamic emit walk and +5-10% on the full pipeline (geomean ~8%), byte-identical output: every roundtrip and cross-engine differential-fuzz test (zlib, libdeflate, miniz_oxide) still passes. Because the emit walk is shared, every level's dynamic and fixed emit gets the same speedup.

The change is transparent to the emit functions and their proofs: they call `writeBits`/`writeHuffCode` through the unchanged `toBits`/`bitLength`/`flush` contracts. Only the `BitWriter` internals move — a new `flushBatched` reference reused by `writeBits_def`/`writeHuffCode_def`, the `wf` invariant relaxed from `bitCount < 8` to `< 32`, `flushBatched_spec` layered over the existing `flushAcc_spec`, and `flush` now draining the multiple pending bytes before the final partial. The `toBits` logical bit sequence is unchanged, so block sizing (`bitLength`) and the flushed bytes depend only on the total bits written, not on when they are drained. No theorem is weakened.

Follow-up to #2731 (shipped the `deflate_fast` L1 matcher) and the #2726 attribution — this is the half #2731 left. Re-running the tokens-held-constant attribution at the shipped cd4/ic2 L1 (below) showed the emit token-walk, not `tokenFreqsP` or dynamic sizing, dominates the emit path — and, crucially, that the walk was **FFI-bound rather than compute-bound**: de-boxing the code tables (`Array (UInt16 × UInt8)` → `Array UInt32`) or folding frequencies into the matcher each moved little (candidate B measured -2%), while batching the writer moved a lot. L1 stays matcher-bound overall (~60% of the pipeline; a zero-cost emit would cap it near ~99 MB/s), so this closes the reachable encode/emit gap rather than the full distance to the pure-language pack.

Step-1 re-attribution (level 1, tokens held constant, Silesia, MB/s vs uncompressed):

| file | freqs | freqs+dynSize | fixSize | fixed emit | full base | branch |
|------|-------|---------------|---------|-----------|-----------|--------|
| dickens | 886 | 866 | 885 | 177 | 148 | dynamic |
| mozilla | 959 | 944 | 961 | 237 | 184 | dynamic |
| nci | 3312 | 3249 | 3311 | 725 | 564 | dynamic |
| samba | 1473 | 1398 | 1476 | 321 | 252 | dynamic |
| webster | 1012 | 1005 | 1013 | 234 | 183 | dynamic |
| x-ray | 563 | 537 | 563 | 154 | 114 | dynamic |

Every file emits a dynamic block; the emit walk (~83% of the base emit path) dwarfs `tokenFreqsP` (~17%) and dynamic sizing (~2%).

Full L1 before/after (Silesia, MB/s; ratios byte-identical):

| file | before | after | Δ |
|------|--------|-------|---|
| dickens | 59.1 | 64.4 | +9.0% |
| mozilla | 74.4 | 79.8 | +7.3% |
| mr | 72.1 | 78.9 | +9.4% |
| nci | 211.5 | 232.8 | +10.1% |
| ooffice | 52.1 | 55.9 | +7.3% |
| osdb | 81.9 | 89.1 | +8.8% |
| reymont | 75.2 | 82.2 | +9.3% |
| samba | 100.8 | 108.4 | +7.5% |
| sao | 43.2 | 46.5 | +7.6% |
| webster | 75.7 | 82.9 | +9.5% |
| x-ray | 41.1 | 43.2 | +5.1% |
| xml | 162.8 | 176.0 | +8.1% |

🤖 Prepared with Claude Code
