### PR TITLE
perf: native array-based Huffman code-length build

### DIFF
--- a/Zip/Native/DeflateFreqs.lean
+++ b/Zip/Native/DeflateFreqs.lean
@@ -1,6 +1,7 @@
 import Zip.Native.Deflate
 import Zip.Spec.EmitTokensCorrect
 import Zip.Spec.HuffmanEncode
+import Zip.Native.HuffmanEncode
 
 /-!
   Token-stream frequency analysis and dynamic-Huffman code-length selection,
@@ -258,8 +259,8 @@ def freqsToPairs (freqs : Array Nat) : List (Nat × Nat) :=
     block emitter (`deflateDynamicBlock`) and the size-then-emit dispatch so both
     select identical trees from a single computation. -/
 def dynamicCodeLengths (litFreqs distFreqs : Array Nat) : List Nat × List Nat :=
-  let litLens := Huffman.Spec.computeCodeLengths (freqsToPairs litFreqs) 286 15
-  let distLens := Huffman.Spec.computeCodeLengths (freqsToPairs distFreqs) 30 15
+  let litLens := (Huffman.Spec.computeCodeLengthsN (freqsToPairs litFreqs) 286 15).toList
+  let distLens := (Huffman.Spec.computeCodeLengthsN (freqsToPairs distFreqs) 30 15).toList
   let distLens := if distLens.all (· == 0) then distLens.set 0 1 else distLens
   (litLens, distLens)
 
@@ -268,10 +269,13 @@ def dynamicCodeLengths (litFreqs distFreqs : Array Nat) : List Nat × List Nat :
 theorem dynamicCodeLengths_length (litFreqs distFreqs : Array Nat) :
     (dynamicCodeLengths litFreqs distFreqs).1.length = 286 ∧
     (dynamicCodeLengths litFreqs distFreqs).2.length = 30 := by
-  refine ⟨Huffman.Spec.computeCodeLengths_length _ 286 15, ?_⟩
-  show List.length (if _ then _ else _) = 30
-  split
-  · rw [List.length_set]; exact Huffman.Spec.computeCodeLengths_length _ 30 15
-  · exact Huffman.Spec.computeCodeLengths_length _ 30 15
+  refine ⟨?_, ?_⟩
+  · show ((Huffman.Spec.computeCodeLengthsN _ 286 15).toList).length = 286
+    rw [Array.length_toList]; exact Huffman.Spec.computeCodeLengthsN_size _ 286 15
+  · show List.length (if _ then _ else _) = 30
+    split
+    · rw [List.length_set, Array.length_toList]
+      exact Huffman.Spec.computeCodeLengthsN_size _ 30 15
+    · rw [Array.length_toList]; exact Huffman.Spec.computeCodeLengthsN_size _ 30 15
 
 end Zip.Native.Deflate

--- a/Zip/Native/HuffmanEncode.lean
+++ b/Zip/Native/HuffmanEncode.lean
@@ -1,0 +1,118 @@
+import Zip.Spec.HuffmanEncode
+
+/-!
+# Native array-based Huffman code-length construction
+
+Array twins of the `List`-based code-length pipeline in
+`Zip.Spec.HuffmanEncode`. The spec versions (`assignLengths`, `fixKraftList`,
+`computeCodeLengths`) stay untouched as the reference; here we recompute the
+same code lengths with `Array` accumulators so the hot `dynamicCodeLengths`
+path (one build per split block per sizing candidate on large heterogeneous
+members) no longer pays the `O(n²)` `List.set`/`List.length` churn that
+`assignLengths` incurs, nor the allocator/reference-count traffic of the
+`List Nat` result the emitters immediately `toArray` anyway.
+
+The correspondence theorems (`computeCodeLengthsN_toList`,
+`computeCodeLengthsN_toArray`) prove the array pipeline yields exactly the spec
+`List`, so every downstream property of `computeCodeLengths` (length,
+`ValidLengths`, completeness, nonzero) transfers verbatim and the compressed
+output is byte-identical.
+
+The tree build (`limitedPairs`) is reused unchanged: only the leaf-depth
+histogram it feeds and the symbol→length assignment are array-native here. The
+`O(n²)` cost lived in `assignLengths`, not the merge.
+-/
+
+namespace Huffman.Spec
+
+/-! ## Array-based symbol→length assignment -/
+
+/-- Array twin of `assignLengths`: assign code lengths into an array indexed by
+    symbol number, symbols not mentioned getting length 0. `setIfInBounds`
+    mirrors the `if sym < acc.length` guard of the `List` fold exactly, so an
+    out-of-range symbol leaves the accumulator unchanged. -/
+def assignLengthsN (depths : List (Nat × Nat)) (numSymbols : Nat) : Array Nat :=
+  depths.foldl (fun acc (p : Nat × Nat) => acc.setIfInBounds p.1 p.2)
+    (Array.replicate numSymbols 0)
+
+/-- The array assignment, read back as a list, is the spec `List` assignment.
+    Proved by an accumulator-generalized induction: `setIfInBounds`'s `toList`
+    is `List.set`, and its size guard is the list-length guard. -/
+theorem assignLengthsN_toList (depths : List (Nat × Nat)) (numSymbols : Nat) :
+    (assignLengthsN depths numSymbols).toList = assignLengths depths numSymbols := by
+  simp only [assignLengthsN, assignLengths]
+  suffices h : ∀ (acc : Array Nat),
+      (depths.foldl (fun acc (p : Nat × Nat) => acc.setIfInBounds p.1 p.2) acc).toList
+        = depths.foldl (fun (acc : List Nat) (p : Nat × Nat) =>
+            if p.1 < acc.length then acc.set p.1 p.2 else acc) acc.toList by
+    have := h (Array.replicate numSymbols 0)
+    simpa only [Array.toList_replicate] using this
+  intro acc
+  induction depths generalizing acc with
+  | nil => simp only [List.foldl_nil]
+  | cons d ds ih =>
+    simp only [List.foldl_cons]
+    rw [ih (acc.setIfInBounds d.1 d.2), Array.toList_setIfInBounds]
+    by_cases h : d.1 < acc.toList.length
+    · rw [if_pos h]
+    · rw [if_neg h, List.set_eq_of_length_le (by omega)]
+
+/-! ## Array-based Kraft fixup -/
+
+/-- Array twin of `fixKraftList`. The Kraft-sum test is computed over the
+    array's list view (an `O(n)` pass done once per call, not the `O(n²)`
+    assignment it guards); on the common path the lengths pass through
+    unchanged, and only the rare overflow branch rewrites via `Array.map`. -/
+def fixKraftListN (lengths : Array Nat) (maxBits : Nat) : Array Nat :=
+  if kraftSum (lengths.toList.filter (· != 0)) maxBits ≤ 2 ^ maxBits then lengths
+  else lengths.map fun l => if l == 0 then 0 else maxBits
+
+/-- The array Kraft fixup, read back as a list, is the spec `List` fixup. -/
+theorem fixKraftListN_toList (lengths : Array Nat) (maxBits : Nat) :
+    (fixKraftListN lengths maxBits).toList = fixKraftList lengths.toList maxBits := by
+  simp only [fixKraftListN, fixKraftList]
+  split
+  · rfl
+  · simp only [Array.toList_map]
+
+/-! ## Array-based code-length pipeline -/
+
+/-- Array twin of `computeCodeLengths`: same branch structure and same tree
+    build (`limitedPairs`), but the symbol→length assignment and Kraft fixup are
+    array-native. Returns the code lengths as an `Array Nat` directly, saving the
+    emitters the `List Nat → Array` round-trip. -/
+def computeCodeLengthsN (freqs : List (Nat × Nat)) (numSymbols : Nat)
+    (maxBits : Nat := 15) : Array Nat :=
+  let nonzero := freqs.filter (fun (_, f) => f > 0)
+  if nonzero.isEmpty then Array.replicate numSymbols 0
+  else if nonzero.length == 1 then
+    let (sym, _) := nonzero.head!
+    assignLengthsN [(sym, 1)] numSymbols
+  else
+    fixKraftListN (assignLengthsN (limitedPairs nonzero maxBits) numSymbols) maxBits
+
+/-- **Correspondence.** The array pipeline read back as a list is exactly the
+    spec `List` pipeline, so every property of `computeCodeLengths` transfers. -/
+theorem computeCodeLengthsN_toList (freqs : List (Nat × Nat)) (numSymbols maxBits : Nat) :
+    (computeCodeLengthsN freqs numSymbols maxBits).toList
+      = computeCodeLengths freqs numSymbols maxBits := by
+  simp only [computeCodeLengthsN, computeCodeLengths]
+  split
+  · exact Array.toList_replicate ..
+  · split
+    · exact assignLengthsN_toList ..
+    · rw [fixKraftListN_toList, assignLengthsN_toList]
+
+/-- The array pipeline is the `toArray` of the spec `List` pipeline: the form
+    the emitters (which immediately `toArray`) consume. -/
+theorem computeCodeLengthsN_toArray (freqs : List (Nat × Nat)) (numSymbols maxBits : Nat) :
+    computeCodeLengthsN freqs numSymbols maxBits
+      = (computeCodeLengths freqs numSymbols maxBits).toArray := by
+  rw [← computeCodeLengthsN_toList, Array.toArray_toList]
+
+/-- `computeCodeLengthsN` produces an array of size `numSymbols`. -/
+theorem computeCodeLengthsN_size (freqs : List (Nat × Nat)) (numSymbols maxBits : Nat) :
+    (computeCodeLengthsN freqs numSymbols maxBits).size = numSymbols := by
+  rw [← Array.length_toList, computeCodeLengthsN_toList, computeCodeLengths_length]
+
+end Huffman.Spec

--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -486,8 +486,8 @@ theorem deflateDynamicBlock_spec (data : ByteArray) (tokens : Array LZ77Token)
         (dynamicCodeLengths_length (tokenFreqs tokens).1 (tokenFreqs tokens).2).1
         (dynamicCodeLengths_length (tokenFreqs tokens).1 (tokenFreqs tokens).2).2 = _
     unfold deflateDynamicBlockCore emitDynBlock
-    cases hz : data.size == 0 <;>
-      simp only [hz, Bool.false_eq_true, ↓reduceIte] <;> rfl
+    cases data.size == 0 <;>
+      simp only [Bool.false_eq_true, ↓reduceIte] <;> rfl
   rw [heq, flush_toBits_aligned _ hwf, htoBits]
 
 /-- `deflateDynamic` (greedy LZ77 + dynamic Huffman) produces a bytestream whose

--- a/Zip/Spec/DeflateDynamicCorrect.lean
+++ b/Zip/Spec/DeflateDynamicCorrect.lean
@@ -63,22 +63,30 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
   let distFreqs := (tokenFreqs tokens).2
   let litFreqPairs := freqsToPairs litFreqs
   let distFreqPairs := freqsToPairs distFreqs
-  let litLens := Huffman.Spec.computeCodeLengths litFreqPairs 286 15
-  let distLens₀ := Huffman.Spec.computeCodeLengths distFreqPairs 30 15
+  -- `litLens`/`distLens` are defined through the array twin `computeCodeLengthsN`
+  -- exactly as `dynamicCodeLengths` does, so they are *definitionally* `(dynLens
+  -- tokens).1`/`.2`; `computeCodeLengthsN_toList` bridges to the spec
+  -- `computeCodeLengths` for the property lemmas below.
+  let litLens := (Huffman.Spec.computeCodeLengthsN litFreqPairs 286 15).toList
+  let distLens₀ := (Huffman.Spec.computeCodeLengthsN distFreqPairs 30 15).toList
   let distLens := if distLens₀.all (fun x => x == 0) then distLens₀.set 0 1 else distLens₀
+  have hlit_bridge : litLens = Huffman.Spec.computeCodeLengths litFreqPairs 286 15 :=
+    Huffman.Spec.computeCodeLengthsN_toList litFreqPairs 286 15
+  have hdist₀_bridge : distLens₀ = Huffman.Spec.computeCodeLengths distFreqPairs 30 15 :=
+    Huffman.Spec.computeCodeLengthsN_toList distFreqPairs 30 15
   -- Properties of computeCodeLengths
-  have hlit_len : litLens.length = 286 :=
-    Huffman.Spec.computeCodeLengths_length litFreqPairs 286 15
-  have hdist₀_len : distLens₀.length = 30 :=
-    Huffman.Spec.computeCodeLengths_length distFreqPairs 30 15
-  have hlit_valid : Huffman.Spec.ValidLengths litLens 15 :=
-    Huffman.Spec.computeCodeLengths_valid litFreqPairs 286 15 (by omega) (by omega)
-  have hlit_bound : ∀ x ∈ litLens, x ≤ 15 :=
-    Huffman.Spec.computeCodeLengths_bounded litFreqPairs 286 15 (by omega)
-  have hdist₀_valid : Huffman.Spec.ValidLengths distLens₀ 15 :=
-    Huffman.Spec.computeCodeLengths_valid distFreqPairs 30 15 (by omega) (by omega)
-  have hdist₀_bound : ∀ x ∈ distLens₀, x ≤ 15 :=
-    Huffman.Spec.computeCodeLengths_bounded distFreqPairs 30 15 (by omega)
+  have hlit_len : litLens.length = 286 := by
+    rw [hlit_bridge]; exact Huffman.Spec.computeCodeLengths_length litFreqPairs 286 15
+  have hdist₀_len : distLens₀.length = 30 := by
+    rw [hdist₀_bridge]; exact Huffman.Spec.computeCodeLengths_length distFreqPairs 30 15
+  have hlit_valid : Huffman.Spec.ValidLengths litLens 15 := by
+    rw [hlit_bridge]; exact Huffman.Spec.computeCodeLengths_valid litFreqPairs 286 15 (by omega) (by omega)
+  have hlit_bound : ∀ x ∈ litLens, x ≤ 15 := by
+    rw [hlit_bridge]; exact Huffman.Spec.computeCodeLengths_bounded litFreqPairs 286 15 (by omega)
+  have hdist₀_valid : Huffman.Spec.ValidLengths distLens₀ 15 := by
+    rw [hdist₀_bridge]; exact Huffman.Spec.computeCodeLengths_valid distFreqPairs 30 15 (by omega) (by omega)
+  have hdist₀_bound : ∀ x ∈ distLens₀, x ≤ 15 := by
+    rw [hdist₀_bridge]; exact Huffman.Spec.computeCodeLengths_bounded distFreqPairs 30 15 (by omega)
   -- distLens properties (with the fixup)
   have hdist_len : distLens.length = 30 := by
     simp only [distLens]; split
@@ -193,9 +201,11 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
         simp only [Deflate.Spec.encodeLitLen]
         have hb_lt : b.toNat < litLens.length := by rw [hlit_len]; have := UInt8.toNat_lt b; omega
         have hfreq := Deflate.tokenFreqs_literal_pos tokens b ht_mem
-        have hlen_nz := Huffman.Spec.computeCodeLengths_nonzero litFreqPairs 286 15
-          (by omega) b.toNat (by have := UInt8.toNat_lt b; omega)
-          (Deflate.freqPairs_witness litFreqs b.toNat (by have := UInt8.toNat_lt b; omega) hfreq)
+        have hlen_nz : litLens[b.toNat]! ≠ 0 := by
+          rw [hlit_bridge]
+          exact Huffman.Spec.computeCodeLengths_nonzero litFreqPairs 286 15
+            (by omega) b.toNat (by have := UInt8.toNat_lt b; omega)
+            (Deflate.freqPairs_witness litFreqs b.toNat (by have := UInt8.toNat_lt b; omega) hfreq)
         have hlen_le := getElem!_le_of_forall_mem_le litLens b.toNat 15 hb_lt hlit_bound
         exact Deflate.Spec.encodeSymbol_fixed_isSome litLens 15 b.toNat hb_lt hlen_nz hlen_le
       | reference len dist =>
@@ -215,9 +225,11 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
           have hsym : 257 + idx < litLens.length := by rw [hlit_len]; omega
           have hfreq := Deflate.tokenFreqs_lengthCode_pos tokens len dist idx extraN
             extraV.toUInt32 ht_mem hflc_native
-          have hlen_nz := Huffman.Spec.computeCodeLengths_nonzero litFreqPairs 286 15
-            (by omega) (257 + idx) (by omega)
-            (Deflate.freqPairs_witness litFreqs (257 + idx) (by omega) hfreq)
+          have hlen_nz : litLens[257 + idx]! ≠ 0 := by
+            rw [hlit_bridge]
+            exact Huffman.Spec.computeCodeLengths_nonzero litFreqPairs 286 15
+              (by omega) (257 + idx) (by omega)
+              (Deflate.freqPairs_witness litFreqs (257 + idx) (by omega) hfreq)
           have hlen_le' := getElem!_le_of_forall_mem_le litLens (257 + idx) 15 hsym hlit_bound
           have hlit_enc := Deflate.Spec.encodeSymbol_fixed_isSome litLens 15 (257 + idx)
             hsym hlen_nz hlen_le'
@@ -240,9 +252,11 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
                 -- There's a reference, so distFreqs has a positive entry
                 have hdfreq := Deflate.tokenFreqs_distCode_pos tokens len dist dCode dExtraN
                   dExtraV.toUInt32 ht_mem hfdc_native
-                have hdlen_nz := Huffman.Spec.computeCodeLengths_nonzero distFreqPairs 30 15
-                  (by omega) dCode (by omega)
-                  (Deflate.freqPairs_witness distFreqs dCode (by omega) hdfreq)
+                have hdlen_nz : distLens₀[dCode]! ≠ 0 := by
+                  rw [hdist₀_bridge]
+                  exact Huffman.Spec.computeCodeLengths_nonzero distFreqPairs 30 15
+                    (by omega) dCode (by omega)
+                    (Deflate.freqPairs_witness distFreqs dCode (by omega) hdfreq)
                 -- If all were zero, distLens₀[dCode]! would be 0, contradiction
                 intro hall
                 have hdc_lt : dCode < distLens₀.length := by omega
@@ -260,7 +274,7 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
               have hdfreq := Deflate.tokenFreqs_distCode_pos tokens len dist dCode dExtraN
                 dExtraV.toUInt32 ht_mem hfdc_native
               have hdlen_nz : distLens[dCode]! ≠ 0 := by
-                rw [hdl_eq]
+                rw [hdl_eq, hdist₀_bridge]
                 exact Huffman.Spec.computeCodeLengths_nonzero distFreqPairs 30 15
                   (by omega) dCode (by omega)
                   (Deflate.freqPairs_witness distFreqs dCode (by omega) hdfreq)
@@ -281,9 +295,11 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
       simp only [Deflate.Spec.encodeLitLen]
       have hsym : 256 < litLens.length := by rw [hlit_len]; omega
       have hfreq := Deflate.tokenFreqs_eob_pos tokens
-      have hlen_nz := Huffman.Spec.computeCodeLengths_nonzero litFreqPairs 286 15
-        (by omega) 256 (by omega)
-        (Deflate.freqPairs_witness litFreqs 256 (by omega) hfreq)
+      have hlen_nz : litLens[256]! ≠ 0 := by
+        rw [hlit_bridge]
+        exact Huffman.Spec.computeCodeLengths_nonzero litFreqPairs 286 15
+          (by omega) 256 (by omega)
+          (Deflate.freqPairs_witness litFreqs 256 (by omega) hfreq)
       have hlen_le := getElem!_le_of_forall_mem_le litLens 256 15 hsym hlit_bound
       exact Deflate.Spec.encodeSymbol_fixed_isSome litLens 15 256 hsym hlen_nz hlen_le
   -- Extract the actual values
@@ -406,6 +422,9 @@ theorem emitDynBlock_spec (bw : BitWriter) (hbw : bw.wf)
         have hwf_blk :
             (emitDynBlock bw data tokens litLens distLens hlit_len hdist_len isFinal).wf := by
           rw [hdef]; exact hwf_eob
+        -- `litLens`/`distLens` are *definitionally* `(dynLens tokens).1`/`.2`
+        -- (both go through `computeCodeLengthsN`), so the witnesses match by `rfl`
+        -- and `htoBits`/`hwf_blk` already speak about the goal's writer.
         exact ⟨litLens, distLens, headerBits, symBits, rfl, rfl,
           hlit_valid, hdist_valid, by omega, by omega, by omega, by omega,
           hlit_bound, hdist_bound, henc_trees, henc_syms, htoBits, hwf_blk⟩

--- a/bench/ZipHuffBench.lean
+++ b/bench/ZipHuffBench.lean
@@ -1,0 +1,103 @@
+import Zip
+/-! # Huffman code-length build microbench (issue #2761)
+
+Times the per-block dynamic-Huffman code-length construction — the hot cluster
+on heterogeneous, heavily-split members (mozilla L6) — comparing the spec
+`List`-based `computeCodeLengths` against the array twin `computeCodeLengthsN`.
+
+Tokens are matched once per file, split into fixed-size blocks (to mimic the
+split-block regime), and each block's `(litFreqs, distFreqs)` is summarised
+once. The timed region is only the code-length build over every block's
+frequencies, so the measurement isolates exactly the cluster the issue targets.
+
+Run: `lake exe huff-bench [corpusDir]`  (default `bench/corpora/canterbury`).
+-/
+
+open Zip.Native.Deflate
+
+@[noinline] def timeNs (iters : Nat) (op : Unit → Nat) : IO Nat := do
+  let t0 ← IO.monoNanosNow
+  let mut acc : Nat := 0
+  for _ in [:iters] do
+    acc := acc + op ()
+  let t1 ← IO.monoNanosNow
+  if acc == 0 then IO.eprintln "unreachable"
+  return (t1 - t0) / (max iters 1)
+
+def medianNs (xs : List Nat) : Nat :=
+  let a := xs.toArray.qsort (· < ·)
+  if a.size == 0 then 0 else a[a.size / 2]!
+
+/-- Per-block frequency summaries for a file: split the packed token stream into
+    `blockToks`-sized blocks and summarise each. -/
+def blockFreqs (ptokens : Array UInt32) (blockToks : Nat) : Array (Array Nat × Array Nat) := Id.run do
+  let mut out : Array (Array Nat × Array Nat) := #[]
+  let mut i := 0
+  while i < ptokens.size do
+    let j := min (i + blockToks) ptokens.size
+    out := out.push (tokenFreqsP (ptokens.extract i j))
+    i := j
+  return out
+
+/-- Sum of all built lengths (keeps the build live and unelided). `@[noinline]`
+    and a per-call `bump` folded into `litFreqs[0]` so the timing loop cannot
+    CSE the call across iterations/reps. -/
+@[noinline] def sumListBuild (blocks : Array (Array Nat × Array Nat)) (bump : Nat) : Nat := Id.run do
+  let mut acc := 0
+  for (lf, df) in blocks do
+    let lf := lf.set! 0 (lf.getD 0 0 + bump)
+    acc := acc + (Huffman.Spec.computeCodeLengths (freqsToPairs lf) 286 15).foldl (· + ·) 0
+    acc := acc + (Huffman.Spec.computeCodeLengths (freqsToPairs df) 30 15).foldl (· + ·) 0
+  return acc
+
+@[noinline] def sumArrBuild (blocks : Array (Array Nat × Array Nat)) (bump : Nat) : Nat := Id.run do
+  let mut acc := 0
+  for (lf, df) in blocks do
+    let lf := lf.set! 0 (lf.getD 0 0 + bump)
+    acc := acc + (Huffman.Spec.computeCodeLengthsN (freqsToPairs lf) 286 15).foldl (· + ·) 0
+    acc := acc + (Huffman.Spec.computeCodeLengthsN (freqsToPairs df) 30 15).foldl (· + ·) 0
+  return acc
+
+def reps : Nat := 7
+
+def analyzeFile (name : String) (data : ByteArray) (blockToks : Nat) : IO Unit := do
+  let ptokens := lzMatchP data 6
+  let blocks := blockFreqs ptokens blockToks
+  -- Replicate the file's blocks so a single build pass is milliseconds (the
+  -- split-block regime of a large member), and time single passes (`iters = 1`)
+  -- so nothing loop-invariant can be hoisted across iterations.
+  let target := 4000
+  let copies := max 1 ((target + blocks.size) / max 1 blocks.size)
+  let big := (Array.replicate copies blocks).flatten
+  let okList := sumListBuild big 7
+  let okArr := sumArrBuild big 7
+  let mut tl : List Nat := []
+  let mut ta : List Nat := []
+  for k in [:reps] do
+    tl := (← timeNs 1 (fun _ => sumListBuild big (k + 1))) :: tl
+    ta := (← timeNs 1 (fun _ => sumArrBuild big (k + 1))) :: ta
+  let ml := medianNs tl
+  let ma := medianNs ta
+  let speedup := if ma == 0 then 0.0 else ml.toFloat / ma.toFloat
+  let perBuildL := ml / (max 1 big.size)
+  let perBuildA := ma / (max 1 big.size)
+  let agree := if okList == okArr then "ok" else "MISMATCH"
+  IO.println s!"| {name} | {data.size} | {big.size} | {ml/1000} | {ma/1000} | {perBuildL} | {perBuildA} | {(speedup * 100.0).round / 100.0}x | {agree} |"
+
+def main (args : List String) : IO Unit := do
+  let dir := args.headD "bench/corpora/canterbury"
+  let blockToks := (args[1]?).bind (·.toNat?) |>.getD 2048
+  let root := System.FilePath.mk dir
+  unless ← root.pathExists do
+    IO.eprintln s!"corpus dir not found: {root}"; return
+  IO.println s!"## Huffman code-length build: List `computeCodeLengths` vs array `computeCodeLengthsN`"
+  IO.println s!"(tokens matched once at L6, {blockToks} tokens/block; median-of-{reps} ns for the build over all blocks)"
+  IO.println ""
+  IO.println "| file | bytes | blocks | List µs | Array µs | List ns/blk | Array ns/blk | speedup | agree |"
+  IO.println "|------|-------|--------|---------|----------|-------------|--------------|---------|-------|"
+  let entries ← root.readDir
+  let paths := (entries.map (·.path)).qsort (fun a b => a.toString < b.toString)
+  for path in paths do
+    unless ← path.isDir do
+      let data ← IO.FS.readBinFile path
+      analyzeFile (path.fileName.getD "") data blockToks

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p490df6c679)">
+   <g clip-path="url(#pb6bae649af)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDUlEQVR4nO3YvYpdVQCG4TkzZzQxowTFGA0EQUvBShvt7b0Qr8DGa/AORLAXwcLaxlJsFAUJIaBCYv5mJpPzYyF4Be9imc3zXMG3Wex93rNWu/tf7Q94tpw/mr1gnCfLfLb9xfnsCcOsXro2e8IYz78we8E4q8PZC8Z4utz3bKlntr97e/aEYZZ5YgAAEwksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY+tbq7uwNQ1xsz2dPGOb61TdnTxjmZHdt9oQhVmcPZk8Y5vuzn2dPGOKN516dPWGY7W4ze8IQDzensycMs9lvZ08Y4r0Xb8yeMIwbLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIitT46vzt4wxG69mz1hmJODS7MnjPP3rdkLhtifPZg9YZj3b34we8IQp5vlntnjhT7b2yfvzJ4wzMVqM3vCEPvff5w9YRg3WAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABBbXz46mb1hiPPt6ewJ46wW3MWXXpq9YIjVgs/seLOZPWGIJZ/ZlfUy37M/Lu7MnjDMZncxe8IQN65cnT1hmOV+QQAAJhFYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEFttf/psP3sE/Ge3m70A/nXo/+czx/eD/xFfEACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIitP/nr1uwNQzx4sp09YZgf7jycPWGYbz7+cPaEIV67fHP2hGHe/eLL2ROG+Oitl2dPGOa3e2ezJwxxeX00e8IwX3/7y+wJQ5x+/unsCcO4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYarP7bj97xAjb3Wb2hGEOV8vt4qPz09kTxjhaz14wzuO7sxcMsb16ffaEYXb73ewJQxyvlvuePd0v8zfteLPM5zo4cIMFAJATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsfXh04vZG4Y4PFzPnjDOn7/OXjDM/tH92RPG2GxmLxhm9crrsycMcbTdzZ4wztFC/1vfuz17wTDHZw9mTxhi/3Ch3/wDN1gAADmBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ+wfth4K8R0QyZwAAAABJRU5ErkJggg==" id="image21944d7de8" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJF0lEQVR4nO3YzYqk5R2H4aruanViK4PgBwqSkCwDrpKN7t17IB6BG4/BMwiB7EPARdZuXIqbhATCEAwxYdRRe3p66sNFIEdwP/y1uK4j+L08vG/d9WyP3/zhtOGn5fa76QXrPDnPZzvd3U5PWGb74ivTE9Z49mfTC9bZXkwvWOPp+b5n53pmp4f/nJ6wzHmeGADAIIEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDbPdg+nN6wxN3hdnrCMq/d//n0hGWuj69MT1hi+/jR9IRlPnn8l+kJS7z+zMvTE5Y5HPfTE5b4dn8zPWGZ/ekwPWGJ37zwxvSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx3fXV/esMSx91xesIy15vnpies8/WD6QVLnB4/mp6wzG/ffHt6whI3+/M9s+/P9Nl+df3r6QnL3G330xOWOP3js+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNju3uX19IYlbg830xPW2Z5xFz/34vSCJbZnfGZX+/30hCXO+cye353ne/bvuy+mJyyzP95NT1jijefvT09Y5ny/IAAAQwQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxLaHzz88TY+A/zsepxfA/1z4//mT4/vBj4gvCABATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMR27//nwfSGJR49OUxPWObTL76dnrDMn957Z3rCEq/ee3N6wjJv/e730xOWePeXL01PWObvXz2enrDEvd3l9IRl/vjxX6cnLHHz0QfTE5ZxgwUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx7f7459P0iBUOx/30hGUutufbxZe3N9MT1rjcTS9Y5/uH0wuWONx/bXrCMsfTcXrCElfb833Pnp7O8zftan+ez7XZuMECAMgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2O7icJzesMTF5TPTE9b58m/TC5Y53Xw9PWGNu6fTC5bZvvqL6QlLXJ7np3Gz2Ww2x+30gkW+++/0gmWuntxMT1ji9PBf0xOWcYMFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsR8A3ECC0LzRZSAAAAAASUVORK5CYII=" id="image22da82dc48" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m70d0eb3e4b" d="M 0 0 
+       <path id="mcd39e66306" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m70d0eb3e4b" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcd39e66306" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m07a2dc99fe" d="M 0 0 
+       <path id="m35331957b0" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m07a2dc99fe" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35331957b0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m07a2dc99fe" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35331957b0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m07a2dc99fe" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35331957b0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m07a2dc99fe" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35331957b0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m07a2dc99fe" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35331957b0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m07a2dc99fe" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35331957b0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m07a2dc99fe" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35331957b0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m07a2dc99fe" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m35331957b0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,37 +1303,8 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -14 -->
-    <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
     <!-- -8 -->
-    <g transform="translate(151.312096 68.904519) scale(0.065 -0.065)">
+    <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1379,9 +1350,94 @@ z
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
     </g>
    </g>
+   <g id="text_21">
+    <!-- -1 -->
+    <g transform="translate(151.312096 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
    <g id="text_22">
-    <!-- -64 -->
+    <!-- -57 -->
     <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -82 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -90 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -38 -->
+    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -6 -->
+    <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1416,56 +1472,11 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -87 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -94 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -55 -->
-    <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -10 -->
-    <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +7 -->
-    <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
+    <!-- +10 -->
+    <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1484,36 +1495,58 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -49 -->
+    <!-- -35 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -70 -->
+    <!-- -50 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -94 -->
+    <!-- -91 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
     <!-- +4 -->
     <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
@@ -1575,40 +1608,6 @@ z
    <g id="text_39">
     <!-- -3 -->
     <g transform="translate(426.067685 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -2181,18 +2180,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image71cda7bb84" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image77f2afe851" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mdd03cddc87" d="M 0 0 
+       <path id="m085b58ea64" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdd03cddc87" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m085b58ea64" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2215,7 +2214,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mdd03cddc87" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m085b58ea64" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2229,7 +2228,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mdd03cddc87" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m085b58ea64" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2243,7 +2242,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mdd03cddc87" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m085b58ea64" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2256,7 +2255,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mdd03cddc87" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m085b58ea64" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2269,7 +2268,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mdd03cddc87" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m085b58ea64" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2282,7 +2281,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mdd03cddc87" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m085b58ea64" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2943,8 +2942,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.687734 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.380391 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3011,16 +3010,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3061,108 +3060,108 @@ z
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p490df6c679">
+  <clipPath id="pb6bae649af">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mc852c6beca" d="M 0 0 
+       <path id="m6eba45d44e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc852c6beca" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6eba45d44e" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc852c6beca" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6eba45d44e" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc852c6beca" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6eba45d44e" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc852c6beca" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6eba45d44e" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc852c6beca" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6eba45d44e" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc852c6beca" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6eba45d44e" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc852c6beca" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6eba45d44e" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m69a621b2e9" d="M 0 0 
+       <path id="m1727ca7e1d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m69a621b2e9" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1727ca7e1d" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m69a621b2e9" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1727ca7e1d" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m69a621b2e9" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1727ca7e1d" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m52b97157d8" d="M 0 0 
+       <path id="mdb5e39ec65" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m52b97157d8" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mdb5e39ec65" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 160.316466) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 147.798199) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 301.905418) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 298.12969) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m8201a32ea5" d="M -2.5 2.5 
+     <path id="ma84a192c3d" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3aaf15e627)">
-     <use xlink:href="#m8201a32ea5" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8201a32ea5" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8201a32ea5" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8201a32ea5" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8201a32ea5" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8201a32ea5" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8201a32ea5" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8201a32ea5" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8201a32ea5" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p95022286a9)">
+     <use xlink:href="#ma84a192c3d" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma84a192c3d" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma84a192c3d" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma84a192c3d" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma84a192c3d" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma84a192c3d" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma84a192c3d" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma84a192c3d" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma84a192c3d" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="mf4758b086d" d="M 0 -2.5 
+     <path id="ma5263759ec" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3aaf15e627)">
-     <use xlink:href="#mf4758b086d" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4758b086d" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4758b086d" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4758b086d" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4758b086d" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4758b086d" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4758b086d" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4758b086d" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf4758b086d" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p95022286a9)">
+     <use xlink:href="#ma5263759ec" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5263759ec" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5263759ec" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5263759ec" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5263759ec" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5263759ec" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5263759ec" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5263759ec" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma5263759ec" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="ma8de32e618" d="M -0 3.535534 
+     <path id="m4a937c07dc" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3aaf15e627)">
-     <use xlink:href="#ma8de32e618" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma8de32e618" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p95022286a9)">
+     <use xlink:href="#m4a937c07dc" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4a937c07dc" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m56c2750bfe" d="M -0 2.5 
+     <path id="m06b4eb8a2d" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3aaf15e627)">
-     <use xlink:href="#m56c2750bfe" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p95022286a9)">
+     <use xlink:href="#m06b4eb8a2d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="mcac27d6d46" d="M -0.833333 2.5 
+     <path id="m35aab4875e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3aaf15e627)">
-     <use xlink:href="#mcac27d6d46" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcac27d6d46" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcac27d6d46" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcac27d6d46" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcac27d6d46" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcac27d6d46" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcac27d6d46" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcac27d6d46" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcac27d6d46" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p95022286a9)">
+     <use xlink:href="#m35aab4875e" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35aab4875e" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35aab4875e" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35aab4875e" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35aab4875e" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35aab4875e" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35aab4875e" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35aab4875e" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m35aab4875e" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="me4b4cede54" d="M -1.25 2.5 
+     <path id="m85bac3a0ed" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3aaf15e627)">
-     <use xlink:href="#me4b4cede54" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4cede54" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4cede54" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4cede54" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4cede54" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4cede54" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4cede54" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4cede54" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4cede54" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p95022286a9)">
+     <use xlink:href="#m85bac3a0ed" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85bac3a0ed" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85bac3a0ed" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85bac3a0ed" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85bac3a0ed" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85bac3a0ed" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85bac3a0ed" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85bac3a0ed" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m85bac3a0ed" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m737e32427b" d="M 0 -2.5 
+     <path id="mb2a95fcfdd" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p3aaf15e627)">
-     <use xlink:href="#m737e32427b" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m737e32427b" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m737e32427b" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m737e32427b" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m737e32427b" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m737e32427b" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m737e32427b" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m737e32427b" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m737e32427b" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p95022286a9)">
+     <use xlink:href="#mb2a95fcfdd" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb2a95fcfdd" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb2a95fcfdd" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb2a95fcfdd" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb2a95fcfdd" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb2a95fcfdd" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb2a95fcfdd" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb2a95fcfdd" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mb2a95fcfdd" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m318fe77cb1" d="M 0 -2.5 
+     <path id="maa52ccf2bd" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3aaf15e627)">
-     <use xlink:href="#m318fe77cb1" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318fe77cb1" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318fe77cb1" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318fe77cb1" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318fe77cb1" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318fe77cb1" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318fe77cb1" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318fe77cb1" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m318fe77cb1" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p95022286a9)">
+     <use xlink:href="#maa52ccf2bd" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa52ccf2bd" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa52ccf2bd" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa52ccf2bd" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa52ccf2bd" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa52ccf2bd" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa52ccf2bd" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa52ccf2bd" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maa52ccf2bd" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m1f5d4b9d96" d="M 0 3.5 
+      <path id="m1cf56156c9" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m1f5d4b9d96" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m1cf56156c9" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m8201a32ea5" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma84a192c3d" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#mf4758b086d" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma5263759ec" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#ma8de32e618" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4a937c07dc" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m56c2750bfe" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m06b4eb8a2d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#mcac27d6d46" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m35aab4875e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#me4b4cede54" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m85bac3a0ed" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m737e32427b" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mb2a95fcfdd" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m318fe77cb1" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#maa52ccf2bd" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p3aaf15e627)">
-     <use xlink:href="#m1f5d4b9d96" x="289.669676" y="165.316466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1f5d4b9d96" x="223.847406" y="174.96204" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1f5d4b9d96" x="212.215046" y="178.482168" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1f5d4b9d96" x="186.58897" y="187.275824" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1f5d4b9d96" x="169.057218" y="196.198972" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1f5d4b9d96" x="158.596848" y="208.242379" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1f5d4b9d96" x="152.867313" y="213.428968" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1f5d4b9d96" x="150.950891" y="215.894006" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1f5d4b9d96" x="115.225692" y="281.749714" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1f5d4b9d96" x="99.852312" y="306.905418" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p95022286a9)">
+     <use xlink:href="#m1cf56156c9" x="289.669676" y="152.798199" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1cf56156c9" x="223.847406" y="163.663924" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1cf56156c9" x="212.215046" y="167.391399" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1cf56156c9" x="186.58897" y="177.108872" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1cf56156c9" x="169.057218" y="186.848851" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1cf56156c9" x="158.596848" y="196.294266" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1cf56156c9" x="152.867313" y="202.223877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1cf56156c9" x="150.950891" y="205.361615" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1cf56156c9" x="115.225692" y="277.324326" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1cf56156c9" x="99.852312" y="303.12969" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 165.316466 
-L 288.298379 165.5388 
-L 286.927082 165.760096 
-L 285.555784 165.980364 
-L 284.184487 166.199613 
-L 282.81319 166.417852 
-L 281.441892 166.635091 
-L 280.070595 166.851339 
-L 278.699298 167.066604 
-L 277.328 167.280897 
-L 275.956703 167.494225 
-L 274.585406 167.706597 
-L 273.214109 167.918022 
-L 271.842811 168.128508 
-L 270.471514 168.338064 
-L 269.100217 168.546697 
-L 267.728919 168.754416 
-L 266.357622 168.961228 
-L 264.986325 169.167142 
-L 263.615028 169.372166 
-L 262.24373 169.576306 
-L 260.872433 169.779571 
-L 259.501136 169.981968 
-L 258.129838 170.183504 
-L 256.758541 170.384187 
-L 255.387244 170.584024 
-L 254.015947 170.783022 
-L 252.644649 170.981188 
-L 251.273352 171.178529 
-L 249.902055 171.375052 
-L 248.530757 171.570763 
-L 247.15946 171.76567 
-L 245.788163 171.959778 
-L 244.416866 172.153095 
-L 243.045568 172.345626 
-L 241.674271 172.537379 
-L 240.302974 172.728359 
-L 238.931676 172.918572 
-L 237.560379 173.108026 
-L 236.189082 173.296725 
-L 234.817784 173.484676 
-L 233.446487 173.671884 
-L 232.07519 173.858356 
-L 230.703893 174.044097 
-L 229.332595 174.229113 
-L 227.961298 174.41341 
-L 226.590001 174.596993 
-L 225.218703 174.779868 
-L 223.847406 174.96204 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 152.798199 
+L 288.298379 153.051936 
+L 286.927082 153.304322 
+L 285.555784 153.555371 
+L 284.184487 153.805097 
+L 282.81319 154.053515 
+L 281.441892 154.300637 
+L 280.070595 154.546478 
+L 278.699298 154.79105 
+L 277.328 155.034367 
+L 275.956703 155.276441 
+L 274.585406 155.517285 
+L 273.214109 155.756912 
+L 271.842811 155.995333 
+L 270.471514 156.232561 
+L 269.100217 156.468607 
+L 267.728919 156.703484 
+L 266.357622 156.937203 
+L 264.986325 157.169774 
+L 263.615028 157.401211 
+L 262.24373 157.631522 
+L 260.872433 157.86072 
+L 259.501136 158.088815 
+L 258.129838 158.315818 
+L 256.758541 158.541739 
+L 255.387244 158.766588 
+L 254.015947 158.990375 
+L 252.644649 159.213111 
+L 251.273352 159.434805 
+L 249.902055 159.655467 
+L 248.530757 159.875106 
+L 247.15946 160.093732 
+L 245.788163 160.311355 
+L 244.416866 160.527983 
+L 243.045568 160.743625 
+L 241.674271 160.958291 
+L 240.302974 161.171989 
+L 238.931676 161.384728 
+L 237.560379 161.596516 
+L 236.189082 161.807362 
+L 234.817784 162.017274 
+L 233.446487 162.226261 
+L 232.07519 162.434331 
+L 230.703893 162.641491 
+L 229.332595 162.847749 
+L 227.961298 163.053114 
+L 226.590001 163.257593 
+L 225.218703 163.461194 
+L 223.847406 163.663924 
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 174.96204 
-L 223.605065 175.038107 
-L 223.362724 175.114051 
-L 223.120384 175.189875 
-L 222.878043 175.265577 
-L 222.635702 175.341159 
-L 222.393361 175.41662 
-L 222.15102 175.491961 
-L 221.908679 175.567183 
-L 221.666339 175.642286 
-L 221.423998 175.71727 
-L 221.181657 175.792135 
-L 220.939316 175.866882 
-L 220.696975 175.941512 
-L 220.454635 176.016024 
-L 220.212294 176.090419 
-L 219.969953 176.164698 
-L 219.727612 176.238861 
-L 219.485271 176.312907 
-L 219.24293 176.386838 
-L 219.00059 176.460655 
-L 218.758249 176.534356 
-L 218.515908 176.607943 
-L 218.273567 176.681415 
-L 218.031226 176.754774 
-L 217.788885 176.82802 
-L 217.546545 176.901153 
-L 217.304204 176.974173 
-L 217.061863 177.047081 
-L 216.819522 177.119876 
-L 216.577181 177.19256 
-L 216.33484 177.265133 
-L 216.0925 177.337595 
-L 215.850159 177.409946 
-L 215.607818 177.482187 
-L 215.365477 177.554318 
-L 215.123136 177.62634 
-L 214.880795 177.698252 
-L 214.638455 177.770055 
-L 214.396114 177.84175 
-L 214.153773 177.913336 
-L 213.911432 177.984815 
-L 213.669091 178.056185 
-L 213.42675 178.127449 
-L 213.18441 178.198605 
-L 212.942069 178.269655 
-L 212.699728 178.340599 
-L 212.457387 178.411436 
-L 212.215046 178.482168 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 163.663924 
+L 223.605065 163.744646 
+L 223.362724 163.82523 
+L 223.120384 163.905678 
+L 222.878043 163.98599 
+L 222.635702 164.066166 
+L 222.393361 164.146207 
+L 222.15102 164.226112 
+L 221.908679 164.305883 
+L 221.666339 164.38552 
+L 221.423998 164.465024 
+L 221.181657 164.544394 
+L 220.939316 164.623632 
+L 220.696975 164.702737 
+L 220.454635 164.781711 
+L 220.212294 164.860553 
+L 219.969953 164.939264 
+L 219.727612 165.017845 
+L 219.485271 165.096296 
+L 219.24293 165.174617 
+L 219.00059 165.252809 
+L 218.758249 165.330872 
+L 218.515908 165.408807 
+L 218.273567 165.486614 
+L 218.031226 165.564293 
+L 217.788885 165.641845 
+L 217.546545 165.719271 
+L 217.304204 165.79657 
+L 217.061863 165.873744 
+L 216.819522 165.950792 
+L 216.577181 166.027715 
+L 216.33484 166.104513 
+L 216.0925 166.181187 
+L 215.850159 166.257737 
+L 215.607818 166.334164 
+L 215.365477 166.410468 
+L 215.123136 166.486649 
+L 214.880795 166.562708 
+L 214.638455 166.638645 
+L 214.396114 166.714461 
+L 214.153773 166.790155 
+L 213.911432 166.865729 
+L 213.669091 166.941183 
+L 213.42675 167.016516 
+L 213.18441 167.09173 
+L 212.942069 167.166825 
+L 212.699728 167.241801 
+L 212.457387 167.316659 
+L 212.215046 167.391399 
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 178.482168 
-L 211.68117 178.683038 
-L 211.147293 178.883061 
-L 210.613417 179.082244 
-L 210.07954 179.280593 
-L 209.545663 179.478115 
-L 209.011787 179.674818 
-L 208.47791 179.870707 
-L 207.944034 180.065791 
-L 207.410157 180.260074 
-L 206.87628 180.453565 
-L 206.342404 180.646269 
-L 205.808527 180.838193 
-L 205.274651 181.029343 
-L 204.740774 181.219725 
-L 204.206897 181.409345 
-L 203.673021 181.59821 
-L 203.139144 181.786325 
-L 202.605268 181.973697 
-L 202.071391 182.160331 
-L 201.537515 182.346233 
-L 201.003638 182.531408 
-L 200.469761 182.715863 
-L 199.935885 182.899603 
-L 199.402008 183.082634 
-L 198.868132 183.26496 
-L 198.334255 183.446588 
-L 197.800378 183.627522 
-L 197.266502 183.807768 
-L 196.732625 183.987332 
-L 196.198749 184.166218 
-L 195.664872 184.344431 
-L 195.130995 184.521977 
-L 194.597119 184.69886 
-L 194.063242 184.875085 
-L 193.529366 185.050658 
-L 192.995489 185.225583 
-L 192.461612 185.399864 
-L 191.927736 185.573508 
-L 191.393859 185.746517 
-L 190.859983 185.918897 
-L 190.326106 186.090652 
-L 189.79223 186.261788 
-L 189.258353 186.432308 
-L 188.724476 186.602216 
-L 188.1906 186.771517 
-L 187.656723 186.940216 
-L 187.122847 187.108317 
-L 186.58897 187.275824 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 167.391399 
+L 211.68117 167.615561 
+L 211.147293 167.838669 
+L 210.613417 168.060731 
+L 210.07954 168.281758 
+L 209.545663 168.501759 
+L 209.011787 168.720744 
+L 208.47791 168.938721 
+L 207.944034 169.155701 
+L 207.410157 169.371692 
+L 206.87628 169.586703 
+L 206.342404 169.800743 
+L 205.808527 170.013821 
+L 205.274651 170.225945 
+L 204.740774 170.437125 
+L 204.206897 170.647367 
+L 203.673021 170.856681 
+L 203.139144 171.065075 
+L 202.605268 171.272557 
+L 202.071391 171.479134 
+L 201.537515 171.684815 
+L 201.003638 171.889608 
+L 200.469761 172.093519 
+L 199.935885 172.296557 
+L 199.402008 172.498728 
+L 198.868132 172.700042 
+L 198.334255 172.900503 
+L 197.800378 173.100121 
+L 197.266502 173.298901 
+L 196.732625 173.496851 
+L 196.198749 173.693978 
+L 195.664872 173.890289 
+L 195.130995 174.08579 
+L 194.597119 174.280487 
+L 194.063242 174.474389 
+L 193.529366 174.6675 
+L 192.995489 174.859828 
+L 192.461612 175.051378 
+L 191.927736 175.242157 
+L 191.393859 175.432172 
+L 190.859983 175.621428 
+L 190.326106 175.809931 
+L 189.79223 175.997688 
+L 189.258353 176.184704 
+L 188.724476 176.370985 
+L 188.1906 176.556536 
+L 187.656723 176.741364 
+L 187.122847 176.925474 
+L 186.58897 177.108872 
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 186.58897 187.275824 
-L 186.223725 187.479933 
-L 185.85848 187.683166 
-L 185.493235 187.885532 
-L 185.127991 188.087038 
-L 184.762746 188.287691 
-L 184.397501 188.487498 
-L 184.032256 188.686466 
-L 183.667011 188.884602 
-L 183.301766 189.081914 
-L 182.936522 189.278407 
-L 182.571277 189.47409 
-L 182.206032 189.668968 
-L 181.840787 189.863047 
-L 181.475542 190.056336 
-L 181.110297 190.248839 
-L 180.745053 190.440564 
-L 180.379808 190.631517 
-L 180.014563 190.821703 
-L 179.649318 191.011129 
-L 179.284073 191.199801 
-L 178.918828 191.387725 
-L 178.553584 191.574907 
-L 178.188339 191.761353 
-L 177.823094 191.947068 
-L 177.457849 192.132058 
-L 177.092604 192.31633 
-L 176.727359 192.499887 
-L 176.362115 192.682737 
-L 175.99687 192.864883 
-L 175.631625 193.046333 
-L 175.26638 193.227091 
-L 174.901135 193.407161 
-L 174.53589 193.586551 
-L 174.170645 193.765264 
-L 173.805401 193.943305 
-L 173.440156 194.120681 
-L 173.074911 194.297395 
-L 172.709666 194.473453 
-L 172.344421 194.648859 
-L 171.979176 194.823618 
-L 171.613932 194.997736 
-L 171.248687 195.171216 
-L 170.883442 195.344064 
-L 170.518197 195.516283 
-L 170.152952 195.687879 
-L 169.787707 195.858856 
-L 169.422463 196.029219 
-L 169.057218 196.198972 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.58897 177.108872 
+L 186.223725 177.333608 
+L 185.85848 177.557283 
+L 185.493235 177.779908 
+L 185.127991 178.001492 
+L 184.762746 178.222044 
+L 184.397501 178.441576 
+L 184.032256 178.660095 
+L 183.667011 178.877611 
+L 183.301766 179.094134 
+L 182.936522 179.309672 
+L 182.571277 179.524235 
+L 182.206032 179.73783 
+L 181.840787 179.950468 
+L 181.475542 180.162156 
+L 181.110297 180.372902 
+L 180.745053 180.582716 
+L 180.379808 180.791605 
+L 180.014563 180.999577 
+L 179.649318 181.206641 
+L 179.284073 181.412804 
+L 178.918828 181.618075 
+L 178.553584 181.82246 
+L 178.188339 182.025968 
+L 177.823094 182.228606 
+L 177.457849 182.430381 
+L 177.092604 182.631301 
+L 176.727359 182.831372 
+L 176.362115 183.030603 
+L 175.99687 183.229 
+L 175.631625 183.42657 
+L 175.26638 183.62332 
+L 174.901135 183.819256 
+L 174.53589 184.014386 
+L 174.170645 184.208716 
+L 173.805401 184.402252 
+L 173.440156 184.595001 
+L 173.074911 184.78697 
+L 172.709666 184.978164 
+L 172.344421 185.168591 
+L 171.979176 185.358255 
+L 171.613932 185.547163 
+L 171.248687 185.735322 
+L 170.883442 185.922736 
+L 170.518197 186.109412 
+L 170.152952 186.295356 
+L 169.787707 186.480574 
+L 169.422463 186.66507 
+L 169.057218 186.848851 
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 169.057218 196.198972 
-L 168.839293 196.483774 
-L 168.621369 196.766876 
-L 168.403445 197.048297 
-L 168.18552 197.328057 
-L 167.967596 197.606176 
-L 167.749672 197.882672 
-L 167.531747 198.157564 
-L 167.313823 198.430872 
-L 167.095898 198.702612 
-L 166.877974 198.972804 
-L 166.66005 199.241464 
-L 166.442125 199.50861 
-L 166.224201 199.774258 
-L 166.006277 200.038427 
-L 165.788352 200.30113 
-L 165.570428 200.562386 
-L 165.352503 200.82221 
-L 165.134579 201.080618 
-L 164.916655 201.337624 
-L 164.69873 201.593244 
-L 164.480806 201.847493 
-L 164.262882 202.100386 
-L 164.044957 202.351936 
-L 163.827033 202.602159 
-L 163.609108 202.851067 
-L 163.391184 203.098675 
-L 163.17326 203.344996 
-L 162.955335 203.590044 
-L 162.737411 203.833832 
-L 162.519487 204.076372 
-L 162.301562 204.317677 
-L 162.083638 204.55776 
-L 161.865713 204.796634 
-L 161.647789 205.034309 
-L 161.429865 205.270798 
-L 161.21194 205.506114 
-L 160.994016 205.740267 
-L 160.776092 205.973269 
-L 160.558167 206.205131 
-L 160.340243 206.435864 
-L 160.122318 206.66548 
-L 159.904394 206.893989 
-L 159.68647 207.121401 
-L 159.468545 207.347728 
-L 159.250621 207.572979 
-L 159.032697 207.797164 
-L 158.814772 208.020294 
-L 158.596848 208.242379 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 169.057218 186.848851 
+L 168.839293 187.066109 
+L 168.621369 187.282375 
+L 168.403445 187.497658 
+L 168.18552 187.711969 
+L 167.967596 187.925315 
+L 167.749672 188.137704 
+L 167.531747 188.349147 
+L 167.313823 188.55965 
+L 167.095898 188.769223 
+L 166.877974 188.977873 
+L 166.66005 189.185608 
+L 166.442125 189.392437 
+L 166.224201 189.598368 
+L 166.006277 189.803407 
+L 165.788352 190.007564 
+L 165.570428 190.210845 
+L 165.352503 190.413258 
+L 165.134579 190.61481 
+L 164.916655 190.815509 
+L 164.69873 191.015361 
+L 164.480806 191.214374 
+L 164.262882 191.412556 
+L 164.044957 191.609912 
+L 163.827033 191.80645 
+L 163.609108 192.002176 
+L 163.391184 192.197097 
+L 163.17326 192.39122 
+L 162.955335 192.584551 
+L 162.737411 192.777097 
+L 162.519487 192.968864 
+L 162.301562 193.159858 
+L 162.083638 193.350086 
+L 161.865713 193.539553 
+L 161.647789 193.728266 
+L 161.429865 193.91623 
+L 161.21194 194.103452 
+L 160.994016 194.289938 
+L 160.776092 194.475692 
+L 160.558167 194.660722 
+L 160.340243 194.845032 
+L 160.122318 195.028628 
+L 159.904394 195.211516 
+L 159.68647 195.3937 
+L 159.468545 195.575188 
+L 159.250621 195.755983 
+L 159.032697 195.936091 
+L 158.814772 196.115517 
+L 158.596848 196.294266 
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 158.596848 208.242379 
-L 158.477483 208.356429 
-L 158.358117 208.470206 
-L 158.238752 208.58371 
-L 158.119387 208.696942 
-L 158.000021 208.809905 
-L 157.880656 208.9226 
-L 157.761291 209.035027 
-L 157.641925 209.147188 
-L 157.52256 209.259084 
-L 157.403195 209.370716 
-L 157.28383 209.482087 
-L 157.164464 209.593196 
-L 157.045099 209.704046 
-L 156.925734 209.814636 
-L 156.806368 209.92497 
-L 156.687003 210.035047 
-L 156.567638 210.144869 
-L 156.448272 210.254437 
-L 156.328907 210.363753 
-L 156.209542 210.472817 
-L 156.090177 210.581631 
-L 155.970811 210.690195 
-L 155.851446 210.798511 
-L 155.732081 210.906581 
-L 155.612715 211.014404 
-L 155.49335 211.121983 
-L 155.373985 211.229318 
-L 155.254619 211.336411 
-L 155.135254 211.443262 
-L 155.015889 211.549873 
-L 154.896524 211.656245 
-L 154.777158 211.762378 
-L 154.657793 211.868275 
-L 154.538428 211.973935 
-L 154.419062 212.07936 
-L 154.299697 212.184551 
-L 154.180332 212.28951 
-L 154.060966 212.394236 
-L 153.941601 212.498732 
-L 153.822236 212.602998 
-L 153.702871 212.707035 
-L 153.583505 212.810844 
-L 153.46414 212.914426 
-L 153.344775 213.017782 
-L 153.225409 213.120914 
-L 153.106044 213.223821 
-L 152.986679 213.326506 
-L 152.867313 213.428968 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.596848 196.294266 
+L 158.477483 196.425677 
+L 158.358117 196.556724 
+L 158.238752 196.687411 
+L 158.119387 196.817737 
+L 158.000021 196.947707 
+L 157.880656 197.077321 
+L 157.761291 197.206582 
+L 157.641925 197.335491 
+L 157.52256 197.46405 
+L 157.403195 197.592262 
+L 157.28383 197.720127 
+L 157.164464 197.847649 
+L 157.045099 197.974829 
+L 156.925734 198.101668 
+L 156.806368 198.228169 
+L 156.687003 198.354333 
+L 156.567638 198.480162 
+L 156.448272 198.605658 
+L 156.328907 198.730823 
+L 156.209542 198.855658 
+L 156.090177 198.980165 
+L 155.970811 199.104345 
+L 155.851446 199.228202 
+L 155.732081 199.351735 
+L 155.612715 199.474948 
+L 155.49335 199.597841 
+L 155.373985 199.720416 
+L 155.254619 199.842675 
+L 155.135254 199.964619 
+L 155.015889 200.086251 
+L 154.896524 200.207571 
+L 154.777158 200.328581 
+L 154.657793 200.449284 
+L 154.538428 200.569679 
+L 154.419062 200.68977 
+L 154.299697 200.809557 
+L 154.180332 200.929043 
+L 154.060966 201.048227 
+L 153.941601 201.167113 
+L 153.822236 201.285702 
+L 153.702871 201.403994 
+L 153.583505 201.521992 
+L 153.46414 201.639697 
+L 153.344775 201.75711 
+L 153.225409 201.874233 
+L 153.106044 201.991068 
+L 152.986679 202.107615 
+L 152.867313 202.223877 
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 152.867313 213.428968 
-L 152.827388 213.481653 
-L 152.787463 213.534279 
-L 152.747537 213.586846 
-L 152.707612 213.639356 
-L 152.667686 213.691807 
-L 152.627761 213.7442 
-L 152.587835 213.796536 
-L 152.54791 213.848814 
-L 152.507984 213.901034 
-L 152.468059 213.953197 
-L 152.428133 214.005302 
-L 152.388208 214.05735 
-L 152.348282 214.109341 
-L 152.308357 214.161275 
-L 152.268432 214.213152 
-L 152.228506 214.264973 
-L 152.188581 214.316737 
-L 152.148655 214.368444 
-L 152.10873 214.420095 
-L 152.068804 214.47169 
-L 152.028879 214.523229 
-L 151.988953 214.574712 
-L 151.949028 214.626139 
-L 151.909102 214.67751 
-L 151.869177 214.728826 
-L 151.829252 214.780086 
-L 151.789326 214.83129 
-L 151.749401 214.88244 
-L 151.709475 214.933534 
-L 151.66955 214.984573 
-L 151.629624 215.035558 
-L 151.589699 215.086488 
-L 151.549773 215.137362 
-L 151.509848 215.188183 
-L 151.469922 215.238949 
-L 151.429997 215.289661 
-L 151.390072 215.340318 
-L 151.350146 215.390921 
-L 151.310221 215.441471 
-L 151.270295 215.491966 
-L 151.23037 215.542408 
-L 151.190444 215.592796 
-L 151.150519 215.643131 
-L 151.110593 215.693412 
-L 151.070668 215.74364 
-L 151.030742 215.793815 
-L 150.990817 215.843937 
-L 150.950891 215.894006 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 152.867313 202.223877 
+L 152.827388 202.29141 
+L 152.787463 202.358848 
+L 152.747537 202.42619 
+L 152.707612 202.493436 
+L 152.667686 202.560587 
+L 152.627761 202.627643 
+L 152.587835 202.694604 
+L 152.54791 202.761471 
+L 152.507984 202.828243 
+L 152.468059 202.894922 
+L 152.428133 202.961507 
+L 152.388208 203.027998 
+L 152.348282 203.094397 
+L 152.308357 203.160702 
+L 152.268432 203.226915 
+L 152.228506 203.293036 
+L 152.188581 203.359064 
+L 152.148655 203.425001 
+L 152.10873 203.490846 
+L 152.068804 203.556599 
+L 152.028879 203.622262 
+L 151.988953 203.687834 
+L 151.949028 203.753315 
+L 151.909102 203.818705 
+L 151.869177 203.884006 
+L 151.829252 203.949217 
+L 151.789326 204.014338 
+L 151.749401 204.07937 
+L 151.709475 204.144313 
+L 151.66955 204.209167 
+L 151.629624 204.273932 
+L 151.589699 204.338609 
+L 151.549773 204.403198 
+L 151.509848 204.467699 
+L 151.469922 204.532112 
+L 151.429997 204.596438 
+L 151.390072 204.660677 
+L 151.350146 204.724829 
+L 151.310221 204.788894 
+L 151.270295 204.852872 
+L 151.23037 204.916765 
+L 151.190444 204.980571 
+L 151.150519 205.044291 
+L 151.110593 205.107926 
+L 151.070668 205.171476 
+L 151.030742 205.234941 
+L 150.990817 205.29832 
+L 150.950891 205.361615 
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 215.894006 
-L 150.206616 218.779081 
-L 149.462341 221.498578 
-L 148.718066 224.070474 
-L 147.973791 226.509972 
-L 147.229517 228.830036 
-L 146.485242 231.041819 
-L 145.740967 233.154978 
-L 144.996692 235.177934 
-L 144.252417 237.118074 
-L 143.508142 238.981914 
-L 142.763867 240.775227 
-L 142.019592 242.503157 
-L 141.275317 244.170305 
-L 140.531042 245.780801 
-L 139.786767 247.338371 
-L 139.042492 248.846382 
-L 138.298217 250.30789 
-L 137.553942 251.725679 
-L 136.809667 253.102288 
-L 136.065392 254.440042 
-L 135.321117 255.741074 
-L 134.576842 257.007346 
-L 133.832567 258.240669 
-L 133.088292 259.442712 
-L 132.344017 260.615024 
-L 131.599742 261.759039 
-L 130.855467 262.876093 
-L 130.111192 263.967425 
-L 129.366917 265.034195 
-L 128.622642 266.077483 
-L 127.878367 267.098302 
-L 127.134092 268.097598 
-L 126.389817 269.07626 
-L 125.645542 270.035124 
-L 124.901267 270.974974 
-L 124.156992 271.896551 
-L 123.412717 272.80055 
-L 122.668442 273.68763 
-L 121.924167 274.558413 
-L 121.179892 275.413487 
-L 120.435617 276.253408 
-L 119.691342 277.078704 
-L 118.947067 277.889876 
-L 118.202792 278.687399 
-L 117.458517 279.471725 
-L 116.714242 280.243283 
-L 115.969967 281.002483 
-L 115.225692 281.749714 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 150.950891 205.361615 
+L 150.206616 208.756605 
+L 149.462341 211.924594 
+L 148.718066 214.894046 
+L 147.973791 217.688384 
+L 147.229517 220.327116 
+L 146.485242 222.826663 
+L 145.740967 225.200975 
+L 144.996692 227.462005 
+L 144.252417 229.620071 
+L 143.508142 231.684145 
+L 142.763867 233.662074 
+L 142.019592 235.56076 
+L 141.275317 237.38631 
+L 140.531042 239.14415 
+L 139.786767 240.839123 
+L 139.042492 242.47557 
+L 138.298217 244.0574 
+L 137.553942 245.58814 
+L 136.809667 247.070988 
+L 136.065392 248.50885 
+L 135.321117 249.904375 
+L 134.576842 251.259985 
+L 133.832567 252.577901 
+L 133.088292 253.860161 
+L 132.344017 255.108644 
+L 131.599742 256.325085 
+L 130.855467 257.511087 
+L 130.111192 258.668136 
+L 129.366917 259.797612 
+L 128.622642 260.900799 
+L 127.878367 261.978892 
+L 127.134092 263.033009 
+L 126.389817 264.064192 
+L 125.645542 265.073418 
+L 124.901267 266.061603 
+L 124.156992 267.029605 
+L 123.412717 267.978234 
+L 122.668442 268.908249 
+L 121.924167 269.820367 
+L 121.179892 270.715264 
+L 120.435617 271.593577 
+L 119.691342 272.455911 
+L 118.947067 273.302836 
+L 118.202792 274.134894 
+L 117.458517 274.952596 
+L 116.714242 275.756432 
+L 115.969967 276.546862 
+L 115.225692 277.324326 
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.225692 281.749714 
-L 114.905413 282.436114 
-L 114.585134 283.112715 
-L 114.264856 283.779794 
-L 113.944577 284.437614 
-L 113.624298 285.08643 
-L 113.304019 285.726485 
-L 112.983741 286.358011 
-L 112.663462 286.981234 
-L 112.343183 287.596369 
-L 112.022904 288.203622 
-L 111.702626 288.803194 
-L 111.382347 289.395277 
-L 111.062068 289.980054 
-L 110.741789 290.557705 
-L 110.421511 291.128401 
-L 110.101232 291.692307 
-L 109.780953 292.249583 
-L 109.460674 292.800383 
-L 109.140396 293.344856 
-L 108.820117 293.883146 
-L 108.499838 294.415391 
-L 108.17956 294.941726 
-L 107.859281 295.46228 
-L 107.539002 295.977179 
-L 107.218723 296.486545 
-L 106.898445 296.990496 
-L 106.578166 297.489144 
-L 106.257887 297.982602 
-L 105.937608 298.470974 
-L 105.61733 298.954367 
-L 105.297051 299.432879 
-L 104.976772 299.906609 
-L 104.656493 300.37565 
-L 104.336215 300.840096 
-L 104.015936 301.300035 
-L 103.695657 301.755554 
-L 103.375378 302.206736 
-L 103.0551 302.653665 
-L 102.734821 303.096418 
-L 102.414542 303.535074 
-L 102.094264 303.969708 
-L 101.773985 304.400393 
-L 101.453706 304.827199 
-L 101.133427 305.250196 
-L 100.813149 305.669452 
-L 100.49287 306.085032 
-L 100.172591 306.497 
-L 99.852312 306.905418 
-" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.225692 277.324326 
+L 114.905413 278.033556 
+L 114.585134 278.732331 
+L 114.264856 279.420953 
+L 113.944577 280.099713 
+L 113.624298 280.768891 
+L 113.304019 281.428753 
+L 112.983741 282.079555 
+L 112.663462 282.721541 
+L 112.343183 283.354949 
+L 112.022904 283.980003 
+L 111.702626 284.596923 
+L 111.382347 285.205915 
+L 111.062068 285.807183 
+L 110.741789 286.400918 
+L 110.421511 286.987308 
+L 110.101232 287.566533 
+L 109.780953 288.138764 
+L 109.460674 288.704169 
+L 109.140396 289.26291 
+L 108.820117 289.81514 
+L 108.499838 290.361011 
+L 108.17956 290.900666 
+L 107.859281 291.434247 
+L 107.539002 291.961887 
+L 107.218723 292.483719 
+L 106.898445 292.999868 
+L 106.578166 293.510457 
+L 106.257887 294.015605 
+L 105.937608 294.515425 
+L 105.61733 295.01003 
+L 105.297051 295.499527 
+L 104.976772 295.984021 
+L 104.656493 296.463612 
+L 104.336215 296.9384 
+L 104.015936 297.408478 
+L 103.695657 297.87394 
+L 103.375378 298.334876 
+L 103.0551 298.791373 
+L 102.734821 299.243515 
+L 102.414542 299.691384 
+L 102.094264 300.135062 
+L 101.773985 300.574625 
+L 101.453706 301.010149 
+L 101.133427 301.441707 
+L 100.813149 301.869372 
+L 100.49287 302.293212 
+L 100.172591 302.713296 
+L 99.852312 303.12969 
+" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.687734 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.380391 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6265,31 +6265,6 @@ L 1172 0
 L 2766 4134 
 L 525 4134 
 L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
@@ -6441,16 +6416,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6491,108 +6466,108 @@ z
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3aaf15e627">
+  <clipPath id="p95022286a9">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pf3eb7f8b4c)">
+   <g clip-path="url(#p36856600c4)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="image0386cedcdb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="imagee04f5b8cf9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mb46beef313" d="M 0 0 
+       <path id="m63b0fd2f7e" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb46beef313" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mb46beef313" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mb46beef313" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb46beef313" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mb46beef313" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb46beef313" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mb46beef313" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb46beef313" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mb46beef313" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb46beef313" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mb46beef313" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m63b0fd2f7e" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m5eb75f3fcd" d="M 0 0 
+       <path id="md119eec9e7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md119eec9e7" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md119eec9e7" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md119eec9e7" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md119eec9e7" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md119eec9e7" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md119eec9e7" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md119eec9e7" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md119eec9e7" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imageeba73428b3" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8a61406706" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="mbc98d845d9" d="M 0 0 
+       <path id="m059cf37bdf" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbc98d845d9" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m059cf37bdf" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mbc98d845d9" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m059cf37bdf" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mbc98d845d9" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m059cf37bdf" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mbc98d845d9" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m059cf37bdf" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mbc98d845d9" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m059cf37bdf" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mbc98d845d9" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m059cf37bdf" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mbc98d845d9" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m059cf37bdf" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mbc98d845d9" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m059cf37bdf" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mbc98d845d9" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m059cf37bdf" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.687734 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.380391 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2950,16 +2950,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3000,108 +3000,108 @@ z
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf3eb7f8b4c">
+  <clipPath id="p36856600c4">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.024531pt" height="386.202469pt" viewBox="0 0 575.024531 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.639219pt" height="386.202469pt" viewBox="0 0 575.639219 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.024531 386.202469 
-L 575.024531 0 
+L 575.639219 386.202469 
+L 575.639219 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.637266 104.1264 
-L 294.262266 104.1264 
-L 294.262266 74.7432 
-L 189.637266 74.7432 
+    <path d="M 189.944609 104.1264 
+L 294.569609 104.1264 
+L 294.569609 74.7432 
+L 189.944609 74.7432 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.262266 104.1264 
-L 398.887266 104.1264 
-L 398.887266 74.7432 
-L 294.262266 74.7432 
+    <path d="M 294.569609 104.1264 
+L 399.194609 104.1264 
+L 399.194609 74.7432 
+L 294.569609 74.7432 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.887266 104.1264 
-L 503.512266 104.1264 
-L 503.512266 74.7432 
-L 398.887266 74.7432 
+    <path d="M 399.194609 104.1264 
+L 503.819609 104.1264 
+L 503.819609 74.7432 
+L 399.194609 74.7432 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.637266 133.5096 
-L 294.262266 133.5096 
-L 294.262266 104.1264 
-L 189.637266 104.1264 
+    <path d="M 189.944609 133.5096 
+L 294.569609 133.5096 
+L 294.569609 104.1264 
+L 189.944609 104.1264 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.262266 133.5096 
-L 398.887266 133.5096 
-L 398.887266 104.1264 
-L 294.262266 104.1264 
+    <path d="M 294.569609 133.5096 
+L 399.194609 133.5096 
+L 399.194609 104.1264 
+L 294.569609 104.1264 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.887266 133.5096 
-L 503.512266 133.5096 
-L 503.512266 104.1264 
-L 398.887266 104.1264 
+    <path d="M 399.194609 133.5096 
+L 503.819609 133.5096 
+L 503.819609 104.1264 
+L 399.194609 104.1264 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.637266 162.8928 
-L 294.262266 162.8928 
-L 294.262266 133.5096 
-L 189.637266 133.5096 
+    <path d="M 189.944609 162.8928 
+L 294.569609 162.8928 
+L 294.569609 133.5096 
+L 189.944609 133.5096 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.262266 162.8928 
-L 398.887266 162.8928 
-L 398.887266 133.5096 
-L 294.262266 133.5096 
+    <path d="M 294.569609 162.8928 
+L 399.194609 162.8928 
+L 399.194609 133.5096 
+L 294.569609 133.5096 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.887266 162.8928 
-L 503.512266 162.8928 
-L 503.512266 133.5096 
-L 398.887266 133.5096 
+    <path d="M 399.194609 162.8928 
+L 503.819609 162.8928 
+L 503.819609 133.5096 
+L 399.194609 133.5096 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.637266 192.276 
-L 294.262266 192.276 
-L 294.262266 162.8928 
-L 189.637266 162.8928 
+    <path d="M 189.944609 192.276 
+L 294.569609 192.276 
+L 294.569609 162.8928 
+L 189.944609 162.8928 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.262266 192.276 
-L 398.887266 192.276 
-L 398.887266 162.8928 
-L 294.262266 162.8928 
+    <path d="M 294.569609 192.276 
+L 399.194609 192.276 
+L 399.194609 162.8928 
+L 294.569609 162.8928 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.887266 192.276 
-L 503.512266 192.276 
-L 503.512266 162.8928 
-L 398.887266 162.8928 
+    <path d="M 399.194609 192.276 
+L 503.819609 192.276 
+L 503.819609 162.8928 
+L 399.194609 162.8928 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.637266 221.6592 
-L 294.262266 221.6592 
-L 294.262266 192.276 
-L 189.637266 192.276 
+    <path d="M 189.944609 221.6592 
+L 294.569609 221.6592 
+L 294.569609 192.276 
+L 189.944609 192.276 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.262266 221.6592 
-L 398.887266 221.6592 
-L 398.887266 192.276 
-L 294.262266 192.276 
+    <path d="M 294.569609 221.6592 
+L 399.194609 221.6592 
+L 399.194609 192.276 
+L 294.569609 192.276 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.887266 221.6592 
-L 503.512266 221.6592 
-L 503.512266 192.276 
-L 398.887266 192.276 
+    <path d="M 399.194609 221.6592 
+L 503.819609 221.6592 
+L 503.819609 192.276 
+L 399.194609 192.276 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.637266 251.0424 
-L 294.262266 251.0424 
-L 294.262266 221.6592 
-L 189.637266 221.6592 
+    <path d="M 189.944609 251.0424 
+L 294.569609 251.0424 
+L 294.569609 221.6592 
+L 189.944609 221.6592 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.262266 251.0424 
-L 398.887266 251.0424 
-L 398.887266 221.6592 
-L 294.262266 221.6592 
+    <path d="M 294.569609 251.0424 
+L 399.194609 251.0424 
+L 399.194609 221.6592 
+L 294.569609 221.6592 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.887266 251.0424 
-L 503.512266 251.0424 
-L 503.512266 221.6592 
-L 398.887266 221.6592 
+    <path d="M 399.194609 251.0424 
+L 503.819609 251.0424 
+L 503.819609 221.6592 
+L 399.194609 221.6592 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.637266 280.4256 
-L 294.262266 280.4256 
-L 294.262266 251.0424 
-L 189.637266 251.0424 
+    <path d="M 189.944609 280.4256 
+L 294.569609 280.4256 
+L 294.569609 251.0424 
+L 189.944609 251.0424 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.262266 280.4256 
-L 398.887266 280.4256 
-L 398.887266 251.0424 
-L 294.262266 251.0424 
+    <path d="M 294.569609 280.4256 
+L 399.194609 280.4256 
+L 399.194609 251.0424 
+L 294.569609 251.0424 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.887266 280.4256 
-L 503.512266 280.4256 
-L 503.512266 251.0424 
-L 398.887266 251.0424 
+    <path d="M 399.194609 280.4256 
+L 503.819609 280.4256 
+L 503.819609 251.0424 
+L 399.194609 251.0424 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.637266 309.8088 
-L 294.262266 309.8088 
-L 294.262266 280.4256 
-L 189.637266 280.4256 
+    <path d="M 189.944609 309.8088 
+L 294.569609 309.8088 
+L 294.569609 280.4256 
+L 189.944609 280.4256 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.262266 309.8088 
-L 398.887266 309.8088 
-L 398.887266 280.4256 
-L 294.262266 280.4256 
+    <path d="M 294.569609 309.8088 
+L 399.194609 309.8088 
+L 399.194609 280.4256 
+L 294.569609 280.4256 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.887266 309.8088 
-L 503.512266 309.8088 
-L 503.512266 280.4256 
-L 398.887266 280.4256 
+    <path d="M 399.194609 309.8088 
+L 503.819609 309.8088 
+L 503.819609 280.4256 
+L 399.194609 280.4256 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.637266 339.192 
-L 294.262266 339.192 
-L 294.262266 309.8088 
-L 189.637266 309.8088 
+    <path d="M 189.944609 339.192 
+L 294.569609 339.192 
+L 294.569609 309.8088 
+L 189.944609 309.8088 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.262266 339.192 
-L 398.887266 339.192 
-L 398.887266 309.8088 
-L 294.262266 309.8088 
+    <path d="M 294.569609 339.192 
+L 399.194609 339.192 
+L 399.194609 309.8088 
+L 294.569609 309.8088 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.887266 339.192 
-L 503.512266 339.192 
-L 503.512266 309.8088 
-L 398.887266 309.8088 
+    <path d="M 399.194609 339.192 
+L 503.819609 339.192 
+L 503.819609 309.8088 
+L 399.194609 309.8088 
 z
-" clip-path="url(#p6e2f4a2ee9)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pbaae916470)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.624531 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.931875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.90875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.216094 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.480859 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.788203 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.832578 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(407.139922 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.562266 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.869609 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(230.498516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(338.939766 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(339.247109 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(443.564766 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.200391 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.507734 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(230.498516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(341.484766 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(443.564766 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(130.463516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(130.770859 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(230.498516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(341.484766 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(443.564766 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(100.893516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(101.200859 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(230.498516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(341.484766 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(443.564766 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.769766 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(114.077109 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(230.498516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(341.484766 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(443.564766 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(121.926016 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(122.233359 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(230.498516 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(341.484766 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,104 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(446.109766 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(446.417109 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- OCaml decompress -->
-    <g transform="translate(98.386641 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-4f" d="M 2522 4238 
-Q 1834 4238 1429 3725 
-Q 1025 3213 1025 2328 
-Q 1025 1447 1429 934 
-Q 1834 422 2522 422 
-Q 3209 422 3611 934 
-Q 4013 1447 4013 2328 
-Q 4013 3213 3611 3725 
-Q 3209 4238 2522 4238 
-z
-M 2522 4750 
-Q 3503 4750 4090 4092 
-Q 4678 3434 4678 2328 
-Q 4678 1225 4090 567 
-Q 3503 -91 2522 -91 
-Q 1538 -91 948 565 
-Q 359 1222 359 2328 
-Q 359 3434 948 4092 
-Q 1538 4750 2522 4750 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-43" d="M 4122 4306 
-L 4122 3641 
-Q 3803 3938 3442 4084 
-Q 3081 4231 2675 4231 
-Q 1875 4231 1450 3742 
-Q 1025 3253 1025 2328 
-Q 1025 1406 1450 917 
-Q 1875 428 2675 428 
-Q 3081 428 3442 575 
-Q 3803 722 4122 1019 
-L 4122 359 
-Q 3791 134 3420 21 
-Q 3050 -91 2638 -91 
-Q 1578 -91 968 557 
-Q 359 1206 359 2328 
-Q 359 3453 968 4101 
-Q 1578 4750 2638 4750 
-Q 3056 4750 3426 4639 
-Q 3797 4528 4122 4306 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-4f"/>
-     <use xlink:href="#DejaVuSans-43" transform="translate(78.710938 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(148.535156 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(209.814453 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(307.226562 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(335.009766 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(366.796875 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(430.273438 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(491.796875 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(546.777344 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(607.958984 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(705.371094 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(768.847656 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(807.710938 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(869.234375 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(921.333984 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- 0.321 -->
-    <g transform="translate(230.498516 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
-    <!-- 23 -->
-    <g transform="translate(341.484766 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 117 -->
-    <g transform="translate(443.564766 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.271641 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(100.578984 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1841,9 +1751,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_34">
+   <g id="text_30">
     <!-- 0.298 -->
-    <g transform="translate(229.297891 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.605234 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1972,9 +1882,37 @@ z
      <use xlink:href="#DejaVuSans-Bold-38" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- 19 -->
-    <g transform="translate(341.008516 297.3247) scale(0.08 -0.08)">
+   <g id="text_31">
+    <!-- 24 -->
+    <g transform="translate(341.315859 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 136 -->
+    <g transform="translate(443.157734 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1990,15 +1928,6 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-Bold-31"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 137 -->
-    <g transform="translate(442.850391 297.3247) scale(0.08 -0.08)">
-     <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
 Q 3944 1791 3944 1325 
@@ -2031,25 +1960,135 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- OCaml decompress -->
+    <g transform="translate(98.693984 297.3247) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-4f" d="M 2522 4238 
+Q 1834 4238 1429 3725 
+Q 1025 3213 1025 2328 
+Q 1025 1447 1429 934 
+Q 1834 422 2522 422 
+Q 3209 422 3611 934 
+Q 4013 1447 4013 2328 
+Q 4013 3213 3611 3725 
+Q 3209 4238 2522 4238 
+z
+M 2522 4750 
+Q 3503 4750 4090 4092 
+Q 4678 3434 4678 2328 
+Q 4678 1225 4090 567 
+Q 3503 -91 2522 -91 
+Q 1538 -91 948 565 
+Q 359 1222 359 2328 
+Q 359 3434 948 4092 
+Q 1538 4750 2522 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-43" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-43" transform="translate(78.710938 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(148.535156 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(209.814453 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(307.226562 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(335.009766 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(366.796875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(430.273438 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(491.796875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(546.777344 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(607.958984 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(705.371094 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(768.847656 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(807.710938 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(869.234375 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(921.333984 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- 0.321 -->
+    <g transform="translate(230.805859 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- 23 -->
+    <g transform="translate(341.792109 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- 117 -->
+    <g transform="translate(443.872109 297.3247) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.607891 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.915234 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2060,7 +2099,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(230.498516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2070,13 +2109,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(344.029766 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.337109 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.199766 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.507109 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2092,7 +2131,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(137.021016 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(137.328359 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2231,36 +2270,6 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2305,7 +2314,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2444,16 +2453,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2494,109 +2503,109 @@ z
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p6e2f4a2ee9">
-   <rect x="85.012266" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pbaae916470">
+   <rect x="85.319609" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p3ffefac427)">
+   <g clip-path="url(#p1974a3c697)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ80lEQVR4nO3YsY6cVx2H4ezOeLM2kuXYYoWjCAkahChQIllRboProKLlGrgBOkougIKGggIpNCldEREbJCskVmJZzrA7u8tFROf9m0/PcwW/T2e+mXfOyc3Xf7h9Z8su30wvWOvkdHrBWjfH6QVrbf38jpfTC9a692B6wVr/fT29gO9jdza9YK2tfz7vnE8vWGrjv34AALxtBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9Z8dn0xuWOruzn56w1OF4OT1hqcf335+esNQXr55PT1jqeHI9PWGpn999OD1hqeO759MTlvr3639NT1jq4u7F9ISlDmfH6QlLnbzzZnrCUm5AAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1P7i3sX0hqUe/+Cn0xOW+vLNs+kJS/3osO3/SPcf/XJ6wlJnu/PpCUtd3xynJyy19fPb/POdbvv59qcfTE9Y6vxwmJ6w1LZ/3QEAeOsIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUvt3d/emNyz18vBiesJSWz+/6/ceTk9Y6vk3n01PWOr11WF6wlJP3nsyPWGpy9vj9ISlvnj1+fSEpX7x6KPpCUt9+uJv0xOW+vCH2z4/N6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqZPrv/7mdnrEUjc30wv4PrZ+fqf+A8KYrb9/vj//vx2P0wuW2vjpAQDwthGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9hefPp3esNTubDc9Yakvn/5nesJSv//1h9MTlvrd37d9fp98cH96wlJ//Mvn0xOW+u2vfjY9Yak//ePb6QlL/eTB3ekJS7387mp6wlIfP743PWEpN6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDq5Or6z7fTI1baXV1OT1hrdza9YK3jYXrBWvvz6QVr7fbTC9a6vZlesNbVxt+/k43fwZxu+/27Otn2+3fneJyesNTG3z4AAN42AhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNT+5vZmesNSu6/+OT1hrQfvTy9Y69WL6QVrnd+fXrDWnfPpBWtt/flePptesNbDH08vWOvwanrBUvvnT6cnrPXo8fSCpdyAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKT+B169eLPa5stFAAAAAElFTkSuQmCC" id="imagef150d98969" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7UlEQVR4nO3YwY6kVR2HYbqrpukZZcIAdhwzG90Q48JAQgy34XW4Yss1cAPuXHoBLty4YEECG5YkJJIAmgwYJ0KGseiu7vYiJuf9j1+e5wp+lVOnvre+k5t//+n2pS27fDa9YK2T0+kFa90cpxestfXzO15OL1jr3qvTC9b68en0Ap7H7mx6wVpb/37eOZ9esNTGn34AALxoBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9p8evpjcsdXZnPz1hqcPxcnrCUg/v/2J6wlJffv/19ISljifX0xOW+vXd16YnLHV8+Xx6wlL/fPqP6QlLXdy9mJ6w1OHsOD1hqZOXnk1PWMobUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILW/uHcxvWGphz/51fSEpb599tX0hKV+ftj2f6T7r/92esJSZ7vz6QlLXd8cpycstfXz2/znO93259ufPpqesNT54TA9YaltP90BAHjhCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL7l3f3pjcs9eTweHrCUls/v+sHr01PWOrr/3w6PWGpp1eH6QlLvfPgnekJS13eHqcnLPXl919MT1jqN6+/PT1hqY8ffzQ9Yam3frbt8/MGFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACB1cv3he7fTI5a6uZlewPPY+vmd+g8IY7Z+//x+/n87HqcXLLXx0wMA4EUjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0vPv5sesNSu7Pd9ISlvv3sX9MTlvrjH96anrDUB59s+/zefXR/esJSf/7bF9MTlnr/929OT1jqL3//bnrCUr989e70hKWe/PdqesJSv3t4b3rCUt6AAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqZOr67/eTo9YaXd1OT1hrd3Z9IK1jofpBWvtz6cXrLXbTy9Y6/ZmesFaVxu/fycbfwdzuu37d3Wy7ft353icnrDUxm8fAAAvGgEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqf3N7M71hqd0PT6YnrPXTN6YXrPXd4+kFa71yMb2A57E/m16w1tbv34NH0wvWOh6mFyx155vPpyestfHnuzegAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn/AUineMpbWK/WAAAAAElFTkSuQmCC" id="image7be6dd23b1" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m58cb58d4a1" d="M 0 0 
+       <path id="m7edbed4d21" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m58cb58d4a1" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m58cb58d4a1" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7edbed4d21" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mc068637832" d="M 0 0 
+       <path id="m09565980af" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc068637832" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09565980af" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc068637832" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09565980af" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc068637832" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09565980af" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mc068637832" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09565980af" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mc068637832" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09565980af" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc068637832" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09565980af" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mc068637832" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09565980af" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc068637832" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09565980af" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1192,65 +1192,65 @@ z
     </g>
    </g>
    <g id="text_22">
-    <!-- -50 -->
+    <!-- -33 -->
     <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -20 -->
+    <!-- -12 -->
     <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
      <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
 L 3431 0 
@@ -1277,12 +1277,12 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- -48 -->
+    <!-- -44 -->
     <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
@@ -1304,6 +1304,16 @@ L 313 1709
 L 2253 4666 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -18 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1345,161 +1355,44 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -32 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -23 -->
+    <!-- -18 -->
     <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -13 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -48 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_29">
-    <!-- -13 -->
-    <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
+   <g id="text_27">
+    <!-- -11 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -21 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- -72 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- -40 -->
-    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+   <g id="text_28">
+    <!-- -41 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- +7 -->
-    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -13 -->
-    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
+   <g id="text_29">
+    <!-- -9 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
     </g>
    </g>
-   <g id="text_35">
-    <!-- -5 -->
-    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
+   <g id="text_30">
     <!-- -16 -->
-    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1532,6 +1425,114 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -60 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- -36 -->
+    <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_33">
+    <!-- +7 -->
+    <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -13 -->
+    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -5 -->
+    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -16 -->
+    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
@@ -2193,18 +2194,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagea45671e477" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image5b7cc89f80" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="md5c0b4d70f" d="M 0 0 
+       <path id="mcb2c8d09f2" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md5c0b4d70f" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2227,7 +2228,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md5c0b4d70f" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2241,7 +2242,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#md5c0b4d70f" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2255,7 +2256,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md5c0b4d70f" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2268,7 +2269,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#md5c0b4d70f" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2281,7 +2282,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md5c0b4d70f" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2294,7 +2295,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#md5c0b4d70f" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2910,8 +2911,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.687734 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.380391 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3000,16 +3001,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3050,108 +3051,108 @@ z
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3ffefac427">
+  <clipPath id="p1974a3c697">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="me848e37d32" d="M 0 0 
+       <path id="m5b7f8f699a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me848e37d32" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b7f8f699a" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me848e37d32" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b7f8f699a" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me848e37d32" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b7f8f699a" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#me848e37d32" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b7f8f699a" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#me848e37d32" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b7f8f699a" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#me848e37d32" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b7f8f699a" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#me848e37d32" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b7f8f699a" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m804cfc89a7" d="M 0 0 
+       <path id="mc2ee42282c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m804cfc89a7" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2ee42282c" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m804cfc89a7" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2ee42282c" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m804cfc89a7" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc2ee42282c" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="meb2d454d2d" d="M 0 0 
+       <path id="mfea2ffb232" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#meb2d454d2d" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfea2ffb232" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 123.058606) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 123.22342) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 314.934389) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 312.538371) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m832c1ea07f" d="M -2.5 2.5 
+     <path id="m1abd775f1e" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbc76cd86a)">
-     <use xlink:href="#m832c1ea07f" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m832c1ea07f" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m832c1ea07f" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m832c1ea07f" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m832c1ea07f" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m832c1ea07f" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m832c1ea07f" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m832c1ea07f" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m832c1ea07f" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1264520be9)">
+     <use xlink:href="#m1abd775f1e" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1abd775f1e" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1abd775f1e" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1abd775f1e" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1abd775f1e" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1abd775f1e" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1abd775f1e" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1abd775f1e" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1abd775f1e" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="md510416027" d="M 0 -2.5 
+     <path id="m5169c26881" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbc76cd86a)">
-     <use xlink:href="#md510416027" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md510416027" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md510416027" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md510416027" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md510416027" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md510416027" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md510416027" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md510416027" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md510416027" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1264520be9)">
+     <use xlink:href="#m5169c26881" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5169c26881" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5169c26881" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5169c26881" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5169c26881" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5169c26881" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5169c26881" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5169c26881" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5169c26881" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="me65eec0431" d="M -0 3.535534 
+     <path id="me944f5d7e7" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbc76cd86a)">
-     <use xlink:href="#me65eec0431" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me65eec0431" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1264520be9)">
+     <use xlink:href="#me944f5d7e7" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me944f5d7e7" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="mefedd32353" d="M -0 2.5 
+     <path id="mccade9820f" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbc76cd86a)">
-     <use xlink:href="#mefedd32353" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1264520be9)">
+     <use xlink:href="#mccade9820f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m2904fc1a84" d="M -0.833333 2.5 
+     <path id="m3d9c49e61e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbc76cd86a)">
-     <use xlink:href="#m2904fc1a84" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2904fc1a84" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2904fc1a84" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2904fc1a84" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2904fc1a84" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2904fc1a84" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2904fc1a84" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2904fc1a84" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2904fc1a84" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1264520be9)">
+     <use xlink:href="#m3d9c49e61e" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d9c49e61e" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d9c49e61e" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d9c49e61e" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d9c49e61e" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d9c49e61e" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d9c49e61e" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d9c49e61e" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3d9c49e61e" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="mfa0971461d" d="M -1.25 2.5 
+     <path id="mc1c42fe743" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbc76cd86a)">
-     <use xlink:href="#mfa0971461d" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa0971461d" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa0971461d" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa0971461d" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa0971461d" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa0971461d" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa0971461d" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa0971461d" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfa0971461d" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1264520be9)">
+     <use xlink:href="#mc1c42fe743" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc1c42fe743" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc1c42fe743" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc1c42fe743" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc1c42fe743" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc1c42fe743" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc1c42fe743" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc1c42fe743" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc1c42fe743" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mbc23ff7fc2" d="M 0 -2.5 
+     <path id="mbe4ffeb296" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pbbc76cd86a)">
-     <use xlink:href="#mbc23ff7fc2" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc23ff7fc2" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc23ff7fc2" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc23ff7fc2" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc23ff7fc2" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc23ff7fc2" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc23ff7fc2" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc23ff7fc2" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbc23ff7fc2" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p1264520be9)">
+     <use xlink:href="#mbe4ffeb296" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbe4ffeb296" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbe4ffeb296" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbe4ffeb296" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbe4ffeb296" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbe4ffeb296" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbe4ffeb296" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbe4ffeb296" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbe4ffeb296" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m40ed5004f9" d="M 0 -2.5 
+     <path id="m259be2d04b" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pbbc76cd86a)">
-     <use xlink:href="#m40ed5004f9" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40ed5004f9" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40ed5004f9" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40ed5004f9" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40ed5004f9" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40ed5004f9" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40ed5004f9" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40ed5004f9" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m40ed5004f9" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1264520be9)">
+     <use xlink:href="#m259be2d04b" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m259be2d04b" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m259be2d04b" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m259be2d04b" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m259be2d04b" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m259be2d04b" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m259be2d04b" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m259be2d04b" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m259be2d04b" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m63d95b7ef4" d="M 0 3.5 
+      <path id="m36486bcaa9" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m63d95b7ef4" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m36486bcaa9" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m832c1ea07f" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1abd775f1e" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#md510416027" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5169c26881" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#me65eec0431" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me944f5d7e7" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#mefedd32353" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mccade9820f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m2904fc1a84" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3d9c49e61e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#mfa0971461d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc1c42fe743" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mbc23ff7fc2" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mbe4ffeb296" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m40ed5004f9" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m259be2d04b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#pbbc76cd86a)">
-     <use xlink:href="#m63d95b7ef4" x="319.643112" y="128.058606" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m63d95b7ef4" x="269.129958" y="143.619588" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m63d95b7ef4" x="247.452898" y="148.796216" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m63d95b7ef4" x="199.905291" y="164.613561" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m63d95b7ef4" x="190.316224" y="176.51234" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m63d95b7ef4" x="165.455859" y="194.390137" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m63d95b7ef4" x="159.141659" y="202.712405" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m63d95b7ef4" x="158.180344" y="207.202304" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m63d95b7ef4" x="120.106777" y="293.917646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m63d95b7ef4" x="97.799363" y="319.934389" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p1264520be9)">
+     <use xlink:href="#m36486bcaa9" x="319.643112" y="128.22342" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36486bcaa9" x="269.129958" y="143.747411" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36486bcaa9" x="247.452898" y="148.738527" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36486bcaa9" x="199.905291" y="164.022524" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36486bcaa9" x="190.316224" y="177.266549" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36486bcaa9" x="165.455859" y="188.087183" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36486bcaa9" x="159.141659" y="197.334556" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36486bcaa9" x="158.180344" y="201.58708" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36486bcaa9" x="120.106777" y="290.168877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m36486bcaa9" x="97.799363" y="317.538371" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 128.058606 
-L 318.590755 128.432898 
-L 317.538397 128.80462 
-L 316.48604 129.173806 
-L 315.433682 129.540492 
-L 314.381325 129.90471 
-L 313.328968 130.266494 
-L 312.27661 130.625876 
-L 311.224253 130.982888 
-L 310.171896 131.337561 
-L 309.119538 131.689925 
-L 308.067181 132.04001 
-L 307.014823 132.387846 
-L 305.962466 132.733461 
-L 304.910109 133.076883 
-L 303.857751 133.41814 
-L 302.805394 133.757259 
-L 301.753037 134.094267 
-L 300.700679 134.42919 
-L 299.648322 134.762053 
-L 298.595965 135.092882 
-L 297.543607 135.421701 
-L 296.49125 135.748535 
-L 295.438892 136.073407 
-L 294.386535 136.396342 
-L 293.334178 136.717361 
-L 292.28182 137.036487 
-L 291.229463 137.353744 
-L 290.177106 137.669151 
-L 289.124748 137.982732 
-L 288.072391 138.294506 
-L 287.020033 138.604495 
-L 285.967676 138.912719 
-L 284.915319 139.219198 
-L 283.862961 139.523951 
-L 282.810604 139.826999 
-L 281.758247 140.128359 
-L 280.705889 140.42805 
-L 279.653532 140.726092 
-L 278.601175 141.022501 
-L 277.548817 141.317297 
-L 276.49646 141.610495 
-L 275.444102 141.902114 
-L 274.391745 142.192171 
-L 273.339388 142.480681 
-L 272.28703 142.767662 
-L 271.234673 143.05313 
-L 270.182316 143.3371 
-L 269.129958 143.619588 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 128.22342 
+L 318.590755 128.596692 
+L 317.538397 128.967408 
+L 316.48604 129.335602 
+L 315.433682 129.701309 
+L 314.381325 130.064561 
+L 313.328968 130.425392 
+L 312.27661 130.783834 
+L 311.224253 131.139918 
+L 310.171896 131.493675 
+L 309.119538 131.845135 
+L 308.067181 132.194328 
+L 307.014823 132.541283 
+L 305.962466 132.886028 
+L 304.910109 133.228591 
+L 303.857751 133.569 
+L 302.805394 133.907282 
+L 301.753037 134.243463 
+L 300.700679 134.577569 
+L 299.648322 134.909625 
+L 298.595965 135.239657 
+L 297.543607 135.567689 
+L 296.49125 135.893745 
+L 295.438892 136.217849 
+L 294.386535 136.540023 
+L 293.334178 136.860292 
+L 292.28182 137.178677 
+L 291.229463 137.4952 
+L 290.177106 137.809883 
+L 289.124748 138.122748 
+L 288.072391 138.433814 
+L 287.020033 138.743103 
+L 285.967676 139.050635 
+L 284.915319 139.35643 
+L 283.862961 139.660507 
+L 282.810604 139.962885 
+L 281.758247 140.263584 
+L 280.705889 140.562621 
+L 279.653532 140.860016 
+L 278.601175 141.155785 
+L 277.548817 141.449947 
+L 276.49646 141.74252 
+L 275.444102 142.033519 
+L 274.391745 142.322963 
+L 273.339388 142.610867 
+L 272.28703 142.897248 
+L 271.234673 143.182122 
+L 270.182316 143.465504 
+L 269.129958 143.747411 
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 143.619588 
-L 268.678353 143.732641 
-L 268.226747 143.845459 
-L 267.775142 143.958042 
-L 267.323537 144.070391 
-L 266.871931 144.182508 
-L 266.420326 144.294393 
-L 265.96872 144.406047 
-L 265.517115 144.517472 
-L 265.065509 144.628667 
-L 264.613904 144.739635 
-L 264.162299 144.850376 
-L 263.710693 144.96089 
-L 263.259088 145.071179 
-L 262.807482 145.181244 
-L 262.355877 145.291086 
-L 261.904271 145.400705 
-L 261.452666 145.510103 
-L 261.001061 145.61928 
-L 260.549455 145.728238 
-L 260.09785 145.836976 
-L 259.646244 145.945497 
-L 259.194639 146.0538 
-L 258.743034 146.161887 
-L 258.291428 146.269759 
-L 257.839823 146.377416 
-L 257.388217 146.48486 
-L 256.936612 146.59209 
-L 256.485006 146.699109 
-L 256.033401 146.805916 
-L 255.581796 146.912513 
-L 255.13019 147.018901 
-L 254.678585 147.12508 
-L 254.226979 147.231051 
-L 253.775374 147.336815 
-L 253.323769 147.442373 
-L 252.872163 147.547726 
-L 252.420558 147.652873 
-L 251.968952 147.757817 
-L 251.517347 147.862558 
-L 251.065741 147.967097 
-L 250.614136 148.071434 
-L 250.162531 148.17557 
-L 249.710925 148.279506 
-L 249.25932 148.383244 
-L 248.807714 148.486782 
-L 248.356109 148.590123 
-L 247.904503 148.693268 
-L 247.452898 148.796216 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 143.747411 
+L 268.678353 143.856228 
+L 268.226747 143.964826 
+L 267.775142 144.073207 
+L 267.323537 144.181372 
+L 266.871931 144.28932 
+L 266.420326 144.397054 
+L 265.96872 144.504574 
+L 265.517115 144.611881 
+L 265.065509 144.718975 
+L 264.613904 144.825858 
+L 264.162299 144.93253 
+L 263.710693 145.038993 
+L 263.259088 145.145246 
+L 262.807482 145.251292 
+L 262.355877 145.35713 
+L 261.904271 145.462761 
+L 261.452666 145.568187 
+L 261.001061 145.673408 
+L 260.549455 145.778425 
+L 260.09785 145.883238 
+L 259.646244 145.987849 
+L 259.194639 146.092258 
+L 258.743034 146.196466 
+L 258.291428 146.300474 
+L 257.839823 146.404282 
+L 257.388217 146.507892 
+L 256.936612 146.611303 
+L 256.485006 146.714518 
+L 256.033401 146.817536 
+L 255.581796 146.920359 
+L 255.13019 147.022986 
+L 254.678585 147.125419 
+L 254.226979 147.227659 
+L 253.775374 147.329706 
+L 253.323769 147.431561 
+L 252.872163 147.533225 
+L 252.420558 147.634698 
+L 251.968952 147.735982 
+L 251.517347 147.837076 
+L 251.065741 147.937982 
+L 250.614136 148.0387 
+L 250.162531 148.139231 
+L 249.710925 148.239575 
+L 249.25932 148.339734 
+L 248.807714 148.439708 
+L 248.356109 148.539498 
+L 247.904503 148.639104 
+L 247.452898 148.738527 
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 148.796216 
-L 246.462323 149.177595 
-L 245.471748 149.556305 
-L 244.481173 149.932385 
-L 243.490597 150.30587 
-L 242.500022 150.676795 
-L 241.509447 151.045197 
-L 240.518872 151.411107 
-L 239.528297 151.774561 
-L 238.537722 152.135591 
-L 237.547147 152.494229 
-L 236.556571 152.850507 
-L 235.565996 153.204455 
-L 234.575421 153.556103 
-L 233.584846 153.905482 
-L 232.594271 154.252621 
-L 231.603696 154.597547 
-L 230.613121 154.940289 
-L 229.622545 155.280875 
-L 228.63197 155.619332 
-L 227.641395 155.955685 
-L 226.65082 156.289961 
-L 225.660245 156.622186 
-L 224.66967 156.952384 
-L 223.679095 157.28058 
-L 222.688519 157.606798 
-L 221.697944 157.931063 
-L 220.707369 158.253396 
-L 219.716794 158.573821 
-L 218.726219 158.892361 
-L 217.735644 159.209037 
-L 216.745069 159.523871 
-L 215.754493 159.836885 
-L 214.763918 160.148099 
-L 213.773343 160.457534 
-L 212.782768 160.76521 
-L 211.792193 161.071148 
-L 210.801618 161.375366 
-L 209.811043 161.677883 
-L 208.820467 161.97872 
-L 207.829892 162.277894 
-L 206.839317 162.575424 
-L 205.848742 162.871327 
-L 204.858167 163.165621 
-L 203.867592 163.458324 
-L 202.877017 163.749453 
-L 201.886441 164.039024 
-L 200.895866 164.327055 
-L 199.905291 164.613561 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 148.738527 
+L 246.462323 149.105198 
+L 245.471748 149.469403 
+L 244.481173 149.831173 
+L 243.490597 150.190542 
+L 242.500022 150.547541 
+L 241.509447 150.902201 
+L 240.518872 151.254552 
+L 239.528297 151.604624 
+L 238.537722 151.952447 
+L 237.547147 152.29805 
+L 236.556571 152.64146 
+L 235.565996 152.982704 
+L 234.575421 153.321812 
+L 233.584846 153.658808 
+L 232.594271 153.993719 
+L 231.603696 154.326571 
+L 230.613121 154.657388 
+L 229.622545 154.986196 
+L 228.63197 155.313019 
+L 227.641395 155.63788 
+L 226.65082 155.960804 
+L 225.660245 156.281812 
+L 224.66967 156.600928 
+L 223.679095 156.918174 
+L 222.688519 157.233571 
+L 221.697944 157.547142 
+L 220.707369 157.858906 
+L 219.716794 158.168885 
+L 218.726219 158.477099 
+L 217.735644 158.783568 
+L 216.745069 159.088312 
+L 215.754493 159.391349 
+L 214.763918 159.6927 
+L 213.773343 159.992382 
+L 212.782768 160.290415 
+L 211.792193 160.586815 
+L 210.801618 160.881601 
+L 209.811043 161.174791 
+L 208.820467 161.466401 
+L 207.829892 161.756449 
+L 206.839317 162.044951 
+L 205.848742 162.331923 
+L 204.858167 162.617382 
+L 203.867592 162.901344 
+L 202.877017 163.183823 
+L 201.886441 163.464836 
+L 200.895866 163.744398 
+L 199.905291 164.022524 
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 199.905291 164.613561 
-L 199.705519 164.890101 
-L 199.505747 165.165235 
-L 199.305974 165.438977 
-L 199.106202 165.711342 
-L 198.90643 165.982344 
-L 198.706658 166.251996 
-L 198.506885 166.520311 
-L 198.307113 166.787303 
-L 198.107341 167.052984 
-L 197.907569 167.317367 
-L 197.707797 167.580466 
-L 197.508024 167.842292 
-L 197.308252 168.102858 
-L 197.10848 168.362175 
-L 196.908708 168.620257 
-L 196.708935 168.877113 
-L 196.509163 169.132757 
-L 196.309391 169.387198 
-L 196.109619 169.64045 
-L 195.909846 169.892522 
-L 195.710074 170.143426 
-L 195.510302 170.393172 
-L 195.31053 170.641771 
-L 195.110758 170.889234 
-L 194.910985 171.13557 
-L 194.711213 171.380791 
-L 194.511441 171.624905 
-L 194.311669 171.867924 
-L 194.111896 172.109857 
-L 193.912124 172.350713 
-L 193.712352 172.590502 
-L 193.51258 172.829234 
-L 193.312807 173.066918 
-L 193.113035 173.303562 
-L 192.913263 173.539176 
-L 192.713491 173.77377 
-L 192.513719 174.00735 
-L 192.313946 174.239928 
-L 192.114174 174.47151 
-L 191.914402 174.702106 
-L 191.71463 174.931724 
-L 191.514857 175.160372 
-L 191.315085 175.388058 
-L 191.115313 175.61479 
-L 190.915541 175.840577 
-L 190.715768 176.065425 
-L 190.515996 176.289344 
-L 190.316224 176.51234 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.905291 164.022524 
+L 199.705519 164.334225 
+L 199.505747 164.644142 
+L 199.305974 164.952295 
+L 199.106202 165.258703 
+L 198.90643 165.563387 
+L 198.706658 165.866365 
+L 198.506885 166.167657 
+L 198.307113 166.467281 
+L 198.107341 166.765256 
+L 197.907569 167.0616 
+L 197.707797 167.35633 
+L 197.508024 167.649464 
+L 197.308252 167.941019 
+L 197.10848 168.231012 
+L 196.908708 168.51946 
+L 196.708935 168.806379 
+L 196.509163 169.091786 
+L 196.309391 169.375695 
+L 196.109619 169.658123 
+L 195.909846 169.939085 
+L 195.710074 170.218597 
+L 195.510302 170.496672 
+L 195.31053 170.773326 
+L 195.110758 171.048574 
+L 194.910985 171.322429 
+L 194.711213 171.594906 
+L 194.511441 171.866018 
+L 194.311669 172.135778 
+L 194.111896 172.404202 
+L 193.912124 172.6713 
+L 193.712352 172.937088 
+L 193.51258 173.201576 
+L 193.312807 173.464779 
+L 193.113035 173.726708 
+L 192.913263 173.987375 
+L 192.713491 174.246794 
+L 192.513719 174.504975 
+L 192.313946 174.76193 
+L 192.114174 175.017672 
+L 191.914402 175.272211 
+L 191.71463 175.525559 
+L 191.514857 175.777726 
+L 191.315085 176.028724 
+L 191.115313 176.278564 
+L 190.915541 176.527256 
+L 190.715768 176.774811 
+L 190.515996 177.021238 
+L 190.316224 177.266549 
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 190.316224 176.51234 
-L 189.7983 176.951879 
-L 189.280375 177.387877 
-L 188.762451 177.820392 
-L 188.244527 178.249478 
-L 187.726603 178.67519 
-L 187.208678 179.09758 
-L 186.690754 179.516699 
-L 186.17283 179.932598 
-L 185.654906 180.345326 
-L 185.136981 180.754932 
-L 184.619057 181.16146 
-L 184.101133 181.564959 
-L 183.583208 181.965472 
-L 183.065284 182.363044 
-L 182.54736 182.757716 
-L 182.029436 183.149532 
-L 181.511511 183.538533 
-L 180.993587 183.924757 
-L 180.475663 184.308246 
-L 179.957739 184.689037 
-L 179.439814 185.067168 
-L 178.92189 185.442676 
-L 178.403966 185.815596 
-L 177.886041 186.185966 
-L 177.368117 186.553818 
-L 176.850193 186.919188 
-L 176.332269 187.282108 
-L 175.814344 187.642611 
-L 175.29642 188.000728 
-L 174.778496 188.356493 
-L 174.260572 188.709934 
-L 173.742647 189.061083 
-L 173.224723 189.409968 
-L 172.706799 189.756619 
-L 172.188874 190.101064 
-L 171.67095 190.443332 
-L 171.153026 190.783449 
-L 170.635102 191.121442 
-L 170.117177 191.457338 
-L 169.599253 191.791162 
-L 169.081329 192.122941 
-L 168.563404 192.452698 
-L 168.04548 192.780458 
-L 167.527556 193.106246 
-L 167.009632 193.430085 
-L 166.491707 193.751998 
-L 165.973783 194.072008 
-L 165.455859 194.390137 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 190.316224 177.266549 
+L 189.7983 177.515516 
+L 189.280375 177.763344 
+L 188.762451 178.010041 
+L 188.244527 178.25562 
+L 187.726603 178.50009 
+L 187.208678 178.74346 
+L 186.690754 178.985741 
+L 186.17283 179.226943 
+L 185.654906 179.467075 
+L 185.136981 179.706146 
+L 184.619057 179.944166 
+L 184.101133 180.181143 
+L 183.583208 180.417088 
+L 183.065284 180.652009 
+L 182.54736 180.885915 
+L 182.029436 181.118815 
+L 181.511511 181.350716 
+L 180.993587 181.581629 
+L 180.475663 181.81156 
+L 179.957739 182.040519 
+L 179.439814 182.268514 
+L 178.92189 182.495553 
+L 178.403966 182.721643 
+L 177.886041 182.946793 
+L 177.368117 183.17101 
+L 176.850193 183.394302 
+L 176.332269 183.616677 
+L 175.814344 183.838142 
+L 175.29642 184.058705 
+L 174.778496 184.278373 
+L 174.260572 184.497153 
+L 173.742647 184.715052 
+L 173.224723 184.932078 
+L 172.706799 185.148237 
+L 172.188874 185.363536 
+L 171.67095 185.577982 
+L 171.153026 185.791583 
+L 170.635102 186.004343 
+L 170.117177 186.216271 
+L 169.599253 186.427372 
+L 169.081329 186.637653 
+L 168.563404 186.84712 
+L 168.04548 187.05578 
+L 167.527556 187.263639 
+L 167.009632 187.470703 
+L 166.491707 187.676977 
+L 165.973783 187.882469 
+L 165.455859 188.087183 
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 165.455859 194.390137 
-L 165.324313 194.577232 
-L 165.192767 194.763683 
-L 165.061221 194.949493 
-L 164.929675 195.134668 
-L 164.79813 195.319212 
-L 164.666584 195.503128 
-L 164.535038 195.686422 
-L 164.403492 195.869097 
-L 164.271946 196.051158 
-L 164.1404 196.232609 
-L 164.008855 196.413453 
-L 163.877309 196.593695 
-L 163.745763 196.77334 
-L 163.614217 196.952389 
-L 163.482671 197.130849 
-L 163.351125 197.308722 
-L 163.21958 197.486013 
-L 163.088034 197.662724 
-L 162.956488 197.838861 
-L 162.824942 198.014427 
-L 162.693396 198.189425 
-L 162.56185 198.363859 
-L 162.430305 198.537732 
-L 162.298759 198.711049 
-L 162.167213 198.883813 
-L 162.035667 199.056028 
-L 161.904121 199.227696 
-L 161.772575 199.398821 
-L 161.64103 199.569407 
-L 161.509484 199.739457 
-L 161.377938 199.908975 
-L 161.246392 200.077964 
-L 161.114846 200.246426 
-L 160.9833 200.414366 
-L 160.851754 200.581787 
-L 160.720209 200.748691 
-L 160.588663 200.915082 
-L 160.457117 201.080964 
-L 160.325571 201.246338 
-L 160.194025 201.411209 
-L 160.062479 201.575579 
-L 159.930934 201.739452 
-L 159.799388 201.90283 
-L 159.667842 202.065717 
-L 159.536296 202.228114 
-L 159.40475 202.390026 
-L 159.273204 202.551456 
-L 159.141659 202.712405 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.455859 188.087183 
+L 165.324313 188.296864 
+L 165.192767 188.505736 
+L 165.061221 188.713806 
+L 164.929675 188.921078 
+L 164.79813 189.12756 
+L 164.666584 189.333257 
+L 164.535038 189.538176 
+L 164.403492 189.742322 
+L 164.271946 189.945701 
+L 164.1404 190.148318 
+L 164.008855 190.35018 
+L 163.877309 190.551292 
+L 163.745763 190.75166 
+L 163.614217 190.951288 
+L 163.482671 191.150183 
+L 163.351125 191.34835 
+L 163.21958 191.545794 
+L 163.088034 191.742521 
+L 162.956488 191.938535 
+L 162.824942 192.133842 
+L 162.693396 192.328447 
+L 162.56185 192.522355 
+L 162.430305 192.715571 
+L 162.298759 192.908099 
+L 162.167213 193.099945 
+L 162.035667 193.291114 
+L 161.904121 193.481609 
+L 161.772575 193.671437 
+L 161.64103 193.860602 
+L 161.509484 194.049107 
+L 161.377938 194.236959 
+L 161.246392 194.424161 
+L 161.114846 194.610717 
+L 160.9833 194.796633 
+L 160.851754 194.981913 
+L 160.720209 195.16656 
+L 160.588663 195.35058 
+L 160.457117 195.533977 
+L 160.325571 195.716754 
+L 160.194025 195.898916 
+L 160.062479 196.080467 
+L 159.930934 196.261411 
+L 159.799388 196.441753 
+L 159.667842 196.621495 
+L 159.536296 196.800643 
+L 159.40475 196.9792 
+L 159.273204 197.15717 
+L 159.141659 197.334556 
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 159.141659 202.712405 
-L 159.121631 202.809845 
-L 159.101604 202.907111 
-L 159.081576 203.004202 
-L 159.061549 203.101119 
-L 159.041522 203.197863 
-L 159.021494 203.294435 
-L 159.001467 203.390834 
-L 158.98144 203.487062 
-L 158.961412 203.58312 
-L 158.941385 203.679007 
-L 158.921357 203.774725 
-L 158.90133 203.870273 
-L 158.881303 203.965654 
-L 158.861275 204.060866 
-L 158.841248 204.155912 
-L 158.82122 204.25079 
-L 158.801193 204.345503 
-L 158.781166 204.44005 
-L 158.761138 204.534433 
-L 158.741111 204.628651 
-L 158.721084 204.722706 
-L 158.701056 204.816597 
-L 158.681029 204.910326 
-L 158.661001 205.003893 
-L 158.640974 205.097298 
-L 158.620947 205.190542 
-L 158.600919 205.283627 
-L 158.580892 205.376551 
-L 158.560865 205.469316 
-L 158.540837 205.561922 
-L 158.52081 205.65437 
-L 158.500782 205.746661 
-L 158.480755 205.838795 
-L 158.460728 205.930771 
-L 158.4407 206.022592 
-L 158.420673 206.114258 
-L 158.400645 206.205768 
-L 158.380618 206.297124 
-L 158.360591 206.388327 
-L 158.340563 206.479375 
-L 158.320536 206.570271 
-L 158.300509 206.661015 
-L 158.280481 206.751606 
-L 158.260454 206.842046 
-L 158.240426 206.932336 
-L 158.220399 207.022475 
-L 158.200372 207.112464 
-L 158.180344 207.202304 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.141659 197.334556 
+L 159.121631 197.426645 
+L 159.101604 197.518577 
+L 159.081576 197.610354 
+L 159.061549 197.701975 
+L 159.041522 197.793441 
+L 159.021494 197.884753 
+L 159.001467 197.975912 
+L 158.98144 198.066917 
+L 158.961412 198.157769 
+L 158.941385 198.248469 
+L 158.921357 198.339018 
+L 158.90133 198.429415 
+L 158.881303 198.519661 
+L 158.861275 198.609757 
+L 158.841248 198.699704 
+L 158.82122 198.789501 
+L 158.801193 198.87915 
+L 158.781166 198.96865 
+L 158.761138 199.058003 
+L 158.741111 199.147208 
+L 158.721084 199.236267 
+L 158.701056 199.325179 
+L 158.681029 199.413946 
+L 158.661001 199.502567 
+L 158.640974 199.591043 
+L 158.620947 199.679375 
+L 158.600919 199.767563 
+L 158.580892 199.855608 
+L 158.560865 199.943509 
+L 158.540837 200.031269 
+L 158.52081 200.118886 
+L 158.500782 200.206361 
+L 158.480755 200.293696 
+L 158.460728 200.380889 
+L 158.4407 200.467943 
+L 158.420673 200.554856 
+L 158.400645 200.641631 
+L 158.380618 200.728266 
+L 158.360591 200.814763 
+L 158.340563 200.901122 
+L 158.320536 200.987344 
+L 158.300509 201.073428 
+L 158.280481 201.159376 
+L 158.260454 201.245188 
+L 158.240426 201.330863 
+L 158.220399 201.416404 
+L 158.200372 201.501809 
+L 158.180344 201.58708 
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 158.180344 207.202304 
-L 157.387145 211.496253 
-L 156.593946 215.474477 
-L 155.800746 219.180242 
-L 155.007547 222.648488 
-L 154.214348 225.907837 
-L 153.421148 228.98203 
-L 152.627949 231.890978 
-L 151.83475 234.651542 
-L 151.04155 237.278129 
-L 150.248351 239.783144 
-L 149.455152 242.177344 
-L 148.661952 244.470119 
-L 147.868753 246.669716 
-L 147.075554 248.783412 
-L 146.282354 250.817666 
-L 145.489155 252.778233 
-L 144.695956 254.670266 
-L 143.902756 256.498395 
-L 143.109557 258.266795 
-L 142.316358 259.979247 
-L 141.523159 261.639182 
-L 140.729959 263.249727 
-L 139.93676 264.813734 
-L 139.143561 266.333819 
-L 138.350361 267.812381 
-L 137.557162 269.251629 
-L 136.763963 270.653599 
-L 135.970763 272.020173 
-L 135.177564 273.353095 
-L 134.384365 274.653983 
-L 133.591165 275.92434 
-L 132.797966 277.165566 
-L 132.004767 278.378968 
-L 131.211567 279.565766 
-L 130.418368 280.727101 
-L 129.625169 281.864043 
-L 128.831969 282.977596 
-L 128.03877 284.068702 
-L 127.245571 285.13825 
-L 126.452371 286.187073 
-L 125.659172 287.215961 
-L 124.865973 288.225656 
-L 124.072774 289.216863 
-L 123.279574 290.190245 
-L 122.486375 291.146432 
-L 121.693176 292.086022 
-L 120.899976 293.009581 
-L 120.106777 293.917646 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.180344 201.58708 
+L 157.387145 206.06209 
+L 156.593946 210.195234 
+L 155.800746 214.03506 
+L 155.007547 217.620454 
+L 154.214348 220.98305 
+L 153.421148 224.148925 
+L 152.627949 227.139828 
+L 151.83475 229.974093 
+L 151.04155 232.667313 
+L 150.248351 235.232863 
+L 149.455152 237.6823 
+L 148.661952 240.025683 
+L 147.868753 242.271814 
+L 147.075554 244.428445 
+L 146.282354 246.502436 
+L 145.489155 248.499888 
+L 144.695956 250.426249 
+L 143.902756 252.286406 
+L 143.109557 254.084758 
+L 142.316358 255.825282 
+L 141.523159 257.511581 
+L 140.729959 259.146931 
+L 139.93676 260.734321 
+L 139.143561 262.276484 
+L 138.350361 263.775926 
+L 137.557162 265.234951 
+L 136.763963 266.65568 
+L 135.970763 268.040072 
+L 135.177564 269.389939 
+L 134.384365 270.706963 
+L 133.591165 271.992702 
+L 132.797966 273.24861 
+L 132.004767 274.476039 
+L 131.211567 275.676251 
+L 130.418368 276.850429 
+L 129.625169 277.999676 
+L 128.831969 279.125031 
+L 128.03877 280.227466 
+L 127.245571 281.307896 
+L 126.452371 282.367183 
+L 125.659172 283.406138 
+L 124.865973 284.425527 
+L 124.072774 285.426074 
+L 123.279574 286.408461 
+L 122.486375 287.373338 
+L 121.693176 288.321316 
+L 120.899976 289.252978 
+L 120.106777 290.168877 
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 120.106777 293.917646 
-L 119.642039 294.609116 
-L 119.177301 295.291864 
-L 118.712564 295.966108 
-L 118.247826 296.632056 
-L 117.783088 297.289912 
-L 117.31835 297.939868 
-L 116.853612 298.582113 
-L 116.388875 299.216827 
-L 115.924137 299.844185 
-L 115.459399 300.464355 
-L 114.994661 301.077501 
-L 114.529924 301.683779 
-L 114.065186 302.283342 
-L 113.600448 302.876337 
-L 113.13571 303.462906 
-L 112.670972 304.043187 
-L 112.206235 304.617313 
-L 111.741497 305.185414 
-L 111.276759 305.747615 
-L 110.812021 306.304037 
-L 110.347283 306.854797 
-L 109.882546 307.40001 
-L 109.417808 307.939786 
-L 108.95307 308.474233 
-L 108.488332 309.003455 
-L 108.023595 309.527553 
-L 107.558857 310.046625 
-L 107.094119 310.560767 
-L 106.629381 311.070071 
-L 106.164643 311.574629 
-L 105.699906 312.074526 
-L 105.235168 312.56985 
-L 104.77043 313.060682 
-L 104.305692 313.547103 
-L 103.840955 314.029192 
-L 103.376217 314.507026 
-L 102.911479 314.980679 
-L 102.446741 315.450223 
-L 101.982003 315.915729 
-L 101.517266 316.377266 
-L 101.052528 316.834901 
-L 100.58779 317.2887 
-L 100.123052 317.738726 
-L 99.658315 318.185041 
-L 99.193577 318.627707 
-L 98.728839 319.066781 
-L 98.264101 319.502324 
-L 97.799363 319.934389 
-" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 120.106777 290.168877 
+L 119.642039 290.905888 
+L 119.177301 291.633 
+L 118.712564 292.350475 
+L 118.247826 293.058564 
+L 117.783088 293.75751 
+L 117.31835 294.447546 
+L 116.853612 295.128896 
+L 116.388875 295.801777 
+L 115.924137 296.466396 
+L 115.459399 297.122954 
+L 114.994661 297.771644 
+L 114.529924 298.412652 
+L 114.065186 299.046158 
+L 113.600448 299.672336 
+L 113.13571 300.291353 
+L 112.670972 300.903371 
+L 112.206235 301.508547 
+L 111.741497 302.107032 
+L 111.276759 302.698973 
+L 110.812021 303.28451 
+L 110.347283 303.863781 
+L 109.882546 304.436919 
+L 109.417808 305.004052 
+L 108.95307 305.565305 
+L 108.488332 306.120798 
+L 108.023595 306.670648 
+L 107.558857 307.21497 
+L 107.094119 307.753872 
+L 106.629381 308.287463 
+L 106.164643 308.815844 
+L 105.699906 309.339118 
+L 105.235168 309.857382 
+L 104.77043 310.370731 
+L 104.305692 310.879258 
+L 103.840955 311.383051 
+L 103.376217 311.882199 
+L 102.911479 312.376787 
+L 102.446741 312.866896 
+L 101.982003 313.352608 
+L 101.517266 313.834 
+L 101.052528 314.311149 
+L 100.58779 314.784128 
+L 100.123052 315.253011 
+L 99.658315 315.717867 
+L 99.193577 316.178765 
+L 98.728839 316.635772 
+L 98.264101 317.088953 
+L 97.799363 317.538371 
+" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.687734 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.380391 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6177,31 +6177,6 @@ L 1172 0
 L 2766 4134 
 L 525 4134 
 L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
@@ -6353,16 +6328,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6403,108 +6378,108 @@ z
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pbbc76cd86a">
+  <clipPath id="p1264520be9">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m13c9913171" d="M 0 0 
+       <path id="m10ddb3791a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m13c9913171" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10ddb3791a" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m13c9913171" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10ddb3791a" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m13c9913171" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10ddb3791a" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m13c9913171" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10ddb3791a" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m13c9913171" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10ddb3791a" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m13c9913171" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10ddb3791a" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m13c9913171" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10ddb3791a" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.82245 
 L 637.2 391.82245 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mdec1e703fd" d="M 0 0 
+       <path id="mf1276d5b6b" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdec1e703fd" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1276d5b6b" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 265.911133 
 L 637.2 265.911133 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mdec1e703fd" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1276d5b6b" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 265.911133
      <g id="line2d_19">
       <path d="M 49.078125 139.999816 
 L 637.2 139.999816 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mdec1e703fd" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf1276d5b6b" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.999816
      <g id="line2d_21">
       <path d="M 49.078125 411.32636 
 L 637.2 411.32636 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m38eeaadfec" d="M 0 0 
+       <path id="me0aeefcdb5" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 404.024518 
 L 637.2 404.024518 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 404.024518
      <g id="line2d_25">
       <path d="M 49.078125 397.583836 
 L 637.2 397.583836 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.583836
      <g id="line2d_27">
       <path d="M 49.078125 353.919367 
 L 637.2 353.919367 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 353.919367
      <g id="line2d_29">
       <path d="M 49.078125 331.747485 
 L 637.2 331.747485 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 331.747485
      <g id="line2d_31">
       <path d="M 49.078125 316.016284 
 L 637.2 316.016284 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 316.016284
      <g id="line2d_33">
       <path d="M 49.078125 303.814216 
 L 637.2 303.814216 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 303.814216
      <g id="line2d_35">
       <path d="M 49.078125 293.844402 
 L 637.2 293.844402 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 293.844402
      <g id="line2d_37">
       <path d="M 49.078125 285.415043 
 L 637.2 285.415043 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 285.415043
      <g id="line2d_39">
       <path d="M 49.078125 278.113201 
 L 637.2 278.113201 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 278.113201
      <g id="line2d_41">
       <path d="M 49.078125 271.672519 
 L 637.2 271.672519 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 271.672519
      <g id="line2d_43">
       <path d="M 49.078125 228.00805 
 L 637.2 228.00805 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 228.00805
      <g id="line2d_45">
       <path d="M 49.078125 205.836168 
 L 637.2 205.836168 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 205.836168
      <g id="line2d_47">
       <path d="M 49.078125 190.104967 
 L 637.2 190.104967 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 190.104967
      <g id="line2d_49">
       <path d="M 49.078125 177.9029 
 L 637.2 177.9029 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.9029
      <g id="line2d_51">
       <path d="M 49.078125 167.933085 
 L 637.2 167.933085 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.933085
      <g id="line2d_53">
       <path d="M 49.078125 159.503726 
 L 637.2 159.503726 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.503726
      <g id="line2d_55">
       <path d="M 49.078125 152.201884 
 L 637.2 152.201884 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 152.201884
      <g id="line2d_57">
       <path d="M 49.078125 145.761202 
 L 637.2 145.761202 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.761202
      <g id="line2d_59">
       <path d="M 49.078125 102.096733 
 L 637.2 102.096733 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.096733
      <g id="line2d_61">
       <path d="M 49.078125 79.924851 
 L 637.2 79.924851 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 79.924851
      <g id="line2d_63">
       <path d="M 49.078125 64.19365 
 L 637.2 64.19365 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.19365
      <g id="line2d_65">
       <path d="M 49.078125 51.991583 
 L 637.2 51.991583 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m38eeaadfec" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me0aeefcdb5" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p53de07b09c)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m426bc01dfd" d="M -2.5 2.5 
+     <path id="m18bdc1f6e2" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7bba25b3b1)">
-     <use xlink:href="#m426bc01dfd" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m426bc01dfd" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53de07b09c)">
+     <use xlink:href="#m18bdc1f6e2" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m18bdc1f6e2" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="mabee48d180" d="M 0 -2.5 
+     <path id="m4374a419a2" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7bba25b3b1)">
-     <use xlink:href="#mabee48d180" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mabee48d180" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53de07b09c)">
+     <use xlink:href="#m4374a419a2" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4374a419a2" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m147cecbcd9" d="M -0 3.535534 
+     <path id="m0f37c0f409" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7bba25b3b1)">
-     <use xlink:href="#m147cecbcd9" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m147cecbcd9" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53de07b09c)">
+     <use xlink:href="#m0f37c0f409" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m0f37c0f409" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="mcd5d1e1b38" d="M -0.833333 2.5 
+     <path id="m5b9c5fa09c" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7bba25b3b1)">
-     <use xlink:href="#mcd5d1e1b38" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcd5d1e1b38" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53de07b09c)">
+     <use xlink:href="#m5b9c5fa09c" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5b9c5fa09c" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="mc0492ac41b" d="M -1.25 2.5 
+     <path id="m5909457a59" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7bba25b3b1)">
-     <use xlink:href="#mc0492ac41b" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc0492ac41b" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53de07b09c)">
+     <use xlink:href="#m5909457a59" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5909457a59" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m034cfad974" d="M 0 -2.5 
+     <path id="m7f17f7ef48" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p7bba25b3b1)">
-     <use xlink:href="#m034cfad974" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m034cfad974" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p53de07b09c)">
+     <use xlink:href="#m7f17f7ef48" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m7f17f7ef48" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m2fe04c379a" d="M 0 -2.5 
+     <path id="mfc93105d4e" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p7bba25b3b1)">
-     <use xlink:href="#m2fe04c379a" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2fe04c379a" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p53de07b09c)">
+     <use xlink:href="#mfc93105d4e" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfc93105d4e" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="mc0c3f25cb2" d="M 0 3.5 
+      <path id="mbf2aa6c9f7" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mc0c3f25cb2" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mbf2aa6c9f7" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m426bc01dfd" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m18bdc1f6e2" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#mabee48d180" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4374a419a2" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m147cecbcd9" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0f37c0f409" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#mcd5d1e1b38" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5b9c5fa09c" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#mc0492ac41b" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5909457a59" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m034cfad974" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m7f17f7ef48" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m2fe04c379a" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfc93105d4e" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p7bba25b3b1)">
-     <use xlink:href="#mc0c3f25cb2" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mc0c3f25cb2" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p53de07b09c)">
+     <use xlink:href="#mbf2aa6c9f7" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mbf2aa6c9f7" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3184,7 +3184,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p7bba25b3b1">
+  <clipPath id="p53de07b09c">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.788615 308.04375 
 L 290.788615 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mdea3005a9a" d="M 0 0 
+       <path id="m9fc54921cb" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdea3005a9a" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc54921cb" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 447.590599 308.04375 
 L 447.590599 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mdea3005a9a" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m9fc54921cb" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.188732 308.04375 
 L 181.188732 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m66a99e04d8" d="M 0 0 
+       <path id="m1b14bcd49e" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m66a99e04d8" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.800191 308.04375 
 L 208.800191 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m66a99e04d8" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.800191 56.7075
      <g id="line2d_9">
       <path d="M 228.390833 308.04375 
 L 228.390833 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m66a99e04d8" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.390833 56.7075
      <g id="line2d_11">
       <path d="M 243.586515 308.04375 
 L 243.586515 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m66a99e04d8" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.586515 56.7075
      <g id="line2d_13">
       <path d="M 256.002291 308.04375 
 L 256.002291 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m66a99e04d8" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 256.002291 56.7075
      <g id="line2d_15">
       <path d="M 266.499681 308.04375 
 L 266.499681 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m66a99e04d8" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.499681 56.7075
      <g id="line2d_17">
       <path d="M 275.592933 308.04375 
 L 275.592933 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m66a99e04d8" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.592933 56.7075
      <g id="line2d_19">
       <path d="M 283.61375 308.04375 
 L 283.61375 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m66a99e04d8" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.61375 56.7075
      <g id="line2d_21">
       <path d="M 337.990716 308.04375 
 L 337.990716 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m66a99e04d8" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.990716 56.7075
      <g id="line2d_23">
       <path d="M 365.602174 308.04375 
 L 365.602174 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m66a99e04d8" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.602174 56.7075
      <g id="line2d_25">
       <path d="M 385.192816 308.04375 
 L 385.192816 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m66a99e04d8" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 385.192816 56.7075
      <g id="line2d_27">
       <path d="M 400.388498 308.04375 
 L 400.388498 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m66a99e04d8" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 400.388498 56.7075
      <g id="line2d_29">
       <path d="M 412.804275 308.04375 
 L 412.804275 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m66a99e04d8" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.804275 56.7075
      <g id="line2d_31">
       <path d="M 423.301664 308.04375 
 L 423.301664 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m66a99e04d8" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 423.301664 56.7075
      <g id="line2d_33">
       <path d="M 432.394917 308.04375 
 L 432.394917 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m66a99e04d8" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 432.394917 56.7075
      <g id="line2d_35">
       <path d="M 440.415734 308.04375 
 L 440.415734 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m66a99e04d8" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 440.415734 56.7075
      <g id="line2d_37">
       <path d="M 494.792699 308.04375 
 L 494.792699 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m66a99e04d8" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.792699 56.7075
      <g id="line2d_39">
       <path d="M 522.404158 308.04375 
 L 522.404158 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m66a99e04d8" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 522.404158 56.7075
      <g id="line2d_41">
       <path d="M 541.9948 308.04375 
 L 541.9948 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m66a99e04d8" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.9948 56.7075
      <g id="line2d_43">
       <path d="M 557.190482 308.04375 
 L 557.190482 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m66a99e04d8" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m1b14bcd49e" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="mf6026e9257" d="M 0 0 
+       <path id="ma5322bd913" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf6026e9257" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5322bd913" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mf6026e9257" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5322bd913" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1129,7 +1129,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mf6026e9257" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5322bd913" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1242,7 +1242,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mf6026e9257" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5322bd913" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mf6026e9257" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5322bd913" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mf6026e9257" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5322bd913" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mf6026e9257" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5322bd913" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mf6026e9257" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma5322bd913" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.556151 296.619375 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 162.32653 263.978304 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 178.681331 231.337232 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 201.044126 198.696161 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.976983 166.055089 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.121093 133.414018 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 247.282543 100.772946 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.279501 68.131875 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.286834 308.04375 
 L 542.286834 56.7075 
-" clip-path="url(#p7f7272cb28)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p1cdf579760)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1875,7 +1875,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="ma42923418a" d="M 0 3 
+     <path id="m967abd190c" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1887,13 +1887,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p7f7272cb28)">
-     <use xlink:href="#ma42923418a" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p1cdf579760)">
+     <use xlink:href="#m967abd190c" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m38bd4fbc25" d="M 0 3 
+     <path id="m638182d298" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1905,13 +1905,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p7f7272cb28)">
-     <use xlink:href="#m38bd4fbc25" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p1cdf579760)">
+     <use xlink:href="#m638182d298" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m332b2c8996" d="M 0 5 
+     <path id="mb1dab30f48" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1923,13 +1923,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p7f7272cb28)">
-     <use xlink:href="#m332b2c8996" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p1cdf579760)">
+     <use xlink:href="#mb1dab30f48" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m3122648009" d="M 0 3 
+     <path id="mbcf6175b92" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1941,13 +1941,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p7f7272cb28)">
-     <use xlink:href="#m3122648009" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p1cdf579760)">
+     <use xlink:href="#mbcf6175b92" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m066882d5d8" d="M 0 3 
+     <path id="m3f1f3f82f5" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1959,13 +1959,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p7f7272cb28)">
-     <use xlink:href="#m066882d5d8" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p1cdf579760)">
+     <use xlink:href="#m3f1f3f82f5" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m44a3cc8dc9" d="M 0 3 
+     <path id="m4ab57ae9ab" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1977,13 +1977,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p7f7272cb28)">
-     <use xlink:href="#m44a3cc8dc9" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p1cdf579760)">
+     <use xlink:href="#m4ab57ae9ab" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m935ac39f9f" d="M 0 3 
+     <path id="m290ac19bc2" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1995,13 +1995,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p7f7272cb28)">
-     <use xlink:href="#m935ac39f9f" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p1cdf579760)">
+     <use xlink:href="#m290ac19bc2" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m47aa7b27c6" d="M 0 3 
+     <path id="m389a7a9982" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2013,8 +2013,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p7f7272cb28)">
-     <use xlink:href="#m47aa7b27c6" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p1cdf579760)">
+     <use xlink:href="#m389a7a9982" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2869,7 +2869,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p7f7272cb28">
+  <clipPath id="p1cdf579760">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p616e7aafef)">
+   <g clip-path="url(#p5b0afe3818)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image5cdcf1868f" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image937c365c0f" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m6c5602186a" d="M 0 0 
+       <path id="m7d7d4236ac" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6c5602186a" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m6c5602186a" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m6c5602186a" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6c5602186a" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m6c5602186a" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6c5602186a" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m6c5602186a" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6c5602186a" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m6c5602186a" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6c5602186a" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m6c5602186a" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6c5602186a" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7d7d4236ac" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="md4558f574d" d="M 0 0 
+       <path id="m09c8e87ad7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md4558f574d" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09c8e87ad7" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md4558f574d" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09c8e87ad7" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md4558f574d" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09c8e87ad7" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md4558f574d" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09c8e87ad7" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md4558f574d" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09c8e87ad7" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md4558f574d" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09c8e87ad7" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md4558f574d" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09c8e87ad7" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md4558f574d" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m09c8e87ad7" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagee64091f619" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image9a4381bed8" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m3efb680d58" d="M 0 0 
+       <path id="m3cc6ddca55" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3efb680d58" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3cc6ddca55" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3efb680d58" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3cc6ddca55" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3efb680d58" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3cc6ddca55" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3efb680d58" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3cc6ddca55" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m3efb680d58" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3cc6ddca55" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.687734 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.380391 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2868,16 +2868,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2918,108 +2918,108 @@ z
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p616e7aafef">
+  <clipPath id="p5b0afe3818">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.024531pt" height="386.202469pt" viewBox="0 0 575.024531 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.639219pt" height="386.202469pt" viewBox="0 0 575.639219 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.024531 386.202469 
-L 575.024531 0 
+L 575.639219 386.202469 
+L 575.639219 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.637266 104.1264 
-L 294.262266 104.1264 
-L 294.262266 74.7432 
-L 189.637266 74.7432 
+    <path d="M 189.944609 104.1264 
+L 294.569609 104.1264 
+L 294.569609 74.7432 
+L 189.944609 74.7432 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.262266 104.1264 
-L 398.887266 104.1264 
-L 398.887266 74.7432 
-L 294.262266 74.7432 
+    <path d="M 294.569609 104.1264 
+L 399.194609 104.1264 
+L 399.194609 74.7432 
+L 294.569609 74.7432 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 398.887266 104.1264 
-L 503.512266 104.1264 
-L 503.512266 74.7432 
-L 398.887266 74.7432 
+    <path d="M 399.194609 104.1264 
+L 503.819609 104.1264 
+L 503.819609 74.7432 
+L 399.194609 74.7432 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.637266 133.5096 
-L 294.262266 133.5096 
-L 294.262266 104.1264 
-L 189.637266 104.1264 
+    <path d="M 189.944609 133.5096 
+L 294.569609 133.5096 
+L 294.569609 104.1264 
+L 189.944609 104.1264 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.262266 133.5096 
-L 398.887266 133.5096 
-L 398.887266 104.1264 
-L 294.262266 104.1264 
+    <path d="M 294.569609 133.5096 
+L 399.194609 133.5096 
+L 399.194609 104.1264 
+L 294.569609 104.1264 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 398.887266 133.5096 
-L 503.512266 133.5096 
-L 503.512266 104.1264 
-L 398.887266 104.1264 
+    <path d="M 399.194609 133.5096 
+L 503.819609 133.5096 
+L 503.819609 104.1264 
+L 399.194609 104.1264 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.637266 162.8928 
-L 294.262266 162.8928 
-L 294.262266 133.5096 
-L 189.637266 133.5096 
+    <path d="M 189.944609 162.8928 
+L 294.569609 162.8928 
+L 294.569609 133.5096 
+L 189.944609 133.5096 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.262266 162.8928 
-L 398.887266 162.8928 
-L 398.887266 133.5096 
-L 294.262266 133.5096 
+    <path d="M 294.569609 162.8928 
+L 399.194609 162.8928 
+L 399.194609 133.5096 
+L 294.569609 133.5096 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 398.887266 162.8928 
-L 503.512266 162.8928 
-L 503.512266 133.5096 
-L 398.887266 133.5096 
+    <path d="M 399.194609 162.8928 
+L 503.819609 162.8928 
+L 503.819609 133.5096 
+L 399.194609 133.5096 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.637266 192.276 
-L 294.262266 192.276 
-L 294.262266 162.8928 
-L 189.637266 162.8928 
+    <path d="M 189.944609 192.276 
+L 294.569609 192.276 
+L 294.569609 162.8928 
+L 189.944609 162.8928 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.262266 192.276 
-L 398.887266 192.276 
-L 398.887266 162.8928 
-L 294.262266 162.8928 
+    <path d="M 294.569609 192.276 
+L 399.194609 192.276 
+L 399.194609 162.8928 
+L 294.569609 162.8928 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 398.887266 192.276 
-L 503.512266 192.276 
-L 503.512266 162.8928 
-L 398.887266 162.8928 
+    <path d="M 399.194609 192.276 
+L 503.819609 192.276 
+L 503.819609 162.8928 
+L 399.194609 162.8928 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.637266 221.6592 
-L 294.262266 221.6592 
-L 294.262266 192.276 
-L 189.637266 192.276 
+    <path d="M 189.944609 221.6592 
+L 294.569609 221.6592 
+L 294.569609 192.276 
+L 189.944609 192.276 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.262266 221.6592 
-L 398.887266 221.6592 
-L 398.887266 192.276 
-L 294.262266 192.276 
+    <path d="M 294.569609 221.6592 
+L 399.194609 221.6592 
+L 399.194609 192.276 
+L 294.569609 192.276 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 398.887266 221.6592 
-L 503.512266 221.6592 
-L 503.512266 192.276 
-L 398.887266 192.276 
+    <path d="M 399.194609 221.6592 
+L 503.819609 221.6592 
+L 503.819609 192.276 
+L 399.194609 192.276 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.637266 251.0424 
-L 294.262266 251.0424 
-L 294.262266 221.6592 
-L 189.637266 221.6592 
+    <path d="M 189.944609 251.0424 
+L 294.569609 251.0424 
+L 294.569609 221.6592 
+L 189.944609 221.6592 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.262266 251.0424 
-L 398.887266 251.0424 
-L 398.887266 221.6592 
-L 294.262266 221.6592 
+    <path d="M 294.569609 251.0424 
+L 399.194609 251.0424 
+L 399.194609 221.6592 
+L 294.569609 221.6592 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 398.887266 251.0424 
-L 503.512266 251.0424 
-L 503.512266 221.6592 
-L 398.887266 221.6592 
+    <path d="M 399.194609 251.0424 
+L 503.819609 251.0424 
+L 503.819609 221.6592 
+L 399.194609 221.6592 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.637266 280.4256 
-L 294.262266 280.4256 
-L 294.262266 251.0424 
-L 189.637266 251.0424 
+    <path d="M 189.944609 280.4256 
+L 294.569609 280.4256 
+L 294.569609 251.0424 
+L 189.944609 251.0424 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.262266 280.4256 
-L 398.887266 280.4256 
-L 398.887266 251.0424 
-L 294.262266 251.0424 
+    <path d="M 294.569609 280.4256 
+L 399.194609 280.4256 
+L 399.194609 251.0424 
+L 294.569609 251.0424 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fcaa5f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 398.887266 280.4256 
-L 503.512266 280.4256 
-L 503.512266 251.0424 
-L 398.887266 251.0424 
+    <path d="M 399.194609 280.4256 
+L 503.819609 280.4256 
+L 503.819609 251.0424 
+L 399.194609 251.0424 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.637266 309.8088 
-L 294.262266 309.8088 
-L 294.262266 280.4256 
-L 189.637266 280.4256 
+    <path d="M 189.944609 309.8088 
+L 294.569609 309.8088 
+L 294.569609 280.4256 
+L 189.944609 280.4256 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.262266 309.8088 
-L 398.887266 309.8088 
-L 398.887266 280.4256 
-L 294.262266 280.4256 
+    <path d="M 294.569609 309.8088 
+L 399.194609 309.8088 
+L 399.194609 280.4256 
+L 294.569609 280.4256 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 398.887266 309.8088 
-L 503.512266 309.8088 
-L 503.512266 280.4256 
-L 398.887266 280.4256 
+    <path d="M 399.194609 309.8088 
+L 503.819609 309.8088 
+L 503.819609 280.4256 
+L 399.194609 280.4256 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.637266 339.192 
-L 294.262266 339.192 
-L 294.262266 309.8088 
-L 189.637266 309.8088 
+    <path d="M 189.944609 339.192 
+L 294.569609 339.192 
+L 294.569609 309.8088 
+L 189.944609 309.8088 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.262266 339.192 
-L 398.887266 339.192 
-L 398.887266 309.8088 
-L 294.262266 309.8088 
+    <path d="M 294.569609 339.192 
+L 399.194609 339.192 
+L 399.194609 309.8088 
+L 294.569609 309.8088 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 398.887266 339.192 
-L 503.512266 339.192 
-L 503.512266 309.8088 
-L 398.887266 309.8088 
+    <path d="M 399.194609 339.192 
+L 503.819609 339.192 
+L 503.819609 309.8088 
+L 399.194609 309.8088 
 z
-" clip-path="url(#p17ec4c83de)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p75cb7941c7)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.624531 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.931875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(229.90875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.216094 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.480859 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.788203 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.832578 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(407.139922 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.562266 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.869609 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(230.498516 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(338.939766 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(339.247109 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(443.564766 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.200391 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.507734 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(230.498516 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(341.484766 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(443.564766 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(100.893516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(101.200859 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(230.498516 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(341.484766 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(443.564766 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(121.926016 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(122.233359 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(230.498516 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(341.484766 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(443.564766 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(130.463516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(130.770859 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(230.498516 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(341.484766 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(443.564766 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(113.769766 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(114.077109 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(230.498516 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,14 +1634,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(341.484766 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 527 -->
-    <g transform="translate(443.564766 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(443.872109 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1649,7 +1649,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.271641 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.578984 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1758,7 +1758,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.325 -->
-    <g transform="translate(229.297891 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.605234 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1876,40 +1876,9 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 25 -->
-    <g transform="translate(341.008516 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 178 -->
-    <g transform="translate(442.850391 267.9415) scale(0.08 -0.08)">
+    <!-- 28 -->
+    <g transform="translate(341.315859 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
 Q 1891 2088 1709 1903 
 Q 1528 1719 1528 1375 
@@ -1950,14 +1919,66 @@ Q 1631 3694 1631 3419
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 174 -->
+    <g transform="translate(443.157734 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.386641 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.693984 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2022,7 +2043,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(230.498516 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2032,21 +2053,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(341.484766 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.792109 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(446.109766 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(446.417109 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.607891 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.915234 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2057,7 +2078,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(230.498516 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.805859 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2067,13 +2088,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(344.029766 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.337109 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.199766 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.507109 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2089,7 +2110,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(154.113984 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(154.421328 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2233,7 +2254,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2372,16 +2393,16 @@ z
     <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2422,109 +2443,109 @@ z
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
     <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p17ec4c83de">
-   <rect x="85.012266" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p75cb7941c7">
+   <rect x="85.319609" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/lakefile.lean
+++ b/bench/lakefile.lean
@@ -335,6 +335,10 @@ lean_exe «mid-sweep» where
   root := `ZipMidSweep
 
 @[default_target]
+lean_exe «huff-bench» where
+  root := `ZipHuffBench
+
+@[default_target]
 lean_exe fuzz_inflate where
   root := `ZipFuzzInflate
 

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,17491 +1,17491 @@
 {
-"meta": {
-"date": "2026-07-05T22:33:53Z",
-"machine": "Linux chungus2 x86_64",
-"git_commit": "9c93b270",
-"toolchain": "leanprover/lean4:v4.30.0-rc2",
-"note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
-},
-"results": [
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 60455,
-"ratio": 0.3975,
-"compress_mbps": 63.67,
-"decompress_mbps": 112.38
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 56316,
-"ratio": 0.3703,
-"compress_mbps": 46.82,
-"decompress_mbps": 124.69
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 55646,
-"ratio": 0.3659,
-"compress_mbps": 41.97,
-"decompress_mbps": 135.62
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 54681,
-"ratio": 0.3595,
-"compress_mbps": 31.2,
-"decompress_mbps": 138.97
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 54437,
-"ratio": 0.3579,
-"compress_mbps": 24.77,
-"decompress_mbps": 146.05
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54348,
-"ratio": 0.3573,
-"compress_mbps": 21.99,
-"decompress_mbps": 150.55
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54140,
-"ratio": 0.356,
-"compress_mbps": 19.14,
-"decompress_mbps": 151.01
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54127,
-"ratio": 0.3559,
-"compress_mbps": 18.6,
-"decompress_mbps": 152.26
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 52732,
-"ratio": 0.3467,
-"compress_mbps": 4.05,
-"decompress_mbps": 152.01
-},
-{
-"compressor": "native",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 10,
-"out_size": 52078,
-"ratio": 0.3424,
-"compress_mbps": 2.27,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 53135,
-"ratio": 0.4245,
-"compress_mbps": 57.42,
-"decompress_mbps": 106.1
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 50187,
-"ratio": 0.4009,
-"compress_mbps": 43.34,
-"decompress_mbps": 113.72
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 49810,
-"ratio": 0.3979,
-"compress_mbps": 39.39,
-"decompress_mbps": 122.12
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 48992,
-"ratio": 0.3914,
-"compress_mbps": 29.15,
-"decompress_mbps": 126.22
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 48891,
-"ratio": 0.3906,
-"compress_mbps": 25.19,
-"decompress_mbps": 131.56
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48715,
-"ratio": 0.3892,
-"compress_mbps": 20.89,
-"decompress_mbps": 135.46
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48634,
-"ratio": 0.3885,
-"compress_mbps": 19.59,
-"decompress_mbps": 137.08
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48634,
-"ratio": 0.3885,
-"compress_mbps": 19.61,
-"decompress_mbps": 137.01
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 47430,
-"ratio": 0.3789,
-"compress_mbps": 4.33,
-"decompress_mbps": 137.25
-},
-{
-"compressor": "native",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 10,
-"out_size": 46865,
-"ratio": 0.3744,
-"compress_mbps": 2.63,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8476,
-"ratio": 0.3445,
-"compress_mbps": 42.87,
-"decompress_mbps": 125.49
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8271,
-"ratio": 0.3362,
-"compress_mbps": 37.58,
-"decompress_mbps": 129.87
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8158,
-"ratio": 0.3316,
-"compress_mbps": 36.88,
-"decompress_mbps": 132.48
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 7961,
-"ratio": 0.3236,
-"compress_mbps": 32.91,
-"decompress_mbps": 138.56
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 7932,
-"ratio": 0.3224,
-"compress_mbps": 28.44,
-"decompress_mbps": 142.6
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7938,
-"ratio": 0.3226,
-"compress_mbps": 24.51,
-"decompress_mbps": 144.23
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7929,
-"ratio": 0.3223,
-"compress_mbps": 23.44,
-"decompress_mbps": 146.19
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7929,
-"ratio": 0.3223,
-"compress_mbps": 23.44,
-"decompress_mbps": 146.05
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7803,
-"ratio": 0.3172,
-"compress_mbps": 4.42,
-"decompress_mbps": 146.11
-},
-{
-"compressor": "native",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 10,
-"out_size": 7737,
-"ratio": 0.3145,
-"compress_mbps": 2.66,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3509,
-"ratio": 0.3147,
-"compress_mbps": 27.46,
-"decompress_mbps": 100.21
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3269,
-"ratio": 0.2932,
-"compress_mbps": 25.4,
-"decompress_mbps": 103.22
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3208,
-"ratio": 0.2877,
-"compress_mbps": 24.76,
-"decompress_mbps": 106.62
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3141,
-"ratio": 0.2817,
-"compress_mbps": 23.23,
-"decompress_mbps": 108.88
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3128,
-"ratio": 0.2805,
-"compress_mbps": 21.3,
-"decompress_mbps": 110.97
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3135,
-"ratio": 0.2812,
-"compress_mbps": 19.33,
-"decompress_mbps": 111.89
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3128,
-"ratio": 0.2805,
-"compress_mbps": 18.73,
-"decompress_mbps": 111.97
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3128,
-"ratio": 0.2805,
-"compress_mbps": 18.68,
-"decompress_mbps": 111.89
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3056,
-"ratio": 0.2741,
-"compress_mbps": 4.48,
-"decompress_mbps": 111.93
-},
-{
-"compressor": "native",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 10,
-"out_size": 3032,
-"ratio": 0.2719,
-"compress_mbps": 2.59,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1282,
-"ratio": 0.3445,
-"compress_mbps": 12.81,
-"decompress_mbps": 56.78
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1225,
-"ratio": 0.3292,
-"compress_mbps": 12.43,
-"decompress_mbps": 57.55
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1220,
-"ratio": 0.3279,
-"compress_mbps": 12.3,
-"decompress_mbps": 57.59
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1213,
-"ratio": 0.326,
-"compress_mbps": 12.16,
-"decompress_mbps": 58.63
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1209,
-"ratio": 0.3249,
-"compress_mbps": 11.8,
-"decompress_mbps": 59.12
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1209,
-"ratio": 0.3249,
-"compress_mbps": 10.69,
-"decompress_mbps": 59.14
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1209,
-"ratio": 0.3249,
-"compress_mbps": 10.67,
-"decompress_mbps": 58.9
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1209,
-"ratio": 0.3249,
-"compress_mbps": 10.65,
-"decompress_mbps": 59.05
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1205,
-"ratio": 0.3238,
-"compress_mbps": 3.5,
-"decompress_mbps": 59.28
-},
-{
-"compressor": "native",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 10,
-"out_size": 1191,
-"ratio": 0.3201,
-"compress_mbps": 2.15,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 251793,
-"ratio": 0.2445,
-"compress_mbps": 123.04,
-"decompress_mbps": 209.63
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 242565,
-"ratio": 0.2356,
-"compress_mbps": 87.16,
-"decompress_mbps": 223.82
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 242532,
-"ratio": 0.2355,
-"compress_mbps": 74.73,
-"decompress_mbps": 233.6
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 239804,
-"ratio": 0.2329,
-"compress_mbps": 69.36,
-"decompress_mbps": 240.04
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 215530,
-"ratio": 0.2093,
-"compress_mbps": 39.5,
-"decompress_mbps": 236.55
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 201414,
-"ratio": 0.1956,
-"compress_mbps": 22.6,
-"decompress_mbps": 242.79
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 200711,
-"ratio": 0.1949,
-"compress_mbps": 16.19,
-"decompress_mbps": 245.92
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 200719,
-"ratio": 0.1949,
-"compress_mbps": 12.13,
-"decompress_mbps": 248.68
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 182508,
-"ratio": 0.1772,
-"compress_mbps": 2.9,
-"decompress_mbps": 250.04
-},
-{
-"compressor": "native",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 10,
-"out_size": 178067,
-"ratio": 0.1729,
-"compress_mbps": 1.32,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 160674,
-"ratio": 0.3765,
-"compress_mbps": 71.7,
-"decompress_mbps": 120.26
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 149787,
-"ratio": 0.351,
-"compress_mbps": 51.4,
-"decompress_mbps": 129.5
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 148055,
-"ratio": 0.3469,
-"compress_mbps": 45.78,
-"decompress_mbps": 142.25
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 145631,
-"ratio": 0.3413,
-"compress_mbps": 34.03,
-"decompress_mbps": 147.4
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 145321,
-"ratio": 0.3405,
-"compress_mbps": 27.66,
-"decompress_mbps": 154.44
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 145046,
-"ratio": 0.3399,
-"compress_mbps": 23.76,
-"decompress_mbps": 158.09
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 144554,
-"ratio": 0.3387,
-"compress_mbps": 21.1,
-"decompress_mbps": 158.84
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 144540,
-"ratio": 0.3387,
-"compress_mbps": 20.66,
-"decompress_mbps": 159.22
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 140322,
-"ratio": 0.3288,
-"compress_mbps": 4.0,
-"decompress_mbps": 159.35
-},
-{
-"compressor": "native",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 10,
-"out_size": 138830,
-"ratio": 0.3253,
-"compress_mbps": 2.36,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 212588,
-"ratio": 0.4412,
-"compress_mbps": 61.23,
-"decompress_mbps": 100.12
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 199981,
-"ratio": 0.415,
-"compress_mbps": 44.09,
-"decompress_mbps": 109.01
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 198551,
-"ratio": 0.4121,
-"compress_mbps": 39.06,
-"decompress_mbps": 119.07
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 195460,
-"ratio": 0.4056,
-"compress_mbps": 26.52,
-"decompress_mbps": 122.98
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 194902,
-"ratio": 0.4045,
-"compress_mbps": 22.31,
-"decompress_mbps": 129.17
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 195177,
-"ratio": 0.405,
-"compress_mbps": 20.64,
-"decompress_mbps": 132.65
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 194385,
-"ratio": 0.4034,
-"compress_mbps": 18.19,
-"decompress_mbps": 133.19
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 194380,
-"ratio": 0.4034,
-"compress_mbps": 18.07,
-"decompress_mbps": 133.44
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 189365,
-"ratio": 0.393,
-"compress_mbps": 3.87,
-"decompress_mbps": 134.0
-},
-{
-"compressor": "native",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 10,
-"out_size": 186147,
-"ratio": 0.3863,
-"compress_mbps": 2.32,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 60161,
-"ratio": 0.1172,
-"compress_mbps": 181.49,
-"decompress_mbps": 344.42
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 58873,
-"ratio": 0.1147,
-"compress_mbps": 138.62,
-"decompress_mbps": 358.66
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 58327,
-"ratio": 0.1137,
-"compress_mbps": 120.91,
-"decompress_mbps": 383.77
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 55673,
-"ratio": 0.1085,
-"compress_mbps": 83.15,
-"decompress_mbps": 356.0
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 54950,
-"ratio": 0.1071,
-"compress_mbps": 57.89,
-"decompress_mbps": 378.91
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 55259,
-"ratio": 0.1077,
-"compress_mbps": 39.05,
-"decompress_mbps": 408.03
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 53713,
-"ratio": 0.1047,
-"compress_mbps": 29.64,
-"decompress_mbps": 430.78
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 52897,
-"ratio": 0.1031,
-"compress_mbps": 25.45,
-"decompress_mbps": 461.18
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 52729,
-"ratio": 0.1027,
-"compress_mbps": 5.0,
-"decompress_mbps": 474.03
-},
-{
-"compressor": "native",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 10,
-"out_size": 52234,
-"ratio": 0.1018,
-"compress_mbps": 3.33,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14249,
-"ratio": 0.3726,
-"compress_mbps": 31.42,
-"decompress_mbps": 114.62
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13825,
-"ratio": 0.3615,
-"compress_mbps": 28.82,
-"decompress_mbps": 117.1
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13751,
-"ratio": 0.3596,
-"compress_mbps": 28.14,
-"decompress_mbps": 118.31
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13366,
-"ratio": 0.3495,
-"compress_mbps": 25.37,
-"decompress_mbps": 125.33
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13346,
-"ratio": 0.349,
-"compress_mbps": 22.55,
-"decompress_mbps": 131.07
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13040,
-"ratio": 0.341,
-"compress_mbps": 9.92,
-"decompress_mbps": 133.5
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13035,
-"ratio": 0.3409,
-"compress_mbps": 9.29,
-"decompress_mbps": 133.61
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13028,
-"ratio": 0.3407,
-"compress_mbps": 8.63,
-"decompress_mbps": 135.85
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12427,
-"ratio": 0.325,
-"compress_mbps": 4.2,
-"decompress_mbps": 137.28
-},
-{
-"compressor": "native",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 10,
-"out_size": 12274,
-"ratio": 0.321,
-"compress_mbps": 2.53,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1800,
-"ratio": 0.4258,
-"compress_mbps": 14.48,
-"decompress_mbps": 58.16
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1750,
-"ratio": 0.414,
-"compress_mbps": 13.8,
-"decompress_mbps": 58.62
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 13.72,
-"decompress_mbps": 58.69
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1732,
-"ratio": 0.4097,
-"compress_mbps": 13.48,
-"decompress_mbps": 60.15
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1729,
-"ratio": 0.409,
-"compress_mbps": 13.37,
-"decompress_mbps": 60.39
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1729,
-"ratio": 0.409,
-"compress_mbps": 11.61,
-"decompress_mbps": 60.43
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1729,
-"ratio": 0.409,
-"compress_mbps": 11.58,
-"decompress_mbps": 60.32
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1729,
-"ratio": 0.409,
-"compress_mbps": 11.61,
-"decompress_mbps": 60.45
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1708,
-"ratio": 0.4041,
-"compress_mbps": 3.95,
-"decompress_mbps": 60.51
-},
-{
-"compressor": "native",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 10,
-"out_size": 1693,
-"ratio": 0.4005,
-"compress_mbps": 2.45,
-"decompress_mbps": null
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 65130,
-"ratio": 0.4282,
-"compress_mbps": 119.16,
-"decompress_mbps": 393.49
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 62270,
-"ratio": 0.4094,
-"compress_mbps": 102.04,
-"decompress_mbps": 412.56
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 59488,
-"ratio": 0.3911,
-"compress_mbps": 67.18,
-"decompress_mbps": 427.67
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 57679,
-"ratio": 0.3792,
-"compress_mbps": 71.84,
-"decompress_mbps": 406.6
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 55616,
-"ratio": 0.3657,
-"compress_mbps": 41.94,
-"decompress_mbps": 399.81
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54398,
-"ratio": 0.3577,
-"compress_mbps": 25.54,
-"decompress_mbps": 412.45
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54253,
-"ratio": 0.3567,
-"compress_mbps": 21.44,
-"decompress_mbps": 414.47
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54164,
-"ratio": 0.3561,
-"compress_mbps": 17.0,
-"decompress_mbps": 415.54
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 54164,
-"ratio": 0.3561,
-"compress_mbps": 16.98,
-"decompress_mbps": 416.37
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 56791,
-"ratio": 0.4537,
-"compress_mbps": 115.48,
-"decompress_mbps": 386.4
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 54652,
-"ratio": 0.4366,
-"compress_mbps": 97.99,
-"decompress_mbps": 401.9
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 52663,
-"ratio": 0.4207,
-"compress_mbps": 62.55,
-"decompress_mbps": 432.53
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 51266,
-"ratio": 0.4095,
-"compress_mbps": 67.6,
-"decompress_mbps": 400.76
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 49622,
-"ratio": 0.3964,
-"compress_mbps": 37.32,
-"decompress_mbps": 387.54
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48891,
-"ratio": 0.3906,
-"compress_mbps": 22.79,
-"decompress_mbps": 395.44
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48801,
-"ratio": 0.3898,
-"compress_mbps": 20.01,
-"decompress_mbps": 395.17
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48772,
-"ratio": 0.3896,
-"compress_mbps": 18.12,
-"decompress_mbps": 395.78
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48772,
-"ratio": 0.3896,
-"compress_mbps": 18.11,
-"decompress_mbps": 395.81
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 9028,
-"ratio": 0.3669,
-"compress_mbps": 413.16,
-"decompress_mbps": 1048.54
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8811,
-"ratio": 0.3581,
-"compress_mbps": 216.27,
-"decompress_mbps": 1072.51
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8616,
-"ratio": 0.3502,
-"compress_mbps": 155.32,
-"decompress_mbps": 1108.48
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8219,
-"ratio": 0.3341,
-"compress_mbps": 115.91,
-"decompress_mbps": 1125.93
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8001,
-"ratio": 0.3252,
-"compress_mbps": 85.05,
-"decompress_mbps": 1145.5
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7955,
-"ratio": 0.3233,
-"compress_mbps": 68.88,
-"decompress_mbps": 1156.57
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7933,
-"ratio": 0.3224,
-"compress_mbps": 63.0,
-"decompress_mbps": 1160.28
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7934,
-"ratio": 0.3225,
-"compress_mbps": 58.11,
-"decompress_mbps": 1157.25
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7934,
-"ratio": 0.3225,
-"compress_mbps": 57.98,
-"decompress_mbps": 1156.91
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3647,
-"ratio": 0.3271,
-"compress_mbps": 426.88,
-"decompress_mbps": 1068.91
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3501,
-"ratio": 0.314,
-"compress_mbps": 408.45,
-"decompress_mbps": 1109.39
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3393,
-"ratio": 0.3043,
-"compress_mbps": 338.89,
-"decompress_mbps": 1135.33
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3215,
-"ratio": 0.2883,
-"compress_mbps": 274.69,
-"decompress_mbps": 1169.54
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3140,
-"ratio": 0.2816,
-"compress_mbps": 206.54,
-"decompress_mbps": 1204.24
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 154.05,
-"decompress_mbps": 1215.11
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 132.02,
-"decompress_mbps": 1220.83
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3109,
-"ratio": 0.2788,
-"compress_mbps": 111.36,
-"decompress_mbps": 1211.79
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3109,
-"ratio": 0.2788,
-"compress_mbps": 111.17,
-"decompress_mbps": 1221.54
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1326,
-"ratio": 0.3564,
-"compress_mbps": 316.62,
-"decompress_mbps": 784.92
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1306,
-"ratio": 0.351,
-"compress_mbps": 310.47,
-"decompress_mbps": 775.49
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1301,
-"ratio": 0.3496,
-"compress_mbps": 291.4,
-"decompress_mbps": 783.71
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1228,
-"ratio": 0.33,
-"compress_mbps": 233.74,
-"decompress_mbps": 819.16
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 199.28,
-"decompress_mbps": 811.67
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 178.18,
-"decompress_mbps": 810.93
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 170.94,
-"decompress_mbps": 816.34
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 168.09,
-"decompress_mbps": 815.03
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 167.98,
-"decompress_mbps": 812.97
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 242293,
-"ratio": 0.2353,
-"compress_mbps": 262.08,
-"decompress_mbps": 830.92
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 233553,
-"ratio": 0.2268,
-"compress_mbps": 247.77,
-"decompress_mbps": 981.42
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 228222,
-"ratio": 0.2216,
-"compress_mbps": 195.24,
-"decompress_mbps": 1038.02
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 223668,
-"ratio": 0.2172,
-"compress_mbps": 177.62,
-"decompress_mbps": 1069.05
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 205994,
-"ratio": 0.2,
-"compress_mbps": 110.2,
-"decompress_mbps": 1028.7
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 203986,
-"ratio": 0.1981,
-"compress_mbps": 49.93,
-"decompress_mbps": 1032.63
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 207681,
-"ratio": 0.2017,
-"compress_mbps": 37.01,
-"decompress_mbps": 1024.77
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 206827,
-"ratio": 0.2009,
-"compress_mbps": 7.3,
-"decompress_mbps": 996.72
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 207023,
-"ratio": 0.201,
-"compress_mbps": 3.43,
-"decompress_mbps": 994.12
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 174124,
-"ratio": 0.408,
-"compress_mbps": 123.62,
-"decompress_mbps": 391.8
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 166150,
-"ratio": 0.3893,
-"compress_mbps": 104.81,
-"decompress_mbps": 401.7
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 158784,
-"ratio": 0.3721,
-"compress_mbps": 70.23,
-"decompress_mbps": 419.82
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 152782,
-"ratio": 0.358,
-"compress_mbps": 73.72,
-"decompress_mbps": 407.18
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 147196,
-"ratio": 0.3449,
-"compress_mbps": 43.35,
-"decompress_mbps": 401.98
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144898,
-"ratio": 0.3395,
-"compress_mbps": 26.3,
-"decompress_mbps": 412.86
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 144589,
-"ratio": 0.3388,
-"compress_mbps": 22.81,
-"decompress_mbps": 413.61
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 144436,
-"ratio": 0.3385,
-"compress_mbps": 19.6,
-"decompress_mbps": 413.12
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 144433,
-"ratio": 0.3384,
-"compress_mbps": 19.54,
-"decompress_mbps": 413.31
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 228883,
-"ratio": 0.475,
-"compress_mbps": 107.83,
-"decompress_mbps": 367.64
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 219047,
-"ratio": 0.4546,
-"compress_mbps": 90.66,
-"decompress_mbps": 385.82
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 209408,
-"ratio": 0.4346,
-"compress_mbps": 55.28,
-"decompress_mbps": 400.37
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 205916,
-"ratio": 0.4273,
-"compress_mbps": 62.18,
-"decompress_mbps": 375.5
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 199188,
-"ratio": 0.4134,
-"compress_mbps": 32.87,
-"decompress_mbps": 358.02
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 195255,
-"ratio": 0.4052,
-"compress_mbps": 19.31,
-"decompress_mbps": 359.99
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 194657,
-"ratio": 0.404,
-"compress_mbps": 16.33,
-"decompress_mbps": 360.28
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 194326,
-"ratio": 0.4033,
-"compress_mbps": 12.9,
-"decompress_mbps": 366.37
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 194326,
-"ratio": 0.4033,
-"compress_mbps": 12.9,
-"decompress_mbps": 362.41
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 65553,
-"ratio": 0.1277,
-"compress_mbps": 273.36,
-"decompress_mbps": 876.91
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 63891,
-"ratio": 0.1245,
-"compress_mbps": 247.13,
-"decompress_mbps": 903.46
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 62515,
-"ratio": 0.1218,
-"compress_mbps": 193.01,
-"decompress_mbps": 962.2
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 58451,
-"ratio": 0.1139,
-"compress_mbps": 168.63,
-"decompress_mbps": 693.08
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 57410,
-"ratio": 0.1119,
-"compress_mbps": 130.05,
-"decompress_mbps": 721.34
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 56459,
-"ratio": 0.11,
-"compress_mbps": 76.97,
-"decompress_mbps": 771.47
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 55358,
-"ratio": 0.1079,
-"compress_mbps": 60.1,
-"decompress_mbps": 803.98
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 52991,
-"ratio": 0.1033,
-"compress_mbps": 27.44,
-"decompress_mbps": 859.31
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 52215,
-"ratio": 0.1017,
-"compress_mbps": 9.79,
-"decompress_mbps": 872.15
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14112,
-"ratio": 0.369,
-"compress_mbps": 128.53,
-"decompress_mbps": 939.3
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13815,
-"ratio": 0.3613,
-"compress_mbps": 109.01,
-"decompress_mbps": 977.63
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13795,
-"ratio": 0.3607,
-"compress_mbps": 78.92,
-"decompress_mbps": 1019.56
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13375,
-"ratio": 0.3498,
-"compress_mbps": 80.43,
-"decompress_mbps": 996.76
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13062,
-"ratio": 0.3416,
-"compress_mbps": 55.68,
-"decompress_mbps": 1020.16
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 12984,
-"ratio": 0.3395,
-"compress_mbps": 33.03,
-"decompress_mbps": 1058.22
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12949,
-"ratio": 0.3386,
-"compress_mbps": 25.4,
-"decompress_mbps": 1066.55
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12894,
-"ratio": 0.3372,
-"compress_mbps": 11.05,
-"decompress_mbps": 1073.99
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12832,
-"ratio": 0.3356,
-"compress_mbps": 5.08,
-"decompress_mbps": 1078.09
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1846,
-"ratio": 0.4367,
-"compress_mbps": 291.54,
-"decompress_mbps": 710.22
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1820,
-"ratio": 0.4306,
-"compress_mbps": 285.68,
-"decompress_mbps": 721.53
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1808,
-"ratio": 0.4277,
-"compress_mbps": 273.13,
-"decompress_mbps": 722.95
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1749,
-"ratio": 0.4138,
-"compress_mbps": 226.8,
-"decompress_mbps": 747.21
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 202.13,
-"decompress_mbps": 753.35
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 199.33,
-"decompress_mbps": 752.79
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 196.97,
-"decompress_mbps": 754.48
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 197.03,
-"decompress_mbps": 752.65
-},
-{
-"compressor": "zlib",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 197.14,
-"decompress_mbps": 753.21
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 76470,
-"ratio": 0.5028,
-"compress_mbps": 157.78,
-"decompress_mbps": 442.94
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 62765,
-"ratio": 0.4127,
-"compress_mbps": 132.14,
-"decompress_mbps": 490.51
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 57162,
-"ratio": 0.3758,
-"compress_mbps": 72.22,
-"decompress_mbps": 551.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56826,
-"ratio": 0.3736,
-"compress_mbps": 64.16,
-"decompress_mbps": 535.92
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 55696,
-"ratio": 0.3662,
-"compress_mbps": 46.86,
-"decompress_mbps": 525.1
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54440,
-"ratio": 0.3579,
-"compress_mbps": 26.56,
-"decompress_mbps": 542.84
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54283,
-"ratio": 0.3569,
-"compress_mbps": 22.4,
-"decompress_mbps": 543.39
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54221,
-"ratio": 0.3565,
-"compress_mbps": 19.71,
-"decompress_mbps": 544.04
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 54217,
-"ratio": 0.3565,
-"compress_mbps": 19.49,
-"decompress_mbps": 546.52
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 64926,
-"ratio": 0.5187,
-"compress_mbps": 151.42,
-"decompress_mbps": 421.18
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 54985,
-"ratio": 0.4393,
-"compress_mbps": 123.65,
-"decompress_mbps": 467.93
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51148,
-"ratio": 0.4086,
-"compress_mbps": 67.07,
-"decompress_mbps": 534.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50599,
-"ratio": 0.4042,
-"compress_mbps": 58.95,
-"decompress_mbps": 519.63
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 49775,
-"ratio": 0.3976,
-"compress_mbps": 42.66,
-"decompress_mbps": 506.03
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48967,
-"ratio": 0.3912,
-"compress_mbps": 24.99,
-"decompress_mbps": 519.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48870,
-"ratio": 0.3904,
-"compress_mbps": 22.17,
-"decompress_mbps": 525.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48845,
-"ratio": 0.3902,
-"compress_mbps": 20.89,
-"decompress_mbps": 523.43
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48845,
-"ratio": 0.3902,
-"compress_mbps": 20.9,
-"decompress_mbps": 518.44
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 10024,
-"ratio": 0.4074,
-"compress_mbps": 531.61,
-"decompress_mbps": 900.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8577,
-"ratio": 0.3486,
-"compress_mbps": 261.38,
-"decompress_mbps": 926.45
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8168,
-"ratio": 0.332,
-"compress_mbps": 156.0,
-"decompress_mbps": 944.92
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8069,
-"ratio": 0.328,
-"compress_mbps": 114.85,
-"decompress_mbps": 969.72
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 7997,
-"ratio": 0.325,
-"compress_mbps": 100.16,
-"decompress_mbps": 998.61
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7952,
-"ratio": 0.3232,
-"compress_mbps": 74.97,
-"decompress_mbps": 1005.75
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7947,
-"ratio": 0.323,
-"compress_mbps": 72.58,
-"decompress_mbps": 1011.17
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7947,
-"ratio": 0.323,
-"compress_mbps": 71.43,
-"decompress_mbps": 1011.35
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7947,
-"ratio": 0.323,
-"compress_mbps": 71.29,
-"decompress_mbps": 1010.78
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 4061,
-"ratio": 0.3642,
-"compress_mbps": 489.84,
-"decompress_mbps": 854.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3446,
-"ratio": 0.3091,
-"compress_mbps": 305.95,
-"decompress_mbps": 893.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3201,
-"ratio": 0.2871,
-"compress_mbps": 233.51,
-"decompress_mbps": 927.8
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 193.82,
-"decompress_mbps": 956.16
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3139,
-"ratio": 0.2815,
-"compress_mbps": 162.46,
-"decompress_mbps": 972.16
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3115,
-"ratio": 0.2794,
-"compress_mbps": 116.38,
-"decompress_mbps": 985.86
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 106.48,
-"decompress_mbps": 989.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 103.65,
-"decompress_mbps": 993.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 103.26,
-"decompress_mbps": 992.76
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1410,
-"ratio": 0.3789,
-"compress_mbps": 366.9,
-"decompress_mbps": 596.01
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1262,
-"ratio": 0.3392,
-"compress_mbps": 234.45,
-"decompress_mbps": 604.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1238,
-"ratio": 0.3327,
-"compress_mbps": 203.34,
-"decompress_mbps": 605.36
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1219,
-"ratio": 0.3276,
-"compress_mbps": 174.55,
-"decompress_mbps": 620.28
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 160.35,
-"decompress_mbps": 629.75
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 146.33,
-"decompress_mbps": 631.65
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 145.11,
-"decompress_mbps": 634.93
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 145.24,
-"decompress_mbps": 633.23
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1216,
-"ratio": 0.3268,
-"compress_mbps": 144.99,
-"decompress_mbps": 630.75
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 274412,
-"ratio": 0.2665,
-"compress_mbps": 449.9,
-"decompress_mbps": 793.96
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 213239,
-"ratio": 0.2071,
-"compress_mbps": 272.27,
-"decompress_mbps": 896.17
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 232107,
-"ratio": 0.2254,
-"compress_mbps": 136.67,
-"decompress_mbps": 941.49
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 202733,
-"ratio": 0.1969,
-"compress_mbps": 129.64,
-"decompress_mbps": 941.54
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 207803,
-"ratio": 0.2018,
-"compress_mbps": 84.14,
-"decompress_mbps": 955.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 205270,
-"ratio": 0.1993,
-"compress_mbps": 27.3,
-"decompress_mbps": 979.27
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 209951,
-"ratio": 0.2039,
-"compress_mbps": 19.31,
-"decompress_mbps": 995.45
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 209656,
-"ratio": 0.2036,
-"compress_mbps": 12.24,
-"decompress_mbps": 1009.18
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 209189,
-"ratio": 0.2031,
-"compress_mbps": 8.96,
-"decompress_mbps": 1011.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 208640,
-"ratio": 0.4889,
-"compress_mbps": 157.45,
-"decompress_mbps": 423.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 167329,
-"ratio": 0.3921,
-"compress_mbps": 137.6,
-"decompress_mbps": 464.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 151097,
-"ratio": 0.3541,
-"compress_mbps": 73.65,
-"decompress_mbps": 512.52
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 150035,
-"ratio": 0.3516,
-"compress_mbps": 66.13,
-"decompress_mbps": 509.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 147375,
-"ratio": 0.3453,
-"compress_mbps": 48.14,
-"decompress_mbps": 506.78
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144908,
-"ratio": 0.3396,
-"compress_mbps": 28.05,
-"decompress_mbps": 518.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 144562,
-"ratio": 0.3387,
-"compress_mbps": 24.64,
-"decompress_mbps": 518.63
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 144449,
-"ratio": 0.3385,
-"compress_mbps": 22.4,
-"decompress_mbps": 516.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 144438,
-"ratio": 0.3385,
-"compress_mbps": 22.34,
-"decompress_mbps": 517.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 264549,
-"ratio": 0.549,
-"compress_mbps": 136.07,
-"decompress_mbps": 376.66
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 223724,
-"ratio": 0.4643,
-"compress_mbps": 118.11,
-"decompress_mbps": 422.07
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 204825,
-"ratio": 0.4251,
-"compress_mbps": 60.64,
-"decompress_mbps": 477.68
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 203945,
-"ratio": 0.4232,
-"compress_mbps": 53.78,
-"decompress_mbps": 471.87
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 199780,
-"ratio": 0.4146,
-"compress_mbps": 37.88,
-"decompress_mbps": 455.85
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 195417,
-"ratio": 0.4055,
-"compress_mbps": 21.15,
-"decompress_mbps": 465.48
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 194796,
-"ratio": 0.4043,
-"compress_mbps": 17.87,
-"decompress_mbps": 466.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 194543,
-"ratio": 0.4037,
-"compress_mbps": 15.68,
-"decompress_mbps": 465.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 194460,
-"ratio": 0.4036,
-"compress_mbps": 15.02,
-"decompress_mbps": 465.94
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 67436,
-"ratio": 0.1314,
-"compress_mbps": 626.36,
-"decompress_mbps": 1001.38
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 59257,
-"ratio": 0.1155,
-"compress_mbps": 276.28,
-"decompress_mbps": 1056.51
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 58316,
-"ratio": 0.1136,
-"compress_mbps": 180.05,
-"decompress_mbps": 1135.86
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 56291,
-"ratio": 0.1097,
-"compress_mbps": 183.07,
-"decompress_mbps": 1151.41
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 56220,
-"ratio": 0.1095,
-"compress_mbps": 144.89,
-"decompress_mbps": 1205.93
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 55972,
-"ratio": 0.1091,
-"compress_mbps": 74.28,
-"decompress_mbps": 1269.6
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 55121,
-"ratio": 0.1074,
-"compress_mbps": 51.98,
-"decompress_mbps": 1309.93
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 54124,
-"ratio": 0.1055,
-"compress_mbps": 36.61,
-"decompress_mbps": 1367.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 53699,
-"ratio": 0.1046,
-"compress_mbps": 28.61,
-"decompress_mbps": 1404.21
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 15612,
-"ratio": 0.4083,
-"compress_mbps": 513.43,
-"decompress_mbps": 865.99
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 14133,
-"ratio": 0.3696,
-"compress_mbps": 144.5,
-"decompress_mbps": 895.42
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13341,
-"ratio": 0.3489,
-"compress_mbps": 87.64,
-"decompress_mbps": 919.3
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13289,
-"ratio": 0.3475,
-"compress_mbps": 82.82,
-"decompress_mbps": 945.1
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13052,
-"ratio": 0.3413,
-"compress_mbps": 66.19,
-"decompress_mbps": 984.73
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 12996,
-"ratio": 0.3399,
-"compress_mbps": 37.0,
-"decompress_mbps": 1002.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12972,
-"ratio": 0.3392,
-"compress_mbps": 27.16,
-"decompress_mbps": 1006.0
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12951,
-"ratio": 0.3387,
-"compress_mbps": 19.0,
-"decompress_mbps": 1014.42
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12933,
-"ratio": 0.3382,
-"compress_mbps": 14.84,
-"decompress_mbps": 1016.18
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1988,
-"ratio": 0.4703,
-"compress_mbps": 352.16,
-"decompress_mbps": 550.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1802,
-"ratio": 0.4263,
-"compress_mbps": 218.43,
-"decompress_mbps": 554.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 205.02,
-"decompress_mbps": 556.18
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1732,
-"ratio": 0.4097,
-"compress_mbps": 169.87,
-"decompress_mbps": 571.64
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 166.82,
-"decompress_mbps": 581.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 165.11,
-"decompress_mbps": 580.19
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 165.65,
-"decompress_mbps": 581.36
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 164.8,
-"decompress_mbps": 583.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1730,
-"ratio": 0.4093,
-"compress_mbps": 165.0,
-"decompress_mbps": 583.21
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 59790,
-"ratio": 0.3931,
-"compress_mbps": 259.33,
-"decompress_mbps": 996.52
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 57173,
-"ratio": 0.3759,
-"compress_mbps": 180.49,
-"decompress_mbps": 1070.19
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 56189,
-"ratio": 0.3694,
-"compress_mbps": 150.33,
-"decompress_mbps": 1145.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 55816,
-"ratio": 0.367,
-"compress_mbps": 137.81,
-"decompress_mbps": 1185.99
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 54758,
-"ratio": 0.36,
-"compress_mbps": 108.84,
-"decompress_mbps": 1238.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54220,
-"ratio": 0.3565,
-"compress_mbps": 84.22,
-"decompress_mbps": 1278.06
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 53801,
-"ratio": 0.3537,
-"compress_mbps": 60.73,
-"decompress_mbps": 1281.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 53573,
-"ratio": 0.3522,
-"compress_mbps": 39.0,
-"decompress_mbps": 1280.04
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 53546,
-"ratio": 0.3521,
-"compress_mbps": 34.45,
-"decompress_mbps": 1277.72
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 10,
-"out_size": 51721,
-"ratio": 0.3401,
-"compress_mbps": 12.18,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 11,
-"out_size": 51662,
-"ratio": 0.3397,
-"compress_mbps": 8.34,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 12,
-"out_size": 51662,
-"ratio": 0.3397,
-"compress_mbps": 5.1,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 52276,
-"ratio": 0.4176,
-"compress_mbps": 241.61,
-"decompress_mbps": 939.42
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 50534,
-"ratio": 0.4037,
-"compress_mbps": 168.24,
-"decompress_mbps": 989.01
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 49919,
-"ratio": 0.3988,
-"compress_mbps": 141.33,
-"decompress_mbps": 1053.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 49715,
-"ratio": 0.3972,
-"compress_mbps": 130.46,
-"decompress_mbps": 1090.5
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 48735,
-"ratio": 0.3893,
-"compress_mbps": 100.2,
-"decompress_mbps": 1139.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48422,
-"ratio": 0.3868,
-"compress_mbps": 79.3,
-"decompress_mbps": 1156.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48249,
-"ratio": 0.3854,
-"compress_mbps": 60.96,
-"decompress_mbps": 1163.41
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 47977,
-"ratio": 0.3833,
-"compress_mbps": 43.03,
-"decompress_mbps": 1166.29
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 47971,
-"ratio": 0.3832,
-"compress_mbps": 41.09,
-"decompress_mbps": 1165.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 10,
-"out_size": 46657,
-"ratio": 0.3727,
-"compress_mbps": 13.62,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 11,
-"out_size": 46515,
-"ratio": 0.3716,
-"compress_mbps": 9.25,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 12,
-"out_size": 46469,
-"ratio": 0.3712,
-"compress_mbps": 7.05,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8385,
-"ratio": 0.3408,
-"compress_mbps": 695.0,
-"decompress_mbps": 957.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8380,
-"ratio": 0.3406,
-"compress_mbps": 441.98,
-"decompress_mbps": 969.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8286,
-"ratio": 0.3368,
-"compress_mbps": 405.77,
-"decompress_mbps": 985.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8163,
-"ratio": 0.3318,
-"compress_mbps": 377.87,
-"decompress_mbps": 999.24
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8053,
-"ratio": 0.3273,
-"compress_mbps": 337.25,
-"decompress_mbps": 1015.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7986,
-"ratio": 0.3246,
-"compress_mbps": 276.49,
-"decompress_mbps": 1030.31
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7954,
-"ratio": 0.3233,
-"compress_mbps": 190.41,
-"decompress_mbps": 1032.9
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7916,
-"ratio": 0.3217,
-"compress_mbps": 126.18,
-"decompress_mbps": 1029.63
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7916,
-"ratio": 0.3217,
-"compress_mbps": 125.1,
-"decompress_mbps": 1031.53
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 10,
-"out_size": 7725,
-"ratio": 0.314,
-"compress_mbps": 15.79,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 11,
-"out_size": 7727,
-"ratio": 0.3141,
-"compress_mbps": 10.77,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 12,
-"out_size": 7723,
-"ratio": 0.3139,
-"compress_mbps": 7.18,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3401,
-"ratio": 0.305,
-"compress_mbps": 586.51,
-"decompress_mbps": 768.31
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3307,
-"ratio": 0.2966,
-"compress_mbps": 399.66,
-"decompress_mbps": 789.24
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3242,
-"ratio": 0.2908,
-"compress_mbps": 367.93,
-"decompress_mbps": 807.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3205,
-"ratio": 0.2874,
-"compress_mbps": 351.44,
-"decompress_mbps": 815.58
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3150,
-"ratio": 0.2825,
-"compress_mbps": 313.88,
-"decompress_mbps": 830.35
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3126,
-"ratio": 0.2804,
-"compress_mbps": 266.83,
-"decompress_mbps": 840.06
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3106,
-"ratio": 0.2786,
-"compress_mbps": 206.86,
-"decompress_mbps": 839.2
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3102,
-"ratio": 0.2782,
-"compress_mbps": 147.64,
-"decompress_mbps": 843.66
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3102,
-"ratio": 0.2782,
-"compress_mbps": 140.31,
-"decompress_mbps": 843.26
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 10,
-"out_size": 3026,
-"ratio": 0.2714,
-"compress_mbps": 17.51,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 11,
-"out_size": 3024,
-"ratio": 0.2712,
-"compress_mbps": 13.82,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 12,
-"out_size": 3024,
-"ratio": 0.2712,
-"compress_mbps": 10.64,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1251,
-"ratio": 0.3362,
-"compress_mbps": 382.39,
-"decompress_mbps": 436.06
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1228,
-"ratio": 0.33,
-"compress_mbps": 271.65,
-"decompress_mbps": 441.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1219,
-"ratio": 0.3276,
-"compress_mbps": 261.74,
-"decompress_mbps": 439.73
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1220,
-"ratio": 0.3279,
-"compress_mbps": 256.64,
-"decompress_mbps": 442.14
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 240.91,
-"decompress_mbps": 448.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 224.04,
-"decompress_mbps": 450.45
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 203.76,
-"decompress_mbps": 450.96
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1204,
-"ratio": 0.3236,
-"compress_mbps": 169.34,
-"decompress_mbps": 451.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1204,
-"ratio": 0.3236,
-"compress_mbps": 168.85,
-"decompress_mbps": 450.56
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 10,
-"out_size": 1186,
-"ratio": 0.3187,
-"compress_mbps": 41.99,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 11,
-"out_size": 1186,
-"ratio": 0.3187,
-"compress_mbps": 32.99,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 12,
-"out_size": 1186,
-"ratio": 0.3187,
-"compress_mbps": 24.38,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 221813,
-"ratio": 0.2154,
-"compress_mbps": 595.78,
-"decompress_mbps": 1009.43
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 199825,
-"ratio": 0.1941,
-"compress_mbps": 410.21,
-"decompress_mbps": 1465.65
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 195675,
-"ratio": 0.19,
-"compress_mbps": 283.21,
-"decompress_mbps": 1533.25
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 195664,
-"ratio": 0.19,
-"compress_mbps": 280.07,
-"decompress_mbps": 1537.01
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 198900,
-"ratio": 0.1932,
-"compress_mbps": 239.61,
-"decompress_mbps": 1128.92
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 199347,
-"ratio": 0.1936,
-"compress_mbps": 204.37,
-"decompress_mbps": 1127.33
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 199777,
-"ratio": 0.194,
-"compress_mbps": 123.58,
-"decompress_mbps": 1186.64
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 182094,
-"ratio": 0.1768,
-"compress_mbps": 25.62,
-"decompress_mbps": 1170.25
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 181451,
-"ratio": 0.1762,
-"compress_mbps": 13.6,
-"decompress_mbps": 1174.11
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 10,
-"out_size": 179347,
-"ratio": 0.1742,
-"compress_mbps": 30.78,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 11,
-"out_size": 179096,
-"ratio": 0.1739,
-"compress_mbps": 19.99,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 12,
-"out_size": 179049,
-"ratio": 0.1739,
-"compress_mbps": 15.46,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 159063,
-"ratio": 0.3727,
-"compress_mbps": 263.79,
-"decompress_mbps": 1021.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 152115,
-"ratio": 0.3564,
-"compress_mbps": 186.84,
-"decompress_mbps": 1101.82
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 149162,
-"ratio": 0.3495,
-"compress_mbps": 156.34,
-"decompress_mbps": 1190.05
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 148359,
-"ratio": 0.3476,
-"compress_mbps": 142.52,
-"decompress_mbps": 1028.42
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 145353,
-"ratio": 0.3406,
-"compress_mbps": 112.89,
-"decompress_mbps": 996.54
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144209,
-"ratio": 0.3379,
-"compress_mbps": 87.51,
-"decompress_mbps": 1031.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 143604,
-"ratio": 0.3365,
-"compress_mbps": 66.73,
-"decompress_mbps": 1039.91
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 142086,
-"ratio": 0.3329,
-"compress_mbps": 44.23,
-"decompress_mbps": 1037.6
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 142027,
-"ratio": 0.3328,
-"compress_mbps": 40.4,
-"decompress_mbps": 1036.5
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 10,
-"out_size": 138116,
-"ratio": 0.3236,
-"compress_mbps": 12.68,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 11,
-"out_size": 137923,
-"ratio": 0.3232,
-"compress_mbps": 8.69,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 12,
-"out_size": 137921,
-"ratio": 0.3232,
-"compress_mbps": 7.36,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 210662,
-"ratio": 0.4372,
-"compress_mbps": 228.42,
-"decompress_mbps": 865.39
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 202881,
-"ratio": 0.421,
-"compress_mbps": 158.66,
-"decompress_mbps": 938.79
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 200409,
-"ratio": 0.4159,
-"compress_mbps": 133.13,
-"decompress_mbps": 1016.29
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 199678,
-"ratio": 0.4144,
-"compress_mbps": 122.65,
-"decompress_mbps": 841.37
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 195798,
-"ratio": 0.4063,
-"compress_mbps": 93.06,
-"decompress_mbps": 790.98
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 194029,
-"ratio": 0.4027,
-"compress_mbps": 71.77,
-"decompress_mbps": 811.6
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 192773,
-"ratio": 0.4001,
-"compress_mbps": 50.51,
-"decompress_mbps": 815.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 191739,
-"ratio": 0.3979,
-"compress_mbps": 33.65,
-"decompress_mbps": 821.06
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 191676,
-"ratio": 0.3978,
-"compress_mbps": 31.02,
-"decompress_mbps": 821.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 10,
-"out_size": 185328,
-"ratio": 0.3846,
-"compress_mbps": 12.74,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 11,
-"out_size": 184440,
-"ratio": 0.3828,
-"compress_mbps": 8.96,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 12,
-"out_size": 184371,
-"ratio": 0.3826,
-"compress_mbps": 5.45,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 58079,
-"ratio": 0.1132,
-"compress_mbps": 371.33,
-"decompress_mbps": 1662.96
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 57838,
-"ratio": 0.1127,
-"compress_mbps": 410.38,
-"decompress_mbps": 1764.85
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 57554,
-"ratio": 0.1121,
-"compress_mbps": 390.9,
-"decompress_mbps": 1862.82
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 57064,
-"ratio": 0.1112,
-"compress_mbps": 371.73,
-"decompress_mbps": 1695.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 55743,
-"ratio": 0.1086,
-"compress_mbps": 341.58,
-"decompress_mbps": 1774.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 55102,
-"ratio": 0.1074,
-"compress_mbps": 278.3,
-"decompress_mbps": 1856.38
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 54742,
-"ratio": 0.1067,
-"compress_mbps": 192.18,
-"decompress_mbps": 1914.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 53133,
-"ratio": 0.1035,
-"compress_mbps": 102.47,
-"decompress_mbps": 1969.76
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 52186,
-"ratio": 0.1017,
-"compress_mbps": 72.13,
-"decompress_mbps": 2001.32
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 10,
-"out_size": 51319,
-"ratio": 0.1,
-"compress_mbps": 12.76,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 11,
-"out_size": 49675,
-"ratio": 0.0968,
-"compress_mbps": 6.04,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 12,
-"out_size": 49194,
-"ratio": 0.0959,
-"compress_mbps": 3.5,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14122,
-"ratio": 0.3693,
-"compress_mbps": 651.19,
-"decompress_mbps": 823.09
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13374,
-"ratio": 0.3497,
-"compress_mbps": 345.74,
-"decompress_mbps": 878.53
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13293,
-"ratio": 0.3476,
-"compress_mbps": 286.57,
-"decompress_mbps": 952.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13259,
-"ratio": 0.3467,
-"compress_mbps": 265.38,
-"decompress_mbps": 948.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 12641,
-"ratio": 0.3306,
-"compress_mbps": 189.13,
-"decompress_mbps": 989.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 12432,
-"ratio": 0.3251,
-"compress_mbps": 164.09,
-"decompress_mbps": 1011.41
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 12439,
-"ratio": 0.3253,
-"compress_mbps": 122.75,
-"decompress_mbps": 1008.2
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 12579,
-"ratio": 0.3289,
-"compress_mbps": 67.84,
-"decompress_mbps": 1015.44
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 12574,
-"ratio": 0.3288,
-"compress_mbps": 47.51,
-"decompress_mbps": 1027.14
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 10,
-"out_size": 11975,
-"ratio": 0.3132,
-"compress_mbps": 19.93,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 11,
-"out_size": 11966,
-"ratio": 0.3129,
-"compress_mbps": 13.28,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 12,
-"out_size": 11965,
-"ratio": 0.3129,
-"compress_mbps": 10.53,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1777,
-"ratio": 0.4204,
-"compress_mbps": 383.89,
-"decompress_mbps": 399.96
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1756,
-"ratio": 0.4154,
-"compress_mbps": 258.74,
-"decompress_mbps": 401.83
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1746,
-"ratio": 0.4131,
-"compress_mbps": 256.81,
-"decompress_mbps": 403.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1740,
-"ratio": 0.4116,
-"compress_mbps": 254.22,
-"decompress_mbps": 409.76
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1722,
-"ratio": 0.4074,
-"compress_mbps": 239.57,
-"decompress_mbps": 415.67
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1721,
-"ratio": 0.4071,
-"compress_mbps": 234.6,
-"decompress_mbps": 415.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 233.37,
-"decompress_mbps": 414.43
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1717,
-"ratio": 0.4062,
-"compress_mbps": 216.54,
-"decompress_mbps": 413.37
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1717,
-"ratio": 0.4062,
-"compress_mbps": 216.39,
-"decompress_mbps": 413.88
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 10,
-"out_size": 1692,
-"ratio": 0.4003,
-"compress_mbps": 54.8,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 11,
-"out_size": 1690,
-"ratio": 0.3998,
-"compress_mbps": 45.13,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 12,
-"out_size": 1690,
-"ratio": 0.3998,
-"compress_mbps": 29.88,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4259644,
-"ratio": 0.4179,
-"compress_mbps": 65.86,
-"decompress_mbps": 105.55
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 3977395,
-"ratio": 0.3902,
-"compress_mbps": 47.37,
-"decompress_mbps": 114.1
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3945296,
-"ratio": 0.3871,
-"compress_mbps": 41.44,
-"decompress_mbps": 125.54
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3882303,
-"ratio": 0.3809,
-"compress_mbps": 29.15,
-"decompress_mbps": 128.05
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3870984,
-"ratio": 0.3798,
-"compress_mbps": 24.26,
-"decompress_mbps": 133.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3878499,
-"ratio": 0.3805,
-"compress_mbps": 22.99,
-"decompress_mbps": 137.77
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3865234,
-"ratio": 0.3792,
-"compress_mbps": 19.95,
-"decompress_mbps": 138.22
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3864805,
-"ratio": 0.3792,
-"compress_mbps": 19.45,
-"decompress_mbps": 138.39
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3766584,
-"ratio": 0.3695,
-"compress_mbps": 3.92,
-"decompress_mbps": 142.27
-},
-{
-"compressor": "native",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 10,
-"out_size": 3711172,
-"ratio": 0.3641,
-"compress_mbps": 2.32,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 21267086,
-"ratio": 0.4152,
-"compress_mbps": 79.55,
-"decompress_mbps": 134.07
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20802983,
-"ratio": 0.4061,
-"compress_mbps": 63.79,
-"decompress_mbps": 140.56
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 20665485,
-"ratio": 0.4035,
-"compress_mbps": 58.91,
-"decompress_mbps": 144.94
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 20393572,
-"ratio": 0.3982,
-"compress_mbps": 44.93,
-"decompress_mbps": 152.03
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 20264932,
-"ratio": 0.3956,
-"compress_mbps": 33.04,
-"decompress_mbps": 160.26
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19208910,
-"ratio": 0.375,
-"compress_mbps": 17.28,
-"decompress_mbps": 164.29
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19177573,
-"ratio": 0.3744,
-"compress_mbps": 14.3,
-"decompress_mbps": 164.74
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19172591,
-"ratio": 0.3743,
-"compress_mbps": 12.52,
-"decompress_mbps": 162.27
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18686872,
-"ratio": 0.3648,
-"compress_mbps": 3.76,
-"decompress_mbps": 164.35
-},
-{
-"compressor": "native",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 10,
-"out_size": 18539905,
-"ratio": 0.362,
-"compress_mbps": 2.09,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3864163,
-"ratio": 0.3876,
-"compress_mbps": 80.07,
-"decompress_mbps": 117.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3734957,
-"ratio": 0.3746,
-"compress_mbps": 60.7,
-"decompress_mbps": 128.07
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3708443,
-"ratio": 0.3719,
-"compress_mbps": 52.31,
-"decompress_mbps": 136.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3707604,
-"ratio": 0.3719,
-"compress_mbps": 34.04,
-"decompress_mbps": 133.34
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3705174,
-"ratio": 0.3716,
-"compress_mbps": 27.09,
-"decompress_mbps": 139.01
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3612809,
-"ratio": 0.3623,
-"compress_mbps": 20.92,
-"decompress_mbps": 143.87
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3608980,
-"ratio": 0.362,
-"compress_mbps": 18.09,
-"decompress_mbps": 145.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3609490,
-"ratio": 0.362,
-"compress_mbps": 16.61,
-"decompress_mbps": 148.42
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3581441,
-"ratio": 0.3592,
-"compress_mbps": 4.2,
-"decompress_mbps": 152.41
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 10,
-"out_size": 3512886,
-"ratio": 0.3523,
-"compress_mbps": 2.62,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3785443,
-"ratio": 0.1128,
-"compress_mbps": 232.74,
-"decompress_mbps": 364.56
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3761560,
-"ratio": 0.1121,
-"compress_mbps": 145.7,
-"decompress_mbps": 411.17
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3606997,
-"ratio": 0.1075,
-"compress_mbps": 124.89,
-"decompress_mbps": 458.24
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3225450,
-"ratio": 0.0961,
-"compress_mbps": 92.12,
-"decompress_mbps": 468.85
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3145121,
-"ratio": 0.0937,
-"compress_mbps": 63.08,
-"decompress_mbps": 533.8
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3158854,
-"ratio": 0.0941,
-"compress_mbps": 59.78,
-"decompress_mbps": 573.38
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3124878,
-"ratio": 0.0931,
-"compress_mbps": 42.13,
-"decompress_mbps": 588.15
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3112207,
-"ratio": 0.0928,
-"compress_mbps": 34.57,
-"decompress_mbps": 604.7
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3034875,
-"ratio": 0.0904,
-"compress_mbps": 3.12,
-"decompress_mbps": 588.57
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 10,
-"out_size": 2902186,
-"ratio": 0.0865,
-"compress_mbps": 1.83,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3357083,
-"ratio": 0.5457,
-"compress_mbps": 56.31,
-"decompress_mbps": 92.77
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3285077,
-"ratio": 0.534,
-"compress_mbps": 46.39,
-"decompress_mbps": 96.56
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3272746,
-"ratio": 0.532,
-"compress_mbps": 44.65,
-"decompress_mbps": 97.16
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3237094,
-"ratio": 0.5262,
-"compress_mbps": 35.72,
-"decompress_mbps": 104.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3233792,
-"ratio": 0.5256,
-"compress_mbps": 31.99,
-"decompress_mbps": 109.12
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3168386,
-"ratio": 0.515,
-"compress_mbps": 17.83,
-"decompress_mbps": 110.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3165783,
-"ratio": 0.5146,
-"compress_mbps": 16.79,
-"decompress_mbps": 112.05
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3165909,
-"ratio": 0.5146,
-"compress_mbps": 16.07,
-"decompress_mbps": 112.63
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3048772,
-"ratio": 0.4956,
-"compress_mbps": 4.4,
-"decompress_mbps": 114.06
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 10,
-"out_size": 3021986,
-"ratio": 0.4912,
-"compress_mbps": 2.84,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3838828,
-"ratio": 0.3806,
-"compress_mbps": 90.02,
-"decompress_mbps": 159.08
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3792520,
-"ratio": 0.376,
-"compress_mbps": 66.94,
-"decompress_mbps": 164.47
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3783171,
-"ratio": 0.3751,
-"compress_mbps": 64.0,
-"decompress_mbps": 162.67
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3706928,
-"ratio": 0.3675,
-"compress_mbps": 55.82,
-"decompress_mbps": 173.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3707010,
-"ratio": 0.3676,
-"compress_mbps": 52.61,
-"decompress_mbps": 178.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3707065,
-"ratio": 0.3676,
-"compress_mbps": 38.29,
-"decompress_mbps": 187.64
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3706769,
-"ratio": 0.3675,
-"compress_mbps": 38.13,
-"decompress_mbps": 189.46
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3706769,
-"ratio": 0.3675,
-"compress_mbps": 38.38,
-"decompress_mbps": 190.47
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3665069,
-"ratio": 0.3634,
-"compress_mbps": 5.19,
-"decompress_mbps": 195.86
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 10,
-"out_size": 3647321,
-"ratio": 0.3616,
-"compress_mbps": 3.07,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2254442,
-"ratio": 0.3402,
-"compress_mbps": 83.54,
-"decompress_mbps": 126.2
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2044843,
-"ratio": 0.3086,
-"compress_mbps": 56.06,
-"decompress_mbps": 142.3
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 1992105,
-"ratio": 0.3006,
-"compress_mbps": 45.26,
-"decompress_mbps": 156.6
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1901081,
-"ratio": 0.2869,
-"compress_mbps": 27.96,
-"decompress_mbps": 160.98
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1874829,
-"ratio": 0.2829,
-"compress_mbps": 17.0,
-"decompress_mbps": 170.98
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1867098,
-"ratio": 0.2817,
-"compress_mbps": 19.93,
-"decompress_mbps": 180.53
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1843421,
-"ratio": 0.2782,
-"compress_mbps": 13.07,
-"decompress_mbps": 180.83
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1841388,
-"ratio": 0.2779,
-"compress_mbps": 10.89,
-"decompress_mbps": 187.16
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1773447,
-"ratio": 0.2676,
-"compress_mbps": 2.7,
-"decompress_mbps": 191.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 10,
-"out_size": 1718500,
-"ratio": 0.2593,
-"compress_mbps": 1.49,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6406301,
-"ratio": 0.2965,
-"compress_mbps": 109.58,
-"decompress_mbps": 197.79
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 6102377,
-"ratio": 0.2824,
-"compress_mbps": 81.1,
-"decompress_mbps": 209.1
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 6022184,
-"ratio": 0.2787,
-"compress_mbps": 73.79,
-"decompress_mbps": 218.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5880979,
-"ratio": 0.2722,
-"compress_mbps": 54.12,
-"decompress_mbps": 227.73
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5839944,
-"ratio": 0.2703,
-"compress_mbps": 41.81,
-"decompress_mbps": 240.36
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5425813,
-"ratio": 0.2511,
-"compress_mbps": 29.2,
-"decompress_mbps": 244.92
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5409983,
-"ratio": 0.2504,
-"compress_mbps": 25.86,
-"decompress_mbps": 247.57
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5407066,
-"ratio": 0.2503,
-"compress_mbps": 24.17,
-"decompress_mbps": 249.21
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5235865,
-"ratio": 0.2423,
-"compress_mbps": 3.88,
-"decompress_mbps": 245.07
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 10,
-"out_size": 5177560,
-"ratio": 0.2396,
-"compress_mbps": 2.29,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5612204,
-"ratio": 0.7739,
-"compress_mbps": 44.94,
-"decompress_mbps": 90.15
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5533875,
-"ratio": 0.7631,
-"compress_mbps": 38.92,
-"decompress_mbps": 88.31
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5522436,
-"ratio": 0.7615,
-"compress_mbps": 36.25,
-"decompress_mbps": 95.47
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5498823,
-"ratio": 0.7583,
-"compress_mbps": 28.94,
-"decompress_mbps": 97.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5496802,
-"ratio": 0.758,
-"compress_mbps": 27.76,
-"decompress_mbps": 99.62
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5478405,
-"ratio": 0.7554,
-"compress_mbps": 20.04,
-"decompress_mbps": 105.13
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5474648,
-"ratio": 0.7549,
-"compress_mbps": 19.37,
-"decompress_mbps": 106.41
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5474139,
-"ratio": 0.7549,
-"compress_mbps": 19.29,
-"decompress_mbps": 104.39
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5284536,
-"ratio": 0.7287,
-"compress_mbps": 3.99,
-"decompress_mbps": 98.8
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 10,
-"out_size": 5262319,
-"ratio": 0.7256,
-"compress_mbps": 3.03,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13727247,
-"ratio": 0.3311,
-"compress_mbps": 82.89,
-"decompress_mbps": 137.04
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 12940398,
-"ratio": 0.3121,
-"compress_mbps": 60.03,
-"decompress_mbps": 147.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12703756,
-"ratio": 0.3064,
-"compress_mbps": 55.24,
-"decompress_mbps": 159.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12229398,
-"ratio": 0.295,
-"compress_mbps": 37.8,
-"decompress_mbps": 156.27
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12123671,
-"ratio": 0.2924,
-"compress_mbps": 29.29,
-"decompress_mbps": 167.85
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12167341,
-"ratio": 0.2935,
-"compress_mbps": 28.55,
-"decompress_mbps": 165.43
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12109369,
-"ratio": 0.2921,
-"compress_mbps": 24.01,
-"decompress_mbps": 182.62
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12106058,
-"ratio": 0.292,
-"compress_mbps": 21.77,
-"decompress_mbps": 177.07
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11806466,
-"ratio": 0.2848,
-"compress_mbps": 3.59,
-"decompress_mbps": 184.45
-},
-{
-"compressor": "native",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 10,
-"out_size": 11636727,
-"ratio": 0.2807,
-"compress_mbps": 1.92,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6438176,
-"ratio": 0.7597,
-"compress_mbps": 42.9,
-"decompress_mbps": 78.68
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6392101,
-"ratio": 0.7543,
-"compress_mbps": 41.08,
-"decompress_mbps": 79.19
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6392124,
-"ratio": 0.7543,
-"compress_mbps": 41.28,
-"decompress_mbps": 80.76
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6368719,
-"ratio": 0.7515,
-"compress_mbps": 38.87,
-"decompress_mbps": 80.9
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6368717,
-"ratio": 0.7515,
-"compress_mbps": 38.89,
-"decompress_mbps": 82.91
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6278507,
-"ratio": 0.7409,
-"compress_mbps": 9.86,
-"decompress_mbps": 82.94
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6278507,
-"ratio": 0.7409,
-"compress_mbps": 10.01,
-"decompress_mbps": 82.88
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6278507,
-"ratio": 0.7409,
-"compress_mbps": 9.77,
-"decompress_mbps": 83.32
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5952505,
-"ratio": 0.7024,
-"compress_mbps": 4.98,
-"decompress_mbps": 84.24
-},
-{
-"compressor": "native",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 10,
-"out_size": 5848663,
-"ratio": 0.6902,
-"compress_mbps": 3.78,
-"decompress_mbps": null
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 858525,
-"ratio": 0.1606,
-"compress_mbps": 177.29,
-"decompress_mbps": 270.55
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 846807,
-"ratio": 0.1584,
-"compress_mbps": 112.57,
-"decompress_mbps": 301.81
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 806798,
-"ratio": 0.1509,
-"compress_mbps": 102.84,
-"decompress_mbps": 338.17
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 721655,
-"ratio": 0.135,
-"compress_mbps": 73.68,
-"decompress_mbps": 333.13
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 710636,
-"ratio": 0.1329,
-"compress_mbps": 53.59,
-"decompress_mbps": 365.86
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 688375,
-"ratio": 0.1288,
-"compress_mbps": 47.38,
-"decompress_mbps": 403.0
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 676544,
-"ratio": 0.1266,
-"compress_mbps": 38.07,
-"decompress_mbps": 413.62
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 674362,
-"ratio": 0.1262,
-"compress_mbps": 33.09,
-"decompress_mbps": 424.31
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 659417,
-"ratio": 0.1234,
-"compress_mbps": 4.19,
-"decompress_mbps": 449.48
-},
-{
-"compressor": "native",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 10,
-"out_size": 643093,
-"ratio": 0.1203,
-"compress_mbps": 2.84,
-"decompress_mbps": null
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4585612,
-"ratio": 0.4499,
-"compress_mbps": 112.9,
-"decompress_mbps": 344.92
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4389474,
-"ratio": 0.4307,
-"compress_mbps": 95.43,
-"decompress_mbps": 367.17
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4192079,
-"ratio": 0.4113,
-"compress_mbps": 59.17,
-"decompress_mbps": 398.26
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4095021,
-"ratio": 0.4018,
-"compress_mbps": 65.65,
-"decompress_mbps": 380.09
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3949169,
-"ratio": 0.3875,
-"compress_mbps": 35.62,
-"decompress_mbps": 367.61
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3871628,
-"ratio": 0.3799,
-"compress_mbps": 21.17,
-"decompress_mbps": 377.77
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3858876,
-"ratio": 0.3786,
-"compress_mbps": 17.65,
-"decompress_mbps": 379.94
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3854729,
-"ratio": 0.3782,
-"compress_mbps": 15.03,
-"decompress_mbps": 379.97
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3854729,
-"ratio": 0.3782,
-"compress_mbps": 15.0,
-"decompress_mbps": 380.17
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20577220,
-"ratio": 0.4017,
-"compress_mbps": 112.07,
-"decompress_mbps": 353.52
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20247697,
-"ratio": 0.3953,
-"compress_mbps": 100.19,
-"decompress_mbps": 366.17
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19987880,
-"ratio": 0.3902,
-"compress_mbps": 76.03,
-"decompress_mbps": 373.04
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19512665,
-"ratio": 0.381,
-"compress_mbps": 75.24,
-"decompress_mbps": 363.97
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19213507,
-"ratio": 0.3751,
-"compress_mbps": 53.09,
-"decompress_mbps": 369.34
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19089118,
-"ratio": 0.3727,
-"compress_mbps": 34.33,
-"decompress_mbps": 373.69
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19061204,
-"ratio": 0.3721,
-"compress_mbps": 27.3,
-"decompress_mbps": 376.83
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19040998,
-"ratio": 0.3717,
-"compress_mbps": 15.4,
-"decompress_mbps": 376.27
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19044390,
-"ratio": 0.3718,
-"compress_mbps": 9.51,
-"decompress_mbps": 377.24
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3828360,
-"ratio": 0.384,
-"compress_mbps": 143.06,
-"decompress_mbps": 466.9
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3798539,
-"ratio": 0.381,
-"compress_mbps": 126.34,
-"decompress_mbps": 481.52
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3674568,
-"ratio": 0.3685,
-"compress_mbps": 79.25,
-"decompress_mbps": 499.48
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3680923,
-"ratio": 0.3692,
-"compress_mbps": 87.5,
-"decompress_mbps": 443.81
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3698707,
-"ratio": 0.371,
-"compress_mbps": 47.33,
-"decompress_mbps": 415.52
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3675935,
-"ratio": 0.3687,
-"compress_mbps": 26.24,
-"decompress_mbps": 432.27
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3670281,
-"ratio": 0.3681,
-"compress_mbps": 20.75,
-"decompress_mbps": 438.0
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3661103,
-"ratio": 0.3672,
-"compress_mbps": 10.99,
-"decompress_mbps": 447.92
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3660788,
-"ratio": 0.3672,
-"compress_mbps": 9.51,
-"decompress_mbps": 448.66
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4624591,
-"ratio": 0.1378,
-"compress_mbps": 334.74,
-"decompress_mbps": 810.57
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4303176,
-"ratio": 0.1282,
-"compress_mbps": 309.81,
-"decompress_mbps": 840.23
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 4010156,
-"ratio": 0.1195,
-"compress_mbps": 258.23,
-"decompress_mbps": 922.43
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3713866,
-"ratio": 0.1107,
-"compress_mbps": 212.43,
-"decompress_mbps": 899.61
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3378136,
-"ratio": 0.1007,
-"compress_mbps": 165.59,
-"decompress_mbps": 955.5
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3200182,
-"ratio": 0.0954,
-"compress_mbps": 114.19,
-"decompress_mbps": 1003.83
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3141278,
-"ratio": 0.0936,
-"compress_mbps": 90.27,
-"decompress_mbps": 1014.87
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3031199,
-"ratio": 0.0903,
-"compress_mbps": 39.33,
-"decompress_mbps": 1003.59
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2987995,
-"ratio": 0.0891,
-"compress_mbps": 21.46,
-"decompress_mbps": 1030.56
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3290526,
-"ratio": 0.5349,
-"compress_mbps": 78.63,
-"decompress_mbps": 253.04
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3238282,
-"ratio": 0.5264,
-"compress_mbps": 71.42,
-"decompress_mbps": 258.74
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3193366,
-"ratio": 0.5191,
-"compress_mbps": 56.57,
-"decompress_mbps": 265.13
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3158012,
-"ratio": 0.5133,
-"compress_mbps": 55.17,
-"decompress_mbps": 266.79
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3115309,
-"ratio": 0.5064,
-"compress_mbps": 39.03,
-"decompress_mbps": 270.19
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3097288,
-"ratio": 0.5034,
-"compress_mbps": 26.4,
-"decompress_mbps": 273.25
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3094363,
-"ratio": 0.503,
-"compress_mbps": 21.97,
-"decompress_mbps": 273.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3093026,
-"ratio": 0.5028,
-"compress_mbps": 17.15,
-"decompress_mbps": 274.45
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3092920,
-"ratio": 0.5027,
-"compress_mbps": 15.57,
-"decompress_mbps": 273.36
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4076385,
-"ratio": 0.4042,
-"compress_mbps": 126.52,
-"decompress_mbps": 451.69
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3991014,
-"ratio": 0.3957,
-"compress_mbps": 117.71,
-"decompress_mbps": 492.11
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3934055,
-"ratio": 0.3901,
-"compress_mbps": 93.9,
-"decompress_mbps": 511.69
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3825092,
-"ratio": 0.3793,
-"compress_mbps": 85.01,
-"decompress_mbps": 505.76
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3752932,
-"ratio": 0.3721,
-"compress_mbps": 64.85,
-"decompress_mbps": 500.03
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3695164,
-"ratio": 0.3664,
-"compress_mbps": 49.58,
-"decompress_mbps": 511.28
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3676881,
-"ratio": 0.3646,
-"compress_mbps": 38.18,
-"decompress_mbps": 520.25
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3673171,
-"ratio": 0.3642,
-"compress_mbps": 32.02,
-"decompress_mbps": 524.7
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3673171,
-"ratio": 0.3642,
-"compress_mbps": 31.98,
-"decompress_mbps": 523.22
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2376424,
-"ratio": 0.3586,
-"compress_mbps": 130.75,
-"decompress_mbps": 395.81
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2259060,
-"ratio": 0.3409,
-"compress_mbps": 112.16,
-"decompress_mbps": 412.15
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2135664,
-"ratio": 0.3223,
-"compress_mbps": 72.65,
-"decompress_mbps": 434.27
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 2052793,
-"ratio": 0.3098,
-"compress_mbps": 82.15,
-"decompress_mbps": 431.28
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1932127,
-"ratio": 0.2915,
-"compress_mbps": 45.47,
-"decompress_mbps": 432.58
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1860865,
-"ratio": 0.2808,
-"compress_mbps": 22.86,
-"decompress_mbps": 430.09
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1838671,
-"ratio": 0.2774,
-"compress_mbps": 15.9,
-"decompress_mbps": 431.27
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1823235,
-"ratio": 0.2751,
-"compress_mbps": 8.11,
-"decompress_mbps": 430.78
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1823190,
-"ratio": 0.2751,
-"compress_mbps": 8.07,
-"decompress_mbps": 436.02
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6329449,
-"ratio": 0.2929,
-"compress_mbps": 168.35,
-"decompress_mbps": 457.14
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 6128866,
-"ratio": 0.2837,
-"compress_mbps": 155.31,
-"decompress_mbps": 544.24
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5982546,
-"ratio": 0.2769,
-"compress_mbps": 124.88,
-"decompress_mbps": 568.18
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5656400,
-"ratio": 0.2618,
-"compress_mbps": 116.79,
-"decompress_mbps": 567.03
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5511352,
-"ratio": 0.2551,
-"compress_mbps": 82.16,
-"decompress_mbps": 575.02
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5451399,
-"ratio": 0.2523,
-"compress_mbps": 56.58,
-"decompress_mbps": 558.24
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5417123,
-"ratio": 0.2507,
-"compress_mbps": 46.62,
-"decompress_mbps": 589.12
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5404364,
-"ratio": 0.2501,
-"compress_mbps": 32.68,
-"decompress_mbps": 594.94
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5402704,
-"ratio": 0.2501,
-"compress_mbps": 29.8,
-"decompress_mbps": 596.17
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5567768,
-"ratio": 0.7678,
-"compress_mbps": 64.24,
-"decompress_mbps": 313.33
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5504009,
-"ratio": 0.759,
-"compress_mbps": 58.26,
-"decompress_mbps": 324.49
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5439339,
-"ratio": 0.7501,
-"compress_mbps": 46.28,
-"decompress_mbps": 333.53
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5394604,
-"ratio": 0.7439,
-"compress_mbps": 47.91,
-"decompress_mbps": 343.92
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5370116,
-"ratio": 0.7405,
-"compress_mbps": 33.04,
-"decompress_mbps": 337.26
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5331793,
-"ratio": 0.7352,
-"compress_mbps": 23.02,
-"decompress_mbps": 342.64
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5327677,
-"ratio": 0.7347,
-"compress_mbps": 21.09,
-"decompress_mbps": 340.24
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5325914,
-"ratio": 0.7344,
-"compress_mbps": 18.88,
-"decompress_mbps": 343.38
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5325914,
-"ratio": 0.7344,
-"compress_mbps": 18.86,
-"decompress_mbps": 340.76
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 14991236,
-"ratio": 0.3616,
-"compress_mbps": 136.57,
-"decompress_mbps": 360.93
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 14249692,
-"ratio": 0.3437,
-"compress_mbps": 120.26,
-"decompress_mbps": 393.57
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 13627761,
-"ratio": 0.3287,
-"compress_mbps": 87.43,
-"decompress_mbps": 409.97
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 13001990,
-"ratio": 0.3136,
-"compress_mbps": 84.92,
-"decompress_mbps": 390.84
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12445991,
-"ratio": 0.3002,
-"compress_mbps": 54.7,
-"decompress_mbps": 387.48
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12213941,
-"ratio": 0.2946,
-"compress_mbps": 36.36,
-"decompress_mbps": 394.08
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12130416,
-"ratio": 0.2926,
-"compress_mbps": 29.55,
-"decompress_mbps": 396.12
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12073697,
-"ratio": 0.2912,
-"compress_mbps": 21.38,
-"decompress_mbps": 398.65
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12073469,
-"ratio": 0.2912,
-"compress_mbps": 21.24,
-"decompress_mbps": 400.02
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6033926,
-"ratio": 0.712,
-"compress_mbps": 74.72,
-"decompress_mbps": 290.16
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 5997474,
-"ratio": 0.7077,
-"compress_mbps": 68.17,
-"decompress_mbps": 298.3
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 5966621,
-"ratio": 0.7041,
-"compress_mbps": 55.2,
-"decompress_mbps": 305.36
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6091108,
-"ratio": 0.7188,
-"compress_mbps": 45.51,
-"decompress_mbps": 262.1
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6053566,
-"ratio": 0.7143,
-"compress_mbps": 36.91,
-"decompress_mbps": 270.38
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6045111,
-"ratio": 0.7134,
-"compress_mbps": 34.75,
-"decompress_mbps": 275.14
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6045034,
-"ratio": 0.7133,
-"compress_mbps": 34.64,
-"decompress_mbps": 275.6
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6045032,
-"ratio": 0.7133,
-"compress_mbps": 34.69,
-"decompress_mbps": 275.05
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6045032,
-"ratio": 0.7133,
-"compress_mbps": 34.64,
-"decompress_mbps": 274.34
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 965242,
-"ratio": 0.1806,
-"compress_mbps": 262.6,
-"decompress_mbps": 674.71
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 887265,
-"ratio": 0.166,
-"compress_mbps": 245.29,
-"decompress_mbps": 734.01
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 822167,
-"ratio": 0.1538,
-"compress_mbps": 190.93,
-"decompress_mbps": 787.19
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 807518,
-"ratio": 0.1511,
-"compress_mbps": 168.99,
-"decompress_mbps": 754.09
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 730574,
-"ratio": 0.1367,
-"compress_mbps": 121.67,
-"decompress_mbps": 801.04
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 687991,
-"ratio": 0.1287,
-"compress_mbps": 79.4,
-"decompress_mbps": 858.56
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 673933,
-"ratio": 0.1261,
-"compress_mbps": 65.06,
-"decompress_mbps": 870.44
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 659518,
-"ratio": 0.1234,
-"compress_mbps": 43.03,
-"decompress_mbps": 886.73
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 658899,
-"ratio": 0.1233,
-"compress_mbps": 39.76,
-"decompress_mbps": 889.25
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 5363862,
-"ratio": 0.5263,
-"compress_mbps": 142.13,
-"decompress_mbps": 367.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4438205,
-"ratio": 0.4354,
-"compress_mbps": 127.41,
-"decompress_mbps": 418.03
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4054333,
-"ratio": 0.3978,
-"compress_mbps": 63.93,
-"decompress_mbps": 465.47
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4038550,
-"ratio": 0.3962,
-"compress_mbps": 57.58,
-"decompress_mbps": 461.6
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3954920,
-"ratio": 0.388,
-"compress_mbps": 40.28,
-"decompress_mbps": 451.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3872874,
-"ratio": 0.38,
-"compress_mbps": 22.59,
-"decompress_mbps": 463.35
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3859937,
-"ratio": 0.3787,
-"compress_mbps": 18.86,
-"decompress_mbps": 464.51
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3855935,
-"ratio": 0.3783,
-"compress_mbps": 17.01,
-"decompress_mbps": 462.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3855791,
-"ratio": 0.3783,
-"compress_mbps": 17.01,
-"decompress_mbps": 464.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 22334882,
-"ratio": 0.4361,
-"compress_mbps": 237.47,
-"decompress_mbps": 359.97
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20150366,
-"ratio": 0.3934,
-"compress_mbps": 119.56,
-"decompress_mbps": 371.65
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19495014,
-"ratio": 0.3806,
-"compress_mbps": 70.05,
-"decompress_mbps": 380.8
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19424978,
-"ratio": 0.3792,
-"compress_mbps": 71.25,
-"decompress_mbps": 394.95
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19298736,
-"ratio": 0.3768,
-"compress_mbps": 54.15,
-"decompress_mbps": 408.78
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19179167,
-"ratio": 0.3744,
-"compress_mbps": 29.73,
-"decompress_mbps": 415.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19151324,
-"ratio": 0.3739,
-"compress_mbps": 21.93,
-"decompress_mbps": 416.25
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19144373,
-"ratio": 0.3738,
-"compress_mbps": 16.58,
-"decompress_mbps": 419.75
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19141383,
-"ratio": 0.3737,
-"compress_mbps": 14.19,
-"decompress_mbps": 404.15
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 4249731,
-"ratio": 0.4262,
-"compress_mbps": 311.43,
-"decompress_mbps": 518.78
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3775479,
-"ratio": 0.3787,
-"compress_mbps": 156.55,
-"decompress_mbps": 540.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3656966,
-"ratio": 0.3668,
-"compress_mbps": 79.24,
-"decompress_mbps": 565.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3740378,
-"ratio": 0.3751,
-"compress_mbps": 67.15,
-"decompress_mbps": 526.93
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3713604,
-"ratio": 0.3725,
-"compress_mbps": 48.3,
-"decompress_mbps": 488.73
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3683556,
-"ratio": 0.3694,
-"compress_mbps": 24.9,
-"decompress_mbps": 510.52
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3683797,
-"ratio": 0.3695,
-"compress_mbps": 18.88,
-"decompress_mbps": 500.66
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3684477,
-"ratio": 0.3695,
-"compress_mbps": 14.29,
-"decompress_mbps": 526.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3679414,
-"ratio": 0.369,
-"compress_mbps": 12.32,
-"decompress_mbps": 528.49
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 5594622,
-"ratio": 0.1667,
-"compress_mbps": 433.14,
-"decompress_mbps": 839.24
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4179532,
-"ratio": 0.1246,
-"compress_mbps": 326.71,
-"decompress_mbps": 924.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3542329,
-"ratio": 0.1056,
-"compress_mbps": 211.96,
-"decompress_mbps": 841.08
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3323363,
-"ratio": 0.099,
-"compress_mbps": 198.1,
-"decompress_mbps": 871.39
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3230343,
-"ratio": 0.0963,
-"compress_mbps": 162.32,
-"decompress_mbps": 955.61
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3123421,
-"ratio": 0.0931,
-"compress_mbps": 96.23,
-"decompress_mbps": 1013.27
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3093778,
-"ratio": 0.0922,
-"compress_mbps": 70.75,
-"decompress_mbps": 977.54
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3067318,
-"ratio": 0.0914,
-"compress_mbps": 50.12,
-"decompress_mbps": 1016.81
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3050695,
-"ratio": 0.0909,
-"compress_mbps": 42.12,
-"decompress_mbps": 1024.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3543611,
-"ratio": 0.576,
-"compress_mbps": 167.45,
-"decompress_mbps": 270.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3226818,
-"ratio": 0.5245,
-"compress_mbps": 85.72,
-"decompress_mbps": 286.81
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3144140,
-"ratio": 0.5111,
-"compress_mbps": 52.56,
-"decompress_mbps": 297.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3129833,
-"ratio": 0.5087,
-"compress_mbps": 51.44,
-"decompress_mbps": 326.1
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3114809,
-"ratio": 0.5063,
-"compress_mbps": 40.37,
-"decompress_mbps": 338.6
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3095705,
-"ratio": 0.5032,
-"compress_mbps": 25.15,
-"decompress_mbps": 345.2
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3090055,
-"ratio": 0.5023,
-"compress_mbps": 20.49,
-"decompress_mbps": 346.01
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3087665,
-"ratio": 0.5019,
-"compress_mbps": 17.42,
-"decompress_mbps": 347.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3087158,
-"ratio": 0.5018,
-"compress_mbps": 16.34,
-"decompress_mbps": 347.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 5419510,
-"ratio": 0.5373,
-"compress_mbps": 240.9,
-"decompress_mbps": 518.99
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3982547,
-"ratio": 0.3949,
-"compress_mbps": 122.69,
-"decompress_mbps": 541.32
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3806102,
-"ratio": 0.3774,
-"compress_mbps": 81.9,
-"decompress_mbps": 559.37
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3761477,
-"ratio": 0.373,
-"compress_mbps": 78.54,
-"decompress_mbps": 591.74
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3740298,
-"ratio": 0.3709,
-"compress_mbps": 67.47,
-"decompress_mbps": 592.01
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3686116,
-"ratio": 0.3655,
-"compress_mbps": 49.5,
-"decompress_mbps": 626.28
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3668442,
-"ratio": 0.3637,
-"compress_mbps": 38.83,
-"decompress_mbps": 638.73
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3665072,
-"ratio": 0.3634,
-"compress_mbps": 33.19,
-"decompress_mbps": 636.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3665057,
-"ratio": 0.3634,
-"compress_mbps": 33.07,
-"decompress_mbps": 636.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2842321,
-"ratio": 0.4289,
-"compress_mbps": 190.94,
-"decompress_mbps": 438.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2232180,
-"ratio": 0.3368,
-"compress_mbps": 151.11,
-"decompress_mbps": 509.32
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2003056,
-"ratio": 0.3022,
-"compress_mbps": 82.05,
-"decompress_mbps": 549.56
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1985375,
-"ratio": 0.2996,
-"compress_mbps": 73.94,
-"decompress_mbps": 556.86
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1933775,
-"ratio": 0.2918,
-"compress_mbps": 51.93,
-"decompress_mbps": 532.62
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1858103,
-"ratio": 0.2804,
-"compress_mbps": 22.01,
-"decompress_mbps": 538.05
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1840414,
-"ratio": 0.2777,
-"compress_mbps": 15.12,
-"decompress_mbps": 544.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1831679,
-"ratio": 0.2764,
-"compress_mbps": 11.71,
-"decompress_mbps": 532.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1827137,
-"ratio": 0.2757,
-"compress_mbps": 10.14,
-"decompress_mbps": 539.04
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 7089759,
-"ratio": 0.3281,
-"compress_mbps": 290.39,
-"decompress_mbps": 563.58
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5966231,
-"ratio": 0.2761,
-"compress_mbps": 173.09,
-"decompress_mbps": 612.26
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5611838,
-"ratio": 0.2597,
-"compress_mbps": 111.24,
-"decompress_mbps": 638.04
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5535436,
-"ratio": 0.2562,
-"compress_mbps": 105.15,
-"decompress_mbps": 662.01
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5480971,
-"ratio": 0.2537,
-"compress_mbps": 81.26,
-"decompress_mbps": 670.81
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5437556,
-"ratio": 0.2517,
-"compress_mbps": 49.58,
-"decompress_mbps": 684.55
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5432108,
-"ratio": 0.2514,
-"compress_mbps": 40.49,
-"decompress_mbps": 626.85
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5428571,
-"ratio": 0.2512,
-"compress_mbps": 33.69,
-"decompress_mbps": 690.55
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5425526,
-"ratio": 0.2511,
-"compress_mbps": 30.52,
-"decompress_mbps": 688.43
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5900800,
-"ratio": 0.8137,
-"compress_mbps": 187.81,
-"decompress_mbps": 312.3
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5523611,
-"ratio": 0.7617,
-"compress_mbps": 68.34,
-"decompress_mbps": 337.84
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5393086,
-"ratio": 0.7437,
-"compress_mbps": 40.05,
-"decompress_mbps": 349.72
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5401582,
-"ratio": 0.7448,
-"compress_mbps": 40.5,
-"decompress_mbps": 365.18
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5371274,
-"ratio": 0.7407,
-"compress_mbps": 31.19,
-"decompress_mbps": 358.17
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5330096,
-"ratio": 0.735,
-"compress_mbps": 20.78,
-"decompress_mbps": 364.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5325437,
-"ratio": 0.7343,
-"compress_mbps": 18.99,
-"decompress_mbps": 366.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5323934,
-"ratio": 0.7341,
-"compress_mbps": 18.04,
-"decompress_mbps": 358.83
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323621,
-"ratio": 0.7341,
-"compress_mbps": 17.73,
-"decompress_mbps": 364.14
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 17587173,
-"ratio": 0.4242,
-"compress_mbps": 184.15,
-"decompress_mbps": 360.59
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 14171707,
-"ratio": 0.3418,
-"compress_mbps": 147.7,
-"decompress_mbps": 408.57
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12774851,
-"ratio": 0.3081,
-"compress_mbps": 85.53,
-"decompress_mbps": 439.04
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12612554,
-"ratio": 0.3042,
-"compress_mbps": 75.97,
-"decompress_mbps": 437.95
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12392339,
-"ratio": 0.2989,
-"compress_mbps": 57.99,
-"decompress_mbps": 450.61
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12158314,
-"ratio": 0.2933,
-"compress_mbps": 34.34,
-"decompress_mbps": 456.5
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12107840,
-"ratio": 0.292,
-"compress_mbps": 27.58,
-"decompress_mbps": 459.59
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12081311,
-"ratio": 0.2914,
-"compress_mbps": 22.87,
-"decompress_mbps": 460.8
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12081011,
-"ratio": 0.2914,
-"compress_mbps": 22.77,
-"decompress_mbps": 460.43
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6527324,
-"ratio": 0.7703,
-"compress_mbps": 238.01,
-"decompress_mbps": 325.92
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6051483,
-"ratio": 0.7141,
-"compress_mbps": 75.23,
-"decompress_mbps": 327.25
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6010123,
-"ratio": 0.7092,
-"compress_mbps": 51.94,
-"decompress_mbps": 330.03
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6024815,
-"ratio": 0.711,
-"compress_mbps": 44.37,
-"decompress_mbps": 279.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6005181,
-"ratio": 0.7086,
-"compress_mbps": 40.25,
-"decompress_mbps": 285.12
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5997508,
-"ratio": 0.7077,
-"compress_mbps": 37.74,
-"decompress_mbps": 289.09
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5997403,
-"ratio": 0.7077,
-"compress_mbps": 37.64,
-"decompress_mbps": 290.49
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5997403,
-"ratio": 0.7077,
-"compress_mbps": 37.67,
-"decompress_mbps": 289.81
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5997403,
-"ratio": 0.7077,
-"compress_mbps": 37.67,
-"decompress_mbps": 289.76
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 1147652,
-"ratio": 0.2147,
-"compress_mbps": 387.25,
-"decompress_mbps": 750.94
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 919639,
-"ratio": 0.172,
-"compress_mbps": 261.15,
-"decompress_mbps": 942.03
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 752341,
-"ratio": 0.1407,
-"compress_mbps": 166.75,
-"decompress_mbps": 1050.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 735537,
-"ratio": 0.1376,
-"compress_mbps": 161.05,
-"decompress_mbps": 1025.31
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 706789,
-"ratio": 0.1322,
-"compress_mbps": 123.6,
-"decompress_mbps": 1117.4
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 676279,
-"ratio": 0.1265,
-"compress_mbps": 69.65,
-"decompress_mbps": 1201.48
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 668772,
-"ratio": 0.1251,
-"compress_mbps": 56.08,
-"decompress_mbps": 1218.43
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 665340,
-"ratio": 0.1245,
-"compress_mbps": 47.65,
-"decompress_mbps": 1208.96
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 664273,
-"ratio": 0.1243,
-"compress_mbps": 45.88,
-"decompress_mbps": 1215.47
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": 239.71,
-"decompress_mbps": 790.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4053259,
-"ratio": 0.3977,
-"compress_mbps": 168.86,
-"decompress_mbps": 853.57
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": 139.03,
-"decompress_mbps": 927.64
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3972869,
-"ratio": 0.3898,
-"compress_mbps": 127.1,
-"decompress_mbps": 821.17
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3894026,
-"ratio": 0.3821,
-"compress_mbps": 98.79,
-"decompress_mbps": 797.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": 75.36,
-"decompress_mbps": 823.04
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3837515,
-"ratio": 0.3765,
-"compress_mbps": 55.56,
-"decompress_mbps": 819.25
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3811467,
-"ratio": 0.374,
-"compress_mbps": 36.02,
-"decompress_mbps": 820.77
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": 32.7,
-"decompress_mbps": 826.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 10,
-"out_size": 3681797,
-"ratio": 0.3612,
-"compress_mbps": 12.47,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 11,
-"out_size": 3679289,
-"ratio": 0.361,
-"compress_mbps": 9.08,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": 7.51,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": 242.73,
-"decompress_mbps": 677.88
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 19374226,
-"ratio": 0.3783,
-"compress_mbps": 185.59,
-"decompress_mbps": 715.55
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": 173.02,
-"decompress_mbps": 729.95
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19145385,
-"ratio": 0.3738,
-"compress_mbps": 162.19,
-"decompress_mbps": 727.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 18878875,
-"ratio": 0.3686,
-"compress_mbps": 142.6,
-"decompress_mbps": 748.14
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": 120.03,
-"decompress_mbps": 759.24
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 18749947,
-"ratio": 0.3661,
-"compress_mbps": 87.47,
-"decompress_mbps": 759.27
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 18718540,
-"ratio": 0.3655,
-"compress_mbps": 47.44,
-"decompress_mbps": 760.16
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": 33.55,
-"decompress_mbps": 756.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 10,
-"out_size": 18268811,
-"ratio": 0.3567,
-"compress_mbps": 16.29,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 11,
-"out_size": 18245674,
-"ratio": 0.3562,
-"compress_mbps": 11.63,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": 9.25,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": 292.32,
-"decompress_mbps": 717.67
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3707407,
-"ratio": 0.3718,
-"compress_mbps": 215.91,
-"decompress_mbps": 749.51
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": 184.12,
-"decompress_mbps": 784.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3660011,
-"ratio": 0.3671,
-"compress_mbps": 170.1,
-"decompress_mbps": 717.47
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3664245,
-"ratio": 0.3675,
-"compress_mbps": 140.41,
-"decompress_mbps": 675.48
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": 105.4,
-"decompress_mbps": 708.33
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3635323,
-"ratio": 0.3646,
-"compress_mbps": 67.54,
-"decompress_mbps": 729.2
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3624778,
-"ratio": 0.3635,
-"compress_mbps": 42.96,
-"decompress_mbps": 774.95
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": 38.8,
-"decompress_mbps": 752.82
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 10,
-"out_size": 3461494,
-"ratio": 0.3472,
-"compress_mbps": 18.25,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 11,
-"out_size": 3446053,
-"ratio": 0.3456,
-"compress_mbps": 10.54,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": 5.38,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": 605.16,
-"decompress_mbps": 1502.39
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3714632,
-"ratio": 0.1107,
-"compress_mbps": 460.38,
-"decompress_mbps": 1712.18
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": 424.4,
-"decompress_mbps": 1819.21
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3431843,
-"ratio": 0.1023,
-"compress_mbps": 387.62,
-"decompress_mbps": 1807.25
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3268188,
-"ratio": 0.0974,
-"compress_mbps": 347.18,
-"decompress_mbps": 1824.98
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": 263.43,
-"decompress_mbps": 1809.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3032499,
-"ratio": 0.0904,
-"compress_mbps": 185.26,
-"decompress_mbps": 1828.9
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 2949097,
-"ratio": 0.0879,
-"compress_mbps": 97.29,
-"decompress_mbps": 1755.09
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": 69.11,
-"decompress_mbps": 1716.66
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 10,
-"out_size": 2782465,
-"ratio": 0.0829,
-"compress_mbps": 8.4,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 11,
-"out_size": 2751857,
-"ratio": 0.082,
-"compress_mbps": 5.49,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": 4.05,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": 166.4,
-"decompress_mbps": 432.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3150806,
-"ratio": 0.5121,
-"compress_mbps": 126.88,
-"decompress_mbps": 498.99
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": 119.44,
-"decompress_mbps": 523.59
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3129676,
-"ratio": 0.5087,
-"compress_mbps": 115.62,
-"decompress_mbps": 542.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3079277,
-"ratio": 0.5005,
-"compress_mbps": 98.82,
-"decompress_mbps": 561.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": 87.08,
-"decompress_mbps": 570.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3068123,
-"ratio": 0.4987,
-"compress_mbps": 74.7,
-"decompress_mbps": 573.32
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3067299,
-"ratio": 0.4986,
-"compress_mbps": 55.04,
-"decompress_mbps": 575.17
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": 49.77,
-"decompress_mbps": 573.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 10,
-"out_size": 2995902,
-"ratio": 0.487,
-"compress_mbps": 18.97,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 11,
-"out_size": 2994386,
-"ratio": 0.4867,
-"compress_mbps": 14.38,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": 12.27,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": 278.48,
-"decompress_mbps": 739.01
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3839158,
-"ratio": 0.3807,
-"compress_mbps": 207.66,
-"decompress_mbps": 860.45
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": 193.08,
-"decompress_mbps": 890.83
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3789325,
-"ratio": 0.3757,
-"compress_mbps": 176.73,
-"decompress_mbps": 926.5
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3666476,
-"ratio": 0.3635,
-"compress_mbps": 155.97,
-"decompress_mbps": 937.62
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": 140.77,
-"decompress_mbps": 974.05
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3659491,
-"ratio": 0.3628,
-"compress_mbps": 133.11,
-"decompress_mbps": 952.39
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3654863,
-"ratio": 0.3624,
-"compress_mbps": 114.1,
-"decompress_mbps": 972.29
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": 114.29,
-"decompress_mbps": 945.42
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 10,
-"out_size": 3608746,
-"ratio": 0.3578,
-"compress_mbps": 18.87,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 11,
-"out_size": 3608161,
-"ratio": 0.3578,
-"compress_mbps": 14.63,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": 13.05,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": 298.73,
-"decompress_mbps": 852.56
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2082309,
-"ratio": 0.3142,
-"compress_mbps": 214.22,
-"decompress_mbps": 934.45
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": 178.25,
-"decompress_mbps": 1068.04
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1990952,
-"ratio": 0.3004,
-"compress_mbps": 158.42,
-"decompress_mbps": 1003.76
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1921113,
-"ratio": 0.2899,
-"compress_mbps": 127.07,
-"decompress_mbps": 952.93
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": 86.95,
-"decompress_mbps": 960.2
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1832695,
-"ratio": 0.2765,
-"compress_mbps": 46.57,
-"decompress_mbps": 907.88
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1809967,
-"ratio": 0.2731,
-"compress_mbps": 24.25,
-"decompress_mbps": 844.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": 19.88,
-"decompress_mbps": 905.95
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 10,
-"out_size": 1697693,
-"ratio": 0.2562,
-"compress_mbps": 8.75,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 11,
-"out_size": 1696742,
-"ratio": 0.256,
-"compress_mbps": 6.54,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": 5.61,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": 340.26,
-"decompress_mbps": 952.81
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5695942,
-"ratio": 0.2636,
-"compress_mbps": 255.24,
-"decompress_mbps": 1038.53
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": 231.7,
-"decompress_mbps": 1069.2
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5553432,
-"ratio": 0.257,
-"compress_mbps": 215.99,
-"decompress_mbps": 1047.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5416713,
-"ratio": 0.2507,
-"compress_mbps": 186.63,
-"decompress_mbps": 1059.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": 143.25,
-"decompress_mbps": 1056.25
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5310181,
-"ratio": 0.2458,
-"compress_mbps": 100.19,
-"decompress_mbps": 1049.35
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5272761,
-"ratio": 0.244,
-"compress_mbps": 62.34,
-"decompress_mbps": 1056.09
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": 50.09,
-"decompress_mbps": 1037.46
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 10,
-"out_size": 5137640,
-"ratio": 0.2378,
-"compress_mbps": 15.84,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 11,
-"out_size": 5122694,
-"ratio": 0.2371,
-"compress_mbps": 9.54,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": 6.89,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": 163.85,
-"decompress_mbps": 458.98
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5417142,
-"ratio": 0.747,
-"compress_mbps": 116.56,
-"decompress_mbps": 504.35
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": 103.93,
-"decompress_mbps": 508.38
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5391125,
-"ratio": 0.7434,
-"compress_mbps": 98.9,
-"decompress_mbps": 517.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5352212,
-"ratio": 0.738,
-"compress_mbps": 86.65,
-"decompress_mbps": 504.77
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": 72.7,
-"decompress_mbps": 509.45
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5325697,
-"ratio": 0.7344,
-"compress_mbps": 62.93,
-"decompress_mbps": 516.26
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5324004,
-"ratio": 0.7341,
-"compress_mbps": 52.25,
-"decompress_mbps": 513.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": 50.74,
-"decompress_mbps": 504.37
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 10,
-"out_size": 5250862,
-"ratio": 0.7241,
-"compress_mbps": 25.48,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 11,
-"out_size": 5250747,
-"ratio": 0.724,
-"compress_mbps": 20.78,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": 19.39,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": 270.14,
-"decompress_mbps": 883.43
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 13130705,
-"ratio": 0.3167,
-"compress_mbps": 201.99,
-"decompress_mbps": 989.91
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": 178.64,
-"decompress_mbps": 1030.28
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12601933,
-"ratio": 0.304,
-"compress_mbps": 163.2,
-"decompress_mbps": 905.55
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12310776,
-"ratio": 0.2969,
-"compress_mbps": 132.49,
-"decompress_mbps": 607.45
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": 105.68,
-"decompress_mbps": 896.67
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12025296,
-"ratio": 0.2901,
-"compress_mbps": 75.3,
-"decompress_mbps": 900.54
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 11893824,
-"ratio": 0.2869,
-"compress_mbps": 46.13,
-"decompress_mbps": 806.33
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": 37.39,
-"decompress_mbps": 815.43
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 10,
-"out_size": 11526846,
-"ratio": 0.278,
-"compress_mbps": 10.06,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 11,
-"out_size": 11520969,
-"ratio": 0.2779,
-"compress_mbps": 6.91,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": 5.85,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": 147.98,
-"decompress_mbps": 465.49
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6058412,
-"ratio": 0.7149,
-"compress_mbps": 119.79,
-"decompress_mbps": 506.86
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": 119.2,
-"decompress_mbps": 514.84
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6058363,
-"ratio": 0.7149,
-"compress_mbps": 119.3,
-"decompress_mbps": 415.52
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 5998400,
-"ratio": 0.7078,
-"compress_mbps": 105.57,
-"decompress_mbps": 432.18
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": 105.97,
-"decompress_mbps": 440.63
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5998439,
-"ratio": 0.7078,
-"compress_mbps": 106.47,
-"decompress_mbps": 438.91
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": 88.92,
-"decompress_mbps": 434.5
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": 87.71,
-"decompress_mbps": 416.28
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 10,
-"out_size": 5748096,
-"ratio": 0.6783,
-"compress_mbps": 37.77,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 11,
-"out_size": 5747172,
-"ratio": 0.6782,
-"compress_mbps": 28.72,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": 26.57,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": 487.74,
-"decompress_mbps": 1232.1
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 843475,
-"ratio": 0.1578,
-"compress_mbps": 361.41,
-"decompress_mbps": 1500.87
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": 333.76,
-"decompress_mbps": 1649.87
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 747602,
-"ratio": 0.1399,
-"compress_mbps": 302.22,
-"decompress_mbps": 1613.69
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 718615,
-"ratio": 0.1344,
-"compress_mbps": 260.88,
-"decompress_mbps": 1656.06
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": 204.65,
-"decompress_mbps": 1603.35
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 664859,
-"ratio": 0.1244,
-"compress_mbps": 141.51,
-"decompress_mbps": 1662.71
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 650835,
-"ratio": 0.1218,
-"compress_mbps": 84.48,
-"decompress_mbps": 1415.83
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": 68.12,
-"decompress_mbps": 1568.14
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 10,
-"out_size": 637425,
-"ratio": 0.1193,
-"compress_mbps": 11.89,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 11,
-"out_size": 630827,
-"ratio": 0.118,
-"compress_mbps": 7.0,
-"decompress_mbps": null
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": 4.54,
-"decompress_mbps": null
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 65708,
-"ratio": 0.432,
-"compress_mbps": 109.44,
-"decompress_mbps": 192.48
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 60259,
-"ratio": 0.3962,
-"compress_mbps": 79.44,
-"decompress_mbps": 219.13
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 58544,
-"ratio": 0.3849,
-"compress_mbps": 66.36,
-"decompress_mbps": 226.05
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56238,
-"ratio": 0.3698,
-"compress_mbps": 65.73,
-"decompress_mbps": 231.45
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 54764,
-"ratio": 0.3601,
-"compress_mbps": 39.45,
-"decompress_mbps": 234.66
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54311,
-"ratio": 0.3571,
-"compress_mbps": 30.43,
-"decompress_mbps": 235.25
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54262,
-"ratio": 0.3568,
-"compress_mbps": 27.11,
-"decompress_mbps": 235.47
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 54247,
-"ratio": 0.3567,
-"compress_mbps": 25.8,
-"decompress_mbps": 238.36
-},
-{
-"compressor": "go",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 54247,
-"ratio": 0.3567,
-"compress_mbps": 25.76,
-"decompress_mbps": 236.1
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 56882,
-"ratio": 0.4544,
-"compress_mbps": 104.58,
-"decompress_mbps": 183.83
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 52826,
-"ratio": 0.422,
-"compress_mbps": 73.05,
-"decompress_mbps": 205.6
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51625,
-"ratio": 0.4124,
-"compress_mbps": 61.78,
-"decompress_mbps": 211.24
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50034,
-"ratio": 0.3997,
-"compress_mbps": 61.66,
-"decompress_mbps": 217.96
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 48912,
-"ratio": 0.3907,
-"compress_mbps": 37.33,
-"decompress_mbps": 217.44
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48738,
-"ratio": 0.3893,
-"compress_mbps": 31.17,
-"decompress_mbps": 219.56
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48719,
-"ratio": 0.3892,
-"compress_mbps": 29.9,
-"decompress_mbps": 220.02
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48716,
-"ratio": 0.3892,
-"compress_mbps": 29.7,
-"decompress_mbps": 219.36
-},
-{
-"compressor": "go",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48716,
-"ratio": 0.3892,
-"compress_mbps": 30.07,
-"decompress_mbps": 219.72
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8988,
-"ratio": 0.3653,
-"compress_mbps": 195.21,
-"decompress_mbps": 289.47
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8564,
-"ratio": 0.3481,
-"compress_mbps": 143.69,
-"decompress_mbps": 317.83
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8390,
-"ratio": 0.341,
-"compress_mbps": 129.4,
-"decompress_mbps": 337.5
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8167,
-"ratio": 0.332,
-"compress_mbps": 115.12,
-"decompress_mbps": 328.64
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 7965,
-"ratio": 0.3237,
-"compress_mbps": 81.76,
-"decompress_mbps": 356.34
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7916,
-"ratio": 0.3217,
-"compress_mbps": 62.46,
-"decompress_mbps": 356.77
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7900,
-"ratio": 0.3211,
-"compress_mbps": 59.77,
-"decompress_mbps": 329.36
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7900,
-"ratio": 0.3211,
-"compress_mbps": 56.57,
-"decompress_mbps": 357.23
-},
-{
-"compressor": "go",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7900,
-"ratio": 0.3211,
-"compress_mbps": 56.39,
-"decompress_mbps": 355
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3731,
-"ratio": 0.3346,
-"compress_mbps": 160.08,
-"decompress_mbps": 347.11
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3491,
-"ratio": 0.3131,
-"compress_mbps": 156.38,
-"decompress_mbps": 385.2
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3384,
-"ratio": 0.3035,
-"compress_mbps": 156.98,
-"decompress_mbps": 389.78
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3220,
-"ratio": 0.2888,
-"compress_mbps": 135.13,
-"decompress_mbps": 416.97
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3138,
-"ratio": 0.2814,
-"compress_mbps": 113.25,
-"decompress_mbps": 431.73
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3118,
-"ratio": 0.2796,
-"compress_mbps": 92.3,
-"decompress_mbps": 425.1
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 82.76,
-"decompress_mbps": 423.91
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 80.39,
-"decompress_mbps": 436.84
-},
-{
-"compressor": "go",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3116,
-"ratio": 0.2795,
-"compress_mbps": 79.5,
-"decompress_mbps": 428.65
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1352,
-"ratio": 0.3633,
-"compress_mbps": 79.19,
-"decompress_mbps": 292.96
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1287,
-"ratio": 0.3459,
-"compress_mbps": 91.56,
-"decompress_mbps": 299.79
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1284,
-"ratio": 0.3451,
-"compress_mbps": 87.27,
-"decompress_mbps": 297.35
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1226,
-"ratio": 0.3295,
-"compress_mbps": 81.6,
-"decompress_mbps": 307.4
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 75.85,
-"decompress_mbps": 311.15
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 74.64,
-"decompress_mbps": 316.22
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 70.12,
-"decompress_mbps": 326.4
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 68.19,
-"decompress_mbps": 326.31
-},
-{
-"compressor": "go",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1211,
-"ratio": 0.3255,
-"compress_mbps": 71.6,
-"decompress_mbps": 319.55
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 245423,
-"ratio": 0.2383,
-"compress_mbps": 247.5,
-"decompress_mbps": 426.86
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 229642,
-"ratio": 0.223,
-"compress_mbps": 222.09,
-"decompress_mbps": 492.5
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 225678,
-"ratio": 0.2192,
-"compress_mbps": 184.98,
-"decompress_mbps": 499.76
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 218218,
-"ratio": 0.2119,
-"compress_mbps": 172.54,
-"decompress_mbps": 531.98
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 210550,
-"ratio": 0.2045,
-"compress_mbps": 98.16,
-"decompress_mbps": 510.74
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 207949,
-"ratio": 0.2019,
-"compress_mbps": 41.8,
-"decompress_mbps": 512.45
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 207413,
-"ratio": 0.2014,
-"compress_mbps": 24.36,
-"decompress_mbps": 505.8
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 207478,
-"ratio": 0.2015,
-"compress_mbps": 7.43,
-"decompress_mbps": 502.84
-},
-{
-"compressor": "go",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 207482,
-"ratio": 0.2015,
-"compress_mbps": 3.6,
-"decompress_mbps": 504.79
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 175980,
-"ratio": 0.4124,
-"compress_mbps": 114.75,
-"decompress_mbps": 196.92
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 160455,
-"ratio": 0.376,
-"compress_mbps": 84.36,
-"decompress_mbps": 222.57
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 156690,
-"ratio": 0.3672,
-"compress_mbps": 70.92,
-"decompress_mbps": 227.01
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 149064,
-"ratio": 0.3493,
-"compress_mbps": 69.92,
-"decompress_mbps": 237.82
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 145616,
-"ratio": 0.3412,
-"compress_mbps": 42.26,
-"decompress_mbps": 237.6
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144773,
-"ratio": 0.3392,
-"compress_mbps": 33.93,
-"decompress_mbps": 241.57
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 144603,
-"ratio": 0.3388,
-"compress_mbps": 30.55,
-"decompress_mbps": 240.64
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 144573,
-"ratio": 0.3388,
-"compress_mbps": 29.22,
-"decompress_mbps": 239.94
-},
-{
-"compressor": "go",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 144570,
-"ratio": 0.3388,
-"compress_mbps": 29.23,
-"decompress_mbps": 236.89
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 228837,
-"ratio": 0.4749,
-"compress_mbps": 101.53,
-"decompress_mbps": 170.49
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 211248,
-"ratio": 0.4384,
-"compress_mbps": 69.11,
-"decompress_mbps": 193.03
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 205619,
-"ratio": 0.4267,
-"compress_mbps": 56.87,
-"decompress_mbps": 198.04
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 200595,
-"ratio": 0.4163,
-"compress_mbps": 57.72,
-"decompress_mbps": 203.39
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 195418,
-"ratio": 0.4055,
-"compress_mbps": 33.47,
-"decompress_mbps": 204.8
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 194148,
-"ratio": 0.4029,
-"compress_mbps": 25.84,
-"decompress_mbps": 204.61
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 193994,
-"ratio": 0.4026,
-"compress_mbps": 23.88,
-"decompress_mbps": 204.82
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 193991,
-"ratio": 0.4026,
-"compress_mbps": 23.63,
-"decompress_mbps": 205.49
-},
-{
-"compressor": "go",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 193991,
-"ratio": 0.4026,
-"compress_mbps": 23.71,
-"decompress_mbps": 204.38
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 60990,
-"ratio": 0.1188,
-"compress_mbps": 318.56,
-"decompress_mbps": 589.73
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 61650,
-"ratio": 0.1201,
-"compress_mbps": 306.96,
-"decompress_mbps": 659.53
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 60035,
-"ratio": 0.117,
-"compress_mbps": 269.08,
-"decompress_mbps": 683.91
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 57005,
-"ratio": 0.1111,
-"compress_mbps": 223.63,
-"decompress_mbps": 691.14
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 55779,
-"ratio": 0.1087,
-"compress_mbps": 171.39,
-"decompress_mbps": 699.37
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 54970,
-"ratio": 0.1071,
-"compress_mbps": 114,
-"decompress_mbps": 721.14
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 53922,
-"ratio": 0.1051,
-"compress_mbps": 83.73,
-"decompress_mbps": 760.74
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 51977,
-"ratio": 0.1013,
-"compress_mbps": 29.04,
-"decompress_mbps": 793.55
-},
-{
-"compressor": "go",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 51474,
-"ratio": 0.1003,
-"compress_mbps": 7.47,
-"decompress_mbps": 773.32
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14783,
-"ratio": 0.3866,
-"compress_mbps": 113.64,
-"decompress_mbps": 269.04
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 14101,
-"ratio": 0.3688,
-"compress_mbps": 107.75,
-"decompress_mbps": 299.25
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13975,
-"ratio": 0.3655,
-"compress_mbps": 100.63,
-"decompress_mbps": 306.25
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13632,
-"ratio": 0.3565,
-"compress_mbps": 91.77,
-"decompress_mbps": 310.62
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13302,
-"ratio": 0.3479,
-"compress_mbps": 69.51,
-"decompress_mbps": 325.89
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13279,
-"ratio": 0.3473,
-"compress_mbps": 52.22,
-"decompress_mbps": 324.3
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13274,
-"ratio": 0.3471,
-"compress_mbps": 41.96,
-"decompress_mbps": 325.59
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13260,
-"ratio": 0.3468,
-"compress_mbps": 22,
-"decompress_mbps": 332.6
-},
-{
-"compressor": "go",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13260,
-"ratio": 0.3468,
-"compress_mbps": 13.89,
-"decompress_mbps": 332.15
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1862,
-"ratio": 0.4405,
-"compress_mbps": 88.73,
-"decompress_mbps": 262.09
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1803,
-"ratio": 0.4265,
-"compress_mbps": 91.48,
-"decompress_mbps": 272.93
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1791,
-"ratio": 0.4237,
-"compress_mbps": 90.92,
-"decompress_mbps": 277.92
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1746,
-"ratio": 0.4131,
-"compress_mbps": 85.18,
-"decompress_mbps": 279.61
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 81.24,
-"decompress_mbps": 274.79
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 80.27,
-"decompress_mbps": 275.17
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 80.46,
-"decompress_mbps": 279.25
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 82.41,
-"decompress_mbps": 285.9
-},
-{
-"compressor": "go",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1725,
-"ratio": 0.4081,
-"compress_mbps": 79.5,
-"decompress_mbps": 277.76
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4623589,
-"ratio": 0.4536,
-"compress_mbps": 106.98,
-"decompress_mbps": 176.02
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4241525,
-"ratio": 0.4161,
-"compress_mbps": 74.17,
-"decompress_mbps": 194.53
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4123202,
-"ratio": 0.4045,
-"compress_mbps": 61.3,
-"decompress_mbps": 203.94
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3985937,
-"ratio": 0.3911,
-"compress_mbps": 61.86,
-"decompress_mbps": 202.71
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3883839,
-"ratio": 0.3811,
-"compress_mbps": 35.88,
-"decompress_mbps": 207.24
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3860437,
-"ratio": 0.3788,
-"compress_mbps": 27.91,
-"decompress_mbps": 211.1
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3857076,
-"ratio": 0.3784,
-"compress_mbps": 25.28,
-"decompress_mbps": 210.73
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3856651,
-"ratio": 0.3784,
-"compress_mbps": 24.89,
-"decompress_mbps": 210.33
-},
-{
-"compressor": "go",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3856651,
-"ratio": 0.3784,
-"compress_mbps": 24.92,
-"decompress_mbps": 207.99
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 21508211,
-"ratio": 0.4199,
-"compress_mbps": 140.53,
-"decompress_mbps": 236.89
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 20538783,
-"ratio": 0.401,
-"compress_mbps": 109.51,
-"decompress_mbps": 239
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 20334352,
-"ratio": 0.397,
-"compress_mbps": 95.46,
-"decompress_mbps": 239.62
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19886937,
-"ratio": 0.3883,
-"compress_mbps": 92.08,
-"decompress_mbps": 243.19
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19582363,
-"ratio": 0.3823,
-"compress_mbps": 66.13,
-"decompress_mbps": 255.01
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19512479,
-"ratio": 0.381,
-"compress_mbps": 44.92,
-"decompress_mbps": 263.81
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19489160,
-"ratio": 0.3805,
-"compress_mbps": 32.8,
-"decompress_mbps": 264.43
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19475109,
-"ratio": 0.3802,
-"compress_mbps": 18.46,
-"decompress_mbps": 257.16
-},
-{
-"compressor": "go",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19476276,
-"ratio": 0.3802,
-"compress_mbps": 10.54,
-"decompress_mbps": 253.25
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3967718,
-"ratio": 0.3979,
-"compress_mbps": 149.74,
-"decompress_mbps": 229.45
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3773274,
-"ratio": 0.3784,
-"compress_mbps": 107.04,
-"decompress_mbps": 231
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3670460,
-"ratio": 0.3681,
-"compress_mbps": 78.33,
-"decompress_mbps": 243.29
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3655100,
-"ratio": 0.3666,
-"compress_mbps": 88.4,
-"decompress_mbps": 240.27
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3620881,
-"ratio": 0.3632,
-"compress_mbps": 51.48,
-"decompress_mbps": 252.04
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3606626,
-"ratio": 0.3617,
-"compress_mbps": 33.56,
-"decompress_mbps": 245.58
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3605405,
-"ratio": 0.3616,
-"compress_mbps": 30.67,
-"decompress_mbps": 251.27
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3601635,
-"ratio": 0.3612,
-"compress_mbps": 26.32,
-"decompress_mbps": 248.46
-},
-{
-"compressor": "go",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3601151,
-"ratio": 0.3612,
-"compress_mbps": 19.54,
-"decompress_mbps": 245.27
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4501482,
-"ratio": 0.1342,
-"compress_mbps": 336.67,
-"decompress_mbps": 474.09
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3875891,
-"ratio": 0.1155,
-"compress_mbps": 318.06,
-"decompress_mbps": 611.55
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3731525,
-"ratio": 0.1112,
-"compress_mbps": 286.8,
-"decompress_mbps": 640.47
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3542242,
-"ratio": 0.1056,
-"compress_mbps": 238.32,
-"decompress_mbps": 645.82
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3239184,
-"ratio": 0.0965,
-"compress_mbps": 174.47,
-"decompress_mbps": 710.22
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3113927,
-"ratio": 0.0928,
-"compress_mbps": 122.16,
-"decompress_mbps": 697.72
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3063520,
-"ratio": 0.0913,
-"compress_mbps": 84.42,
-"decompress_mbps": 735.89
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 2961320,
-"ratio": 0.0883,
-"compress_mbps": 29.4,
-"decompress_mbps": 787.56
-},
-{
-"compressor": "go",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2940087,
-"ratio": 0.0876,
-"compress_mbps": 20.47,
-"decompress_mbps": 776.18
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3462708,
-"ratio": 0.5628,
-"compress_mbps": 101.43,
-"decompress_mbps": 165.18
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3327399,
-"ratio": 0.5408,
-"compress_mbps": 74.25,
-"decompress_mbps": 175.32
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3297422,
-"ratio": 0.536,
-"compress_mbps": 67.06,
-"decompress_mbps": 175.22
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3249485,
-"ratio": 0.5282,
-"compress_mbps": 64.75,
-"decompress_mbps": 173.73
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3220046,
-"ratio": 0.5234,
-"compress_mbps": 50.21,
-"decompress_mbps": 178.36
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3213239,
-"ratio": 0.5223,
-"compress_mbps": 43.5,
-"decompress_mbps": 179.43
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3212009,
-"ratio": 0.5221,
-"compress_mbps": 39.47,
-"decompress_mbps": 177.9
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3211575,
-"ratio": 0.522,
-"compress_mbps": 33.8,
-"decompress_mbps": 180.66
-},
-{
-"compressor": "go",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3211561,
-"ratio": 0.522,
-"compress_mbps": 30.3,
-"decompress_mbps": 180.52
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4334497,
-"ratio": 0.4298,
-"compress_mbps": 144.58,
-"decompress_mbps": 232.26
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3900156,
-"ratio": 0.3867,
-"compress_mbps": 133.61,
-"decompress_mbps": 260.56
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3876099,
-"ratio": 0.3843,
-"compress_mbps": 124.07,
-"decompress_mbps": 258.01
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3782364,
-"ratio": 0.375,
-"compress_mbps": 111.89,
-"decompress_mbps": 261.88
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3679310,
-"ratio": 0.3648,
-"compress_mbps": 90.33,
-"decompress_mbps": 279.39
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3679424,
-"ratio": 0.3648,
-"compress_mbps": 88.7,
-"decompress_mbps": 275.79
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3679163,
-"ratio": 0.3648,
-"compress_mbps": 83.3,
-"decompress_mbps": 267.69
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3679169,
-"ratio": 0.3648,
-"compress_mbps": 82.19,
-"decompress_mbps": 271.3
-},
-{
-"compressor": "go",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3679169,
-"ratio": 0.3648,
-"compress_mbps": 82.74,
-"decompress_mbps": 267.98
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2496363,
-"ratio": 0.3767,
-"compress_mbps": 130.19,
-"decompress_mbps": 209.65
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2202601,
-"ratio": 0.3324,
-"compress_mbps": 94.83,
-"decompress_mbps": 244.49
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2103089,
-"ratio": 0.3173,
-"compress_mbps": 67.59,
-"decompress_mbps": 252.42
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1999697,
-"ratio": 0.3017,
-"compress_mbps": 75.73,
-"decompress_mbps": 258.61
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1892143,
-"ratio": 0.2855,
-"compress_mbps": 37.51,
-"decompress_mbps": 255.03
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1838372,
-"ratio": 0.2774,
-"compress_mbps": 20.39,
-"decompress_mbps": 264.23
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1828850,
-"ratio": 0.276,
-"compress_mbps": 15.79,
-"decompress_mbps": 269.79
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1823159,
-"ratio": 0.2751,
-"compress_mbps": 12.51,
-"decompress_mbps": 260.94
-},
-{
-"compressor": "go",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1823159,
-"ratio": 0.2751,
-"compress_mbps": 12.44,
-"decompress_mbps": 259.47
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6447290,
-"ratio": 0.2984,
-"compress_mbps": 192.72,
-"decompress_mbps": 292.27
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 6030257,
-"ratio": 0.2791,
-"compress_mbps": 149.93,
-"decompress_mbps": 306.13
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5928121,
-"ratio": 0.2744,
-"compress_mbps": 130.08,
-"decompress_mbps": 317.1
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5615804,
-"ratio": 0.2599,
-"compress_mbps": 123.41,
-"decompress_mbps": 335.76
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5496738,
-"ratio": 0.2544,
-"compress_mbps": 82.03,
-"decompress_mbps": 343.64
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5464184,
-"ratio": 0.2529,
-"compress_mbps": 62.81,
-"decompress_mbps": 342.49
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5429645,
-"ratio": 0.2513,
-"compress_mbps": 49.23,
-"decompress_mbps": 339.67
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5418135,
-"ratio": 0.2508,
-"compress_mbps": 37.69,
-"decompress_mbps": 335.21
-},
-{
-"compressor": "go",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5416628,
-"ratio": 0.2507,
-"compress_mbps": 34.16,
-"decompress_mbps": 341.22
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5759187,
-"ratio": 0.7942,
-"compress_mbps": 100.78,
-"decompress_mbps": 175.91
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5619390,
-"ratio": 0.7749,
-"compress_mbps": 65.71,
-"decompress_mbps": 177.71
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5560914,
-"ratio": 0.7668,
-"compress_mbps": 56.9,
-"decompress_mbps": 188.82
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5544069,
-"ratio": 0.7645,
-"compress_mbps": 58.81,
-"decompress_mbps": 183.49
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5518257,
-"ratio": 0.7609,
-"compress_mbps": 45.01,
-"decompress_mbps": 179.45
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5508662,
-"ratio": 0.7596,
-"compress_mbps": 39.88,
-"decompress_mbps": 181.4
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5507534,
-"ratio": 0.7595,
-"compress_mbps": 38.81,
-"decompress_mbps": 185.25
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5507183,
-"ratio": 0.7594,
-"compress_mbps": 38.34,
-"decompress_mbps": 181
-},
-{
-"compressor": "go",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5507183,
-"ratio": 0.7594,
-"compress_mbps": 38.39,
-"decompress_mbps": 179.46
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 15230651,
-"ratio": 0.3674,
-"compress_mbps": 124.61,
-"decompress_mbps": 206.2
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 13822040,
-"ratio": 0.3334,
-"compress_mbps": 97.4,
-"decompress_mbps": 219.05
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 13397592,
-"ratio": 0.3232,
-"compress_mbps": 84.32,
-"decompress_mbps": 233.41
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12759940,
-"ratio": 0.3078,
-"compress_mbps": 82.61,
-"decompress_mbps": 238.83
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12274278,
-"ratio": 0.2961,
-"compress_mbps": 54.59,
-"decompress_mbps": 253.03
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12131738,
-"ratio": 0.2926,
-"compress_mbps": 40.48,
-"decompress_mbps": 247.18
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12060450,
-"ratio": 0.2909,
-"compress_mbps": 33.75,
-"decompress_mbps": 253.63
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12036900,
-"ratio": 0.2903,
-"compress_mbps": 30.14,
-"decompress_mbps": 251.44
-},
-{
-"compressor": "go",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12036900,
-"ratio": 0.2903,
-"compress_mbps": 30.19,
-"decompress_mbps": 249.33
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6653052,
-"ratio": 0.7851,
-"compress_mbps": 172.49,
-"decompress_mbps": 182.77
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6305035,
-"ratio": 0.744,
-"compress_mbps": 69.43,
-"decompress_mbps": 165.29
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6302730,
-"ratio": 0.7438,
-"compress_mbps": 68.88,
-"decompress_mbps": 168.25
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6299134,
-"ratio": 0.7433,
-"compress_mbps": 68.45,
-"decompress_mbps": 166.89
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6289022,
-"ratio": 0.7421,
-"compress_mbps": 65.16,
-"decompress_mbps": 169.15
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6289013,
-"ratio": 0.7421,
-"compress_mbps": 65.19,
-"decompress_mbps": 167.45
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6289013,
-"ratio": 0.7421,
-"compress_mbps": 65.58,
-"decompress_mbps": 165.62
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6289012,
-"ratio": 0.7421,
-"compress_mbps": 65.58,
-"decompress_mbps": 165.13
-},
-{
-"compressor": "go",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6289012,
-"ratio": 0.7421,
-"compress_mbps": 65.51,
-"decompress_mbps": 167.6
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 989456,
-"ratio": 0.1851,
-"compress_mbps": 255.45,
-"decompress_mbps": 390.55
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 839766,
-"ratio": 0.1571,
-"compress_mbps": 233.42,
-"decompress_mbps": 504.86
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 800619,
-"ratio": 0.1498,
-"compress_mbps": 201.28,
-"decompress_mbps": 494.08
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 776397,
-"ratio": 0.1452,
-"compress_mbps": 178.01,
-"decompress_mbps": 508.96
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 712679,
-"ratio": 0.1333,
-"compress_mbps": 126.49,
-"decompress_mbps": 592.48
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 683707,
-"ratio": 0.1279,
-"compress_mbps": 95.75,
-"decompress_mbps": 571.97
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 668601,
-"ratio": 0.1251,
-"compress_mbps": 71.72,
-"decompress_mbps": 590.26
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 659106,
-"ratio": 0.1233,
-"compress_mbps": 48.43,
-"decompress_mbps": 582.15
-},
-{
-"compressor": "go",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 658920,
-"ratio": 0.1233,
-"compress_mbps": 47.23,
-"decompress_mbps": 637.82
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 87.23,
-"decompress_mbps": 313.92
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 87.82,
-"decompress_mbps": 313.53
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 84.18,
-"decompress_mbps": 314.84
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56099,
-"ratio": 0.3689,
-"compress_mbps": 88.33,
-"decompress_mbps": 311.1
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 54531,
-"ratio": 0.3585,
-"compress_mbps": 54.91,
-"decompress_mbps": 307.09
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 54068,
-"ratio": 0.3555,
-"compress_mbps": 42.11,
-"decompress_mbps": 310.58
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 54003,
-"ratio": 0.3551,
-"compress_mbps": 37.17,
-"decompress_mbps": 312.05
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 53974,
-"ratio": 0.3549,
-"compress_mbps": 32.72,
-"decompress_mbps": 307.61
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 53974,
-"ratio": 0.3549,
-"compress_mbps": 32.8,
-"decompress_mbps": 305.54
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 83.09,
-"decompress_mbps": 278.48
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 83.15,
-"decompress_mbps": 279.32
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 82.26,
-"decompress_mbps": 275.94
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50031,
-"ratio": 0.3997,
-"compress_mbps": 83.53,
-"decompress_mbps": 277.74
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 48753,
-"ratio": 0.3895,
-"compress_mbps": 50.56,
-"decompress_mbps": 275.32
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 48557,
-"ratio": 0.3879,
-"compress_mbps": 40.4,
-"decompress_mbps": 278.51
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 48523,
-"ratio": 0.3876,
-"compress_mbps": 38.25,
-"decompress_mbps": 278.64
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 48522,
-"ratio": 0.3876,
-"compress_mbps": 37.36,
-"decompress_mbps": 279.9
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 48522,
-"ratio": 0.3876,
-"compress_mbps": 37.5,
-"decompress_mbps": 279.58
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 156.38,
-"decompress_mbps": 280.51
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 173.35,
-"decompress_mbps": 279.44
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 163.42,
-"decompress_mbps": 281.7
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8182,
-"ratio": 0.3326,
-"compress_mbps": 174.83,
-"decompress_mbps": 284.38
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 7965,
-"ratio": 0.3237,
-"compress_mbps": 108.3,
-"decompress_mbps": 287.18
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 7914,
-"ratio": 0.3217,
-"compress_mbps": 86.29,
-"decompress_mbps": 291.13
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 7895,
-"ratio": 0.3209,
-"compress_mbps": 76.54,
-"decompress_mbps": 289.34
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 7896,
-"ratio": 0.3209,
-"compress_mbps": 69.93,
-"decompress_mbps": 292.05
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 7896,
-"ratio": 0.3209,
-"compress_mbps": 72.79,
-"decompress_mbps": 289.49
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 170.42,
-"decompress_mbps": 257.79
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 173.96,
-"decompress_mbps": 255.07
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 171.38,
-"decompress_mbps": 255.39
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3218,
-"ratio": 0.2886,
-"compress_mbps": 163.6,
-"decompress_mbps": 259.71
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3136,
-"ratio": 0.2813,
-"compress_mbps": 141.53,
-"decompress_mbps": 263.78
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3115,
-"ratio": 0.2794,
-"compress_mbps": 124.88,
-"decompress_mbps": 262.73
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 98.74,
-"decompress_mbps": 265.35
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 105.25,
-"decompress_mbps": 265.25
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3112,
-"ratio": 0.2791,
-"compress_mbps": 106.7,
-"decompress_mbps": 266.44
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 120.04,
-"decompress_mbps": 121.08
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 117.35,
-"decompress_mbps": 118.87
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 118.61,
-"decompress_mbps": 118.91
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1221,
-"ratio": 0.3281,
-"compress_mbps": 117.29,
-"decompress_mbps": 117.83
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 108.92,
-"decompress_mbps": 118.49
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 105.41,
-"decompress_mbps": 121.54
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 100.51,
-"decompress_mbps": 119.96
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 100.99,
-"decompress_mbps": 119.54
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1207,
-"ratio": 0.3244,
-"compress_mbps": 100.76,
-"decompress_mbps": 117.12
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 224.07,
-"decompress_mbps": 458.01
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 227.75,
-"decompress_mbps": 460.41
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 229.45,
-"decompress_mbps": 459.42
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 227063,
-"ratio": 0.2205,
-"compress_mbps": 230.58,
-"decompress_mbps": 459.38
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 218313,
-"ratio": 0.212,
-"compress_mbps": 156.12,
-"decompress_mbps": 444.95
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 215095,
-"ratio": 0.2089,
-"compress_mbps": 106.5,
-"decompress_mbps": 447.33
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 213213,
-"ratio": 0.2071,
-"compress_mbps": 71.16,
-"decompress_mbps": 445.04
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 210955,
-"ratio": 0.2049,
-"compress_mbps": 9.25,
-"decompress_mbps": 447.09
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 210981,
-"ratio": 0.2049,
-"compress_mbps": 4.62,
-"decompress_mbps": 451.19
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 92.3,
-"decompress_mbps": 307.48
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 92.07,
-"decompress_mbps": 310.96
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 91.88,
-"decompress_mbps": 308.43
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 148927,
-"ratio": 0.349,
-"compress_mbps": 92.46,
-"decompress_mbps": 309.65
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 145024,
-"ratio": 0.3398,
-"compress_mbps": 57.59,
-"decompress_mbps": 307.15
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 144159,
-"ratio": 0.3378,
-"compress_mbps": 44.47,
-"decompress_mbps": 308.17
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 143991,
-"ratio": 0.3374,
-"compress_mbps": 40.14,
-"decompress_mbps": 307.36
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 143941,
-"ratio": 0.3373,
-"compress_mbps": 36.91,
-"decompress_mbps": 307.68
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 143939,
-"ratio": 0.3373,
-"compress_mbps": 36.73,
-"decompress_mbps": 293.8
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 80.64,
-"decompress_mbps": 252.66
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 80.21,
-"decompress_mbps": 249.45
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 79.98,
-"decompress_mbps": 242.83
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 200074,
-"ratio": 0.4152,
-"compress_mbps": 79.52,
-"decompress_mbps": 245.99
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 194496,
-"ratio": 0.4036,
-"compress_mbps": 45.02,
-"decompress_mbps": 245.25
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 193176,
-"ratio": 0.4009,
-"compress_mbps": 33.8,
-"decompress_mbps": 249.91
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 192991,
-"ratio": 0.4005,
-"compress_mbps": 30.68,
-"decompress_mbps": 248.71
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 192980,
-"ratio": 0.4005,
-"compress_mbps": 29.06,
-"decompress_mbps": 244.39
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 192980,
-"ratio": 0.4005,
-"compress_mbps": 29.11,
-"decompress_mbps": 248.52
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 290.93,
-"decompress_mbps": 708.69
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 288.71,
-"decompress_mbps": 722.23
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 288.41,
-"decompress_mbps": 730.83
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 57484,
-"ratio": 0.112,
-"compress_mbps": 287.22,
-"decompress_mbps": 733.87
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 56050,
-"ratio": 0.1092,
-"compress_mbps": 227.48,
-"decompress_mbps": 754.71
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 55292,
-"ratio": 0.1077,
-"compress_mbps": 151.11,
-"decompress_mbps": 780.26
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 54651,
-"ratio": 0.1065,
-"compress_mbps": 122.76,
-"decompress_mbps": 798.56
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 52583,
-"ratio": 0.1025,
-"compress_mbps": 46.44,
-"decompress_mbps": 818.39
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 51816,
-"ratio": 0.101,
-"compress_mbps": 15.56,
-"decompress_mbps": 803.12
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 116.13,
-"decompress_mbps": 300.55
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 115.93,
-"decompress_mbps": 300.55
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 110.39,
-"decompress_mbps": 299.85
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13765,
-"ratio": 0.36,
-"compress_mbps": 115.14,
-"decompress_mbps": 300.62
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13290,
-"ratio": 0.3475,
-"compress_mbps": 85.87,
-"decompress_mbps": 314.77
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13258,
-"ratio": 0.3467,
-"compress_mbps": 67.57,
-"decompress_mbps": 315.93
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13246,
-"ratio": 0.3464,
-"compress_mbps": 56.2,
-"decompress_mbps": 308.85
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13236,
-"ratio": 0.3461,
-"compress_mbps": 24.96,
-"decompress_mbps": 318.92
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13233,
-"ratio": 0.3461,
-"compress_mbps": 15.95,
-"decompress_mbps": 318.71
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 96.54,
-"decompress_mbps": 131.88
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 93.5,
-"decompress_mbps": 132.47
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 98.07,
-"decompress_mbps": 132.39
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1742,
-"ratio": 0.4121,
-"compress_mbps": 98.56,
-"decompress_mbps": 132.91
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 94.01,
-"decompress_mbps": 133.38
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 93.93,
-"decompress_mbps": 134.14
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 92.87,
-"decompress_mbps": 133.66
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 93.28,
-"decompress_mbps": 133.46
-},
-{
-"compressor": "zig",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1720,
-"ratio": 0.4069,
-"compress_mbps": 95.85,
-"decompress_mbps": 133.7
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 82.59,
-"decompress_mbps": 270.19
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 83.3,
-"decompress_mbps": 274.91
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 83.66,
-"decompress_mbps": 275.15
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 3974126,
-"ratio": 0.3899,
-"compress_mbps": 83.47,
-"decompress_mbps": 271.41
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 3863846,
-"ratio": 0.3791,
-"compress_mbps": 48.19,
-"decompress_mbps": 269.37
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3838854,
-"ratio": 0.3766,
-"compress_mbps": 36.71,
-"decompress_mbps": 269.3
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3835182,
-"ratio": 0.3763,
-"compress_mbps": 33.02,
-"decompress_mbps": 269.03
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3834518,
-"ratio": 0.3762,
-"compress_mbps": 31.03,
-"decompress_mbps": 274.07
-},
-{
-"compressor": "zig",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3834518,
-"ratio": 0.3762,
-"compress_mbps": 31.2,
-"decompress_mbps": 274.73
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 103.35,
-"decompress_mbps": 251.68
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 102.55,
-"decompress_mbps": 253.17
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 101.76,
-"decompress_mbps": 250.34
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19877952,
-"ratio": 0.3881,
-"compress_mbps": 102.91,
-"decompress_mbps": 252.16
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19578840,
-"ratio": 0.3822,
-"compress_mbps": 77.43,
-"decompress_mbps": 261.3
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19492445,
-"ratio": 0.3806,
-"compress_mbps": 57.57,
-"decompress_mbps": 264.67
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19463481,
-"ratio": 0.38,
-"compress_mbps": 45.88,
-"decompress_mbps": 263.63
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19444704,
-"ratio": 0.3796,
-"compress_mbps": 22.74,
-"decompress_mbps": 262.77
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19440748,
-"ratio": 0.3796,
-"compress_mbps": 13.03,
-"decompress_mbps": 265.43
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 112.81,
-"decompress_mbps": 262.84
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 112.15,
-"decompress_mbps": 262.41
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 112.47,
-"decompress_mbps": 260.84
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3662279,
-"ratio": 0.3673,
-"compress_mbps": 112.42,
-"decompress_mbps": 262.7
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3637736,
-"ratio": 0.3648,
-"compress_mbps": 65.76,
-"decompress_mbps": 270.06
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3621530,
-"ratio": 0.3632,
-"compress_mbps": 46.28,
-"decompress_mbps": 271.66
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3623924,
-"ratio": 0.3635,
-"compress_mbps": 41.81,
-"decompress_mbps": 272.81
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3623112,
-"ratio": 0.3634,
-"compress_mbps": 32.5,
-"decompress_mbps": 272.72
-},
-{
-"compressor": "zig",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3623382,
-"ratio": 0.3634,
-"compress_mbps": 24.71,
-"decompress_mbps": 272.05
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 309.13,
-"decompress_mbps": 892.04
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 308.95,
-"decompress_mbps": 885.83
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 306.9,
-"decompress_mbps": 881.55
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3580057,
-"ratio": 0.1067,
-"compress_mbps": 308.3,
-"decompress_mbps": 884.17
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3268887,
-"ratio": 0.0974,
-"compress_mbps": 225.83,
-"decompress_mbps": 931.27
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3131445,
-"ratio": 0.0933,
-"compress_mbps": 161.25,
-"decompress_mbps": 965.09
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3080217,
-"ratio": 0.0918,
-"compress_mbps": 126.08,
-"decompress_mbps": 961.7
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 2978354,
-"ratio": 0.0888,
-"compress_mbps": 54.64,
-"decompress_mbps": 984.8
-},
-{
-"compressor": "zig",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2947971,
-"ratio": 0.0879,
-"compress_mbps": 33.84,
-"decompress_mbps": 989.96
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 71.81,
-"decompress_mbps": 184.61
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 72.12,
-"decompress_mbps": 184.24
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 71.93,
-"decompress_mbps": 184.96
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3221973,
-"ratio": 0.5237,
-"compress_mbps": 72.26,
-"decompress_mbps": 184.78
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3178914,
-"ratio": 0.5167,
-"compress_mbps": 55.7,
-"decompress_mbps": 191.91
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3174170,
-"ratio": 0.5159,
-"compress_mbps": 48.64,
-"decompress_mbps": 193.0
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3172734,
-"ratio": 0.5157,
-"compress_mbps": 45.8,
-"decompress_mbps": 193.57
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3171353,
-"ratio": 0.5155,
-"compress_mbps": 38.57,
-"decompress_mbps": 193.32
-},
-{
-"compressor": "zig",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3171299,
-"ratio": 0.5155,
-"compress_mbps": 34.71,
-"decompress_mbps": 193.42
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 123.53,
-"decompress_mbps": 272.88
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 123.96,
-"decompress_mbps": 275.8
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 123.58,
-"decompress_mbps": 276.01
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3791952,
-"ratio": 0.376,
-"compress_mbps": 123.38,
-"decompress_mbps": 273.95
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3654027,
-"ratio": 0.3623,
-"compress_mbps": 96.18,
-"decompress_mbps": 277.93
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3652732,
-"ratio": 0.3622,
-"compress_mbps": 93.36,
-"decompress_mbps": 277.41
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3652496,
-"ratio": 0.3621,
-"compress_mbps": 87.38,
-"decompress_mbps": 277.61
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3652505,
-"ratio": 0.3621,
-"compress_mbps": 87.25,
-"decompress_mbps": 277.42
-},
-{
-"compressor": "zig",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3652505,
-"ratio": 0.3621,
-"compress_mbps": 87.18,
-"decompress_mbps": 274.43
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 99.53,
-"decompress_mbps": 359.02
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 99.54,
-"decompress_mbps": 357.84
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 98.86,
-"decompress_mbps": 358.42
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 2009824,
-"ratio": 0.3033,
-"compress_mbps": 99.12,
-"decompress_mbps": 358.87
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1892183,
-"ratio": 0.2855,
-"compress_mbps": 52.27,
-"decompress_mbps": 357.11
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1837957,
-"ratio": 0.2773,
-"compress_mbps": 30.32,
-"decompress_mbps": 366.73
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1826603,
-"ratio": 0.2756,
-"compress_mbps": 24.27,
-"decompress_mbps": 366.65
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1818702,
-"ratio": 0.2744,
-"compress_mbps": 15.83,
-"decompress_mbps": 365.68
-},
-{
-"compressor": "zig",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1818702,
-"ratio": 0.2744,
-"compress_mbps": 15.8,
-"decompress_mbps": 366.33
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 144.08,
-"decompress_mbps": 400.86
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 144.61,
-"decompress_mbps": 403.43
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 144.91,
-"decompress_mbps": 404.3
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5633558,
-"ratio": 0.2607,
-"compress_mbps": 144.99,
-"decompress_mbps": 403.33
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5501344,
-"ratio": 0.2546,
-"compress_mbps": 103.0,
-"decompress_mbps": 408.49
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5464646,
-"ratio": 0.2529,
-"compress_mbps": 78.95,
-"decompress_mbps": 412.0
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5429975,
-"ratio": 0.2513,
-"compress_mbps": 66.89,
-"decompress_mbps": 413.55
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5419566,
-"ratio": 0.2508,
-"compress_mbps": 49.42,
-"decompress_mbps": 412.12
-},
-{
-"compressor": "zig",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5417952,
-"ratio": 0.2508,
-"compress_mbps": 45.42,
-"decompress_mbps": 413.22
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.25,
-"decompress_mbps": 162.57
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.57,
-"decompress_mbps": 162.43
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.38,
-"decompress_mbps": 162.61
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5481930,
-"ratio": 0.7559,
-"compress_mbps": 60.32,
-"decompress_mbps": 162.77
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5450496,
-"ratio": 0.7516,
-"compress_mbps": 46.65,
-"decompress_mbps": 165.07
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5440281,
-"ratio": 0.7502,
-"compress_mbps": 40.78,
-"decompress_mbps": 152.94
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5439077,
-"ratio": 0.75,
-"compress_mbps": 40.35,
-"decompress_mbps": 157.42
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5438787,
-"ratio": 0.75,
-"compress_mbps": 38.69,
-"decompress_mbps": 161.6
-},
-{
-"compressor": "zig",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5438787,
-"ratio": 0.75,
-"compress_mbps": 39.68,
-"decompress_mbps": 164.63
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 106.97,
-"decompress_mbps": 315.78
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 108.82,
-"decompress_mbps": 316.45
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 108.42,
-"decompress_mbps": 319.83
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12756531,
-"ratio": 0.3077,
-"compress_mbps": 108.71,
-"decompress_mbps": 320.21
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12238874,
-"ratio": 0.2952,
-"compress_mbps": 72.07,
-"decompress_mbps": 324.63
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12086531,
-"ratio": 0.2915,
-"compress_mbps": 53.46,
-"decompress_mbps": 327.48
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12020742,
-"ratio": 0.2899,
-"compress_mbps": 46.3,
-"decompress_mbps": 327.39
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 11987253,
-"ratio": 0.2891,
-"compress_mbps": 37.94,
-"decompress_mbps": 328.74
-},
-{
-"compressor": "zig",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11987245,
-"ratio": 0.2891,
-"compress_mbps": 37.78,
-"decompress_mbps": 324.52
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 61.03,
-"decompress_mbps": 147.69
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 61.28,
-"decompress_mbps": 147.25
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 61.19,
-"decompress_mbps": 147.99
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6273039,
-"ratio": 0.7402,
-"compress_mbps": 61.15,
-"decompress_mbps": 147.99
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6244483,
-"ratio": 0.7369,
-"compress_mbps": 55.89,
-"decompress_mbps": 149.62
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6244482,
-"ratio": 0.7369,
-"compress_mbps": 55.73,
-"decompress_mbps": 149.73
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6244482,
-"ratio": 0.7369,
-"compress_mbps": 55.89,
-"decompress_mbps": 149.78
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6244480,
-"ratio": 0.7369,
-"compress_mbps": 56.03,
-"decompress_mbps": 149.93
-},
-{
-"compressor": "zig",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6244480,
-"ratio": 0.7369,
-"compress_mbps": 55.95,
-"decompress_mbps": 149.77
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 230.99,
-"decompress_mbps": 681.22
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 231.6,
-"decompress_mbps": 669.32
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 231.88,
-"decompress_mbps": 680.3
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 785041,
-"ratio": 0.1469,
-"compress_mbps": 231.73,
-"decompress_mbps": 679.52
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 716461,
-"ratio": 0.134,
-"compress_mbps": 165.89,
-"decompress_mbps": 714.55
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 687053,
-"ratio": 0.1285,
-"compress_mbps": 124.71,
-"decompress_mbps": 741.63
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 673597,
-"ratio": 0.126,
-"compress_mbps": 101.0,
-"decompress_mbps": 757.21
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 662156,
-"ratio": 0.1239,
-"compress_mbps": 65.42,
-"decompress_mbps": 760.55
-},
-{
-"compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 661610,
-"ratio": 0.1238,
-"compress_mbps": 61.08,
-"decompress_mbps": 762.12
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 73589,
-"ratio": 0.4839,
-"compress_mbps": 34.53,
-"decompress_mbps": 57.57
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 69878,
-"ratio": 0.4595,
-"compress_mbps": 32.9,
-"decompress_mbps": 58.57
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 66917,
-"ratio": 0.44,
-"compress_mbps": 27.28,
-"decompress_mbps": 66.6
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 59388,
-"ratio": 0.3905,
-"compress_mbps": 31.75,
-"decompress_mbps": 80.7
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 57062,
-"ratio": 0.3752,
-"compress_mbps": 22.74,
-"decompress_mbps": 80.55
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 55472,
-"ratio": 0.3647,
-"compress_mbps": 16.38,
-"decompress_mbps": 79.73
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 55265,
-"ratio": 0.3634,
-"compress_mbps": 14.32,
-"decompress_mbps": 80.11
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 55168,
-"ratio": 0.3627,
-"compress_mbps": 11.95,
-"decompress_mbps": 79.65
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 55168,
-"ratio": 0.3627,
-"compress_mbps": 11.97,
-"decompress_mbps": 80.09
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 64551,
-"ratio": 0.5157,
-"compress_mbps": 32.72,
-"decompress_mbps": 54.58
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 62089,
-"ratio": 0.496,
-"compress_mbps": 31.02,
-"decompress_mbps": 58.34
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 58690,
-"ratio": 0.4688,
-"compress_mbps": 24.8,
-"decompress_mbps": 59.71
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 53521,
-"ratio": 0.4276,
-"compress_mbps": 30.17,
-"decompress_mbps": 80.38
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 51677,
-"ratio": 0.4128,
-"compress_mbps": 20.96,
-"decompress_mbps": 78.86
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 50638,
-"ratio": 0.4045,
-"compress_mbps": 14.99,
-"decompress_mbps": 84.28
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 50501,
-"ratio": 0.4034,
-"compress_mbps": 13.57,
-"decompress_mbps": 80.06
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 50452,
-"ratio": 0.403,
-"compress_mbps": 12.62,
-"decompress_mbps": 83.56
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 50452,
-"ratio": 0.403,
-"compress_mbps": 12.61,
-"decompress_mbps": 83.29
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 9859,
-"ratio": 0.4007,
-"compress_mbps": 44.32,
-"decompress_mbps": 113.78
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 10473,
-"ratio": 0.4257,
-"compress_mbps": 48.22,
-"decompress_mbps": 149.83
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 10172,
-"ratio": 0.4134,
-"compress_mbps": 43.3,
-"decompress_mbps": 152.25
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8692,
-"ratio": 0.3533,
-"compress_mbps": 41.91,
-"decompress_mbps": 152.55
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8440,
-"ratio": 0.343,
-"compress_mbps": 36.02,
-"decompress_mbps": 156.73
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 8385,
-"ratio": 0.3408,
-"compress_mbps": 32.13,
-"decompress_mbps": 157.13
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 8366,
-"ratio": 0.34,
-"compress_mbps": 30.34,
-"decompress_mbps": 151.47
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 8367,
-"ratio": 0.3401,
-"compress_mbps": 29.21,
-"decompress_mbps": 158.02
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 8367,
-"ratio": 0.3401,
-"compress_mbps": 29.15,
-"decompress_mbps": 155.98
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 4822,
-"ratio": 0.4325,
-"compress_mbps": 54.52,
-"decompress_mbps": 188.53
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 4593,
-"ratio": 0.4119,
-"compress_mbps": 54.24,
-"decompress_mbps": 193.47
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 4381,
-"ratio": 0.3929,
-"compress_mbps": 52.66,
-"decompress_mbps": 199.66
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3725,
-"ratio": 0.3341,
-"compress_mbps": 52.59,
-"decompress_mbps": 202.76
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3614,
-"ratio": 0.3241,
-"compress_mbps": 44.28,
-"decompress_mbps": 208.75
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3578,
-"ratio": 0.3209,
-"compress_mbps": 39.76,
-"decompress_mbps": 210.48
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3572,
-"ratio": 0.3204,
-"compress_mbps": 37.2,
-"decompress_mbps": 210.06
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3568,
-"ratio": 0.32,
-"compress_mbps": 33.64,
-"decompress_mbps": 209.49
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3568,
-"ratio": 0.32,
-"compress_mbps": 34.12,
-"decompress_mbps": 210.14
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1738,
-"ratio": 0.4671,
-"compress_mbps": 30.63,
-"decompress_mbps": 178.86
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1709,
-"ratio": 0.4593,
-"compress_mbps": 32.07,
-"decompress_mbps": 179.56
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1694,
-"ratio": 0.4553,
-"compress_mbps": 31.49,
-"decompress_mbps": 180.49
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1458,
-"ratio": 0.3918,
-"compress_mbps": 30.44,
-"decompress_mbps": 188.96
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1441,
-"ratio": 0.3873,
-"compress_mbps": 29.17,
-"decompress_mbps": 190.78
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.19,
-"decompress_mbps": 192.85
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.94,
-"decompress_mbps": 190.99
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.47,
-"decompress_mbps": 192.63
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1440,
-"ratio": 0.387,
-"compress_mbps": 27.85,
-"decompress_mbps": 192.42
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 260073,
-"ratio": 0.2526,
-"compress_mbps": 53.47,
-"decompress_mbps": 57.67
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 296764,
-"ratio": 0.2882,
-"compress_mbps": 49.71,
-"decompress_mbps": 76.91
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 288989,
-"ratio": 0.2806,
-"compress_mbps": 38.04,
-"decompress_mbps": 78.61
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 246442,
-"ratio": 0.2393,
-"compress_mbps": 54.21,
-"decompress_mbps": 83.24
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 218888,
-"ratio": 0.2126,
-"compress_mbps": 40.33,
-"decompress_mbps": 77.32
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 217830,
-"ratio": 0.2115,
-"compress_mbps": 24.23,
-"decompress_mbps": 88.27
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 221437,
-"ratio": 0.215,
-"compress_mbps": 19.37,
-"decompress_mbps": 87.65
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 219666,
-"ratio": 0.2133,
-"compress_mbps": 5.51,
-"decompress_mbps": 85.96
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 219921,
-"ratio": 0.2136,
-"compress_mbps": 2.78,
-"decompress_mbps": 87.37
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 194588,
-"ratio": 0.456,
-"compress_mbps": 34.89,
-"decompress_mbps": 52.3
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 185757,
-"ratio": 0.4353,
-"compress_mbps": 33.46,
-"decompress_mbps": 49.8
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 175850,
-"ratio": 0.4121,
-"compress_mbps": 27.59,
-"decompress_mbps": 59.35
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 155951,
-"ratio": 0.3654,
-"compress_mbps": 32.39,
-"decompress_mbps": 73.44
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 150274,
-"ratio": 0.3521,
-"compress_mbps": 23.26,
-"decompress_mbps": 72.52
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 147958,
-"ratio": 0.3467,
-"compress_mbps": 16.81,
-"decompress_mbps": 73.51
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 147522,
-"ratio": 0.3457,
-"compress_mbps": 15.18,
-"decompress_mbps": 71.72
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 147331,
-"ratio": 0.3452,
-"compress_mbps": 13.61,
-"decompress_mbps": 71.04
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 147328,
-"ratio": 0.3452,
-"compress_mbps": 13.61,
-"decompress_mbps": 72.61
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 256904,
-"ratio": 0.5331,
-"compress_mbps": 30.48,
-"decompress_mbps": 46.92
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 245675,
-"ratio": 0.5098,
-"compress_mbps": 29.14,
-"decompress_mbps": 50.06
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 231519,
-"ratio": 0.4805,
-"compress_mbps": 23.07,
-"decompress_mbps": 57.17
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 210028,
-"ratio": 0.4359,
-"compress_mbps": 27.9,
-"decompress_mbps": 65.64
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 203312,
-"ratio": 0.4219,
-"compress_mbps": 18.75,
-"decompress_mbps": 62.62
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 199287,
-"ratio": 0.4136,
-"compress_mbps": 12.87,
-"decompress_mbps": 66.39
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 198474,
-"ratio": 0.4119,
-"compress_mbps": 11.21,
-"decompress_mbps": 66.15
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 198080,
-"ratio": 0.4111,
-"compress_mbps": 8.86,
-"decompress_mbps": 65.49
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 198080,
-"ratio": 0.4111,
-"compress_mbps": 8.91,
-"decompress_mbps": 65.86
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 71229,
-"ratio": 0.1388,
-"compress_mbps": 83.77,
-"decompress_mbps": 131.58
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 69946,
-"ratio": 0.1363,
-"compress_mbps": 80.79,
-"decompress_mbps": 137.1
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 68538,
-"ratio": 0.1335,
-"compress_mbps": 71.18,
-"decompress_mbps": 151.28
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 61320,
-"ratio": 0.1195,
-"compress_mbps": 66.7,
-"decompress_mbps": 167.14
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 59993,
-"ratio": 0.1169,
-"compress_mbps": 57.62,
-"decompress_mbps": 167.58
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 58637,
-"ratio": 0.1143,
-"compress_mbps": 41.62,
-"decompress_mbps": 167.55
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 58209,
-"ratio": 0.1134,
-"compress_mbps": 35.62,
-"decompress_mbps": 175.53
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 55749,
-"ratio": 0.1086,
-"compress_mbps": 19.34,
-"decompress_mbps": 178.8
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 54927,
-"ratio": 0.107,
-"compress_mbps": 7.47,
-"decompress_mbps": 178.91
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 16399,
-"ratio": 0.4288,
-"compress_mbps": 37.32,
-"decompress_mbps": 88.99
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 15933,
-"ratio": 0.4167,
-"compress_mbps": 34.65,
-"decompress_mbps": 90.16
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 15739,
-"ratio": 0.4116,
-"compress_mbps": 28.77,
-"decompress_mbps": 87.25
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13834,
-"ratio": 0.3618,
-"compress_mbps": 32.3,
-"decompress_mbps": 107.86
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13463,
-"ratio": 0.3521,
-"compress_mbps": 26.29,
-"decompress_mbps": 110.38
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13353,
-"ratio": 0.3492,
-"compress_mbps": 19.08,
-"decompress_mbps": 111.13
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13317,
-"ratio": 0.3482,
-"compress_mbps": 15.86,
-"decompress_mbps": 111.35
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13255,
-"ratio": 0.3466,
-"compress_mbps": 8.41,
-"decompress_mbps": 111.28
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13171,
-"ratio": 0.3444,
-"compress_mbps": 4.15,
-"decompress_mbps": 113.75
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 2512,
-"ratio": 0.5943,
-"compress_mbps": 28.93,
-"decompress_mbps": 159.45
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 2477,
-"ratio": 0.586,
-"compress_mbps": 29.81,
-"decompress_mbps": 161.01
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 2452,
-"ratio": 0.5801,
-"compress_mbps": 30.92,
-"decompress_mbps": 161.34
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 2110,
-"ratio": 0.4992,
-"compress_mbps": 29.19,
-"decompress_mbps": 160.49
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.88,
-"decompress_mbps": 169.94
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 29.34,
-"decompress_mbps": 170.83
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.91,
-"decompress_mbps": 169.65
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 29.08,
-"decompress_mbps": 170.68
-},
-{
-"compressor": "ocaml",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 2086,
-"ratio": 0.4935,
-"compress_mbps": 28.76,
-"decompress_mbps": 162.67
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 5183792,
-"ratio": 0.5086,
-"compress_mbps": 31.94,
-"decompress_mbps": 39.96
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4956750,
-"ratio": 0.4863,
-"compress_mbps": 30.27,
-"decompress_mbps": 43.07
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4644095,
-"ratio": 0.4556,
-"compress_mbps": 24.33,
-"decompress_mbps": 47.82
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4178564,
-"ratio": 0.41,
-"compress_mbps": 29.19,
-"decompress_mbps": 60.15
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 4034632,
-"ratio": 0.3958,
-"compress_mbps": 20.02,
-"decompress_mbps": 61.14
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3952244,
-"ratio": 0.3878,
-"compress_mbps": 14.05,
-"decompress_mbps": 61.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3938822,
-"ratio": 0.3864,
-"compress_mbps": 12.28,
-"decompress_mbps": 61.54
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3935171,
-"ratio": 0.3861,
-"compress_mbps": 10.81,
-"decompress_mbps": 61.85
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3935171,
-"ratio": 0.3861,
-"compress_mbps": 10.75,
-"decompress_mbps": 61.78
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 25320013,
-"ratio": 0.4943,
-"compress_mbps": 32.7,
-"decompress_mbps": 34.95
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 24804084,
-"ratio": 0.4843,
-"compress_mbps": 31.11,
-"decompress_mbps": 36.42
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 24241121,
-"ratio": 0.4733,
-"compress_mbps": 26.19,
-"decompress_mbps": 37.28
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 20950547,
-"ratio": 0.409,
-"compress_mbps": 29.54,
-"decompress_mbps": 44.04
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 20592289,
-"ratio": 0.402,
-"compress_mbps": 24.65,
-"decompress_mbps": 45.47
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 20445232,
-"ratio": 0.3992,
-"compress_mbps": 18.85,
-"decompress_mbps": 46.45
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 20407676,
-"ratio": 0.3984,
-"compress_mbps": 16.11,
-"decompress_mbps": 46.66
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 20389473,
-"ratio": 0.3981,
-"compress_mbps": 10.25,
-"decompress_mbps": 45.88
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 20386824,
-"ratio": 0.398,
-"compress_mbps": 6.88,
-"decompress_mbps": 45.39
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3964698,
-"ratio": 0.3976,
-"compress_mbps": 38.8,
-"decompress_mbps": 48.48
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3936391,
-"ratio": 0.3948,
-"compress_mbps": 36.31,
-"decompress_mbps": 49.1
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3823540,
-"ratio": 0.3835,
-"compress_mbps": 28.05,
-"decompress_mbps": 52.45
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3799601,
-"ratio": 0.3811,
-"compress_mbps": 33.08,
-"decompress_mbps": 62.74
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3830938,
-"ratio": 0.3842,
-"compress_mbps": 22.72,
-"decompress_mbps": 57.8
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3808303,
-"ratio": 0.382,
-"compress_mbps": 14.84,
-"decompress_mbps": 58.01
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3802814,
-"ratio": 0.3814,
-"compress_mbps": 12.15,
-"decompress_mbps": 57.78
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3800355,
-"ratio": 0.3812,
-"compress_mbps": 6.76,
-"decompress_mbps": 57.86
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3799676,
-"ratio": 0.3811,
-"compress_mbps": 6.07,
-"decompress_mbps": 58.42
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4899547,
-"ratio": 0.146,
-"compress_mbps": 96.81,
-"decompress_mbps": 130.32
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4587004,
-"ratio": 0.1367,
-"compress_mbps": 96.43,
-"decompress_mbps": 139.86
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 4229035,
-"ratio": 0.126,
-"compress_mbps": 90.78,
-"decompress_mbps": 152.03
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3791322,
-"ratio": 0.113,
-"compress_mbps": 82.31,
-"decompress_mbps": 162.11
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3449193,
-"ratio": 0.1028,
-"compress_mbps": 72.86,
-"decompress_mbps": 166.93
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3269452,
-"ratio": 0.0974,
-"compress_mbps": 58.61,
-"decompress_mbps": 171.28
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3211286,
-"ratio": 0.0957,
-"compress_mbps": 50.41,
-"decompress_mbps": 168.5
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3101534,
-"ratio": 0.0924,
-"compress_mbps": 27.51,
-"decompress_mbps": 171.08
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3058177,
-"ratio": 0.0911,
-"compress_mbps": 16.54,
-"decompress_mbps": 179.25
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 4024327,
-"ratio": 0.6541,
-"compress_mbps": 23.3,
-"decompress_mbps": 29.55
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3953722,
-"ratio": 0.6427,
-"compress_mbps": 22.26,
-"decompress_mbps": 30.51
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3887921,
-"ratio": 0.632,
-"compress_mbps": 18.93,
-"decompress_mbps": 30.66
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3320440,
-"ratio": 0.5397,
-"compress_mbps": 21.59,
-"decompress_mbps": 37.26
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3279338,
-"ratio": 0.533,
-"compress_mbps": 18.04,
-"decompress_mbps": 38.33
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3254309,
-"ratio": 0.529,
-"compress_mbps": 14.03,
-"decompress_mbps": 38.11
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3250139,
-"ratio": 0.5283,
-"compress_mbps": 12.36,
-"decompress_mbps": 37.71
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3247018,
-"ratio": 0.5278,
-"compress_mbps": 10.17,
-"decompress_mbps": 37.99
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3246865,
-"ratio": 0.5278,
-"compress_mbps": 9.55,
-"decompress_mbps": 38.02
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4471091,
-"ratio": 0.4433,
-"compress_mbps": 35.74,
-"decompress_mbps": 69.37
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 4372105,
-"ratio": 0.4335,
-"compress_mbps": 34.44,
-"decompress_mbps": 73.11
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 4305270,
-"ratio": 0.4269,
-"compress_mbps": 30.84,
-"decompress_mbps": 74.76
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3920495,
-"ratio": 0.3887,
-"compress_mbps": 30.64,
-"decompress_mbps": 66.2
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3853177,
-"ratio": 0.382,
-"compress_mbps": 26.77,
-"decompress_mbps": 65.04
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3780878,
-"ratio": 0.3749,
-"compress_mbps": 23.5,
-"decompress_mbps": 63.8
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3763880,
-"ratio": 0.3732,
-"compress_mbps": 20.18,
-"decompress_mbps": 72.63
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3757719,
-"ratio": 0.3726,
-"compress_mbps": 18.28,
-"decompress_mbps": 71.63
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3757719,
-"ratio": 0.3726,
-"compress_mbps": 18.37,
-"decompress_mbps": 72.35
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2722387,
-"ratio": 0.4108,
-"compress_mbps": 38.5,
-"decompress_mbps": 66.16
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2572544,
-"ratio": 0.3882,
-"compress_mbps": 37.5,
-"decompress_mbps": 70.7
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2384328,
-"ratio": 0.3598,
-"compress_mbps": 29.7,
-"decompress_mbps": 80.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 2112060,
-"ratio": 0.3187,
-"compress_mbps": 36.54,
-"decompress_mbps": 85.21
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1991581,
-"ratio": 0.3005,
-"compress_mbps": 25.62,
-"decompress_mbps": 88.33
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1917866,
-"ratio": 0.2894,
-"compress_mbps": 15.14,
-"decompress_mbps": 93.59
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1895353,
-"ratio": 0.286,
-"compress_mbps": 11.09,
-"decompress_mbps": 90.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1880740,
-"ratio": 0.2838,
-"compress_mbps": 5.6,
-"decompress_mbps": 91.25
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1880711,
-"ratio": 0.2838,
-"compress_mbps": 5.58,
-"decompress_mbps": 91.25
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 7441483,
-"ratio": 0.3444,
-"compress_mbps": 45.31,
-"decompress_mbps": 67.23
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 7229248,
-"ratio": 0.3346,
-"compress_mbps": 44.23,
-"decompress_mbps": 69.05
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 7083451,
-"ratio": 0.3278,
-"compress_mbps": 39.55,
-"decompress_mbps": 71.01
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 6189639,
-"ratio": 0.2865,
-"compress_mbps": 42.58,
-"decompress_mbps": 92.48
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 6053058,
-"ratio": 0.2802,
-"compress_mbps": 35.44,
-"decompress_mbps": 96.9
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5988137,
-"ratio": 0.2771,
-"compress_mbps": 28.74,
-"decompress_mbps": 102.79
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5949908,
-"ratio": 0.2754,
-"compress_mbps": 25.39,
-"decompress_mbps": 103.55
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5936656,
-"ratio": 0.2748,
-"compress_mbps": 19.35,
-"decompress_mbps": 106.16
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5934701,
-"ratio": 0.2747,
-"compress_mbps": 18.09,
-"decompress_mbps": 106.06
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 6335542,
-"ratio": 0.8736,
-"compress_mbps": 19.02,
-"decompress_mbps": 31.37
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 6247260,
-"ratio": 0.8615,
-"compress_mbps": 17.95,
-"decompress_mbps": 49.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 6064713,
-"ratio": 0.8363,
-"compress_mbps": 15.55,
-"decompress_mbps": 56.91
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5568111,
-"ratio": 0.7678,
-"compress_mbps": 17.78,
-"decompress_mbps": 60.28
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5544524,
-"ratio": 0.7646,
-"compress_mbps": 14.67,
-"decompress_mbps": 65.44
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5513056,
-"ratio": 0.7602,
-"compress_mbps": 12.16,
-"decompress_mbps": 62.98
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5508915,
-"ratio": 0.7596,
-"compress_mbps": 11.43,
-"decompress_mbps": 64.41
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5508365,
-"ratio": 0.7596,
-"compress_mbps": 10.71,
-"decompress_mbps": 64.32
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5508365,
-"ratio": 0.7596,
-"compress_mbps": 10.65,
-"decompress_mbps": 64.32
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 16776095,
-"ratio": 0.4046,
-"compress_mbps": 38.53,
-"decompress_mbps": 51.03
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 16032651,
-"ratio": 0.3867,
-"compress_mbps": 36.77,
-"decompress_mbps": 55.83
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 15180334,
-"ratio": 0.3662,
-"compress_mbps": 31.71,
-"decompress_mbps": 52.1
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 13261924,
-"ratio": 0.3199,
-"compress_mbps": 36.14,
-"decompress_mbps": 67.86
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12706028,
-"ratio": 0.3065,
-"compress_mbps": 27.77,
-"decompress_mbps": 72.16
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12464158,
-"ratio": 0.3006,
-"compress_mbps": 21.22,
-"decompress_mbps": 72.21
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12375954,
-"ratio": 0.2985,
-"compress_mbps": 18.25,
-"decompress_mbps": 70.48
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12321552,
-"ratio": 0.2972,
-"compress_mbps": 14.41,
-"decompress_mbps": 70.54
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12320276,
-"ratio": 0.2972,
-"compress_mbps": 13.86,
-"decompress_mbps": 70.47
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6799201,
-"ratio": 0.8023,
-"compress_mbps": 18.93,
-"decompress_mbps": 18.26
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 6800500,
-"ratio": 0.8025,
-"compress_mbps": 17.48,
-"decompress_mbps": 18.29
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6803212,
-"ratio": 0.8028,
-"compress_mbps": 15.35,
-"decompress_mbps": 18.41
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 6264611,
-"ratio": 0.7393,
-"compress_mbps": 17.68,
-"decompress_mbps": 25.16
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 6217901,
-"ratio": 0.7337,
-"compress_mbps": 16.03,
-"decompress_mbps": 24.76
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 6201999,
-"ratio": 0.7319,
-"compress_mbps": 15.62,
-"decompress_mbps": 24.92
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 6201883,
-"ratio": 0.7319,
-"compress_mbps": 15.57,
-"decompress_mbps": 24.84
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 6201887,
-"ratio": 0.7319,
-"compress_mbps": 15.53,
-"decompress_mbps": 25.08
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 6201887,
-"ratio": 0.7319,
-"compress_mbps": 15.5,
-"decompress_mbps": 25.13
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 1081679,
-"ratio": 0.2024,
-"compress_mbps": 75.64,
-"decompress_mbps": 107.31
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 1001890,
-"ratio": 0.1874,
-"compress_mbps": 74.66,
-"decompress_mbps": 116.68
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 921722,
-"ratio": 0.1724,
-"compress_mbps": 67.17,
-"decompress_mbps": 127.42
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 849263,
-"ratio": 0.1589,
-"compress_mbps": 65.29,
-"decompress_mbps": 141.45
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 771964,
-"ratio": 0.1444,
-"compress_mbps": 55.0,
-"decompress_mbps": 142.5
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 728098,
-"ratio": 0.1362,
-"compress_mbps": 42.74,
-"decompress_mbps": 149.94
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 713635,
-"ratio": 0.1335,
-"compress_mbps": 37.31,
-"decompress_mbps": 149.43
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 699093,
-"ratio": 0.1308,
-"compress_mbps": 27.08,
-"decompress_mbps": 145.77
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 698459,
-"ratio": 0.1307,
-"compress_mbps": 25.24,
-"decompress_mbps": 150.48
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 1,
-"out_size": 62797,
-"ratio": 0.4129,
-"compress_mbps": 68.56,
-"decompress_mbps": 158.42
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 2,
-"out_size": 59605,
-"ratio": 0.3919,
-"compress_mbps": 57.55,
-"decompress_mbps": 183.76
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 3,
-"out_size": 57675,
-"ratio": 0.3792,
-"compress_mbps": 49.31,
-"decompress_mbps": 171.74
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 4,
-"out_size": 56500,
-"ratio": 0.3715,
-"compress_mbps": 42.67,
-"decompress_mbps": 133.64
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 5,
-"out_size": 56440,
-"ratio": 0.3711,
-"compress_mbps": 42.15,
-"decompress_mbps": 142.06
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 6,
-"out_size": 55443,
-"ratio": 0.3645,
-"compress_mbps": 35.41,
-"decompress_mbps": 138.32
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 7,
-"out_size": 55373,
-"ratio": 0.3641,
-"compress_mbps": 34.36,
-"decompress_mbps": 137
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 8,
-"out_size": 55352,
-"ratio": 0.3639,
-"compress_mbps": 33.41,
-"decompress_mbps": 182.41
-},
-{
-"compressor": "js",
-"pattern": "canterbury/alice29.txt",
-"size": 152089,
-"level": 9,
-"out_size": 55352,
-"ratio": 0.3639,
-"compress_mbps": 33.5,
-"decompress_mbps": 129.92
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 1,
-"out_size": 55063,
-"ratio": 0.4399,
-"compress_mbps": 63.55,
-"decompress_mbps": 163.9
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 2,
-"out_size": 52932,
-"ratio": 0.4229,
-"compress_mbps": 54.4,
-"decompress_mbps": 120.17
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 3,
-"out_size": 51597,
-"ratio": 0.4122,
-"compress_mbps": 46.63,
-"decompress_mbps": 93.11
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 4,
-"out_size": 50780,
-"ratio": 0.4057,
-"compress_mbps": 37.77,
-"decompress_mbps": 86.8
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 5,
-"out_size": 50767,
-"ratio": 0.4056,
-"compress_mbps": 39.45,
-"decompress_mbps": 88.09
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 6,
-"out_size": 50160,
-"ratio": 0.4007,
-"compress_mbps": 32.07,
-"decompress_mbps": 118.41
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 7,
-"out_size": 50138,
-"ratio": 0.4005,
-"compress_mbps": 33.01,
-"decompress_mbps": 92.32
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 8,
-"out_size": 50138,
-"ratio": 0.4005,
-"compress_mbps": 31.73,
-"decompress_mbps": 86.87
-},
-{
-"compressor": "js",
-"pattern": "canterbury/asyoulik.txt",
-"size": 125179,
-"level": 9,
-"out_size": 50138,
-"ratio": 0.4005,
-"compress_mbps": 31.75,
-"decompress_mbps": 124.96
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 1,
-"out_size": 8730,
-"ratio": 0.3548,
-"compress_mbps": 43,
-"decompress_mbps": 35.73
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 2,
-"out_size": 8457,
-"ratio": 0.3437,
-"compress_mbps": 74.58,
-"decompress_mbps": 53.62
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 3,
-"out_size": 8353,
-"ratio": 0.3395,
-"compress_mbps": 39.6,
-"decompress_mbps": 45.98
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 4,
-"out_size": 8301,
-"ratio": 0.3374,
-"compress_mbps": 71.04,
-"decompress_mbps": 49.17
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 5,
-"out_size": 8212,
-"ratio": 0.3338,
-"compress_mbps": 36.39,
-"decompress_mbps": 43.68
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 6,
-"out_size": 8172,
-"ratio": 0.3322,
-"compress_mbps": 58.86,
-"decompress_mbps": 47.79
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 7,
-"out_size": 8171,
-"ratio": 0.3321,
-"compress_mbps": 53.96,
-"decompress_mbps": 46.46
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 8,
-"out_size": 8171,
-"ratio": 0.3321,
-"compress_mbps": 59.01,
-"decompress_mbps": 46.76
-},
-{
-"compressor": "js",
-"pattern": "canterbury/cp.html",
-"size": 24603,
-"level": 9,
-"out_size": 8171,
-"ratio": 0.3321,
-"compress_mbps": 54.5,
-"decompress_mbps": 49.29
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 1,
-"out_size": 3475,
-"ratio": 0.3117,
-"compress_mbps": 77.94,
-"decompress_mbps": 58.2
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 2,
-"out_size": 3305,
-"ratio": 0.2964,
-"compress_mbps": 63.71,
-"decompress_mbps": 51.69
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 3,
-"out_size": 3225,
-"ratio": 0.2892,
-"compress_mbps": 72.96,
-"decompress_mbps": 67.52
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 4,
-"out_size": 3192,
-"ratio": 0.2863,
-"compress_mbps": 71.43,
-"decompress_mbps": 66.05
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 5,
-"out_size": 3180,
-"ratio": 0.2852,
-"compress_mbps": 71.91,
-"decompress_mbps": 61.67
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 6,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 62.79,
-"decompress_mbps": 60.69
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 7,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 52.9,
-"decompress_mbps": 64.49
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 8,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 69.05,
-"decompress_mbps": 64.73
-},
-{
-"compressor": "js",
-"pattern": "canterbury/fields.c",
-"size": 11150,
-"level": 9,
-"out_size": 3168,
-"ratio": 0.2841,
-"compress_mbps": 67.52,
-"decompress_mbps": 60.86
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 1,
-"out_size": 1275,
-"ratio": 0.3426,
-"compress_mbps": 30.33,
-"decompress_mbps": 25.75
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 2,
-"out_size": 1247,
-"ratio": 0.3351,
-"compress_mbps": 26.62,
-"decompress_mbps": 26.26
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 3,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 28.08,
-"decompress_mbps": 24.32
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 4,
-"out_size": 1238,
-"ratio": 0.3327,
-"compress_mbps": 27.91,
-"decompress_mbps": 26.5
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 5,
-"out_size": 1239,
-"ratio": 0.333,
-"compress_mbps": 23.23,
-"decompress_mbps": 26.4
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 6,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 33.51,
-"decompress_mbps": 26.22
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 7,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 26.3,
-"decompress_mbps": 26.34
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 8,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 24.78,
-"decompress_mbps": 26.52
-},
-{
-"compressor": "js",
-"pattern": "canterbury/grammar.lsp",
-"size": 3721,
-"level": 9,
-"out_size": 1237,
-"ratio": 0.3324,
-"compress_mbps": 21.78,
-"decompress_mbps": 28.52
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 1,
-"out_size": 226284,
-"ratio": 0.2197,
-"compress_mbps": 134.49,
-"decompress_mbps": 255.27
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 2,
-"out_size": 221369,
-"ratio": 0.215,
-"compress_mbps": 99.6,
-"decompress_mbps": 268.5
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 3,
-"out_size": 218607,
-"ratio": 0.2123,
-"compress_mbps": 89,
-"decompress_mbps": 272.02
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 4,
-"out_size": 217919,
-"ratio": 0.2116,
-"compress_mbps": 80.85,
-"decompress_mbps": 276.89
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 5,
-"out_size": 217919,
-"ratio": 0.2116,
-"compress_mbps": 81.27,
-"decompress_mbps": 277.27
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 6,
-"out_size": 217312,
-"ratio": 0.211,
-"compress_mbps": 54.76,
-"decompress_mbps": 270.88
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 7,
-"out_size": 215966,
-"ratio": 0.2097,
-"compress_mbps": 40.6,
-"decompress_mbps": 269.26
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 8,
-"out_size": 215930,
-"ratio": 0.2097,
-"compress_mbps": 19.55,
-"decompress_mbps": 274.47
-},
-{
-"compressor": "js",
-"pattern": "canterbury/kennedy.xls",
-"size": 1029744,
-"level": 9,
-"out_size": 215912,
-"ratio": 0.2097,
-"compress_mbps": 15.7,
-"decompress_mbps": 308.1
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 1,
-"out_size": 167622,
-"ratio": 0.3928,
-"compress_mbps": 62.33,
-"decompress_mbps": 106.11
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 2,
-"out_size": 158003,
-"ratio": 0.3702,
-"compress_mbps": 49.14,
-"decompress_mbps": 88.59
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 3,
-"out_size": 152928,
-"ratio": 0.3584,
-"compress_mbps": 49.6,
-"decompress_mbps": 96.98
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 4,
-"out_size": 149886,
-"ratio": 0.3512,
-"compress_mbps": 38.56,
-"decompress_mbps": 119.38
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 5,
-"out_size": 149767,
-"ratio": 0.3509,
-"compress_mbps": 40.53,
-"decompress_mbps": 85.64
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 6,
-"out_size": 147818,
-"ratio": 0.3464,
-"compress_mbps": 34.71,
-"decompress_mbps": 94.25
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 7,
-"out_size": 147733,
-"ratio": 0.3462,
-"compress_mbps": 32.03,
-"decompress_mbps": 99.55
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 8,
-"out_size": 147709,
-"ratio": 0.3461,
-"compress_mbps": 31.41,
-"decompress_mbps": 99.42
-},
-{
-"compressor": "js",
-"pattern": "canterbury/lcet10.txt",
-"size": 426754,
-"level": 9,
-"out_size": 147705,
-"ratio": 0.3461,
-"compress_mbps": 33.45,
-"decompress_mbps": 89.22
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 1,
-"out_size": 222866,
-"ratio": 0.4625,
-"compress_mbps": 71.4,
-"decompress_mbps": 143.74
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 2,
-"out_size": 212925,
-"ratio": 0.4419,
-"compress_mbps": 58.24,
-"decompress_mbps": 157.21
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 3,
-"out_size": 206913,
-"ratio": 0.4294,
-"compress_mbps": 40.37,
-"decompress_mbps": 119.73
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 4,
-"out_size": 202875,
-"ratio": 0.421,
-"compress_mbps": 35.81,
-"decompress_mbps": 112.43
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 5,
-"out_size": 202867,
-"ratio": 0.421,
-"compress_mbps": 35.22,
-"decompress_mbps": 176.5
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 6,
-"out_size": 199818,
-"ratio": 0.4147,
-"compress_mbps": 29.94,
-"decompress_mbps": 122.03
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 7,
-"out_size": 199664,
-"ratio": 0.4144,
-"compress_mbps": 29.08,
-"decompress_mbps": 164.03
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 8,
-"out_size": 199634,
-"ratio": 0.4143,
-"compress_mbps": 28.55,
-"decompress_mbps": 113.85
-},
-{
-"compressor": "js",
-"pattern": "canterbury/plrabn12.txt",
-"size": 481861,
-"level": 9,
-"out_size": 199634,
-"ratio": 0.4143,
-"compress_mbps": 28.96,
-"decompress_mbps": 160.17
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 1,
-"out_size": 60580,
-"ratio": 0.118,
-"compress_mbps": 135.13,
-"decompress_mbps": 168.22
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 2,
-"out_size": 59663,
-"ratio": 0.1163,
-"compress_mbps": 125.37,
-"decompress_mbps": 145.52
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 3,
-"out_size": 59465,
-"ratio": 0.1159,
-"compress_mbps": 117.64,
-"decompress_mbps": 329.46
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 4,
-"out_size": 59353,
-"ratio": 0.1156,
-"compress_mbps": 112.4,
-"decompress_mbps": 158.61
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 5,
-"out_size": 58830,
-"ratio": 0.1146,
-"compress_mbps": 106.94,
-"decompress_mbps": 138.94
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 6,
-"out_size": 57884,
-"ratio": 0.1128,
-"compress_mbps": 71.04,
-"decompress_mbps": 140.49
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 7,
-"out_size": 57206,
-"ratio": 0.1115,
-"compress_mbps": 57.86,
-"decompress_mbps": 137.88
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 8,
-"out_size": 56545,
-"ratio": 0.1102,
-"compress_mbps": 30.93,
-"decompress_mbps": 137.12
-},
-{
-"compressor": "js",
-"pattern": "canterbury/ptt5",
-"size": 513216,
-"level": 9,
-"out_size": 56454,
-"ratio": 0.11,
-"compress_mbps": 12.82,
-"decompress_mbps": 137.07
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 1,
-"out_size": 14194,
-"ratio": 0.3712,
-"compress_mbps": 62.96,
-"decompress_mbps": 62.62
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 2,
-"out_size": 13770,
-"ratio": 0.3601,
-"compress_mbps": 44.68,
-"decompress_mbps": 52.53
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 3,
-"out_size": 13611,
-"ratio": 0.3559,
-"compress_mbps": 60.61,
-"decompress_mbps": 48.72
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 4,
-"out_size": 13534,
-"ratio": 0.3539,
-"compress_mbps": 57.34,
-"decompress_mbps": 60.12
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 5,
-"out_size": 13527,
-"ratio": 0.3537,
-"compress_mbps": 57.3,
-"decompress_mbps": 55.11
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 6,
-"out_size": 13438,
-"ratio": 0.3514,
-"compress_mbps": 37.2,
-"decompress_mbps": 58.23
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 7,
-"out_size": 13419,
-"ratio": 0.3509,
-"compress_mbps": 50.17,
-"decompress_mbps": 60.53
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 8,
-"out_size": 13404,
-"ratio": 0.3505,
-"compress_mbps": 41.25,
-"decompress_mbps": 60.63
-},
-{
-"compressor": "js",
-"pattern": "canterbury/sum",
-"size": 38240,
-"level": 9,
-"out_size": 13390,
-"ratio": 0.3502,
-"compress_mbps": 24.99,
-"decompress_mbps": 60.66
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 1,
-"out_size": 1832,
-"ratio": 0.4334,
-"compress_mbps": 33.47,
-"decompress_mbps": 24.8
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 2,
-"out_size": 1776,
-"ratio": 0.4202,
-"compress_mbps": 28.92,
-"decompress_mbps": 28.77
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 3,
-"out_size": 1764,
-"ratio": 0.4173,
-"compress_mbps": 29.3,
-"decompress_mbps": 25.73
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 4,
-"out_size": 1763,
-"ratio": 0.4171,
-"compress_mbps": 37.31,
-"decompress_mbps": 29.49
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 5,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 27.55,
-"decompress_mbps": 29.7
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 6,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 28.12,
-"decompress_mbps": 27.83
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 7,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 26.98,
-"decompress_mbps": 27.73
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 8,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 23.43,
-"decompress_mbps": 29.45
-},
-{
-"compressor": "js",
-"pattern": "canterbury/xargs.1",
-"size": 4227,
-"level": 9,
-"out_size": 1760,
-"ratio": 0.4164,
-"compress_mbps": 21.87,
-"decompress_mbps": 28.32
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4462632,
-"ratio": 0.4378,
-"compress_mbps": 57.87,
-"decompress_mbps": 125.17
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 2,
-"out_size": 4244833,
-"ratio": 0.4165,
-"compress_mbps": 48.15,
-"decompress_mbps": 147.15
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 4112285,
-"ratio": 0.4035,
-"compress_mbps": 40.82,
-"decompress_mbps": 139.91
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 4,
-"out_size": 4020435,
-"ratio": 0.3945,
-"compress_mbps": 36.37,
-"decompress_mbps": 142.4
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 5,
-"out_size": 4019177,
-"ratio": 0.3943,
-"compress_mbps": 36.45,
-"decompress_mbps": 142.97
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3956464,
-"ratio": 0.3882,
-"compress_mbps": 30.24,
-"decompress_mbps": 159.85
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 7,
-"out_size": 3953310,
-"ratio": 0.3879,
-"compress_mbps": 29.41,
-"decompress_mbps": 146.27
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 8,
-"out_size": 3952872,
-"ratio": 0.3878,
-"compress_mbps": 29.15,
-"decompress_mbps": 161.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3952872,
-"ratio": 0.3878,
-"compress_mbps": 29.91,
-"decompress_mbps": 158.9
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20177423,
-"ratio": 0.3939,
-"compress_mbps": 79.22,
-"decompress_mbps": 165.46
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 2,
-"out_size": 19759467,
-"ratio": 0.3858,
-"compress_mbps": 69.86,
-"decompress_mbps": 153.08
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19583171,
-"ratio": 0.3823,
-"compress_mbps": 62.32,
-"decompress_mbps": 168.16
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 4,
-"out_size": 19479125,
-"ratio": 0.3803,
-"compress_mbps": 54.79,
-"decompress_mbps": 170.19
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 5,
-"out_size": 19423693,
-"ratio": 0.3792,
-"compress_mbps": 52.87,
-"decompress_mbps": 155.75
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 19337683,
-"ratio": 0.3775,
-"compress_mbps": 35.86,
-"decompress_mbps": 158.01
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 7,
-"out_size": 19323922,
-"ratio": 0.3773,
-"compress_mbps": 31.01,
-"decompress_mbps": 162.6
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 8,
-"out_size": 19314797,
-"ratio": 0.3771,
-"compress_mbps": 25.05,
-"decompress_mbps": 170.24
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 19312663,
-"ratio": 0.377,
-"compress_mbps": 10.78,
-"decompress_mbps": 170.64
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3762978,
-"ratio": 0.3774,
-"compress_mbps": 73.55,
-"decompress_mbps": 158.73
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 2,
-"out_size": 3711615,
-"ratio": 0.3723,
-"compress_mbps": 61.61,
-"decompress_mbps": 156.01
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3663131,
-"ratio": 0.3674,
-"compress_mbps": 54.17,
-"decompress_mbps": 162.95
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 4,
-"out_size": 3631512,
-"ratio": 0.3642,
-"compress_mbps": 47.67,
-"decompress_mbps": 162.23
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 5,
-"out_size": 3630867,
-"ratio": 0.3642,
-"compress_mbps": 47.3,
-"decompress_mbps": 136.29
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3615953,
-"ratio": 0.3627,
-"compress_mbps": 36.72,
-"decompress_mbps": 183.9
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 7,
-"out_size": 3615518,
-"ratio": 0.3626,
-"compress_mbps": 34.5,
-"decompress_mbps": 166.79
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 8,
-"out_size": 3613845,
-"ratio": 0.3625,
-"compress_mbps": 29.37,
-"decompress_mbps": 167.22
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3614283,
-"ratio": 0.3625,
-"compress_mbps": 25.49,
-"decompress_mbps": 152.16
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 4418800,
-"ratio": 0.1317,
-"compress_mbps": 147.78,
-"decompress_mbps": 255.76
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 2,
-"out_size": 4026774,
-"ratio": 0.12,
-"compress_mbps": 133.75,
-"decompress_mbps": 246.16
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3837798,
-"ratio": 0.1144,
-"compress_mbps": 127.06,
-"decompress_mbps": 265.57
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 4,
-"out_size": 3751023,
-"ratio": 0.1118,
-"compress_mbps": 119.47,
-"decompress_mbps": 276.82
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 5,
-"out_size": 3643468,
-"ratio": 0.1086,
-"compress_mbps": 109.94,
-"decompress_mbps": 278.05
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3379481,
-"ratio": 0.1007,
-"compress_mbps": 71.5,
-"decompress_mbps": 283.02
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 7,
-"out_size": 3354082,
-"ratio": 0.1,
-"compress_mbps": 63.54,
-"decompress_mbps": 278.98
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 8,
-"out_size": 3330028,
-"ratio": 0.0992,
-"compress_mbps": 48.52,
-"decompress_mbps": 294.14
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 3327482,
-"ratio": 0.0992,
-"compress_mbps": 38.14,
-"decompress_mbps": 281.8
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3233790,
-"ratio": 0.5256,
-"compress_mbps": 49.01,
-"decompress_mbps": 104.92
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 2,
-"out_size": 3184644,
-"ratio": 0.5176,
-"compress_mbps": 43.61,
-"decompress_mbps": 93.6
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3160521,
-"ratio": 0.5137,
-"compress_mbps": 39.95,
-"decompress_mbps": 118.96
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 4,
-"out_size": 3141929,
-"ratio": 0.5107,
-"compress_mbps": 36.7,
-"decompress_mbps": 111.6
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 5,
-"out_size": 3138514,
-"ratio": 0.5101,
-"compress_mbps": 36.34,
-"decompress_mbps": 96.01
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3126843,
-"ratio": 0.5082,
-"compress_mbps": 31.55,
-"decompress_mbps": 95.28
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 7,
-"out_size": 3126796,
-"ratio": 0.5082,
-"compress_mbps": 29.22,
-"decompress_mbps": 93.53
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 8,
-"out_size": 3126322,
-"ratio": 0.5082,
-"compress_mbps": 25.65,
-"decompress_mbps": 95.56
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3126286,
-"ratio": 0.5082,
-"compress_mbps": 22.12,
-"decompress_mbps": 94.53
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 4076349,
-"ratio": 0.4042,
-"compress_mbps": 70.62,
-"decompress_mbps": 128.6
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 2,
-"out_size": 3914739,
-"ratio": 0.3881,
-"compress_mbps": 65.68,
-"decompress_mbps": 162.69
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3845160,
-"ratio": 0.3812,
-"compress_mbps": 62.94,
-"decompress_mbps": 190.14
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 4,
-"out_size": 3822047,
-"ratio": 0.379,
-"compress_mbps": 61.07,
-"decompress_mbps": 175.36
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 5,
-"out_size": 3799472,
-"ratio": 0.3767,
-"compress_mbps": 56.83,
-"decompress_mbps": 195.63
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3783861,
-"ratio": 0.3752,
-"compress_mbps": 54.95,
-"decompress_mbps": 154.3
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 7,
-"out_size": 3783432,
-"ratio": 0.3751,
-"compress_mbps": 54.44,
-"decompress_mbps": 195.71
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 8,
-"out_size": 3783342,
-"ratio": 0.3751,
-"compress_mbps": 54.44,
-"decompress_mbps": 152.64
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3783342,
-"ratio": 0.3751,
-"compress_mbps": 54.41,
-"decompress_mbps": 153.36
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2261112,
-"ratio": 0.3412,
-"compress_mbps": 63.14,
-"decompress_mbps": 144.01
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 2,
-"out_size": 2128691,
-"ratio": 0.3212,
-"compress_mbps": 51.99,
-"decompress_mbps": 119.21
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2049023,
-"ratio": 0.3092,
-"compress_mbps": 42.59,
-"decompress_mbps": 136.54
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 4,
-"out_size": 1990249,
-"ratio": 0.3003,
-"compress_mbps": 36.52,
-"decompress_mbps": 119.84
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 5,
-"out_size": 1975224,
-"ratio": 0.298,
-"compress_mbps": 35.45,
-"decompress_mbps": 187.46
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1910262,
-"ratio": 0.2882,
-"compress_mbps": 26.28,
-"decompress_mbps": 116.08
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 7,
-"out_size": 1902923,
-"ratio": 0.2871,
-"compress_mbps": 24,
-"decompress_mbps": 193.41
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 8,
-"out_size": 1900964,
-"ratio": 0.2868,
-"compress_mbps": 22.36,
-"decompress_mbps": 150.61
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1900958,
-"ratio": 0.2868,
-"compress_mbps": 22.83,
-"decompress_mbps": 141.37
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 6016919,
-"ratio": 0.2785,
-"compress_mbps": 102.33,
-"decompress_mbps": 220.56
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 2,
-"out_size": 5767272,
-"ratio": 0.2669,
-"compress_mbps": 90.9,
-"decompress_mbps": 177.16
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5669548,
-"ratio": 0.2624,
-"compress_mbps": 81.47,
-"decompress_mbps": 209.95
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 4,
-"out_size": 5619947,
-"ratio": 0.2601,
-"compress_mbps": 73.58,
-"decompress_mbps": 212.53
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 5,
-"out_size": 5586034,
-"ratio": 0.2585,
-"compress_mbps": 69.19,
-"decompress_mbps": 216.46
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5540130,
-"ratio": 0.2564,
-"compress_mbps": 59.45,
-"decompress_mbps": 218.47
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 7,
-"out_size": 5537271,
-"ratio": 0.2563,
-"compress_mbps": 50.37,
-"decompress_mbps": 215.76
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 8,
-"out_size": 5530686,
-"ratio": 0.256,
-"compress_mbps": 39.81,
-"decompress_mbps": 229.67
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5529823,
-"ratio": 0.2559,
-"compress_mbps": 37.98,
-"decompress_mbps": 218.14
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5602819,
-"ratio": 0.7726,
-"compress_mbps": 43.77,
-"decompress_mbps": 122.65
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 2,
-"out_size": 5504019,
-"ratio": 0.759,
-"compress_mbps": 39.83,
-"decompress_mbps": 116.35
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5452816,
-"ratio": 0.7519,
-"compress_mbps": 36.31,
-"decompress_mbps": 101.11
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 4,
-"out_size": 5425752,
-"ratio": 0.7482,
-"compress_mbps": 33.34,
-"decompress_mbps": 111.95
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 5,
-"out_size": 5425752,
-"ratio": 0.7482,
-"compress_mbps": 33.33,
-"decompress_mbps": 134.03
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5407602,
-"ratio": 0.7457,
-"compress_mbps": 29.93,
-"decompress_mbps": 117.04
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 7,
-"out_size": 5406417,
-"ratio": 0.7455,
-"compress_mbps": 28.96,
-"decompress_mbps": 101.72
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 8,
-"out_size": 5406380,
-"ratio": 0.7455,
-"compress_mbps": 29.09,
-"decompress_mbps": 101.95
-},
-{
-"compressor": "js",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5406380,
-"ratio": 0.7455,
-"compress_mbps": 29.06,
-"decompress_mbps": 122.69
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 14342407,
-"ratio": 0.3459,
-"compress_mbps": 80.69,
-"decompress_mbps": 148.42
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 2,
-"out_size": 13424966,
-"ratio": 0.3238,
-"compress_mbps": 69.28,
-"decompress_mbps": 152.62
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 13061399,
-"ratio": 0.315,
-"compress_mbps": 61.33,
-"decompress_mbps": 154.49
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 4,
-"out_size": 12877207,
-"ratio": 0.3106,
-"compress_mbps": 55.43,
-"decompress_mbps": 148.12
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 5,
-"out_size": 12671090,
-"ratio": 0.3056,
-"compress_mbps": 51.73,
-"decompress_mbps": 148.74
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12511088,
-"ratio": 0.3018,
-"compress_mbps": 43.72,
-"decompress_mbps": 155.85
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 7,
-"out_size": 12503313,
-"ratio": 0.3016,
-"compress_mbps": 42.4,
-"decompress_mbps": 157.06
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 8,
-"out_size": 12502263,
-"ratio": 0.3016,
-"compress_mbps": 42.05,
-"decompress_mbps": 158.38
-},
-{
-"compressor": "js",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 12502263,
-"ratio": 0.3016,
-"compress_mbps": 42.14,
-"decompress_mbps": 158.28
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6022390,
-"ratio": 0.7107,
-"compress_mbps": 49.65,
-"decompress_mbps": 97.24
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 2,
-"out_size": 5997124,
-"ratio": 0.7077,
-"compress_mbps": 44.68,
-"decompress_mbps": 113.66
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 5979254,
-"ratio": 0.7056,
-"compress_mbps": 41.54,
-"decompress_mbps": 116.97
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 4,
-"out_size": 5967955,
-"ratio": 0.7042,
-"compress_mbps": 39.36,
-"decompress_mbps": 110.22
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 5,
-"out_size": 5967953,
-"ratio": 0.7042,
-"compress_mbps": 39.23,
-"decompress_mbps": 117.4
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5965386,
-"ratio": 0.7039,
-"compress_mbps": 39.35,
-"decompress_mbps": 117.27
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 7,
-"out_size": 5965383,
-"ratio": 0.7039,
-"compress_mbps": 39.62,
-"decompress_mbps": 117.2
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 8,
-"out_size": 5965383,
-"ratio": 0.7039,
-"compress_mbps": 39.1,
-"decompress_mbps": 98.58
-},
-{
-"compressor": "js",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5965383,
-"ratio": 0.7039,
-"compress_mbps": 40.18,
-"decompress_mbps": 98.47
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 985606,
-"ratio": 0.1844,
-"compress_mbps": 93.37,
-"decompress_mbps": 141.78
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 2,
-"out_size": 852636,
-"ratio": 0.1595,
-"compress_mbps": 89.07,
-"decompress_mbps": 238.96
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 814293,
-"ratio": 0.1523,
-"compress_mbps": 81.69,
-"decompress_mbps": 223.79
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 4,
-"out_size": 788388,
-"ratio": 0.1475,
-"compress_mbps": 79.24,
-"decompress_mbps": 251.87
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 5,
-"out_size": 749390,
-"ratio": 0.1402,
-"compress_mbps": 74.77,
-"decompress_mbps": 224.33
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 706892,
-"ratio": 0.1322,
-"compress_mbps": 60.77,
-"decompress_mbps": 269.34
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 7,
-"out_size": 705695,
-"ratio": 0.132,
-"compress_mbps": 58.98,
-"decompress_mbps": 181.3
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 8,
-"out_size": 703904,
-"ratio": 0.1317,
-"compress_mbps": 56.3,
-"decompress_mbps": 170.78
-},
-{
-"compressor": "js",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 703900,
-"ratio": 0.1317,
-"compress_mbps": 56.44,
-"decompress_mbps": 180.91
-}
-]
+ "meta": {
+  "date": "2026-07-06T00:06:40Z",
+  "machine": "Linux chungus2 x86_64",
+  "git_commit": "93184402",
+  "toolchain": "leanprover/lean4:v4.30.0-rc2",
+  "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
+ },
+ "results": [
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 60455,
+   "ratio": 0.3975,
+   "compress_mbps": 67.42,
+   "decompress_mbps": 111.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 56316,
+   "ratio": 0.3703,
+   "compress_mbps": 48.86,
+   "decompress_mbps": 124.33
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 55646,
+   "ratio": 0.3659,
+   "compress_mbps": 43.6,
+   "decompress_mbps": 135.39
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 54681,
+   "ratio": 0.3595,
+   "compress_mbps": 31.9,
+   "decompress_mbps": 138.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54437,
+   "ratio": 0.3579,
+   "compress_mbps": 25.31,
+   "decompress_mbps": 146.06
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54348,
+   "ratio": 0.3573,
+   "compress_mbps": 23.37,
+   "decompress_mbps": 150.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54140,
+   "ratio": 0.356,
+   "compress_mbps": 20.15,
+   "decompress_mbps": 150.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54127,
+   "ratio": 0.3559,
+   "compress_mbps": 19.6,
+   "decompress_mbps": 151.28
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 52732,
+   "ratio": 0.3467,
+   "compress_mbps": 4.09,
+   "decompress_mbps": 151.56
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 10,
+   "out_size": 52078,
+   "ratio": 0.3424,
+   "compress_mbps": 2.27,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 53135,
+   "ratio": 0.4245,
+   "compress_mbps": 61.19,
+   "decompress_mbps": 105.19
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50187,
+   "ratio": 0.4009,
+   "compress_mbps": 45.81,
+   "decompress_mbps": 112.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 49810,
+   "ratio": 0.3979,
+   "compress_mbps": 41.49,
+   "decompress_mbps": 122.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 48992,
+   "ratio": 0.3914,
+   "compress_mbps": 30.31,
+   "decompress_mbps": 126.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48891,
+   "ratio": 0.3906,
+   "compress_mbps": 26.17,
+   "decompress_mbps": 133.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48715,
+   "ratio": 0.3892,
+   "compress_mbps": 22.58,
+   "decompress_mbps": 136.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48634,
+   "ratio": 0.3885,
+   "compress_mbps": 21.11,
+   "decompress_mbps": 136.19
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48634,
+   "ratio": 0.3885,
+   "compress_mbps": 21.07,
+   "decompress_mbps": 136.77
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 47430,
+   "ratio": 0.3789,
+   "compress_mbps": 4.46,
+   "decompress_mbps": 136.89
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 10,
+   "out_size": 46865,
+   "ratio": 0.3744,
+   "compress_mbps": 2.65,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8476,
+   "ratio": 0.3445,
+   "compress_mbps": 61.16,
+   "decompress_mbps": 124.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8271,
+   "ratio": 0.3362,
+   "compress_mbps": 50.87,
+   "decompress_mbps": 129.03
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8158,
+   "ratio": 0.3316,
+   "compress_mbps": 49.21,
+   "decompress_mbps": 131.97
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 7961,
+   "ratio": 0.3236,
+   "compress_mbps": 42.93,
+   "decompress_mbps": 138.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7932,
+   "ratio": 0.3224,
+   "compress_mbps": 35.53,
+   "decompress_mbps": 142.07
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7938,
+   "ratio": 0.3226,
+   "compress_mbps": 29.57,
+   "decompress_mbps": 143.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7929,
+   "ratio": 0.3223,
+   "compress_mbps": 28.01,
+   "decompress_mbps": 145.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7929,
+   "ratio": 0.3223,
+   "compress_mbps": 27.99,
+   "decompress_mbps": 144.83
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7803,
+   "ratio": 0.3172,
+   "compress_mbps": 4.71,
+   "decompress_mbps": 144.7
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 10,
+   "out_size": 7737,
+   "ratio": 0.3145,
+   "compress_mbps": 2.79,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3509,
+   "ratio": 0.3147,
+   "compress_mbps": 46.9,
+   "decompress_mbps": 99.83
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3269,
+   "ratio": 0.2932,
+   "compress_mbps": 40.68,
+   "decompress_mbps": 102.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3208,
+   "ratio": 0.2877,
+   "compress_mbps": 39.7,
+   "decompress_mbps": 106.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3141,
+   "ratio": 0.2817,
+   "compress_mbps": 35.65,
+   "decompress_mbps": 108.65
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 31.5,
+   "decompress_mbps": 110.19
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3135,
+   "ratio": 0.2812,
+   "compress_mbps": 27.17,
+   "decompress_mbps": 111.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 26.1,
+   "decompress_mbps": 111.76
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 26.08,
+   "decompress_mbps": 112.41
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3056,
+   "ratio": 0.2741,
+   "compress_mbps": 5.23,
+   "decompress_mbps": 112.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 10,
+   "out_size": 3032,
+   "ratio": 0.2719,
+   "compress_mbps": 2.92,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1282,
+   "ratio": 0.3445,
+   "compress_mbps": 24.49,
+   "decompress_mbps": 56.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1225,
+   "ratio": 0.3292,
+   "compress_mbps": 22.99,
+   "decompress_mbps": 57.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1220,
+   "ratio": 0.3279,
+   "compress_mbps": 22.87,
+   "decompress_mbps": 57.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1213,
+   "ratio": 0.326,
+   "compress_mbps": 22.05,
+   "decompress_mbps": 58.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 21.34,
+   "decompress_mbps": 59.07
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 17.92,
+   "decompress_mbps": 59.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 17.9,
+   "decompress_mbps": 59.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 17.88,
+   "decompress_mbps": 59.16
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1205,
+   "ratio": 0.3238,
+   "compress_mbps": 4.81,
+   "decompress_mbps": 59.28
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 10,
+   "out_size": 1191,
+   "ratio": 0.3201,
+   "compress_mbps": 2.87,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 251793,
+   "ratio": 0.2445,
+   "compress_mbps": 127.59,
+   "decompress_mbps": 208.75
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 242565,
+   "ratio": 0.2356,
+   "compress_mbps": 89.08,
+   "decompress_mbps": 223.03
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 242532,
+   "ratio": 0.2355,
+   "compress_mbps": 75.34,
+   "decompress_mbps": 232.79
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 239804,
+   "ratio": 0.2329,
+   "compress_mbps": 69.9,
+   "decompress_mbps": 240.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 215530,
+   "ratio": 0.2093,
+   "compress_mbps": 39.78,
+   "decompress_mbps": 234.76
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 201414,
+   "ratio": 0.1956,
+   "compress_mbps": 31.12,
+   "decompress_mbps": 242.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 200711,
+   "ratio": 0.1949,
+   "compress_mbps": 20.89,
+   "decompress_mbps": 245.23
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 200719,
+   "ratio": 0.1949,
+   "compress_mbps": 14.56,
+   "decompress_mbps": 247.84
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 182508,
+   "ratio": 0.1772,
+   "compress_mbps": 2.96,
+   "decompress_mbps": 248.54
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 10,
+   "out_size": 178067,
+   "ratio": 0.1729,
+   "compress_mbps": 1.33,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 160674,
+   "ratio": 0.3765,
+   "compress_mbps": 72.63,
+   "decompress_mbps": 118.86
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 149787,
+   "ratio": 0.351,
+   "compress_mbps": 51.15,
+   "decompress_mbps": 105.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 148055,
+   "ratio": 0.3469,
+   "compress_mbps": 45.79,
+   "decompress_mbps": 140.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 145631,
+   "ratio": 0.3413,
+   "compress_mbps": 34.34,
+   "decompress_mbps": 144.94
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145321,
+   "ratio": 0.3405,
+   "compress_mbps": 27.16,
+   "decompress_mbps": 151.94
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 145046,
+   "ratio": 0.3399,
+   "compress_mbps": 24.63,
+   "decompress_mbps": 151.3
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144554,
+   "ratio": 0.3387,
+   "compress_mbps": 22.35,
+   "decompress_mbps": 158.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144540,
+   "ratio": 0.3387,
+   "compress_mbps": 21.74,
+   "decompress_mbps": 157.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 140322,
+   "ratio": 0.3288,
+   "compress_mbps": 3.96,
+   "decompress_mbps": 157.51
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 10,
+   "out_size": 138830,
+   "ratio": 0.3253,
+   "compress_mbps": 2.37,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 212588,
+   "ratio": 0.4412,
+   "compress_mbps": 61.1,
+   "decompress_mbps": 100.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 199981,
+   "ratio": 0.415,
+   "compress_mbps": 44.64,
+   "decompress_mbps": 109.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 198551,
+   "ratio": 0.4121,
+   "compress_mbps": 39.45,
+   "decompress_mbps": 119.54
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 195460,
+   "ratio": 0.4056,
+   "compress_mbps": 26.67,
+   "decompress_mbps": 122.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 194902,
+   "ratio": 0.4045,
+   "compress_mbps": 22.37,
+   "decompress_mbps": 128.97
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195177,
+   "ratio": 0.405,
+   "compress_mbps": 21.19,
+   "decompress_mbps": 132.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194385,
+   "ratio": 0.4034,
+   "compress_mbps": 18.51,
+   "decompress_mbps": 133.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194380,
+   "ratio": 0.4034,
+   "compress_mbps": 18.38,
+   "decompress_mbps": 133.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 189365,
+   "ratio": 0.393,
+   "compress_mbps": 3.89,
+   "decompress_mbps": 133.39
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 10,
+   "out_size": 186147,
+   "ratio": 0.3863,
+   "compress_mbps": 2.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60161,
+   "ratio": 0.1172,
+   "compress_mbps": 205.6,
+   "decompress_mbps": 343.71
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 58873,
+   "ratio": 0.1147,
+   "compress_mbps": 152.89,
+   "decompress_mbps": 359.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 58327,
+   "ratio": 0.1137,
+   "compress_mbps": 131.82,
+   "decompress_mbps": 381.94
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 55673,
+   "ratio": 0.1085,
+   "compress_mbps": 88.0,
+   "decompress_mbps": 357.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 54950,
+   "ratio": 0.1071,
+   "compress_mbps": 60.35,
+   "decompress_mbps": 380.37
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55259,
+   "ratio": 0.1077,
+   "compress_mbps": 49.82,
+   "decompress_mbps": 406.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 53713,
+   "ratio": 0.1047,
+   "compress_mbps": 35.97,
+   "decompress_mbps": 428.28
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52897,
+   "ratio": 0.1031,
+   "compress_mbps": 29.87,
+   "decompress_mbps": 458.65
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52729,
+   "ratio": 0.1027,
+   "compress_mbps": 5.07,
+   "decompress_mbps": 469.76
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 10,
+   "out_size": 52234,
+   "ratio": 0.1018,
+   "compress_mbps": 3.39,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14249,
+   "ratio": 0.3726,
+   "compress_mbps": 51.67,
+   "decompress_mbps": 113.74
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13825,
+   "ratio": 0.3615,
+   "compress_mbps": 44.99,
+   "decompress_mbps": 116.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13751,
+   "ratio": 0.3596,
+   "compress_mbps": 43.35,
+   "decompress_mbps": 117.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13366,
+   "ratio": 0.3495,
+   "compress_mbps": 37.02,
+   "decompress_mbps": 124.0
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13346,
+   "ratio": 0.349,
+   "compress_mbps": 31.42,
+   "decompress_mbps": 129.69
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13040,
+   "ratio": 0.341,
+   "compress_mbps": 16.57,
+   "decompress_mbps": 132.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13035,
+   "ratio": 0.3409,
+   "compress_mbps": 14.86,
+   "decompress_mbps": 133.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13028,
+   "ratio": 0.3407,
+   "compress_mbps": 13.26,
+   "decompress_mbps": 135.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12427,
+   "ratio": 0.325,
+   "compress_mbps": 4.8,
+   "decompress_mbps": 136.55
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 10,
+   "out_size": 12274,
+   "ratio": 0.321,
+   "compress_mbps": 2.83,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1800,
+   "ratio": 0.4258,
+   "compress_mbps": 25.77,
+   "decompress_mbps": 57.95
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1750,
+   "ratio": 0.414,
+   "compress_mbps": 24.22,
+   "decompress_mbps": 58.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 24.17,
+   "decompress_mbps": 58.56
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1732,
+   "ratio": 0.4097,
+   "compress_mbps": 23.41,
+   "decompress_mbps": 59.7
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 22.92,
+   "decompress_mbps": 59.88
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 18.22,
+   "decompress_mbps": 60.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 18.23,
+   "decompress_mbps": 59.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 18.22,
+   "decompress_mbps": 60.01
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1708,
+   "ratio": 0.4041,
+   "compress_mbps": 5.27,
+   "decompress_mbps": 59.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 10,
+   "out_size": 1693,
+   "ratio": 0.4005,
+   "compress_mbps": 3.17,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 65130,
+   "ratio": 0.4282,
+   "compress_mbps": 119.16,
+   "decompress_mbps": 393.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 62270,
+   "ratio": 0.4094,
+   "compress_mbps": 102.04,
+   "decompress_mbps": 412.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 59488,
+   "ratio": 0.3911,
+   "compress_mbps": 67.18,
+   "decompress_mbps": 427.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 57679,
+   "ratio": 0.3792,
+   "compress_mbps": 71.84,
+   "decompress_mbps": 406.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 55616,
+   "ratio": 0.3657,
+   "compress_mbps": 41.94,
+   "decompress_mbps": 399.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54398,
+   "ratio": 0.3577,
+   "compress_mbps": 25.54,
+   "decompress_mbps": 412.45
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54253,
+   "ratio": 0.3567,
+   "compress_mbps": 21.44,
+   "decompress_mbps": 414.47
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54164,
+   "ratio": 0.3561,
+   "compress_mbps": 17.0,
+   "decompress_mbps": 415.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54164,
+   "ratio": 0.3561,
+   "compress_mbps": 16.98,
+   "decompress_mbps": 416.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 56791,
+   "ratio": 0.4537,
+   "compress_mbps": 115.48,
+   "decompress_mbps": 386.4
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 54652,
+   "ratio": 0.4366,
+   "compress_mbps": 97.99,
+   "decompress_mbps": 401.9
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 52663,
+   "ratio": 0.4207,
+   "compress_mbps": 62.55,
+   "decompress_mbps": 432.53
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 51266,
+   "ratio": 0.4095,
+   "compress_mbps": 67.6,
+   "decompress_mbps": 400.76
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 49622,
+   "ratio": 0.3964,
+   "compress_mbps": 37.32,
+   "decompress_mbps": 387.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48891,
+   "ratio": 0.3906,
+   "compress_mbps": 22.79,
+   "decompress_mbps": 395.44
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48801,
+   "ratio": 0.3898,
+   "compress_mbps": 20.01,
+   "decompress_mbps": 395.17
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48772,
+   "ratio": 0.3896,
+   "compress_mbps": 18.12,
+   "decompress_mbps": 395.78
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48772,
+   "ratio": 0.3896,
+   "compress_mbps": 18.11,
+   "decompress_mbps": 395.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 9028,
+   "ratio": 0.3669,
+   "compress_mbps": 413.16,
+   "decompress_mbps": 1048.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8811,
+   "ratio": 0.3581,
+   "compress_mbps": 216.27,
+   "decompress_mbps": 1072.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8616,
+   "ratio": 0.3502,
+   "compress_mbps": 155.32,
+   "decompress_mbps": 1108.48
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8219,
+   "ratio": 0.3341,
+   "compress_mbps": 115.91,
+   "decompress_mbps": 1125.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8001,
+   "ratio": 0.3252,
+   "compress_mbps": 85.05,
+   "decompress_mbps": 1145.5
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7955,
+   "ratio": 0.3233,
+   "compress_mbps": 68.88,
+   "decompress_mbps": 1156.57
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7933,
+   "ratio": 0.3224,
+   "compress_mbps": 63.0,
+   "decompress_mbps": 1160.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7934,
+   "ratio": 0.3225,
+   "compress_mbps": 58.11,
+   "decompress_mbps": 1157.25
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7934,
+   "ratio": 0.3225,
+   "compress_mbps": 57.98,
+   "decompress_mbps": 1156.91
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3647,
+   "ratio": 0.3271,
+   "compress_mbps": 426.88,
+   "decompress_mbps": 1068.91
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3501,
+   "ratio": 0.314,
+   "compress_mbps": 408.45,
+   "decompress_mbps": 1109.39
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3393,
+   "ratio": 0.3043,
+   "compress_mbps": 338.89,
+   "decompress_mbps": 1135.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3215,
+   "ratio": 0.2883,
+   "compress_mbps": 274.69,
+   "decompress_mbps": 1169.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3140,
+   "ratio": 0.2816,
+   "compress_mbps": 206.54,
+   "decompress_mbps": 1204.24
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 154.05,
+   "decompress_mbps": 1215.11
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 132.02,
+   "decompress_mbps": 1220.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3109,
+   "ratio": 0.2788,
+   "compress_mbps": 111.36,
+   "decompress_mbps": 1211.79
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3109,
+   "ratio": 0.2788,
+   "compress_mbps": 111.17,
+   "decompress_mbps": 1221.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1326,
+   "ratio": 0.3564,
+   "compress_mbps": 316.62,
+   "decompress_mbps": 784.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1306,
+   "ratio": 0.351,
+   "compress_mbps": 310.47,
+   "decompress_mbps": 775.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1301,
+   "ratio": 0.3496,
+   "compress_mbps": 291.4,
+   "decompress_mbps": 783.71
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1228,
+   "ratio": 0.33,
+   "compress_mbps": 233.74,
+   "decompress_mbps": 819.16
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 199.28,
+   "decompress_mbps": 811.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 178.18,
+   "decompress_mbps": 810.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 170.94,
+   "decompress_mbps": 816.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 168.09,
+   "decompress_mbps": 815.03
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 167.98,
+   "decompress_mbps": 812.97
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 242293,
+   "ratio": 0.2353,
+   "compress_mbps": 262.08,
+   "decompress_mbps": 830.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 233553,
+   "ratio": 0.2268,
+   "compress_mbps": 247.77,
+   "decompress_mbps": 981.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 228222,
+   "ratio": 0.2216,
+   "compress_mbps": 195.24,
+   "decompress_mbps": 1038.02
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 223668,
+   "ratio": 0.2172,
+   "compress_mbps": 177.62,
+   "decompress_mbps": 1069.05
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 205994,
+   "ratio": 0.2,
+   "compress_mbps": 110.2,
+   "decompress_mbps": 1028.7
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 203986,
+   "ratio": 0.1981,
+   "compress_mbps": 49.93,
+   "decompress_mbps": 1032.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 207681,
+   "ratio": 0.2017,
+   "compress_mbps": 37.01,
+   "decompress_mbps": 1024.77
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 206827,
+   "ratio": 0.2009,
+   "compress_mbps": 7.3,
+   "decompress_mbps": 996.72
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 207023,
+   "ratio": 0.201,
+   "compress_mbps": 3.43,
+   "decompress_mbps": 994.12
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 174124,
+   "ratio": 0.408,
+   "compress_mbps": 123.62,
+   "decompress_mbps": 391.8
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 166150,
+   "ratio": 0.3893,
+   "compress_mbps": 104.81,
+   "decompress_mbps": 401.7
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 158784,
+   "ratio": 0.3721,
+   "compress_mbps": 70.23,
+   "decompress_mbps": 419.82
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 152782,
+   "ratio": 0.358,
+   "compress_mbps": 73.72,
+   "decompress_mbps": 407.18
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 147196,
+   "ratio": 0.3449,
+   "compress_mbps": 43.35,
+   "decompress_mbps": 401.98
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144898,
+   "ratio": 0.3395,
+   "compress_mbps": 26.3,
+   "decompress_mbps": 412.86
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144589,
+   "ratio": 0.3388,
+   "compress_mbps": 22.81,
+   "decompress_mbps": 413.61
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144436,
+   "ratio": 0.3385,
+   "compress_mbps": 19.6,
+   "decompress_mbps": 413.12
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144433,
+   "ratio": 0.3384,
+   "compress_mbps": 19.54,
+   "decompress_mbps": 413.31
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 228883,
+   "ratio": 0.475,
+   "compress_mbps": 107.83,
+   "decompress_mbps": 367.64
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 219047,
+   "ratio": 0.4546,
+   "compress_mbps": 90.66,
+   "decompress_mbps": 385.82
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 209408,
+   "ratio": 0.4346,
+   "compress_mbps": 55.28,
+   "decompress_mbps": 400.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 205916,
+   "ratio": 0.4273,
+   "compress_mbps": 62.18,
+   "decompress_mbps": 375.5
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 199188,
+   "ratio": 0.4134,
+   "compress_mbps": 32.87,
+   "decompress_mbps": 358.02
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195255,
+   "ratio": 0.4052,
+   "compress_mbps": 19.31,
+   "decompress_mbps": 359.99
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194657,
+   "ratio": 0.404,
+   "compress_mbps": 16.33,
+   "decompress_mbps": 360.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194326,
+   "ratio": 0.4033,
+   "compress_mbps": 12.9,
+   "decompress_mbps": 366.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 194326,
+   "ratio": 0.4033,
+   "compress_mbps": 12.9,
+   "decompress_mbps": 362.41
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 65553,
+   "ratio": 0.1277,
+   "compress_mbps": 273.36,
+   "decompress_mbps": 876.91
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 63891,
+   "ratio": 0.1245,
+   "compress_mbps": 247.13,
+   "decompress_mbps": 903.46
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 62515,
+   "ratio": 0.1218,
+   "compress_mbps": 193.01,
+   "decompress_mbps": 962.2
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 58451,
+   "ratio": 0.1139,
+   "compress_mbps": 168.63,
+   "decompress_mbps": 693.08
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 57410,
+   "ratio": 0.1119,
+   "compress_mbps": 130.05,
+   "decompress_mbps": 721.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 56459,
+   "ratio": 0.11,
+   "compress_mbps": 76.97,
+   "decompress_mbps": 771.47
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 55358,
+   "ratio": 0.1079,
+   "compress_mbps": 60.1,
+   "decompress_mbps": 803.98
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52991,
+   "ratio": 0.1033,
+   "compress_mbps": 27.44,
+   "decompress_mbps": 859.31
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52215,
+   "ratio": 0.1017,
+   "compress_mbps": 9.79,
+   "decompress_mbps": 872.15
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14112,
+   "ratio": 0.369,
+   "compress_mbps": 128.53,
+   "decompress_mbps": 939.3
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13815,
+   "ratio": 0.3613,
+   "compress_mbps": 109.01,
+   "decompress_mbps": 977.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13795,
+   "ratio": 0.3607,
+   "compress_mbps": 78.92,
+   "decompress_mbps": 1019.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13375,
+   "ratio": 0.3498,
+   "compress_mbps": 80.43,
+   "decompress_mbps": 996.76
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13062,
+   "ratio": 0.3416,
+   "compress_mbps": 55.68,
+   "decompress_mbps": 1020.16
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12984,
+   "ratio": 0.3395,
+   "compress_mbps": 33.03,
+   "decompress_mbps": 1058.22
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12949,
+   "ratio": 0.3386,
+   "compress_mbps": 25.4,
+   "decompress_mbps": 1066.55
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12894,
+   "ratio": 0.3372,
+   "compress_mbps": 11.05,
+   "decompress_mbps": 1073.99
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12832,
+   "ratio": 0.3356,
+   "compress_mbps": 5.08,
+   "decompress_mbps": 1078.09
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1846,
+   "ratio": 0.4367,
+   "compress_mbps": 291.54,
+   "decompress_mbps": 710.22
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1820,
+   "ratio": 0.4306,
+   "compress_mbps": 285.68,
+   "decompress_mbps": 721.53
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1808,
+   "ratio": 0.4277,
+   "compress_mbps": 273.13,
+   "decompress_mbps": 722.95
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1749,
+   "ratio": 0.4138,
+   "compress_mbps": 226.8,
+   "decompress_mbps": 747.21
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 202.13,
+   "decompress_mbps": 753.35
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 199.33,
+   "decompress_mbps": 752.79
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 196.97,
+   "decompress_mbps": 754.48
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 197.03,
+   "decompress_mbps": 752.65
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 197.14,
+   "decompress_mbps": 753.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 76470,
+   "ratio": 0.5028,
+   "compress_mbps": 157.78,
+   "decompress_mbps": 442.94
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 62765,
+   "ratio": 0.4127,
+   "compress_mbps": 132.14,
+   "decompress_mbps": 490.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 57162,
+   "ratio": 0.3758,
+   "compress_mbps": 72.22,
+   "decompress_mbps": 551.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56826,
+   "ratio": 0.3736,
+   "compress_mbps": 64.16,
+   "decompress_mbps": 535.92
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 55696,
+   "ratio": 0.3662,
+   "compress_mbps": 46.86,
+   "decompress_mbps": 525.1
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54440,
+   "ratio": 0.3579,
+   "compress_mbps": 26.56,
+   "decompress_mbps": 542.84
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54283,
+   "ratio": 0.3569,
+   "compress_mbps": 22.4,
+   "decompress_mbps": 543.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54221,
+   "ratio": 0.3565,
+   "compress_mbps": 19.71,
+   "decompress_mbps": 544.04
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54217,
+   "ratio": 0.3565,
+   "compress_mbps": 19.49,
+   "decompress_mbps": 546.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 64926,
+   "ratio": 0.5187,
+   "compress_mbps": 151.42,
+   "decompress_mbps": 421.18
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 54985,
+   "ratio": 0.4393,
+   "compress_mbps": 123.65,
+   "decompress_mbps": 467.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51148,
+   "ratio": 0.4086,
+   "compress_mbps": 67.07,
+   "decompress_mbps": 534.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50599,
+   "ratio": 0.4042,
+   "compress_mbps": 58.95,
+   "decompress_mbps": 519.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 49775,
+   "ratio": 0.3976,
+   "compress_mbps": 42.66,
+   "decompress_mbps": 506.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48967,
+   "ratio": 0.3912,
+   "compress_mbps": 24.99,
+   "decompress_mbps": 519.13
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48870,
+   "ratio": 0.3904,
+   "compress_mbps": 22.17,
+   "decompress_mbps": 525.91
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48845,
+   "ratio": 0.3902,
+   "compress_mbps": 20.89,
+   "decompress_mbps": 523.43
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48845,
+   "ratio": 0.3902,
+   "compress_mbps": 20.9,
+   "decompress_mbps": 518.44
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 10024,
+   "ratio": 0.4074,
+   "compress_mbps": 531.61,
+   "decompress_mbps": 900.15
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8577,
+   "ratio": 0.3486,
+   "compress_mbps": 261.38,
+   "decompress_mbps": 926.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8168,
+   "ratio": 0.332,
+   "compress_mbps": 156.0,
+   "decompress_mbps": 944.92
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8069,
+   "ratio": 0.328,
+   "compress_mbps": 114.85,
+   "decompress_mbps": 969.72
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7997,
+   "ratio": 0.325,
+   "compress_mbps": 100.16,
+   "decompress_mbps": 998.61
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7952,
+   "ratio": 0.3232,
+   "compress_mbps": 74.97,
+   "decompress_mbps": 1005.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 72.58,
+   "decompress_mbps": 1011.17
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 71.43,
+   "decompress_mbps": 1011.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 71.29,
+   "decompress_mbps": 1010.78
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 4061,
+   "ratio": 0.3642,
+   "compress_mbps": 489.84,
+   "decompress_mbps": 854.64
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3446,
+   "ratio": 0.3091,
+   "compress_mbps": 305.95,
+   "decompress_mbps": 893.64
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3201,
+   "ratio": 0.2871,
+   "compress_mbps": 233.51,
+   "decompress_mbps": 927.8
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 193.82,
+   "decompress_mbps": 956.16
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3139,
+   "ratio": 0.2815,
+   "compress_mbps": 162.46,
+   "decompress_mbps": 972.16
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3115,
+   "ratio": 0.2794,
+   "compress_mbps": 116.38,
+   "decompress_mbps": 985.86
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 106.48,
+   "decompress_mbps": 989.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 103.65,
+   "decompress_mbps": 993.13
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 103.26,
+   "decompress_mbps": 992.76
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1410,
+   "ratio": 0.3789,
+   "compress_mbps": 366.9,
+   "decompress_mbps": 596.01
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1262,
+   "ratio": 0.3392,
+   "compress_mbps": 234.45,
+   "decompress_mbps": 604.74
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1238,
+   "ratio": 0.3327,
+   "compress_mbps": 203.34,
+   "decompress_mbps": 605.36
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 174.55,
+   "decompress_mbps": 620.28
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 160.35,
+   "decompress_mbps": 629.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 146.33,
+   "decompress_mbps": 631.65
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 145.11,
+   "decompress_mbps": 634.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 145.24,
+   "decompress_mbps": 633.23
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 144.99,
+   "decompress_mbps": 630.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 274412,
+   "ratio": 0.2665,
+   "compress_mbps": 449.9,
+   "decompress_mbps": 793.96
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 213239,
+   "ratio": 0.2071,
+   "compress_mbps": 272.27,
+   "decompress_mbps": 896.17
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 232107,
+   "ratio": 0.2254,
+   "compress_mbps": 136.67,
+   "decompress_mbps": 941.49
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 202733,
+   "ratio": 0.1969,
+   "compress_mbps": 129.64,
+   "decompress_mbps": 941.54
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 207803,
+   "ratio": 0.2018,
+   "compress_mbps": 84.14,
+   "decompress_mbps": 955.89
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 205270,
+   "ratio": 0.1993,
+   "compress_mbps": 27.3,
+   "decompress_mbps": 979.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 209951,
+   "ratio": 0.2039,
+   "compress_mbps": 19.31,
+   "decompress_mbps": 995.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 209656,
+   "ratio": 0.2036,
+   "compress_mbps": 12.24,
+   "decompress_mbps": 1009.18
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 209189,
+   "ratio": 0.2031,
+   "compress_mbps": 8.96,
+   "decompress_mbps": 1011.13
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 208640,
+   "ratio": 0.4889,
+   "compress_mbps": 157.45,
+   "decompress_mbps": 423.89
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 167329,
+   "ratio": 0.3921,
+   "compress_mbps": 137.6,
+   "decompress_mbps": 464.74
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 151097,
+   "ratio": 0.3541,
+   "compress_mbps": 73.65,
+   "decompress_mbps": 512.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 150035,
+   "ratio": 0.3516,
+   "compress_mbps": 66.13,
+   "decompress_mbps": 509.05
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 147375,
+   "ratio": 0.3453,
+   "compress_mbps": 48.14,
+   "decompress_mbps": 506.78
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144908,
+   "ratio": 0.3396,
+   "compress_mbps": 28.05,
+   "decompress_mbps": 518.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144562,
+   "ratio": 0.3387,
+   "compress_mbps": 24.64,
+   "decompress_mbps": 518.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144449,
+   "ratio": 0.3385,
+   "compress_mbps": 22.4,
+   "decompress_mbps": 516.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144438,
+   "ratio": 0.3385,
+   "compress_mbps": 22.34,
+   "decompress_mbps": 517.74
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 264549,
+   "ratio": 0.549,
+   "compress_mbps": 136.07,
+   "decompress_mbps": 376.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 223724,
+   "ratio": 0.4643,
+   "compress_mbps": 118.11,
+   "decompress_mbps": 422.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 204825,
+   "ratio": 0.4251,
+   "compress_mbps": 60.64,
+   "decompress_mbps": 477.68
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 203945,
+   "ratio": 0.4232,
+   "compress_mbps": 53.78,
+   "decompress_mbps": 471.87
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 199780,
+   "ratio": 0.4146,
+   "compress_mbps": 37.88,
+   "decompress_mbps": 455.85
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195417,
+   "ratio": 0.4055,
+   "compress_mbps": 21.15,
+   "decompress_mbps": 465.48
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194796,
+   "ratio": 0.4043,
+   "compress_mbps": 17.87,
+   "decompress_mbps": 466.91
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194543,
+   "ratio": 0.4037,
+   "compress_mbps": 15.68,
+   "decompress_mbps": 465.89
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 194460,
+   "ratio": 0.4036,
+   "compress_mbps": 15.02,
+   "decompress_mbps": 465.94
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 67436,
+   "ratio": 0.1314,
+   "compress_mbps": 626.36,
+   "decompress_mbps": 1001.38
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 59257,
+   "ratio": 0.1155,
+   "compress_mbps": 276.28,
+   "decompress_mbps": 1056.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 58316,
+   "ratio": 0.1136,
+   "compress_mbps": 180.05,
+   "decompress_mbps": 1135.86
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 56291,
+   "ratio": 0.1097,
+   "compress_mbps": 183.07,
+   "decompress_mbps": 1151.41
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 56220,
+   "ratio": 0.1095,
+   "compress_mbps": 144.89,
+   "decompress_mbps": 1205.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55972,
+   "ratio": 0.1091,
+   "compress_mbps": 74.28,
+   "decompress_mbps": 1269.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 55121,
+   "ratio": 0.1074,
+   "compress_mbps": 51.98,
+   "decompress_mbps": 1309.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 54124,
+   "ratio": 0.1055,
+   "compress_mbps": 36.61,
+   "decompress_mbps": 1367.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 53699,
+   "ratio": 0.1046,
+   "compress_mbps": 28.61,
+   "decompress_mbps": 1404.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 15612,
+   "ratio": 0.4083,
+   "compress_mbps": 513.43,
+   "decompress_mbps": 865.99
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 14133,
+   "ratio": 0.3696,
+   "compress_mbps": 144.5,
+   "decompress_mbps": 895.42
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13341,
+   "ratio": 0.3489,
+   "compress_mbps": 87.64,
+   "decompress_mbps": 919.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13289,
+   "ratio": 0.3475,
+   "compress_mbps": 82.82,
+   "decompress_mbps": 945.1
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13052,
+   "ratio": 0.3413,
+   "compress_mbps": 66.19,
+   "decompress_mbps": 984.73
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12996,
+   "ratio": 0.3399,
+   "compress_mbps": 37.0,
+   "decompress_mbps": 1002.74
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12972,
+   "ratio": 0.3392,
+   "compress_mbps": 27.16,
+   "decompress_mbps": 1006.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12951,
+   "ratio": 0.3387,
+   "compress_mbps": 19.0,
+   "decompress_mbps": 1014.42
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12933,
+   "ratio": 0.3382,
+   "compress_mbps": 14.84,
+   "decompress_mbps": 1016.18
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1988,
+   "ratio": 0.4703,
+   "compress_mbps": 352.16,
+   "decompress_mbps": 550.26
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1802,
+   "ratio": 0.4263,
+   "compress_mbps": 218.43,
+   "decompress_mbps": 554.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 205.02,
+   "decompress_mbps": 556.18
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1732,
+   "ratio": 0.4097,
+   "compress_mbps": 169.87,
+   "decompress_mbps": 571.64
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 166.82,
+   "decompress_mbps": 581.2
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 165.11,
+   "decompress_mbps": 580.19
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 165.65,
+   "decompress_mbps": 581.36
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 164.8,
+   "decompress_mbps": 583.89
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 165.0,
+   "decompress_mbps": 583.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 59790,
+   "ratio": 0.3931,
+   "compress_mbps": 259.33,
+   "decompress_mbps": 996.52
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 57173,
+   "ratio": 0.3759,
+   "compress_mbps": 180.49,
+   "decompress_mbps": 1070.19
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 56189,
+   "ratio": 0.3694,
+   "compress_mbps": 150.33,
+   "decompress_mbps": 1145.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 55816,
+   "ratio": 0.367,
+   "compress_mbps": 137.81,
+   "decompress_mbps": 1185.99
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54758,
+   "ratio": 0.36,
+   "compress_mbps": 108.84,
+   "decompress_mbps": 1238.7
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54220,
+   "ratio": 0.3565,
+   "compress_mbps": 84.22,
+   "decompress_mbps": 1278.06
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 53801,
+   "ratio": 0.3537,
+   "compress_mbps": 60.73,
+   "decompress_mbps": 1281.4
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 53573,
+   "ratio": 0.3522,
+   "compress_mbps": 39.0,
+   "decompress_mbps": 1280.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 53546,
+   "ratio": 0.3521,
+   "compress_mbps": 34.45,
+   "decompress_mbps": 1277.72
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 10,
+   "out_size": 51721,
+   "ratio": 0.3401,
+   "compress_mbps": 12.18,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 11,
+   "out_size": 51662,
+   "ratio": 0.3397,
+   "compress_mbps": 8.34,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 12,
+   "out_size": 51662,
+   "ratio": 0.3397,
+   "compress_mbps": 5.1,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 52276,
+   "ratio": 0.4176,
+   "compress_mbps": 241.61,
+   "decompress_mbps": 939.42
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50534,
+   "ratio": 0.4037,
+   "compress_mbps": 168.24,
+   "decompress_mbps": 989.01
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 49919,
+   "ratio": 0.3988,
+   "compress_mbps": 141.33,
+   "decompress_mbps": 1053.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 49715,
+   "ratio": 0.3972,
+   "compress_mbps": 130.46,
+   "decompress_mbps": 1090.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48735,
+   "ratio": 0.3893,
+   "compress_mbps": 100.2,
+   "decompress_mbps": 1139.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48422,
+   "ratio": 0.3868,
+   "compress_mbps": 79.3,
+   "decompress_mbps": 1156.59
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48249,
+   "ratio": 0.3854,
+   "compress_mbps": 60.96,
+   "decompress_mbps": 1163.41
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 47977,
+   "ratio": 0.3833,
+   "compress_mbps": 43.03,
+   "decompress_mbps": 1166.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 47971,
+   "ratio": 0.3832,
+   "compress_mbps": 41.09,
+   "decompress_mbps": 1165.4
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 10,
+   "out_size": 46657,
+   "ratio": 0.3727,
+   "compress_mbps": 13.62,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 11,
+   "out_size": 46515,
+   "ratio": 0.3716,
+   "compress_mbps": 9.25,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 12,
+   "out_size": 46469,
+   "ratio": 0.3712,
+   "compress_mbps": 7.05,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8385,
+   "ratio": 0.3408,
+   "compress_mbps": 695.0,
+   "decompress_mbps": 957.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8380,
+   "ratio": 0.3406,
+   "compress_mbps": 441.98,
+   "decompress_mbps": 969.0
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8286,
+   "ratio": 0.3368,
+   "compress_mbps": 405.77,
+   "decompress_mbps": 985.48
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8163,
+   "ratio": 0.3318,
+   "compress_mbps": 377.87,
+   "decompress_mbps": 999.24
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8053,
+   "ratio": 0.3273,
+   "compress_mbps": 337.25,
+   "decompress_mbps": 1015.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7986,
+   "ratio": 0.3246,
+   "compress_mbps": 276.49,
+   "decompress_mbps": 1030.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7954,
+   "ratio": 0.3233,
+   "compress_mbps": 190.41,
+   "decompress_mbps": 1032.9
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 126.18,
+   "decompress_mbps": 1029.63
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 125.1,
+   "decompress_mbps": 1031.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 10,
+   "out_size": 7725,
+   "ratio": 0.314,
+   "compress_mbps": 15.79,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 11,
+   "out_size": 7727,
+   "ratio": 0.3141,
+   "compress_mbps": 10.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 12,
+   "out_size": 7723,
+   "ratio": 0.3139,
+   "compress_mbps": 7.18,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3401,
+   "ratio": 0.305,
+   "compress_mbps": 586.51,
+   "decompress_mbps": 768.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3307,
+   "ratio": 0.2966,
+   "compress_mbps": 399.66,
+   "decompress_mbps": 789.24
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3242,
+   "ratio": 0.2908,
+   "compress_mbps": 367.93,
+   "decompress_mbps": 807.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3205,
+   "ratio": 0.2874,
+   "compress_mbps": 351.44,
+   "decompress_mbps": 815.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3150,
+   "ratio": 0.2825,
+   "compress_mbps": 313.88,
+   "decompress_mbps": 830.35
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3126,
+   "ratio": 0.2804,
+   "compress_mbps": 266.83,
+   "decompress_mbps": 840.06
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3106,
+   "ratio": 0.2786,
+   "compress_mbps": 206.86,
+   "decompress_mbps": 839.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3102,
+   "ratio": 0.2782,
+   "compress_mbps": 147.64,
+   "decompress_mbps": 843.66
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3102,
+   "ratio": 0.2782,
+   "compress_mbps": 140.31,
+   "decompress_mbps": 843.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 10,
+   "out_size": 3026,
+   "ratio": 0.2714,
+   "compress_mbps": 17.51,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 11,
+   "out_size": 3024,
+   "ratio": 0.2712,
+   "compress_mbps": 13.82,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 12,
+   "out_size": 3024,
+   "ratio": 0.2712,
+   "compress_mbps": 10.64,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1251,
+   "ratio": 0.3362,
+   "compress_mbps": 382.39,
+   "decompress_mbps": 436.06
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1228,
+   "ratio": 0.33,
+   "compress_mbps": 271.65,
+   "decompress_mbps": 441.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 261.74,
+   "decompress_mbps": 439.73
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1220,
+   "ratio": 0.3279,
+   "compress_mbps": 256.64,
+   "decompress_mbps": 442.14
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 240.91,
+   "decompress_mbps": 448.68
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 224.04,
+   "decompress_mbps": 450.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 203.76,
+   "decompress_mbps": 450.96
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1204,
+   "ratio": 0.3236,
+   "compress_mbps": 169.34,
+   "decompress_mbps": 451.48
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1204,
+   "ratio": 0.3236,
+   "compress_mbps": 168.85,
+   "decompress_mbps": 450.56
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 10,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 41.99,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 11,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 32.99,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 12,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 24.38,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 221813,
+   "ratio": 0.2154,
+   "compress_mbps": 595.78,
+   "decompress_mbps": 1009.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 199825,
+   "ratio": 0.1941,
+   "compress_mbps": 410.21,
+   "decompress_mbps": 1465.65
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 195675,
+   "ratio": 0.19,
+   "compress_mbps": 283.21,
+   "decompress_mbps": 1533.25
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 195664,
+   "ratio": 0.19,
+   "compress_mbps": 280.07,
+   "decompress_mbps": 1537.01
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 198900,
+   "ratio": 0.1932,
+   "compress_mbps": 239.61,
+   "decompress_mbps": 1128.92
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 199347,
+   "ratio": 0.1936,
+   "compress_mbps": 204.37,
+   "decompress_mbps": 1127.33
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 199777,
+   "ratio": 0.194,
+   "compress_mbps": 123.58,
+   "decompress_mbps": 1186.64
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 182094,
+   "ratio": 0.1768,
+   "compress_mbps": 25.62,
+   "decompress_mbps": 1170.25
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 181451,
+   "ratio": 0.1762,
+   "compress_mbps": 13.6,
+   "decompress_mbps": 1174.11
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 10,
+   "out_size": 179347,
+   "ratio": 0.1742,
+   "compress_mbps": 30.78,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 11,
+   "out_size": 179096,
+   "ratio": 0.1739,
+   "compress_mbps": 19.99,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 12,
+   "out_size": 179049,
+   "ratio": 0.1739,
+   "compress_mbps": 15.46,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 159063,
+   "ratio": 0.3727,
+   "compress_mbps": 263.79,
+   "decompress_mbps": 1021.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 152115,
+   "ratio": 0.3564,
+   "compress_mbps": 186.84,
+   "decompress_mbps": 1101.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 149162,
+   "ratio": 0.3495,
+   "compress_mbps": 156.34,
+   "decompress_mbps": 1190.05
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 148359,
+   "ratio": 0.3476,
+   "compress_mbps": 142.52,
+   "decompress_mbps": 1028.42
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145353,
+   "ratio": 0.3406,
+   "compress_mbps": 112.89,
+   "decompress_mbps": 996.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144209,
+   "ratio": 0.3379,
+   "compress_mbps": 87.51,
+   "decompress_mbps": 1031.7
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 143604,
+   "ratio": 0.3365,
+   "compress_mbps": 66.73,
+   "decompress_mbps": 1039.91
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 142086,
+   "ratio": 0.3329,
+   "compress_mbps": 44.23,
+   "decompress_mbps": 1037.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 142027,
+   "ratio": 0.3328,
+   "compress_mbps": 40.4,
+   "decompress_mbps": 1036.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 10,
+   "out_size": 138116,
+   "ratio": 0.3236,
+   "compress_mbps": 12.68,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 11,
+   "out_size": 137923,
+   "ratio": 0.3232,
+   "compress_mbps": 8.69,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 12,
+   "out_size": 137921,
+   "ratio": 0.3232,
+   "compress_mbps": 7.36,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 210662,
+   "ratio": 0.4372,
+   "compress_mbps": 228.42,
+   "decompress_mbps": 865.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 202881,
+   "ratio": 0.421,
+   "compress_mbps": 158.66,
+   "decompress_mbps": 938.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 200409,
+   "ratio": 0.4159,
+   "compress_mbps": 133.13,
+   "decompress_mbps": 1016.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 199678,
+   "ratio": 0.4144,
+   "compress_mbps": 122.65,
+   "decompress_mbps": 841.37
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 195798,
+   "ratio": 0.4063,
+   "compress_mbps": 93.06,
+   "decompress_mbps": 790.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 194029,
+   "ratio": 0.4027,
+   "compress_mbps": 71.77,
+   "decompress_mbps": 811.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 192773,
+   "ratio": 0.4001,
+   "compress_mbps": 50.51,
+   "decompress_mbps": 815.68
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 191739,
+   "ratio": 0.3979,
+   "compress_mbps": 33.65,
+   "decompress_mbps": 821.06
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 191676,
+   "ratio": 0.3978,
+   "compress_mbps": 31.02,
+   "decompress_mbps": 821.03
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 10,
+   "out_size": 185328,
+   "ratio": 0.3846,
+   "compress_mbps": 12.74,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 11,
+   "out_size": 184440,
+   "ratio": 0.3828,
+   "compress_mbps": 8.96,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 12,
+   "out_size": 184371,
+   "ratio": 0.3826,
+   "compress_mbps": 5.45,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 58079,
+   "ratio": 0.1132,
+   "compress_mbps": 371.33,
+   "decompress_mbps": 1662.96
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 57838,
+   "ratio": 0.1127,
+   "compress_mbps": 410.38,
+   "decompress_mbps": 1764.85
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 57554,
+   "ratio": 0.1121,
+   "compress_mbps": 390.9,
+   "decompress_mbps": 1862.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57064,
+   "ratio": 0.1112,
+   "compress_mbps": 371.73,
+   "decompress_mbps": 1695.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 55743,
+   "ratio": 0.1086,
+   "compress_mbps": 341.58,
+   "decompress_mbps": 1774.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55102,
+   "ratio": 0.1074,
+   "compress_mbps": 278.3,
+   "decompress_mbps": 1856.38
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 54742,
+   "ratio": 0.1067,
+   "compress_mbps": 192.18,
+   "decompress_mbps": 1914.68
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 53133,
+   "ratio": 0.1035,
+   "compress_mbps": 102.47,
+   "decompress_mbps": 1969.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52186,
+   "ratio": 0.1017,
+   "compress_mbps": 72.13,
+   "decompress_mbps": 2001.32
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 10,
+   "out_size": 51319,
+   "ratio": 0.1,
+   "compress_mbps": 12.76,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 11,
+   "out_size": 49675,
+   "ratio": 0.0968,
+   "compress_mbps": 6.04,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 12,
+   "out_size": 49194,
+   "ratio": 0.0959,
+   "compress_mbps": 3.5,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14122,
+   "ratio": 0.3693,
+   "compress_mbps": 651.19,
+   "decompress_mbps": 823.09
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13374,
+   "ratio": 0.3497,
+   "compress_mbps": 345.74,
+   "decompress_mbps": 878.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13293,
+   "ratio": 0.3476,
+   "compress_mbps": 286.57,
+   "decompress_mbps": 952.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13259,
+   "ratio": 0.3467,
+   "compress_mbps": 265.38,
+   "decompress_mbps": 948.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 12641,
+   "ratio": 0.3306,
+   "compress_mbps": 189.13,
+   "decompress_mbps": 989.89
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12432,
+   "ratio": 0.3251,
+   "compress_mbps": 164.09,
+   "decompress_mbps": 1011.41
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12439,
+   "ratio": 0.3253,
+   "compress_mbps": 122.75,
+   "decompress_mbps": 1008.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12579,
+   "ratio": 0.3289,
+   "compress_mbps": 67.84,
+   "decompress_mbps": 1015.44
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12574,
+   "ratio": 0.3288,
+   "compress_mbps": 47.51,
+   "decompress_mbps": 1027.14
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 10,
+   "out_size": 11975,
+   "ratio": 0.3132,
+   "compress_mbps": 19.93,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 11,
+   "out_size": 11966,
+   "ratio": 0.3129,
+   "compress_mbps": 13.28,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 12,
+   "out_size": 11965,
+   "ratio": 0.3129,
+   "compress_mbps": 10.53,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1777,
+   "ratio": 0.4204,
+   "compress_mbps": 383.89,
+   "decompress_mbps": 399.96
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1756,
+   "ratio": 0.4154,
+   "compress_mbps": 258.74,
+   "decompress_mbps": 401.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1746,
+   "ratio": 0.4131,
+   "compress_mbps": 256.81,
+   "decompress_mbps": 403.4
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1740,
+   "ratio": 0.4116,
+   "compress_mbps": 254.22,
+   "decompress_mbps": 409.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1722,
+   "ratio": 0.4074,
+   "compress_mbps": 239.57,
+   "decompress_mbps": 415.67
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1721,
+   "ratio": 0.4071,
+   "compress_mbps": 234.6,
+   "decompress_mbps": 415.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 233.37,
+   "decompress_mbps": 414.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1717,
+   "ratio": 0.4062,
+   "compress_mbps": 216.54,
+   "decompress_mbps": 413.37
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1717,
+   "ratio": 0.4062,
+   "compress_mbps": 216.39,
+   "decompress_mbps": 413.88
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 10,
+   "out_size": 1692,
+   "ratio": 0.4003,
+   "compress_mbps": 54.8,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 11,
+   "out_size": 1690,
+   "ratio": 0.3998,
+   "compress_mbps": 45.13,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 12,
+   "out_size": 1690,
+   "ratio": 0.3998,
+   "compress_mbps": 29.88,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4259644,
+   "ratio": 0.4179,
+   "compress_mbps": 64.05,
+   "decompress_mbps": 104.86
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 3977395,
+   "ratio": 0.3902,
+   "compress_mbps": 46.09,
+   "decompress_mbps": 113.03
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3945296,
+   "ratio": 0.3871,
+   "compress_mbps": 40.96,
+   "decompress_mbps": 124.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3882303,
+   "ratio": 0.3809,
+   "compress_mbps": 28.68,
+   "decompress_mbps": 127.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3870984,
+   "ratio": 0.3798,
+   "compress_mbps": 24.02,
+   "decompress_mbps": 133.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3878499,
+   "ratio": 0.3805,
+   "compress_mbps": 23.14,
+   "decompress_mbps": 137.73
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3865234,
+   "ratio": 0.3792,
+   "compress_mbps": 19.88,
+   "decompress_mbps": 138.33
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3864805,
+   "ratio": 0.3792,
+   "compress_mbps": 19.58,
+   "decompress_mbps": 138.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3766584,
+   "ratio": 0.3695,
+   "compress_mbps": 3.96,
+   "decompress_mbps": 140.73
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 10,
+   "out_size": 3711172,
+   "ratio": 0.3641,
+   "compress_mbps": 2.34,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 21267086,
+   "ratio": 0.4152,
+   "compress_mbps": 79.48,
+   "decompress_mbps": 132.62
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20802983,
+   "ratio": 0.4061,
+   "compress_mbps": 61.94,
+   "decompress_mbps": 140.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 20665485,
+   "ratio": 0.4035,
+   "compress_mbps": 58.38,
+   "decompress_mbps": 141.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 20393572,
+   "ratio": 0.3982,
+   "compress_mbps": 44.78,
+   "decompress_mbps": 150.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 20264932,
+   "ratio": 0.3956,
+   "compress_mbps": 32.98,
+   "decompress_mbps": 158.8
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19208910,
+   "ratio": 0.375,
+   "compress_mbps": 22.93,
+   "decompress_mbps": 162.75
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19177573,
+   "ratio": 0.3744,
+   "compress_mbps": 18.0,
+   "decompress_mbps": 162.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19172591,
+   "ratio": 0.3743,
+   "compress_mbps": 15.24,
+   "decompress_mbps": 163.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 18686872,
+   "ratio": 0.3648,
+   "compress_mbps": 3.98,
+   "decompress_mbps": 160.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 10,
+   "out_size": 18539905,
+   "ratio": 0.362,
+   "compress_mbps": 2.18,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3864163,
+   "ratio": 0.3876,
+   "compress_mbps": 78.89,
+   "decompress_mbps": 120.29
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3734957,
+   "ratio": 0.3746,
+   "compress_mbps": 60.37,
+   "decompress_mbps": 128.63
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3708443,
+   "ratio": 0.3719,
+   "compress_mbps": 52.15,
+   "decompress_mbps": 140.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3707604,
+   "ratio": 0.3719,
+   "compress_mbps": 33.71,
+   "decompress_mbps": 132.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3705174,
+   "ratio": 0.3716,
+   "compress_mbps": 26.47,
+   "decompress_mbps": 137.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3612809,
+   "ratio": 0.3623,
+   "compress_mbps": 23.22,
+   "decompress_mbps": 142.79
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3608980,
+   "ratio": 0.362,
+   "compress_mbps": 19.82,
+   "decompress_mbps": 145.03
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3609490,
+   "ratio": 0.362,
+   "compress_mbps": 18.04,
+   "decompress_mbps": 148.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3581441,
+   "ratio": 0.3592,
+   "compress_mbps": 4.39,
+   "decompress_mbps": 152.36
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 10,
+   "out_size": 3512886,
+   "ratio": 0.3523,
+   "compress_mbps": 2.72,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3785443,
+   "ratio": 0.1128,
+   "compress_mbps": 227.72,
+   "decompress_mbps": 365.8
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3761560,
+   "ratio": 0.1121,
+   "compress_mbps": 145.98,
+   "decompress_mbps": 411.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3606997,
+   "ratio": 0.1075,
+   "compress_mbps": 125.21,
+   "decompress_mbps": 458.08
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3225450,
+   "ratio": 0.0961,
+   "compress_mbps": 93.71,
+   "decompress_mbps": 468.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3145121,
+   "ratio": 0.0937,
+   "compress_mbps": 63.14,
+   "decompress_mbps": 534.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3158854,
+   "ratio": 0.0941,
+   "compress_mbps": 63.49,
+   "decompress_mbps": 572.62
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3124878,
+   "ratio": 0.0931,
+   "compress_mbps": 43.98,
+   "decompress_mbps": 585.84
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3112207,
+   "ratio": 0.0928,
+   "compress_mbps": 35.69,
+   "decompress_mbps": 603.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3034875,
+   "ratio": 0.0904,
+   "compress_mbps": 3.14,
+   "decompress_mbps": 609.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 10,
+   "out_size": 2902186,
+   "ratio": 0.0865,
+   "compress_mbps": 1.82,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3357083,
+   "ratio": 0.5457,
+   "compress_mbps": 56.42,
+   "decompress_mbps": 91.93
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3285077,
+   "ratio": 0.534,
+   "compress_mbps": 46.16,
+   "decompress_mbps": 94.41
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3272746,
+   "ratio": 0.532,
+   "compress_mbps": 43.73,
+   "decompress_mbps": 98.46
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3237094,
+   "ratio": 0.5262,
+   "compress_mbps": 35.82,
+   "decompress_mbps": 104.05
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3233792,
+   "ratio": 0.5256,
+   "compress_mbps": 31.95,
+   "decompress_mbps": 108.69
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3168386,
+   "ratio": 0.515,
+   "compress_mbps": 21.7,
+   "decompress_mbps": 110.91
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3165783,
+   "ratio": 0.5146,
+   "compress_mbps": 20.06,
+   "decompress_mbps": 111.08
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3165909,
+   "ratio": 0.5146,
+   "compress_mbps": 19.23,
+   "decompress_mbps": 111.08
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3048772,
+   "ratio": 0.4956,
+   "compress_mbps": 4.84,
+   "decompress_mbps": 114.16
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 10,
+   "out_size": 3021986,
+   "ratio": 0.4912,
+   "compress_mbps": 3.04,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3838828,
+   "ratio": 0.3806,
+   "compress_mbps": 89.59,
+   "decompress_mbps": 157.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3792520,
+   "ratio": 0.376,
+   "compress_mbps": 66.89,
+   "decompress_mbps": 163.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3783171,
+   "ratio": 0.3751,
+   "compress_mbps": 64.36,
+   "decompress_mbps": 167.92
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3706928,
+   "ratio": 0.3675,
+   "compress_mbps": 56.35,
+   "decompress_mbps": 180.63
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3707010,
+   "ratio": 0.3676,
+   "compress_mbps": 52.6,
+   "decompress_mbps": 187.18
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3707065,
+   "ratio": 0.3676,
+   "compress_mbps": 40.77,
+   "decompress_mbps": 195.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3706769,
+   "ratio": 0.3675,
+   "compress_mbps": 40.74,
+   "decompress_mbps": 199.07
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3706769,
+   "ratio": 0.3675,
+   "compress_mbps": 40.75,
+   "decompress_mbps": 197.91
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3665069,
+   "ratio": 0.3634,
+   "compress_mbps": 5.65,
+   "decompress_mbps": 196.82
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 10,
+   "out_size": 3647321,
+   "ratio": 0.3616,
+   "compress_mbps": 3.24,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2254442,
+   "ratio": 0.3402,
+   "compress_mbps": 82.66,
+   "decompress_mbps": 131.77
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2044843,
+   "ratio": 0.3086,
+   "compress_mbps": 55.64,
+   "decompress_mbps": 142.94
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 1992105,
+   "ratio": 0.3006,
+   "compress_mbps": 45.81,
+   "decompress_mbps": 160.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1901081,
+   "ratio": 0.2869,
+   "compress_mbps": 28.11,
+   "decompress_mbps": 161.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1874829,
+   "ratio": 0.2829,
+   "compress_mbps": 17.01,
+   "decompress_mbps": 172.37
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1867098,
+   "ratio": 0.2817,
+   "compress_mbps": 20.33,
+   "decompress_mbps": 127.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1843421,
+   "ratio": 0.2782,
+   "compress_mbps": 13.54,
+   "decompress_mbps": 186.11
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1841388,
+   "ratio": 0.2779,
+   "compress_mbps": 11.8,
+   "decompress_mbps": 185.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1773447,
+   "ratio": 0.2676,
+   "compress_mbps": 2.74,
+   "decompress_mbps": 194.58
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 10,
+   "out_size": 1718500,
+   "ratio": 0.2593,
+   "compress_mbps": 1.5,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6406301,
+   "ratio": 0.2965,
+   "compress_mbps": 110.0,
+   "decompress_mbps": 196.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6102377,
+   "ratio": 0.2824,
+   "compress_mbps": 81.35,
+   "decompress_mbps": 209.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 6022184,
+   "ratio": 0.2787,
+   "compress_mbps": 73.44,
+   "decompress_mbps": 218.17
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5880979,
+   "ratio": 0.2722,
+   "compress_mbps": 54.6,
+   "decompress_mbps": 228.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5839944,
+   "ratio": 0.2703,
+   "compress_mbps": 35.52,
+   "decompress_mbps": 240.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5425813,
+   "ratio": 0.2511,
+   "compress_mbps": 33.39,
+   "decompress_mbps": 244.82
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5409983,
+   "ratio": 0.2504,
+   "compress_mbps": 29.06,
+   "decompress_mbps": 247.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5407066,
+   "ratio": 0.2503,
+   "compress_mbps": 26.94,
+   "decompress_mbps": 247.18
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5235865,
+   "ratio": 0.2423,
+   "compress_mbps": 4.44,
+   "decompress_mbps": 248.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 10,
+   "out_size": 5177560,
+   "ratio": 0.2396,
+   "compress_mbps": 2.44,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5612204,
+   "ratio": 0.7739,
+   "compress_mbps": 46.95,
+   "decompress_mbps": 92.41
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5533875,
+   "ratio": 0.7631,
+   "compress_mbps": 39.54,
+   "decompress_mbps": 94.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5522436,
+   "ratio": 0.7615,
+   "compress_mbps": 36.96,
+   "decompress_mbps": 96.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5498823,
+   "ratio": 0.7583,
+   "compress_mbps": 29.88,
+   "decompress_mbps": 100.23
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5496802,
+   "ratio": 0.758,
+   "compress_mbps": 27.93,
+   "decompress_mbps": 103.93
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5478405,
+   "ratio": 0.7554,
+   "compress_mbps": 20.88,
+   "decompress_mbps": 104.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5474648,
+   "ratio": 0.7549,
+   "compress_mbps": 19.59,
+   "decompress_mbps": 104.22
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5474139,
+   "ratio": 0.7549,
+   "compress_mbps": 19.38,
+   "decompress_mbps": 104.19
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5284536,
+   "ratio": 0.7287,
+   "compress_mbps": 4.9,
+   "decompress_mbps": 105.48
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 10,
+   "out_size": 5262319,
+   "ratio": 0.7256,
+   "compress_mbps": 3.42,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 13727247,
+   "ratio": 0.3311,
+   "compress_mbps": 82.48,
+   "decompress_mbps": 138.19
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 12940398,
+   "ratio": 0.3121,
+   "compress_mbps": 60.76,
+   "decompress_mbps": 149.84
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12703756,
+   "ratio": 0.3064,
+   "compress_mbps": 55.86,
+   "decompress_mbps": 160.82
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12229398,
+   "ratio": 0.295,
+   "compress_mbps": 40.73,
+   "decompress_mbps": 167.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12123671,
+   "ratio": 0.2924,
+   "compress_mbps": 29.88,
+   "decompress_mbps": 176.47
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12167341,
+   "ratio": 0.2935,
+   "compress_mbps": 30.38,
+   "decompress_mbps": 181.51
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12109369,
+   "ratio": 0.2921,
+   "compress_mbps": 24.79,
+   "decompress_mbps": 183.46
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12106058,
+   "ratio": 0.292,
+   "compress_mbps": 23.83,
+   "decompress_mbps": 183.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11806466,
+   "ratio": 0.2848,
+   "compress_mbps": 3.69,
+   "decompress_mbps": 184.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 10,
+   "out_size": 11636727,
+   "ratio": 0.2807,
+   "compress_mbps": 1.93,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6438176,
+   "ratio": 0.7597,
+   "compress_mbps": 43.38,
+   "decompress_mbps": 77.61
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6392101,
+   "ratio": 0.7543,
+   "compress_mbps": 41.66,
+   "decompress_mbps": 77.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6392124,
+   "ratio": 0.7543,
+   "compress_mbps": 41.62,
+   "decompress_mbps": 79.72
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6368719,
+   "ratio": 0.7515,
+   "compress_mbps": 38.8,
+   "decompress_mbps": 79.2
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6368717,
+   "ratio": 0.7515,
+   "compress_mbps": 38.63,
+   "decompress_mbps": 81.58
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 13.99,
+   "decompress_mbps": 81.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 13.92,
+   "decompress_mbps": 82.22
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 13.88,
+   "decompress_mbps": 82.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5952505,
+   "ratio": 0.7024,
+   "compress_mbps": 5.86,
+   "decompress_mbps": 83.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 10,
+   "out_size": 5848663,
+   "ratio": 0.6902,
+   "compress_mbps": 4.29,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 858525,
+   "ratio": 0.1606,
+   "compress_mbps": 175.27,
+   "decompress_mbps": 283.22
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 846807,
+   "ratio": 0.1584,
+   "compress_mbps": 112.6,
+   "decompress_mbps": 299.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 806798,
+   "ratio": 0.1509,
+   "compress_mbps": 103.16,
+   "decompress_mbps": 337.23
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 721655,
+   "ratio": 0.135,
+   "compress_mbps": 74.57,
+   "decompress_mbps": 336.11
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 710636,
+   "ratio": 0.1329,
+   "compress_mbps": 54.2,
+   "decompress_mbps": 376.56
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 688375,
+   "ratio": 0.1288,
+   "compress_mbps": 51.18,
+   "decompress_mbps": 405.91
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 676544,
+   "ratio": 0.1266,
+   "compress_mbps": 40.51,
+   "decompress_mbps": 416.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 674362,
+   "ratio": 0.1262,
+   "compress_mbps": 34.88,
+   "decompress_mbps": 426.2
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 659417,
+   "ratio": 0.1234,
+   "compress_mbps": 4.14,
+   "decompress_mbps": 446.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 10,
+   "out_size": 643093,
+   "ratio": 0.1203,
+   "compress_mbps": 2.85,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4585612,
+   "ratio": 0.4499,
+   "compress_mbps": 112.9,
+   "decompress_mbps": 344.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4389474,
+   "ratio": 0.4307,
+   "compress_mbps": 95.43,
+   "decompress_mbps": 367.17
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4192079,
+   "ratio": 0.4113,
+   "compress_mbps": 59.17,
+   "decompress_mbps": 398.26
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4095021,
+   "ratio": 0.4018,
+   "compress_mbps": 65.65,
+   "decompress_mbps": 380.09
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3949169,
+   "ratio": 0.3875,
+   "compress_mbps": 35.62,
+   "decompress_mbps": 367.61
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3871628,
+   "ratio": 0.3799,
+   "compress_mbps": 21.17,
+   "decompress_mbps": 377.77
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3858876,
+   "ratio": 0.3786,
+   "compress_mbps": 17.65,
+   "decompress_mbps": 379.94
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3854729,
+   "ratio": 0.3782,
+   "compress_mbps": 15.03,
+   "decompress_mbps": 379.97
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3854729,
+   "ratio": 0.3782,
+   "compress_mbps": 15.0,
+   "decompress_mbps": 380.17
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20577220,
+   "ratio": 0.4017,
+   "compress_mbps": 112.07,
+   "decompress_mbps": 353.52
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20247697,
+   "ratio": 0.3953,
+   "compress_mbps": 100.19,
+   "decompress_mbps": 366.17
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19987880,
+   "ratio": 0.3902,
+   "compress_mbps": 76.03,
+   "decompress_mbps": 373.04
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19512665,
+   "ratio": 0.381,
+   "compress_mbps": 75.24,
+   "decompress_mbps": 363.97
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19213507,
+   "ratio": 0.3751,
+   "compress_mbps": 53.09,
+   "decompress_mbps": 369.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19089118,
+   "ratio": 0.3727,
+   "compress_mbps": 34.33,
+   "decompress_mbps": 373.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19061204,
+   "ratio": 0.3721,
+   "compress_mbps": 27.3,
+   "decompress_mbps": 376.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19040998,
+   "ratio": 0.3717,
+   "compress_mbps": 15.4,
+   "decompress_mbps": 376.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19044390,
+   "ratio": 0.3718,
+   "compress_mbps": 9.51,
+   "decompress_mbps": 377.24
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3828360,
+   "ratio": 0.384,
+   "compress_mbps": 143.06,
+   "decompress_mbps": 466.9
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3798539,
+   "ratio": 0.381,
+   "compress_mbps": 126.34,
+   "decompress_mbps": 481.52
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3674568,
+   "ratio": 0.3685,
+   "compress_mbps": 79.25,
+   "decompress_mbps": 499.48
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3680923,
+   "ratio": 0.3692,
+   "compress_mbps": 87.5,
+   "decompress_mbps": 443.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3698707,
+   "ratio": 0.371,
+   "compress_mbps": 47.33,
+   "decompress_mbps": 415.52
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3675935,
+   "ratio": 0.3687,
+   "compress_mbps": 26.24,
+   "decompress_mbps": 432.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3670281,
+   "ratio": 0.3681,
+   "compress_mbps": 20.75,
+   "decompress_mbps": 438.0
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3661103,
+   "ratio": 0.3672,
+   "compress_mbps": 10.99,
+   "decompress_mbps": 447.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3660788,
+   "ratio": 0.3672,
+   "compress_mbps": 9.51,
+   "decompress_mbps": 448.66
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4624591,
+   "ratio": 0.1378,
+   "compress_mbps": 334.74,
+   "decompress_mbps": 810.57
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4303176,
+   "ratio": 0.1282,
+   "compress_mbps": 309.81,
+   "decompress_mbps": 840.23
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 4010156,
+   "ratio": 0.1195,
+   "compress_mbps": 258.23,
+   "decompress_mbps": 922.43
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3713866,
+   "ratio": 0.1107,
+   "compress_mbps": 212.43,
+   "decompress_mbps": 899.61
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3378136,
+   "ratio": 0.1007,
+   "compress_mbps": 165.59,
+   "decompress_mbps": 955.5
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3200182,
+   "ratio": 0.0954,
+   "compress_mbps": 114.19,
+   "decompress_mbps": 1003.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3141278,
+   "ratio": 0.0936,
+   "compress_mbps": 90.27,
+   "decompress_mbps": 1014.87
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3031199,
+   "ratio": 0.0903,
+   "compress_mbps": 39.33,
+   "decompress_mbps": 1003.59
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2987995,
+   "ratio": 0.0891,
+   "compress_mbps": 21.46,
+   "decompress_mbps": 1030.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3290526,
+   "ratio": 0.5349,
+   "compress_mbps": 78.63,
+   "decompress_mbps": 253.04
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3238282,
+   "ratio": 0.5264,
+   "compress_mbps": 71.42,
+   "decompress_mbps": 258.74
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3193366,
+   "ratio": 0.5191,
+   "compress_mbps": 56.57,
+   "decompress_mbps": 265.13
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3158012,
+   "ratio": 0.5133,
+   "compress_mbps": 55.17,
+   "decompress_mbps": 266.79
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3115309,
+   "ratio": 0.5064,
+   "compress_mbps": 39.03,
+   "decompress_mbps": 270.19
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3097288,
+   "ratio": 0.5034,
+   "compress_mbps": 26.4,
+   "decompress_mbps": 273.25
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3094363,
+   "ratio": 0.503,
+   "compress_mbps": 21.97,
+   "decompress_mbps": 273.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3093026,
+   "ratio": 0.5028,
+   "compress_mbps": 17.15,
+   "decompress_mbps": 274.45
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3092920,
+   "ratio": 0.5027,
+   "compress_mbps": 15.57,
+   "decompress_mbps": 273.36
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4076385,
+   "ratio": 0.4042,
+   "compress_mbps": 126.52,
+   "decompress_mbps": 451.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3991014,
+   "ratio": 0.3957,
+   "compress_mbps": 117.71,
+   "decompress_mbps": 492.11
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3934055,
+   "ratio": 0.3901,
+   "compress_mbps": 93.9,
+   "decompress_mbps": 511.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3825092,
+   "ratio": 0.3793,
+   "compress_mbps": 85.01,
+   "decompress_mbps": 505.76
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3752932,
+   "ratio": 0.3721,
+   "compress_mbps": 64.85,
+   "decompress_mbps": 500.03
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3695164,
+   "ratio": 0.3664,
+   "compress_mbps": 49.58,
+   "decompress_mbps": 511.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3676881,
+   "ratio": 0.3646,
+   "compress_mbps": 38.18,
+   "decompress_mbps": 520.25
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3673171,
+   "ratio": 0.3642,
+   "compress_mbps": 32.02,
+   "decompress_mbps": 524.7
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3673171,
+   "ratio": 0.3642,
+   "compress_mbps": 31.98,
+   "decompress_mbps": 523.22
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2376424,
+   "ratio": 0.3586,
+   "compress_mbps": 130.75,
+   "decompress_mbps": 395.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2259060,
+   "ratio": 0.3409,
+   "compress_mbps": 112.16,
+   "decompress_mbps": 412.15
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2135664,
+   "ratio": 0.3223,
+   "compress_mbps": 72.65,
+   "decompress_mbps": 434.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2052793,
+   "ratio": 0.3098,
+   "compress_mbps": 82.15,
+   "decompress_mbps": 431.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1932127,
+   "ratio": 0.2915,
+   "compress_mbps": 45.47,
+   "decompress_mbps": 432.58
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1860865,
+   "ratio": 0.2808,
+   "compress_mbps": 22.86,
+   "decompress_mbps": 430.09
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1838671,
+   "ratio": 0.2774,
+   "compress_mbps": 15.9,
+   "decompress_mbps": 431.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1823235,
+   "ratio": 0.2751,
+   "compress_mbps": 8.11,
+   "decompress_mbps": 430.78
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1823190,
+   "ratio": 0.2751,
+   "compress_mbps": 8.07,
+   "decompress_mbps": 436.02
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6329449,
+   "ratio": 0.2929,
+   "compress_mbps": 168.35,
+   "decompress_mbps": 457.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6128866,
+   "ratio": 0.2837,
+   "compress_mbps": 155.31,
+   "decompress_mbps": 544.24
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5982546,
+   "ratio": 0.2769,
+   "compress_mbps": 124.88,
+   "decompress_mbps": 568.18
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5656400,
+   "ratio": 0.2618,
+   "compress_mbps": 116.79,
+   "decompress_mbps": 567.03
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5511352,
+   "ratio": 0.2551,
+   "compress_mbps": 82.16,
+   "decompress_mbps": 575.02
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5451399,
+   "ratio": 0.2523,
+   "compress_mbps": 56.58,
+   "decompress_mbps": 558.24
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5417123,
+   "ratio": 0.2507,
+   "compress_mbps": 46.62,
+   "decompress_mbps": 589.12
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5404364,
+   "ratio": 0.2501,
+   "compress_mbps": 32.68,
+   "decompress_mbps": 594.94
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5402704,
+   "ratio": 0.2501,
+   "compress_mbps": 29.8,
+   "decompress_mbps": 596.17
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5567768,
+   "ratio": 0.7678,
+   "compress_mbps": 64.24,
+   "decompress_mbps": 313.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5504009,
+   "ratio": 0.759,
+   "compress_mbps": 58.26,
+   "decompress_mbps": 324.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5439339,
+   "ratio": 0.7501,
+   "compress_mbps": 46.28,
+   "decompress_mbps": 333.53
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5394604,
+   "ratio": 0.7439,
+   "compress_mbps": 47.91,
+   "decompress_mbps": 343.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5370116,
+   "ratio": 0.7405,
+   "compress_mbps": 33.04,
+   "decompress_mbps": 337.26
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5331793,
+   "ratio": 0.7352,
+   "compress_mbps": 23.02,
+   "decompress_mbps": 342.64
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5327677,
+   "ratio": 0.7347,
+   "compress_mbps": 21.09,
+   "decompress_mbps": 340.24
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5325914,
+   "ratio": 0.7344,
+   "compress_mbps": 18.88,
+   "decompress_mbps": 343.38
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5325914,
+   "ratio": 0.7344,
+   "compress_mbps": 18.86,
+   "decompress_mbps": 340.76
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 14991236,
+   "ratio": 0.3616,
+   "compress_mbps": 136.57,
+   "decompress_mbps": 360.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 14249692,
+   "ratio": 0.3437,
+   "compress_mbps": 120.26,
+   "decompress_mbps": 393.57
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13627761,
+   "ratio": 0.3287,
+   "compress_mbps": 87.43,
+   "decompress_mbps": 409.97
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 13001990,
+   "ratio": 0.3136,
+   "compress_mbps": 84.92,
+   "decompress_mbps": 390.84
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12445991,
+   "ratio": 0.3002,
+   "compress_mbps": 54.7,
+   "decompress_mbps": 387.48
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12213941,
+   "ratio": 0.2946,
+   "compress_mbps": 36.36,
+   "decompress_mbps": 394.08
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12130416,
+   "ratio": 0.2926,
+   "compress_mbps": 29.55,
+   "decompress_mbps": 396.12
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12073697,
+   "ratio": 0.2912,
+   "compress_mbps": 21.38,
+   "decompress_mbps": 398.65
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12073469,
+   "ratio": 0.2912,
+   "compress_mbps": 21.24,
+   "decompress_mbps": 400.02
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6033926,
+   "ratio": 0.712,
+   "compress_mbps": 74.72,
+   "decompress_mbps": 290.16
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 5997474,
+   "ratio": 0.7077,
+   "compress_mbps": 68.17,
+   "decompress_mbps": 298.3
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 5966621,
+   "ratio": 0.7041,
+   "compress_mbps": 55.2,
+   "decompress_mbps": 305.36
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6091108,
+   "ratio": 0.7188,
+   "compress_mbps": 45.51,
+   "decompress_mbps": 262.1
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6053566,
+   "ratio": 0.7143,
+   "compress_mbps": 36.91,
+   "decompress_mbps": 270.38
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6045111,
+   "ratio": 0.7134,
+   "compress_mbps": 34.75,
+   "decompress_mbps": 275.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6045034,
+   "ratio": 0.7133,
+   "compress_mbps": 34.64,
+   "decompress_mbps": 275.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6045032,
+   "ratio": 0.7133,
+   "compress_mbps": 34.69,
+   "decompress_mbps": 275.05
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6045032,
+   "ratio": 0.7133,
+   "compress_mbps": 34.64,
+   "decompress_mbps": 274.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 965242,
+   "ratio": 0.1806,
+   "compress_mbps": 262.6,
+   "decompress_mbps": 674.71
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 887265,
+   "ratio": 0.166,
+   "compress_mbps": 245.29,
+   "decompress_mbps": 734.01
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 822167,
+   "ratio": 0.1538,
+   "compress_mbps": 190.93,
+   "decompress_mbps": 787.19
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 807518,
+   "ratio": 0.1511,
+   "compress_mbps": 168.99,
+   "decompress_mbps": 754.09
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 730574,
+   "ratio": 0.1367,
+   "compress_mbps": 121.67,
+   "decompress_mbps": 801.04
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 687991,
+   "ratio": 0.1287,
+   "compress_mbps": 79.4,
+   "decompress_mbps": 858.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 673933,
+   "ratio": 0.1261,
+   "compress_mbps": 65.06,
+   "decompress_mbps": 870.44
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 659518,
+   "ratio": 0.1234,
+   "compress_mbps": 43.03,
+   "decompress_mbps": 886.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 658899,
+   "ratio": 0.1233,
+   "compress_mbps": 39.76,
+   "decompress_mbps": 889.25
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 5363862,
+   "ratio": 0.5263,
+   "compress_mbps": 142.13,
+   "decompress_mbps": 367.89
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4438205,
+   "ratio": 0.4354,
+   "compress_mbps": 127.41,
+   "decompress_mbps": 418.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4054333,
+   "ratio": 0.3978,
+   "compress_mbps": 63.93,
+   "decompress_mbps": 465.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4038550,
+   "ratio": 0.3962,
+   "compress_mbps": 57.58,
+   "decompress_mbps": 461.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3954920,
+   "ratio": 0.388,
+   "compress_mbps": 40.28,
+   "decompress_mbps": 451.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3872874,
+   "ratio": 0.38,
+   "compress_mbps": 22.59,
+   "decompress_mbps": 463.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3859937,
+   "ratio": 0.3787,
+   "compress_mbps": 18.86,
+   "decompress_mbps": 464.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3855935,
+   "ratio": 0.3783,
+   "compress_mbps": 17.01,
+   "decompress_mbps": 462.2
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3855791,
+   "ratio": 0.3783,
+   "compress_mbps": 17.01,
+   "decompress_mbps": 464.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 22334882,
+   "ratio": 0.4361,
+   "compress_mbps": 237.47,
+   "decompress_mbps": 359.97
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20150366,
+   "ratio": 0.3934,
+   "compress_mbps": 119.56,
+   "decompress_mbps": 371.65
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19495014,
+   "ratio": 0.3806,
+   "compress_mbps": 70.05,
+   "decompress_mbps": 380.8
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19424978,
+   "ratio": 0.3792,
+   "compress_mbps": 71.25,
+   "decompress_mbps": 394.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19298736,
+   "ratio": 0.3768,
+   "compress_mbps": 54.15,
+   "decompress_mbps": 408.78
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19179167,
+   "ratio": 0.3744,
+   "compress_mbps": 29.73,
+   "decompress_mbps": 415.74
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19151324,
+   "ratio": 0.3739,
+   "compress_mbps": 21.93,
+   "decompress_mbps": 416.25
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19144373,
+   "ratio": 0.3738,
+   "compress_mbps": 16.58,
+   "decompress_mbps": 419.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19141383,
+   "ratio": 0.3737,
+   "compress_mbps": 14.19,
+   "decompress_mbps": 404.15
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 4249731,
+   "ratio": 0.4262,
+   "compress_mbps": 311.43,
+   "decompress_mbps": 518.78
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3775479,
+   "ratio": 0.3787,
+   "compress_mbps": 156.55,
+   "decompress_mbps": 540.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3656966,
+   "ratio": 0.3668,
+   "compress_mbps": 79.24,
+   "decompress_mbps": 565.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3740378,
+   "ratio": 0.3751,
+   "compress_mbps": 67.15,
+   "decompress_mbps": 526.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3713604,
+   "ratio": 0.3725,
+   "compress_mbps": 48.3,
+   "decompress_mbps": 488.73
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3683556,
+   "ratio": 0.3694,
+   "compress_mbps": 24.9,
+   "decompress_mbps": 510.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3683797,
+   "ratio": 0.3695,
+   "compress_mbps": 18.88,
+   "decompress_mbps": 500.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3684477,
+   "ratio": 0.3695,
+   "compress_mbps": 14.29,
+   "decompress_mbps": 526.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3679414,
+   "ratio": 0.369,
+   "compress_mbps": 12.32,
+   "decompress_mbps": 528.49
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 5594622,
+   "ratio": 0.1667,
+   "compress_mbps": 433.14,
+   "decompress_mbps": 839.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4179532,
+   "ratio": 0.1246,
+   "compress_mbps": 326.71,
+   "decompress_mbps": 924.08
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3542329,
+   "ratio": 0.1056,
+   "compress_mbps": 211.96,
+   "decompress_mbps": 841.08
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3323363,
+   "ratio": 0.099,
+   "compress_mbps": 198.1,
+   "decompress_mbps": 871.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3230343,
+   "ratio": 0.0963,
+   "compress_mbps": 162.32,
+   "decompress_mbps": 955.61
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3123421,
+   "ratio": 0.0931,
+   "compress_mbps": 96.23,
+   "decompress_mbps": 1013.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3093778,
+   "ratio": 0.0922,
+   "compress_mbps": 70.75,
+   "decompress_mbps": 977.54
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3067318,
+   "ratio": 0.0914,
+   "compress_mbps": 50.12,
+   "decompress_mbps": 1016.81
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3050695,
+   "ratio": 0.0909,
+   "compress_mbps": 42.12,
+   "decompress_mbps": 1024.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3543611,
+   "ratio": 0.576,
+   "compress_mbps": 167.45,
+   "decompress_mbps": 270.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3226818,
+   "ratio": 0.5245,
+   "compress_mbps": 85.72,
+   "decompress_mbps": 286.81
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3144140,
+   "ratio": 0.5111,
+   "compress_mbps": 52.56,
+   "decompress_mbps": 297.2
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3129833,
+   "ratio": 0.5087,
+   "compress_mbps": 51.44,
+   "decompress_mbps": 326.1
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3114809,
+   "ratio": 0.5063,
+   "compress_mbps": 40.37,
+   "decompress_mbps": 338.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3095705,
+   "ratio": 0.5032,
+   "compress_mbps": 25.15,
+   "decompress_mbps": 345.2
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3090055,
+   "ratio": 0.5023,
+   "compress_mbps": 20.49,
+   "decompress_mbps": 346.01
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3087665,
+   "ratio": 0.5019,
+   "compress_mbps": 17.42,
+   "decompress_mbps": 347.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3087158,
+   "ratio": 0.5018,
+   "compress_mbps": 16.34,
+   "decompress_mbps": 347.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 5419510,
+   "ratio": 0.5373,
+   "compress_mbps": 240.9,
+   "decompress_mbps": 518.99
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3982547,
+   "ratio": 0.3949,
+   "compress_mbps": 122.69,
+   "decompress_mbps": 541.32
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3806102,
+   "ratio": 0.3774,
+   "compress_mbps": 81.9,
+   "decompress_mbps": 559.37
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3761477,
+   "ratio": 0.373,
+   "compress_mbps": 78.54,
+   "decompress_mbps": 591.74
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3740298,
+   "ratio": 0.3709,
+   "compress_mbps": 67.47,
+   "decompress_mbps": 592.01
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3686116,
+   "ratio": 0.3655,
+   "compress_mbps": 49.5,
+   "decompress_mbps": 626.28
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3668442,
+   "ratio": 0.3637,
+   "compress_mbps": 38.83,
+   "decompress_mbps": 638.73
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3665072,
+   "ratio": 0.3634,
+   "compress_mbps": 33.19,
+   "decompress_mbps": 636.26
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3665057,
+   "ratio": 0.3634,
+   "compress_mbps": 33.07,
+   "decompress_mbps": 636.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2842321,
+   "ratio": 0.4289,
+   "compress_mbps": 190.94,
+   "decompress_mbps": 438.05
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2232180,
+   "ratio": 0.3368,
+   "compress_mbps": 151.11,
+   "decompress_mbps": 509.32
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2003056,
+   "ratio": 0.3022,
+   "compress_mbps": 82.05,
+   "decompress_mbps": 549.56
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1985375,
+   "ratio": 0.2996,
+   "compress_mbps": 73.94,
+   "decompress_mbps": 556.86
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1933775,
+   "ratio": 0.2918,
+   "compress_mbps": 51.93,
+   "decompress_mbps": 532.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1858103,
+   "ratio": 0.2804,
+   "compress_mbps": 22.01,
+   "decompress_mbps": 538.05
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1840414,
+   "ratio": 0.2777,
+   "compress_mbps": 15.12,
+   "decompress_mbps": 544.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1831679,
+   "ratio": 0.2764,
+   "compress_mbps": 11.71,
+   "decompress_mbps": 532.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1827137,
+   "ratio": 0.2757,
+   "compress_mbps": 10.14,
+   "decompress_mbps": 539.04
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 7089759,
+   "ratio": 0.3281,
+   "compress_mbps": 290.39,
+   "decompress_mbps": 563.58
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5966231,
+   "ratio": 0.2761,
+   "compress_mbps": 173.09,
+   "decompress_mbps": 612.26
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5611838,
+   "ratio": 0.2597,
+   "compress_mbps": 111.24,
+   "decompress_mbps": 638.04
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5535436,
+   "ratio": 0.2562,
+   "compress_mbps": 105.15,
+   "decompress_mbps": 662.01
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5480971,
+   "ratio": 0.2537,
+   "compress_mbps": 81.26,
+   "decompress_mbps": 670.81
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5437556,
+   "ratio": 0.2517,
+   "compress_mbps": 49.58,
+   "decompress_mbps": 684.55
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5432108,
+   "ratio": 0.2514,
+   "compress_mbps": 40.49,
+   "decompress_mbps": 626.85
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5428571,
+   "ratio": 0.2512,
+   "compress_mbps": 33.69,
+   "decompress_mbps": 690.55
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5425526,
+   "ratio": 0.2511,
+   "compress_mbps": 30.52,
+   "decompress_mbps": 688.43
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5900800,
+   "ratio": 0.8137,
+   "compress_mbps": 187.81,
+   "decompress_mbps": 312.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5523611,
+   "ratio": 0.7617,
+   "compress_mbps": 68.34,
+   "decompress_mbps": 337.84
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5393086,
+   "ratio": 0.7437,
+   "compress_mbps": 40.05,
+   "decompress_mbps": 349.72
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5401582,
+   "ratio": 0.7448,
+   "compress_mbps": 40.5,
+   "decompress_mbps": 365.18
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5371274,
+   "ratio": 0.7407,
+   "compress_mbps": 31.19,
+   "decompress_mbps": 358.17
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5330096,
+   "ratio": 0.735,
+   "compress_mbps": 20.78,
+   "decompress_mbps": 364.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5325437,
+   "ratio": 0.7343,
+   "compress_mbps": 18.99,
+   "decompress_mbps": 366.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5323934,
+   "ratio": 0.7341,
+   "compress_mbps": 18.04,
+   "decompress_mbps": 358.83
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5323621,
+   "ratio": 0.7341,
+   "compress_mbps": 17.73,
+   "decompress_mbps": 364.14
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 17587173,
+   "ratio": 0.4242,
+   "compress_mbps": 184.15,
+   "decompress_mbps": 360.59
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 14171707,
+   "ratio": 0.3418,
+   "compress_mbps": 147.7,
+   "decompress_mbps": 408.57
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12774851,
+   "ratio": 0.3081,
+   "compress_mbps": 85.53,
+   "decompress_mbps": 439.04
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12612554,
+   "ratio": 0.3042,
+   "compress_mbps": 75.97,
+   "decompress_mbps": 437.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12392339,
+   "ratio": 0.2989,
+   "compress_mbps": 57.99,
+   "decompress_mbps": 450.61
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12158314,
+   "ratio": 0.2933,
+   "compress_mbps": 34.34,
+   "decompress_mbps": 456.5
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12107840,
+   "ratio": 0.292,
+   "compress_mbps": 27.58,
+   "decompress_mbps": 459.59
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12081311,
+   "ratio": 0.2914,
+   "compress_mbps": 22.87,
+   "decompress_mbps": 460.8
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12081011,
+   "ratio": 0.2914,
+   "compress_mbps": 22.77,
+   "decompress_mbps": 460.43
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6527324,
+   "ratio": 0.7703,
+   "compress_mbps": 238.01,
+   "decompress_mbps": 325.92
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6051483,
+   "ratio": 0.7141,
+   "compress_mbps": 75.23,
+   "decompress_mbps": 327.25
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6010123,
+   "ratio": 0.7092,
+   "compress_mbps": 51.94,
+   "decompress_mbps": 330.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6024815,
+   "ratio": 0.711,
+   "compress_mbps": 44.37,
+   "decompress_mbps": 279.89
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6005181,
+   "ratio": 0.7086,
+   "compress_mbps": 40.25,
+   "decompress_mbps": 285.12
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5997508,
+   "ratio": 0.7077,
+   "compress_mbps": 37.74,
+   "decompress_mbps": 289.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.64,
+   "decompress_mbps": 290.49
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.67,
+   "decompress_mbps": 289.81
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.67,
+   "decompress_mbps": 289.76
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 1147652,
+   "ratio": 0.2147,
+   "compress_mbps": 387.25,
+   "decompress_mbps": 750.94
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 919639,
+   "ratio": 0.172,
+   "compress_mbps": 261.15,
+   "decompress_mbps": 942.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 752341,
+   "ratio": 0.1407,
+   "compress_mbps": 166.75,
+   "decompress_mbps": 1050.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 735537,
+   "ratio": 0.1376,
+   "compress_mbps": 161.05,
+   "decompress_mbps": 1025.31
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 706789,
+   "ratio": 0.1322,
+   "compress_mbps": 123.6,
+   "decompress_mbps": 1117.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 676279,
+   "ratio": 0.1265,
+   "compress_mbps": 69.65,
+   "decompress_mbps": 1201.48
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 668772,
+   "ratio": 0.1251,
+   "compress_mbps": 56.08,
+   "decompress_mbps": 1218.43
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 665340,
+   "ratio": 0.1245,
+   "compress_mbps": 47.65,
+   "decompress_mbps": 1208.96
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 664273,
+   "ratio": 0.1243,
+   "compress_mbps": 45.88,
+   "decompress_mbps": 1215.47
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4217525,
+   "ratio": 0.4138,
+   "compress_mbps": 239.71,
+   "decompress_mbps": 790.0
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4053259,
+   "ratio": 0.3977,
+   "compress_mbps": 168.86,
+   "decompress_mbps": 853.57
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3989875,
+   "ratio": 0.3915,
+   "compress_mbps": 139.03,
+   "decompress_mbps": 927.64
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3972869,
+   "ratio": 0.3898,
+   "compress_mbps": 127.1,
+   "decompress_mbps": 821.17
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3894026,
+   "ratio": 0.3821,
+   "compress_mbps": 98.79,
+   "decompress_mbps": 797.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3859436,
+   "ratio": 0.3787,
+   "compress_mbps": 75.36,
+   "decompress_mbps": 823.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3837515,
+   "ratio": 0.3765,
+   "compress_mbps": 55.56,
+   "decompress_mbps": 819.25
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3811467,
+   "ratio": 0.374,
+   "compress_mbps": 36.02,
+   "decompress_mbps": 820.77
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3810354,
+   "ratio": 0.3738,
+   "compress_mbps": 32.7,
+   "decompress_mbps": 826.03
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 10,
+   "out_size": 3681797,
+   "ratio": 0.3612,
+   "compress_mbps": 12.47,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 11,
+   "out_size": 3679289,
+   "ratio": 0.361,
+   "compress_mbps": 9.08,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 12,
+   "out_size": 3679105,
+   "ratio": 0.361,
+   "compress_mbps": 7.51,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20192961,
+   "ratio": 0.3942,
+   "compress_mbps": 242.73,
+   "decompress_mbps": 677.88
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19374226,
+   "ratio": 0.3783,
+   "compress_mbps": 185.59,
+   "decompress_mbps": 715.55
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19234937,
+   "ratio": 0.3755,
+   "compress_mbps": 173.02,
+   "decompress_mbps": 729.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19145385,
+   "ratio": 0.3738,
+   "compress_mbps": 162.19,
+   "decompress_mbps": 727.78
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 18878875,
+   "ratio": 0.3686,
+   "compress_mbps": 142.6,
+   "decompress_mbps": 748.14
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 18805391,
+   "ratio": 0.3671,
+   "compress_mbps": 120.03,
+   "decompress_mbps": 759.24
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 18749947,
+   "ratio": 0.3661,
+   "compress_mbps": 87.47,
+   "decompress_mbps": 759.27
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 18718540,
+   "ratio": 0.3655,
+   "compress_mbps": 47.44,
+   "decompress_mbps": 760.16
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 18713659,
+   "ratio": 0.3654,
+   "compress_mbps": 33.55,
+   "decompress_mbps": 756.4
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 10,
+   "out_size": 18268811,
+   "ratio": 0.3567,
+   "compress_mbps": 16.29,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 11,
+   "out_size": 18245674,
+   "ratio": 0.3562,
+   "compress_mbps": 11.63,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 12,
+   "out_size": 18241312,
+   "ratio": 0.3561,
+   "compress_mbps": 9.25,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3740775,
+   "ratio": 0.3752,
+   "compress_mbps": 292.32,
+   "decompress_mbps": 717.67
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3707407,
+   "ratio": 0.3718,
+   "compress_mbps": 215.91,
+   "decompress_mbps": 749.51
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3672389,
+   "ratio": 0.3683,
+   "compress_mbps": 184.12,
+   "decompress_mbps": 784.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3660011,
+   "ratio": 0.3671,
+   "compress_mbps": 170.1,
+   "decompress_mbps": 717.47
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3664245,
+   "ratio": 0.3675,
+   "compress_mbps": 140.41,
+   "decompress_mbps": 675.48
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3648644,
+   "ratio": 0.3659,
+   "compress_mbps": 105.4,
+   "decompress_mbps": 708.33
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3635323,
+   "ratio": 0.3646,
+   "compress_mbps": 67.54,
+   "decompress_mbps": 729.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3624778,
+   "ratio": 0.3635,
+   "compress_mbps": 42.96,
+   "decompress_mbps": 774.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3625176,
+   "ratio": 0.3636,
+   "compress_mbps": 38.8,
+   "decompress_mbps": 752.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 10,
+   "out_size": 3461494,
+   "ratio": 0.3472,
+   "compress_mbps": 18.25,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 11,
+   "out_size": 3446053,
+   "ratio": 0.3456,
+   "compress_mbps": 10.54,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 12,
+   "out_size": 3447985,
+   "ratio": 0.3458,
+   "compress_mbps": 5.38,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3837577,
+   "ratio": 0.1144,
+   "compress_mbps": 605.16,
+   "decompress_mbps": 1502.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3714632,
+   "ratio": 0.1107,
+   "compress_mbps": 460.38,
+   "decompress_mbps": 1712.18
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3599455,
+   "ratio": 0.1073,
+   "compress_mbps": 424.4,
+   "decompress_mbps": 1819.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3431843,
+   "ratio": 0.1023,
+   "compress_mbps": 387.62,
+   "decompress_mbps": 1807.25
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3268188,
+   "ratio": 0.0974,
+   "compress_mbps": 347.18,
+   "decompress_mbps": 1824.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3091741,
+   "ratio": 0.0921,
+   "compress_mbps": 263.43,
+   "decompress_mbps": 1809.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3032499,
+   "ratio": 0.0904,
+   "compress_mbps": 185.26,
+   "decompress_mbps": 1828.9
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2949097,
+   "ratio": 0.0879,
+   "compress_mbps": 97.29,
+   "decompress_mbps": 1755.09
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2925243,
+   "ratio": 0.0872,
+   "compress_mbps": 69.11,
+   "decompress_mbps": 1716.66
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 10,
+   "out_size": 2782465,
+   "ratio": 0.0829,
+   "compress_mbps": 8.4,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 11,
+   "out_size": 2751857,
+   "ratio": 0.082,
+   "compress_mbps": 5.49,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 12,
+   "out_size": 2748273,
+   "ratio": 0.0819,
+   "compress_mbps": 4.05,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3275124,
+   "ratio": 0.5324,
+   "compress_mbps": 166.4,
+   "decompress_mbps": 432.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3150806,
+   "ratio": 0.5121,
+   "compress_mbps": 126.88,
+   "decompress_mbps": 498.99
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3137061,
+   "ratio": 0.5099,
+   "compress_mbps": 119.44,
+   "decompress_mbps": 523.59
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3129676,
+   "ratio": 0.5087,
+   "compress_mbps": 115.62,
+   "decompress_mbps": 542.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3079277,
+   "ratio": 0.5005,
+   "compress_mbps": 98.82,
+   "decompress_mbps": 561.4
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3072378,
+   "ratio": 0.4994,
+   "compress_mbps": 87.08,
+   "decompress_mbps": 570.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3068123,
+   "ratio": 0.4987,
+   "compress_mbps": 74.7,
+   "decompress_mbps": 573.32
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3067299,
+   "ratio": 0.4986,
+   "compress_mbps": 55.04,
+   "decompress_mbps": 575.17
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3066968,
+   "ratio": 0.4985,
+   "compress_mbps": 49.77,
+   "decompress_mbps": 573.4
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 10,
+   "out_size": 2995902,
+   "ratio": 0.487,
+   "compress_mbps": 18.97,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 11,
+   "out_size": 2994386,
+   "ratio": 0.4867,
+   "compress_mbps": 14.38,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 12,
+   "out_size": 2994086,
+   "ratio": 0.4867,
+   "compress_mbps": 12.27,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3868663,
+   "ratio": 0.3836,
+   "compress_mbps": 278.48,
+   "decompress_mbps": 739.01
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3839158,
+   "ratio": 0.3807,
+   "compress_mbps": 207.66,
+   "decompress_mbps": 860.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3818964,
+   "ratio": 0.3787,
+   "compress_mbps": 193.08,
+   "decompress_mbps": 890.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3789325,
+   "ratio": 0.3757,
+   "compress_mbps": 176.73,
+   "decompress_mbps": 926.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3666476,
+   "ratio": 0.3635,
+   "compress_mbps": 155.97,
+   "decompress_mbps": 937.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3660266,
+   "ratio": 0.3629,
+   "compress_mbps": 140.77,
+   "decompress_mbps": 974.05
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3659491,
+   "ratio": 0.3628,
+   "compress_mbps": 133.11,
+   "decompress_mbps": 952.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3654863,
+   "ratio": 0.3624,
+   "compress_mbps": 114.1,
+   "decompress_mbps": 972.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3654860,
+   "ratio": 0.3624,
+   "compress_mbps": 114.29,
+   "decompress_mbps": 945.42
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 10,
+   "out_size": 3608746,
+   "ratio": 0.3578,
+   "compress_mbps": 18.87,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 11,
+   "out_size": 3608161,
+   "ratio": 0.3578,
+   "compress_mbps": 14.63,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 12,
+   "out_size": 3608138,
+   "ratio": 0.3577,
+   "compress_mbps": 13.05,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2197055,
+   "ratio": 0.3315,
+   "compress_mbps": 298.73,
+   "decompress_mbps": 852.56
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2082309,
+   "ratio": 0.3142,
+   "compress_mbps": 214.22,
+   "decompress_mbps": 934.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2021047,
+   "ratio": 0.305,
+   "compress_mbps": 178.25,
+   "decompress_mbps": 1068.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1990952,
+   "ratio": 0.3004,
+   "compress_mbps": 158.42,
+   "decompress_mbps": 1003.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1921113,
+   "ratio": 0.2899,
+   "compress_mbps": 127.07,
+   "decompress_mbps": 952.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1876257,
+   "ratio": 0.2831,
+   "compress_mbps": 86.95,
+   "decompress_mbps": 960.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1832695,
+   "ratio": 0.2765,
+   "compress_mbps": 46.57,
+   "decompress_mbps": 907.88
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1809967,
+   "ratio": 0.2731,
+   "compress_mbps": 24.25,
+   "decompress_mbps": 844.4
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1806374,
+   "ratio": 0.2726,
+   "compress_mbps": 19.88,
+   "decompress_mbps": 905.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 10,
+   "out_size": 1697693,
+   "ratio": 0.2562,
+   "compress_mbps": 8.75,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 11,
+   "out_size": 1696742,
+   "ratio": 0.256,
+   "compress_mbps": 6.54,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 12,
+   "out_size": 1696488,
+   "ratio": 0.256,
+   "compress_mbps": 5.61,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 5866517,
+   "ratio": 0.2715,
+   "compress_mbps": 340.26,
+   "decompress_mbps": 952.81
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5695942,
+   "ratio": 0.2636,
+   "compress_mbps": 255.24,
+   "decompress_mbps": 1038.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5605878,
+   "ratio": 0.2595,
+   "compress_mbps": 231.7,
+   "decompress_mbps": 1069.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5553432,
+   "ratio": 0.257,
+   "compress_mbps": 215.99,
+   "decompress_mbps": 1047.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5416713,
+   "ratio": 0.2507,
+   "compress_mbps": 186.63,
+   "decompress_mbps": 1059.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5337149,
+   "ratio": 0.247,
+   "compress_mbps": 143.25,
+   "decompress_mbps": 1056.25
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5310181,
+   "ratio": 0.2458,
+   "compress_mbps": 100.19,
+   "decompress_mbps": 1049.35
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5272761,
+   "ratio": 0.244,
+   "compress_mbps": 62.34,
+   "decompress_mbps": 1056.09
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5270405,
+   "ratio": 0.2439,
+   "compress_mbps": 50.09,
+   "decompress_mbps": 1037.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 10,
+   "out_size": 5137640,
+   "ratio": 0.2378,
+   "compress_mbps": 15.84,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 11,
+   "out_size": 5122694,
+   "ratio": 0.2371,
+   "compress_mbps": 9.54,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 12,
+   "out_size": 5118130,
+   "ratio": 0.2369,
+   "compress_mbps": 6.89,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5575128,
+   "ratio": 0.7688,
+   "compress_mbps": 163.85,
+   "decompress_mbps": 458.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5417142,
+   "ratio": 0.747,
+   "compress_mbps": 116.56,
+   "decompress_mbps": 504.35
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5397999,
+   "ratio": 0.7444,
+   "compress_mbps": 103.93,
+   "decompress_mbps": 508.38
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5391125,
+   "ratio": 0.7434,
+   "compress_mbps": 98.9,
+   "decompress_mbps": 517.7
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5352212,
+   "ratio": 0.738,
+   "compress_mbps": 86.65,
+   "decompress_mbps": 504.77
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5335405,
+   "ratio": 0.7357,
+   "compress_mbps": 72.7,
+   "decompress_mbps": 509.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5325697,
+   "ratio": 0.7344,
+   "compress_mbps": 62.93,
+   "decompress_mbps": 516.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5324004,
+   "ratio": 0.7341,
+   "compress_mbps": 52.25,
+   "decompress_mbps": 513.7
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5323197,
+   "ratio": 0.734,
+   "compress_mbps": 50.74,
+   "decompress_mbps": 504.37
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 10,
+   "out_size": 5250862,
+   "ratio": 0.7241,
+   "compress_mbps": 25.48,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 11,
+   "out_size": 5250747,
+   "ratio": 0.724,
+   "compress_mbps": 20.78,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 12,
+   "out_size": 5250745,
+   "ratio": 0.724,
+   "compress_mbps": 19.39,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 13550569,
+   "ratio": 0.3268,
+   "compress_mbps": 270.14,
+   "decompress_mbps": 883.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13130705,
+   "ratio": 0.3167,
+   "compress_mbps": 201.99,
+   "decompress_mbps": 989.91
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12839361,
+   "ratio": 0.3097,
+   "compress_mbps": 178.64,
+   "decompress_mbps": 1030.28
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12601933,
+   "ratio": 0.304,
+   "compress_mbps": 163.2,
+   "decompress_mbps": 905.55
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12310776,
+   "ratio": 0.2969,
+   "compress_mbps": 132.49,
+   "decompress_mbps": 607.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12140474,
+   "ratio": 0.2928,
+   "compress_mbps": 105.68,
+   "decompress_mbps": 896.67
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12025296,
+   "ratio": 0.2901,
+   "compress_mbps": 75.3,
+   "decompress_mbps": 900.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 11893824,
+   "ratio": 0.2869,
+   "compress_mbps": 46.13,
+   "decompress_mbps": 806.33
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11882496,
+   "ratio": 0.2866,
+   "compress_mbps": 37.39,
+   "decompress_mbps": 815.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 10,
+   "out_size": 11526846,
+   "ratio": 0.278,
+   "compress_mbps": 10.06,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 11,
+   "out_size": 11520969,
+   "ratio": 0.2779,
+   "compress_mbps": 6.91,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 12,
+   "out_size": 11520871,
+   "ratio": 0.2779,
+   "compress_mbps": 5.85,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6293390,
+   "ratio": 0.7426,
+   "compress_mbps": 147.98,
+   "decompress_mbps": 465.49
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6058412,
+   "ratio": 0.7149,
+   "compress_mbps": 119.79,
+   "decompress_mbps": 506.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6058381,
+   "ratio": 0.7149,
+   "compress_mbps": 119.2,
+   "decompress_mbps": 514.84
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6058363,
+   "ratio": 0.7149,
+   "compress_mbps": 119.3,
+   "decompress_mbps": 415.52
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 5998400,
+   "ratio": 0.7078,
+   "compress_mbps": 105.57,
+   "decompress_mbps": 432.18
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5998438,
+   "ratio": 0.7078,
+   "compress_mbps": 105.97,
+   "decompress_mbps": 440.63
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5998439,
+   "ratio": 0.7078,
+   "compress_mbps": 106.47,
+   "decompress_mbps": 438.91
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5986859,
+   "ratio": 0.7065,
+   "compress_mbps": 88.92,
+   "decompress_mbps": 434.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5986859,
+   "ratio": 0.7065,
+   "compress_mbps": 87.71,
+   "decompress_mbps": 416.28
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 10,
+   "out_size": 5748096,
+   "ratio": 0.6783,
+   "compress_mbps": 37.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 11,
+   "out_size": 5747172,
+   "ratio": 0.6782,
+   "compress_mbps": 28.72,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 12,
+   "out_size": 5747146,
+   "ratio": 0.6782,
+   "compress_mbps": 26.57,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 887708,
+   "ratio": 0.1661,
+   "compress_mbps": 487.74,
+   "decompress_mbps": 1232.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 843475,
+   "ratio": 0.1578,
+   "compress_mbps": 361.41,
+   "decompress_mbps": 1500.87
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 793388,
+   "ratio": 0.1484,
+   "compress_mbps": 333.76,
+   "decompress_mbps": 1649.87
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 747602,
+   "ratio": 0.1399,
+   "compress_mbps": 302.22,
+   "decompress_mbps": 1613.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 718615,
+   "ratio": 0.1344,
+   "compress_mbps": 260.88,
+   "decompress_mbps": 1656.06
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 684405,
+   "ratio": 0.128,
+   "compress_mbps": 204.65,
+   "decompress_mbps": 1603.35
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 664859,
+   "ratio": 0.1244,
+   "compress_mbps": 141.51,
+   "decompress_mbps": 1662.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 650835,
+   "ratio": 0.1218,
+   "compress_mbps": 84.48,
+   "decompress_mbps": 1415.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 649494,
+   "ratio": 0.1215,
+   "compress_mbps": 68.12,
+   "decompress_mbps": 1568.14
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 10,
+   "out_size": 637425,
+   "ratio": 0.1193,
+   "compress_mbps": 11.89,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 11,
+   "out_size": 630827,
+   "ratio": 0.118,
+   "compress_mbps": 7.0,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 12,
+   "out_size": 629349,
+   "ratio": 0.1177,
+   "compress_mbps": 4.54,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 65708,
+   "ratio": 0.432,
+   "compress_mbps": 109.44,
+   "decompress_mbps": 192.48
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 60259,
+   "ratio": 0.3962,
+   "compress_mbps": 79.44,
+   "decompress_mbps": 219.13
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 58544,
+   "ratio": 0.3849,
+   "compress_mbps": 66.36,
+   "decompress_mbps": 226.05
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56238,
+   "ratio": 0.3698,
+   "compress_mbps": 65.73,
+   "decompress_mbps": 231.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54764,
+   "ratio": 0.3601,
+   "compress_mbps": 39.45,
+   "decompress_mbps": 234.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54311,
+   "ratio": 0.3571,
+   "compress_mbps": 30.43,
+   "decompress_mbps": 235.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54262,
+   "ratio": 0.3568,
+   "compress_mbps": 27.11,
+   "decompress_mbps": 235.47
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54247,
+   "ratio": 0.3567,
+   "compress_mbps": 25.8,
+   "decompress_mbps": 238.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54247,
+   "ratio": 0.3567,
+   "compress_mbps": 25.76,
+   "decompress_mbps": 236.1
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 56882,
+   "ratio": 0.4544,
+   "compress_mbps": 104.58,
+   "decompress_mbps": 183.83
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 52826,
+   "ratio": 0.422,
+   "compress_mbps": 73.05,
+   "decompress_mbps": 205.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51625,
+   "ratio": 0.4124,
+   "compress_mbps": 61.78,
+   "decompress_mbps": 211.24
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50034,
+   "ratio": 0.3997,
+   "compress_mbps": 61.66,
+   "decompress_mbps": 217.96
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48912,
+   "ratio": 0.3907,
+   "compress_mbps": 37.33,
+   "decompress_mbps": 217.44
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48738,
+   "ratio": 0.3893,
+   "compress_mbps": 31.17,
+   "decompress_mbps": 219.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48719,
+   "ratio": 0.3892,
+   "compress_mbps": 29.9,
+   "decompress_mbps": 220.02
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48716,
+   "ratio": 0.3892,
+   "compress_mbps": 29.7,
+   "decompress_mbps": 219.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48716,
+   "ratio": 0.3892,
+   "compress_mbps": 30.07,
+   "decompress_mbps": 219.72
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8988,
+   "ratio": 0.3653,
+   "compress_mbps": 195.21,
+   "decompress_mbps": 289.47
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8564,
+   "ratio": 0.3481,
+   "compress_mbps": 143.69,
+   "decompress_mbps": 317.83
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8390,
+   "ratio": 0.341,
+   "compress_mbps": 129.4,
+   "decompress_mbps": 337.5
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8167,
+   "ratio": 0.332,
+   "compress_mbps": 115.12,
+   "decompress_mbps": 328.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7965,
+   "ratio": 0.3237,
+   "compress_mbps": 81.76,
+   "decompress_mbps": 356.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 62.46,
+   "decompress_mbps": 356.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 59.77,
+   "decompress_mbps": 329.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 56.57,
+   "decompress_mbps": 357.23
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 56.39,
+   "decompress_mbps": 355
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3731,
+   "ratio": 0.3346,
+   "compress_mbps": 160.08,
+   "decompress_mbps": 347.11
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3491,
+   "ratio": 0.3131,
+   "compress_mbps": 156.38,
+   "decompress_mbps": 385.2
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3384,
+   "ratio": 0.3035,
+   "compress_mbps": 156.98,
+   "decompress_mbps": 389.78
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3220,
+   "ratio": 0.2888,
+   "compress_mbps": 135.13,
+   "decompress_mbps": 416.97
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3138,
+   "ratio": 0.2814,
+   "compress_mbps": 113.25,
+   "decompress_mbps": 431.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3118,
+   "ratio": 0.2796,
+   "compress_mbps": 92.3,
+   "decompress_mbps": 425.1
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 82.76,
+   "decompress_mbps": 423.91
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 80.39,
+   "decompress_mbps": 436.84
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 79.5,
+   "decompress_mbps": 428.65
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1352,
+   "ratio": 0.3633,
+   "compress_mbps": 79.19,
+   "decompress_mbps": 292.96
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1287,
+   "ratio": 0.3459,
+   "compress_mbps": 91.56,
+   "decompress_mbps": 299.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1284,
+   "ratio": 0.3451,
+   "compress_mbps": 87.27,
+   "decompress_mbps": 297.35
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1226,
+   "ratio": 0.3295,
+   "compress_mbps": 81.6,
+   "decompress_mbps": 307.4
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 75.85,
+   "decompress_mbps": 311.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 74.64,
+   "decompress_mbps": 316.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 70.12,
+   "decompress_mbps": 326.4
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 68.19,
+   "decompress_mbps": 326.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 71.6,
+   "decompress_mbps": 319.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 245423,
+   "ratio": 0.2383,
+   "compress_mbps": 247.5,
+   "decompress_mbps": 426.86
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 229642,
+   "ratio": 0.223,
+   "compress_mbps": 222.09,
+   "decompress_mbps": 492.5
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 225678,
+   "ratio": 0.2192,
+   "compress_mbps": 184.98,
+   "decompress_mbps": 499.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 218218,
+   "ratio": 0.2119,
+   "compress_mbps": 172.54,
+   "decompress_mbps": 531.98
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 210550,
+   "ratio": 0.2045,
+   "compress_mbps": 98.16,
+   "decompress_mbps": 510.74
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 207949,
+   "ratio": 0.2019,
+   "compress_mbps": 41.8,
+   "decompress_mbps": 512.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 207413,
+   "ratio": 0.2014,
+   "compress_mbps": 24.36,
+   "decompress_mbps": 505.8
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 207478,
+   "ratio": 0.2015,
+   "compress_mbps": 7.43,
+   "decompress_mbps": 502.84
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 207482,
+   "ratio": 0.2015,
+   "compress_mbps": 3.6,
+   "decompress_mbps": 504.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 175980,
+   "ratio": 0.4124,
+   "compress_mbps": 114.75,
+   "decompress_mbps": 196.92
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 160455,
+   "ratio": 0.376,
+   "compress_mbps": 84.36,
+   "decompress_mbps": 222.57
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 156690,
+   "ratio": 0.3672,
+   "compress_mbps": 70.92,
+   "decompress_mbps": 227.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 149064,
+   "ratio": 0.3493,
+   "compress_mbps": 69.92,
+   "decompress_mbps": 237.82
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145616,
+   "ratio": 0.3412,
+   "compress_mbps": 42.26,
+   "decompress_mbps": 237.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144773,
+   "ratio": 0.3392,
+   "compress_mbps": 33.93,
+   "decompress_mbps": 241.57
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144603,
+   "ratio": 0.3388,
+   "compress_mbps": 30.55,
+   "decompress_mbps": 240.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144573,
+   "ratio": 0.3388,
+   "compress_mbps": 29.22,
+   "decompress_mbps": 239.94
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144570,
+   "ratio": 0.3388,
+   "compress_mbps": 29.23,
+   "decompress_mbps": 236.89
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 228837,
+   "ratio": 0.4749,
+   "compress_mbps": 101.53,
+   "decompress_mbps": 170.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 211248,
+   "ratio": 0.4384,
+   "compress_mbps": 69.11,
+   "decompress_mbps": 193.03
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 205619,
+   "ratio": 0.4267,
+   "compress_mbps": 56.87,
+   "decompress_mbps": 198.04
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 200595,
+   "ratio": 0.4163,
+   "compress_mbps": 57.72,
+   "decompress_mbps": 203.39
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 195418,
+   "ratio": 0.4055,
+   "compress_mbps": 33.47,
+   "decompress_mbps": 204.8
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 194148,
+   "ratio": 0.4029,
+   "compress_mbps": 25.84,
+   "decompress_mbps": 204.61
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 193994,
+   "ratio": 0.4026,
+   "compress_mbps": 23.88,
+   "decompress_mbps": 204.82
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 193991,
+   "ratio": 0.4026,
+   "compress_mbps": 23.63,
+   "decompress_mbps": 205.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 193991,
+   "ratio": 0.4026,
+   "compress_mbps": 23.71,
+   "decompress_mbps": 204.38
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60990,
+   "ratio": 0.1188,
+   "compress_mbps": 318.56,
+   "decompress_mbps": 589.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 61650,
+   "ratio": 0.1201,
+   "compress_mbps": 306.96,
+   "decompress_mbps": 659.53
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 60035,
+   "ratio": 0.117,
+   "compress_mbps": 269.08,
+   "decompress_mbps": 683.91
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57005,
+   "ratio": 0.1111,
+   "compress_mbps": 223.63,
+   "decompress_mbps": 691.14
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 55779,
+   "ratio": 0.1087,
+   "compress_mbps": 171.39,
+   "decompress_mbps": 699.37
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 54970,
+   "ratio": 0.1071,
+   "compress_mbps": 114,
+   "decompress_mbps": 721.14
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 53922,
+   "ratio": 0.1051,
+   "compress_mbps": 83.73,
+   "decompress_mbps": 760.74
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 51977,
+   "ratio": 0.1013,
+   "compress_mbps": 29.04,
+   "decompress_mbps": 793.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 51474,
+   "ratio": 0.1003,
+   "compress_mbps": 7.47,
+   "decompress_mbps": 773.32
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14783,
+   "ratio": 0.3866,
+   "compress_mbps": 113.64,
+   "decompress_mbps": 269.04
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 14101,
+   "ratio": 0.3688,
+   "compress_mbps": 107.75,
+   "decompress_mbps": 299.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13975,
+   "ratio": 0.3655,
+   "compress_mbps": 100.63,
+   "decompress_mbps": 306.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13632,
+   "ratio": 0.3565,
+   "compress_mbps": 91.77,
+   "decompress_mbps": 310.62
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13302,
+   "ratio": 0.3479,
+   "compress_mbps": 69.51,
+   "decompress_mbps": 325.89
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13279,
+   "ratio": 0.3473,
+   "compress_mbps": 52.22,
+   "decompress_mbps": 324.3
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13274,
+   "ratio": 0.3471,
+   "compress_mbps": 41.96,
+   "decompress_mbps": 325.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13260,
+   "ratio": 0.3468,
+   "compress_mbps": 22,
+   "decompress_mbps": 332.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13260,
+   "ratio": 0.3468,
+   "compress_mbps": 13.89,
+   "decompress_mbps": 332.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1862,
+   "ratio": 0.4405,
+   "compress_mbps": 88.73,
+   "decompress_mbps": 262.09
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1803,
+   "ratio": 0.4265,
+   "compress_mbps": 91.48,
+   "decompress_mbps": 272.93
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1791,
+   "ratio": 0.4237,
+   "compress_mbps": 90.92,
+   "decompress_mbps": 277.92
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1746,
+   "ratio": 0.4131,
+   "compress_mbps": 85.18,
+   "decompress_mbps": 279.61
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 81.24,
+   "decompress_mbps": 274.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 80.27,
+   "decompress_mbps": 275.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 80.46,
+   "decompress_mbps": 279.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 82.41,
+   "decompress_mbps": 285.9
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 79.5,
+   "decompress_mbps": 277.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4623589,
+   "ratio": 0.4536,
+   "compress_mbps": 106.98,
+   "decompress_mbps": 176.02
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4241525,
+   "ratio": 0.4161,
+   "compress_mbps": 74.17,
+   "decompress_mbps": 194.53
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4123202,
+   "ratio": 0.4045,
+   "compress_mbps": 61.3,
+   "decompress_mbps": 203.94
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3985937,
+   "ratio": 0.3911,
+   "compress_mbps": 61.86,
+   "decompress_mbps": 202.71
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3883839,
+   "ratio": 0.3811,
+   "compress_mbps": 35.88,
+   "decompress_mbps": 207.24
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3860437,
+   "ratio": 0.3788,
+   "compress_mbps": 27.91,
+   "decompress_mbps": 211.1
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3857076,
+   "ratio": 0.3784,
+   "compress_mbps": 25.28,
+   "decompress_mbps": 210.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3856651,
+   "ratio": 0.3784,
+   "compress_mbps": 24.89,
+   "decompress_mbps": 210.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3856651,
+   "ratio": 0.3784,
+   "compress_mbps": 24.92,
+   "decompress_mbps": 207.99
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 21508211,
+   "ratio": 0.4199,
+   "compress_mbps": 140.53,
+   "decompress_mbps": 236.89
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20538783,
+   "ratio": 0.401,
+   "compress_mbps": 109.51,
+   "decompress_mbps": 239
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 20334352,
+   "ratio": 0.397,
+   "compress_mbps": 95.46,
+   "decompress_mbps": 239.62
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19886937,
+   "ratio": 0.3883,
+   "compress_mbps": 92.08,
+   "decompress_mbps": 243.19
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19582363,
+   "ratio": 0.3823,
+   "compress_mbps": 66.13,
+   "decompress_mbps": 255.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19512479,
+   "ratio": 0.381,
+   "compress_mbps": 44.92,
+   "decompress_mbps": 263.81
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19489160,
+   "ratio": 0.3805,
+   "compress_mbps": 32.8,
+   "decompress_mbps": 264.43
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19475109,
+   "ratio": 0.3802,
+   "compress_mbps": 18.46,
+   "decompress_mbps": 257.16
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19476276,
+   "ratio": 0.3802,
+   "compress_mbps": 10.54,
+   "decompress_mbps": 253.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3967718,
+   "ratio": 0.3979,
+   "compress_mbps": 149.74,
+   "decompress_mbps": 229.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3773274,
+   "ratio": 0.3784,
+   "compress_mbps": 107.04,
+   "decompress_mbps": 231
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3670460,
+   "ratio": 0.3681,
+   "compress_mbps": 78.33,
+   "decompress_mbps": 243.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3655100,
+   "ratio": 0.3666,
+   "compress_mbps": 88.4,
+   "decompress_mbps": 240.27
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3620881,
+   "ratio": 0.3632,
+   "compress_mbps": 51.48,
+   "decompress_mbps": 252.04
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3606626,
+   "ratio": 0.3617,
+   "compress_mbps": 33.56,
+   "decompress_mbps": 245.58
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3605405,
+   "ratio": 0.3616,
+   "compress_mbps": 30.67,
+   "decompress_mbps": 251.27
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3601635,
+   "ratio": 0.3612,
+   "compress_mbps": 26.32,
+   "decompress_mbps": 248.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3601151,
+   "ratio": 0.3612,
+   "compress_mbps": 19.54,
+   "decompress_mbps": 245.27
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4501482,
+   "ratio": 0.1342,
+   "compress_mbps": 336.67,
+   "decompress_mbps": 474.09
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3875891,
+   "ratio": 0.1155,
+   "compress_mbps": 318.06,
+   "decompress_mbps": 611.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3731525,
+   "ratio": 0.1112,
+   "compress_mbps": 286.8,
+   "decompress_mbps": 640.47
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3542242,
+   "ratio": 0.1056,
+   "compress_mbps": 238.32,
+   "decompress_mbps": 645.82
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3239184,
+   "ratio": 0.0965,
+   "compress_mbps": 174.47,
+   "decompress_mbps": 710.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3113927,
+   "ratio": 0.0928,
+   "compress_mbps": 122.16,
+   "decompress_mbps": 697.72
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3063520,
+   "ratio": 0.0913,
+   "compress_mbps": 84.42,
+   "decompress_mbps": 735.89
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2961320,
+   "ratio": 0.0883,
+   "compress_mbps": 29.4,
+   "decompress_mbps": 787.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2940087,
+   "ratio": 0.0876,
+   "compress_mbps": 20.47,
+   "decompress_mbps": 776.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3462708,
+   "ratio": 0.5628,
+   "compress_mbps": 101.43,
+   "decompress_mbps": 165.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3327399,
+   "ratio": 0.5408,
+   "compress_mbps": 74.25,
+   "decompress_mbps": 175.32
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3297422,
+   "ratio": 0.536,
+   "compress_mbps": 67.06,
+   "decompress_mbps": 175.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3249485,
+   "ratio": 0.5282,
+   "compress_mbps": 64.75,
+   "decompress_mbps": 173.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3220046,
+   "ratio": 0.5234,
+   "compress_mbps": 50.21,
+   "decompress_mbps": 178.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3213239,
+   "ratio": 0.5223,
+   "compress_mbps": 43.5,
+   "decompress_mbps": 179.43
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3212009,
+   "ratio": 0.5221,
+   "compress_mbps": 39.47,
+   "decompress_mbps": 177.9
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3211575,
+   "ratio": 0.522,
+   "compress_mbps": 33.8,
+   "decompress_mbps": 180.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3211561,
+   "ratio": 0.522,
+   "compress_mbps": 30.3,
+   "decompress_mbps": 180.52
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4334497,
+   "ratio": 0.4298,
+   "compress_mbps": 144.58,
+   "decompress_mbps": 232.26
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3900156,
+   "ratio": 0.3867,
+   "compress_mbps": 133.61,
+   "decompress_mbps": 260.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3876099,
+   "ratio": 0.3843,
+   "compress_mbps": 124.07,
+   "decompress_mbps": 258.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3782364,
+   "ratio": 0.375,
+   "compress_mbps": 111.89,
+   "decompress_mbps": 261.88
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3679310,
+   "ratio": 0.3648,
+   "compress_mbps": 90.33,
+   "decompress_mbps": 279.39
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3679424,
+   "ratio": 0.3648,
+   "compress_mbps": 88.7,
+   "decompress_mbps": 275.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3679163,
+   "ratio": 0.3648,
+   "compress_mbps": 83.3,
+   "decompress_mbps": 267.69
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3679169,
+   "ratio": 0.3648,
+   "compress_mbps": 82.19,
+   "decompress_mbps": 271.3
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3679169,
+   "ratio": 0.3648,
+   "compress_mbps": 82.74,
+   "decompress_mbps": 267.98
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2496363,
+   "ratio": 0.3767,
+   "compress_mbps": 130.19,
+   "decompress_mbps": 209.65
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2202601,
+   "ratio": 0.3324,
+   "compress_mbps": 94.83,
+   "decompress_mbps": 244.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2103089,
+   "ratio": 0.3173,
+   "compress_mbps": 67.59,
+   "decompress_mbps": 252.42
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1999697,
+   "ratio": 0.3017,
+   "compress_mbps": 75.73,
+   "decompress_mbps": 258.61
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1892143,
+   "ratio": 0.2855,
+   "compress_mbps": 37.51,
+   "decompress_mbps": 255.03
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1838372,
+   "ratio": 0.2774,
+   "compress_mbps": 20.39,
+   "decompress_mbps": 264.23
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1828850,
+   "ratio": 0.276,
+   "compress_mbps": 15.79,
+   "decompress_mbps": 269.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1823159,
+   "ratio": 0.2751,
+   "compress_mbps": 12.51,
+   "decompress_mbps": 260.94
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1823159,
+   "ratio": 0.2751,
+   "compress_mbps": 12.44,
+   "decompress_mbps": 259.47
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6447290,
+   "ratio": 0.2984,
+   "compress_mbps": 192.72,
+   "decompress_mbps": 292.27
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6030257,
+   "ratio": 0.2791,
+   "compress_mbps": 149.93,
+   "decompress_mbps": 306.13
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5928121,
+   "ratio": 0.2744,
+   "compress_mbps": 130.08,
+   "decompress_mbps": 317.1
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5615804,
+   "ratio": 0.2599,
+   "compress_mbps": 123.41,
+   "decompress_mbps": 335.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5496738,
+   "ratio": 0.2544,
+   "compress_mbps": 82.03,
+   "decompress_mbps": 343.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5464184,
+   "ratio": 0.2529,
+   "compress_mbps": 62.81,
+   "decompress_mbps": 342.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5429645,
+   "ratio": 0.2513,
+   "compress_mbps": 49.23,
+   "decompress_mbps": 339.67
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5418135,
+   "ratio": 0.2508,
+   "compress_mbps": 37.69,
+   "decompress_mbps": 335.21
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5416628,
+   "ratio": 0.2507,
+   "compress_mbps": 34.16,
+   "decompress_mbps": 341.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5759187,
+   "ratio": 0.7942,
+   "compress_mbps": 100.78,
+   "decompress_mbps": 175.91
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5619390,
+   "ratio": 0.7749,
+   "compress_mbps": 65.71,
+   "decompress_mbps": 177.71
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5560914,
+   "ratio": 0.7668,
+   "compress_mbps": 56.9,
+   "decompress_mbps": 188.82
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5544069,
+   "ratio": 0.7645,
+   "compress_mbps": 58.81,
+   "decompress_mbps": 183.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5518257,
+   "ratio": 0.7609,
+   "compress_mbps": 45.01,
+   "decompress_mbps": 179.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5508662,
+   "ratio": 0.7596,
+   "compress_mbps": 39.88,
+   "decompress_mbps": 181.4
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5507534,
+   "ratio": 0.7595,
+   "compress_mbps": 38.81,
+   "decompress_mbps": 185.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5507183,
+   "ratio": 0.7594,
+   "compress_mbps": 38.34,
+   "decompress_mbps": 181
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5507183,
+   "ratio": 0.7594,
+   "compress_mbps": 38.39,
+   "decompress_mbps": 179.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 15230651,
+   "ratio": 0.3674,
+   "compress_mbps": 124.61,
+   "decompress_mbps": 206.2
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13822040,
+   "ratio": 0.3334,
+   "compress_mbps": 97.4,
+   "decompress_mbps": 219.05
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13397592,
+   "ratio": 0.3232,
+   "compress_mbps": 84.32,
+   "decompress_mbps": 233.41
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12759940,
+   "ratio": 0.3078,
+   "compress_mbps": 82.61,
+   "decompress_mbps": 238.83
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12274278,
+   "ratio": 0.2961,
+   "compress_mbps": 54.59,
+   "decompress_mbps": 253.03
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12131738,
+   "ratio": 0.2926,
+   "compress_mbps": 40.48,
+   "decompress_mbps": 247.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12060450,
+   "ratio": 0.2909,
+   "compress_mbps": 33.75,
+   "decompress_mbps": 253.63
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12036900,
+   "ratio": 0.2903,
+   "compress_mbps": 30.14,
+   "decompress_mbps": 251.44
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12036900,
+   "ratio": 0.2903,
+   "compress_mbps": 30.19,
+   "decompress_mbps": 249.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6653052,
+   "ratio": 0.7851,
+   "compress_mbps": 172.49,
+   "decompress_mbps": 182.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6305035,
+   "ratio": 0.744,
+   "compress_mbps": 69.43,
+   "decompress_mbps": 165.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6302730,
+   "ratio": 0.7438,
+   "compress_mbps": 68.88,
+   "decompress_mbps": 168.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6299134,
+   "ratio": 0.7433,
+   "compress_mbps": 68.45,
+   "decompress_mbps": 166.89
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6289022,
+   "ratio": 0.7421,
+   "compress_mbps": 65.16,
+   "decompress_mbps": 169.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6289013,
+   "ratio": 0.7421,
+   "compress_mbps": 65.19,
+   "decompress_mbps": 167.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6289013,
+   "ratio": 0.7421,
+   "compress_mbps": 65.58,
+   "decompress_mbps": 165.62
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6289012,
+   "ratio": 0.7421,
+   "compress_mbps": 65.58,
+   "decompress_mbps": 165.13
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6289012,
+   "ratio": 0.7421,
+   "compress_mbps": 65.51,
+   "decompress_mbps": 167.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 989456,
+   "ratio": 0.1851,
+   "compress_mbps": 255.45,
+   "decompress_mbps": 390.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 839766,
+   "ratio": 0.1571,
+   "compress_mbps": 233.42,
+   "decompress_mbps": 504.86
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 800619,
+   "ratio": 0.1498,
+   "compress_mbps": 201.28,
+   "decompress_mbps": 494.08
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 776397,
+   "ratio": 0.1452,
+   "compress_mbps": 178.01,
+   "decompress_mbps": 508.96
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 712679,
+   "ratio": 0.1333,
+   "compress_mbps": 126.49,
+   "decompress_mbps": 592.48
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 683707,
+   "ratio": 0.1279,
+   "compress_mbps": 95.75,
+   "decompress_mbps": 571.97
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 668601,
+   "ratio": 0.1251,
+   "compress_mbps": 71.72,
+   "decompress_mbps": 590.26
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 659106,
+   "ratio": 0.1233,
+   "compress_mbps": 48.43,
+   "decompress_mbps": 582.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 658920,
+   "ratio": 0.1233,
+   "compress_mbps": 47.23,
+   "decompress_mbps": 637.82
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 87.23,
+   "decompress_mbps": 313.92
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 87.82,
+   "decompress_mbps": 313.53
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 84.18,
+   "decompress_mbps": 314.84
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 88.33,
+   "decompress_mbps": 311.1
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54531,
+   "ratio": 0.3585,
+   "compress_mbps": 54.91,
+   "decompress_mbps": 307.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54068,
+   "ratio": 0.3555,
+   "compress_mbps": 42.11,
+   "decompress_mbps": 310.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54003,
+   "ratio": 0.3551,
+   "compress_mbps": 37.17,
+   "decompress_mbps": 312.05
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 53974,
+   "ratio": 0.3549,
+   "compress_mbps": 32.72,
+   "decompress_mbps": 307.61
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 53974,
+   "ratio": 0.3549,
+   "compress_mbps": 32.8,
+   "decompress_mbps": 305.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 83.09,
+   "decompress_mbps": 278.48
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 83.15,
+   "decompress_mbps": 279.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 82.26,
+   "decompress_mbps": 275.94
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 83.53,
+   "decompress_mbps": 277.74
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48753,
+   "ratio": 0.3895,
+   "compress_mbps": 50.56,
+   "decompress_mbps": 275.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48557,
+   "ratio": 0.3879,
+   "compress_mbps": 40.4,
+   "decompress_mbps": 278.51
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48523,
+   "ratio": 0.3876,
+   "compress_mbps": 38.25,
+   "decompress_mbps": 278.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48522,
+   "ratio": 0.3876,
+   "compress_mbps": 37.36,
+   "decompress_mbps": 279.9
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48522,
+   "ratio": 0.3876,
+   "compress_mbps": 37.5,
+   "decompress_mbps": 279.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 156.38,
+   "decompress_mbps": 280.51
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 173.35,
+   "decompress_mbps": 279.44
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 163.42,
+   "decompress_mbps": 281.7
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 174.83,
+   "decompress_mbps": 284.38
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7965,
+   "ratio": 0.3237,
+   "compress_mbps": 108.3,
+   "decompress_mbps": 287.18
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7914,
+   "ratio": 0.3217,
+   "compress_mbps": 86.29,
+   "decompress_mbps": 291.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7895,
+   "ratio": 0.3209,
+   "compress_mbps": 76.54,
+   "decompress_mbps": 289.34
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7896,
+   "ratio": 0.3209,
+   "compress_mbps": 69.93,
+   "decompress_mbps": 292.05
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7896,
+   "ratio": 0.3209,
+   "compress_mbps": 72.79,
+   "decompress_mbps": 289.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 170.42,
+   "decompress_mbps": 257.79
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 173.96,
+   "decompress_mbps": 255.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 171.38,
+   "decompress_mbps": 255.39
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 163.6,
+   "decompress_mbps": 259.71
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3136,
+   "ratio": 0.2813,
+   "compress_mbps": 141.53,
+   "decompress_mbps": 263.78
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3115,
+   "ratio": 0.2794,
+   "compress_mbps": 124.88,
+   "decompress_mbps": 262.73
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 98.74,
+   "decompress_mbps": 265.35
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 105.25,
+   "decompress_mbps": 265.25
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 106.7,
+   "decompress_mbps": 266.44
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 120.04,
+   "decompress_mbps": 121.08
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 117.35,
+   "decompress_mbps": 118.87
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 118.61,
+   "decompress_mbps": 118.91
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 117.29,
+   "decompress_mbps": 117.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 108.92,
+   "decompress_mbps": 118.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 105.41,
+   "decompress_mbps": 121.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 100.51,
+   "decompress_mbps": 119.96
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 100.99,
+   "decompress_mbps": 119.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 100.76,
+   "decompress_mbps": 117.12
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 224.07,
+   "decompress_mbps": 458.01
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 227.75,
+   "decompress_mbps": 460.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 229.45,
+   "decompress_mbps": 459.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 230.58,
+   "decompress_mbps": 459.38
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 218313,
+   "ratio": 0.212,
+   "compress_mbps": 156.12,
+   "decompress_mbps": 444.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 215095,
+   "ratio": 0.2089,
+   "compress_mbps": 106.5,
+   "decompress_mbps": 447.33
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 213213,
+   "ratio": 0.2071,
+   "compress_mbps": 71.16,
+   "decompress_mbps": 445.04
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 210955,
+   "ratio": 0.2049,
+   "compress_mbps": 9.25,
+   "decompress_mbps": 447.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 210981,
+   "ratio": 0.2049,
+   "compress_mbps": 4.62,
+   "decompress_mbps": 451.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.3,
+   "decompress_mbps": 307.48
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.07,
+   "decompress_mbps": 310.96
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 91.88,
+   "decompress_mbps": 308.43
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.46,
+   "decompress_mbps": 309.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145024,
+   "ratio": 0.3398,
+   "compress_mbps": 57.59,
+   "decompress_mbps": 307.15
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144159,
+   "ratio": 0.3378,
+   "compress_mbps": 44.47,
+   "decompress_mbps": 308.17
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 143991,
+   "ratio": 0.3374,
+   "compress_mbps": 40.14,
+   "decompress_mbps": 307.36
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 143941,
+   "ratio": 0.3373,
+   "compress_mbps": 36.91,
+   "decompress_mbps": 307.68
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 143939,
+   "ratio": 0.3373,
+   "compress_mbps": 36.73,
+   "decompress_mbps": 293.8
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 80.64,
+   "decompress_mbps": 252.66
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 80.21,
+   "decompress_mbps": 249.45
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 79.98,
+   "decompress_mbps": 242.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 79.52,
+   "decompress_mbps": 245.99
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 194496,
+   "ratio": 0.4036,
+   "compress_mbps": 45.02,
+   "decompress_mbps": 245.25
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 193176,
+   "ratio": 0.4009,
+   "compress_mbps": 33.8,
+   "decompress_mbps": 249.91
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 192991,
+   "ratio": 0.4005,
+   "compress_mbps": 30.68,
+   "decompress_mbps": 248.71
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 192980,
+   "ratio": 0.4005,
+   "compress_mbps": 29.06,
+   "decompress_mbps": 244.39
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 192980,
+   "ratio": 0.4005,
+   "compress_mbps": 29.11,
+   "decompress_mbps": 248.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 290.93,
+   "decompress_mbps": 708.69
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 288.71,
+   "decompress_mbps": 722.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 288.41,
+   "decompress_mbps": 730.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 287.22,
+   "decompress_mbps": 733.87
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 56050,
+   "ratio": 0.1092,
+   "compress_mbps": 227.48,
+   "decompress_mbps": 754.71
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55292,
+   "ratio": 0.1077,
+   "compress_mbps": 151.11,
+   "decompress_mbps": 780.26
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 54651,
+   "ratio": 0.1065,
+   "compress_mbps": 122.76,
+   "decompress_mbps": 798.56
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52583,
+   "ratio": 0.1025,
+   "compress_mbps": 46.44,
+   "decompress_mbps": 818.39
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 51816,
+   "ratio": 0.101,
+   "compress_mbps": 15.56,
+   "decompress_mbps": 803.12
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 116.13,
+   "decompress_mbps": 300.55
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 115.93,
+   "decompress_mbps": 300.55
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 110.39,
+   "decompress_mbps": 299.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 115.14,
+   "decompress_mbps": 300.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13290,
+   "ratio": 0.3475,
+   "compress_mbps": 85.87,
+   "decompress_mbps": 314.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13258,
+   "ratio": 0.3467,
+   "compress_mbps": 67.57,
+   "decompress_mbps": 315.93
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13246,
+   "ratio": 0.3464,
+   "compress_mbps": 56.2,
+   "decompress_mbps": 308.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13236,
+   "ratio": 0.3461,
+   "compress_mbps": 24.96,
+   "decompress_mbps": 318.92
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13233,
+   "ratio": 0.3461,
+   "compress_mbps": 15.95,
+   "decompress_mbps": 318.71
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 96.54,
+   "decompress_mbps": 131.88
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 93.5,
+   "decompress_mbps": 132.47
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 98.07,
+   "decompress_mbps": 132.39
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 98.56,
+   "decompress_mbps": 132.91
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 94.01,
+   "decompress_mbps": 133.38
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 93.93,
+   "decompress_mbps": 134.14
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 92.87,
+   "decompress_mbps": 133.66
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 93.28,
+   "decompress_mbps": 133.46
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 95.85,
+   "decompress_mbps": 133.7
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 82.59,
+   "decompress_mbps": 270.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 83.3,
+   "decompress_mbps": 274.91
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 83.66,
+   "decompress_mbps": 275.15
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 83.47,
+   "decompress_mbps": 271.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3863846,
+   "ratio": 0.3791,
+   "compress_mbps": 48.19,
+   "decompress_mbps": 269.37
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3838854,
+   "ratio": 0.3766,
+   "compress_mbps": 36.71,
+   "decompress_mbps": 269.3
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3835182,
+   "ratio": 0.3763,
+   "compress_mbps": 33.02,
+   "decompress_mbps": 269.03
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3834518,
+   "ratio": 0.3762,
+   "compress_mbps": 31.03,
+   "decompress_mbps": 274.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3834518,
+   "ratio": 0.3762,
+   "compress_mbps": 31.2,
+   "decompress_mbps": 274.73
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.35,
+   "decompress_mbps": 251.68
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 102.55,
+   "decompress_mbps": 253.17
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 101.76,
+   "decompress_mbps": 250.34
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 102.91,
+   "decompress_mbps": 252.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19578840,
+   "ratio": 0.3822,
+   "compress_mbps": 77.43,
+   "decompress_mbps": 261.3
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19492445,
+   "ratio": 0.3806,
+   "compress_mbps": 57.57,
+   "decompress_mbps": 264.67
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19463481,
+   "ratio": 0.38,
+   "compress_mbps": 45.88,
+   "decompress_mbps": 263.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19444704,
+   "ratio": 0.3796,
+   "compress_mbps": 22.74,
+   "decompress_mbps": 262.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19440748,
+   "ratio": 0.3796,
+   "compress_mbps": 13.03,
+   "decompress_mbps": 265.43
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.81,
+   "decompress_mbps": 262.84
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.15,
+   "decompress_mbps": 262.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.47,
+   "decompress_mbps": 260.84
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.42,
+   "decompress_mbps": 262.7
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3637736,
+   "ratio": 0.3648,
+   "compress_mbps": 65.76,
+   "decompress_mbps": 270.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3621530,
+   "ratio": 0.3632,
+   "compress_mbps": 46.28,
+   "decompress_mbps": 271.66
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3623924,
+   "ratio": 0.3635,
+   "compress_mbps": 41.81,
+   "decompress_mbps": 272.81
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3623112,
+   "ratio": 0.3634,
+   "compress_mbps": 32.5,
+   "decompress_mbps": 272.72
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3623382,
+   "ratio": 0.3634,
+   "compress_mbps": 24.71,
+   "decompress_mbps": 272.05
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 309.13,
+   "decompress_mbps": 892.04
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 308.95,
+   "decompress_mbps": 885.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 306.9,
+   "decompress_mbps": 881.55
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 308.3,
+   "decompress_mbps": 884.17
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3268887,
+   "ratio": 0.0974,
+   "compress_mbps": 225.83,
+   "decompress_mbps": 931.27
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3131445,
+   "ratio": 0.0933,
+   "compress_mbps": 161.25,
+   "decompress_mbps": 965.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3080217,
+   "ratio": 0.0918,
+   "compress_mbps": 126.08,
+   "decompress_mbps": 961.7
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2978354,
+   "ratio": 0.0888,
+   "compress_mbps": 54.64,
+   "decompress_mbps": 984.8
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2947971,
+   "ratio": 0.0879,
+   "compress_mbps": 33.84,
+   "decompress_mbps": 989.96
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 71.81,
+   "decompress_mbps": 184.61
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.12,
+   "decompress_mbps": 184.24
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 71.93,
+   "decompress_mbps": 184.96
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.26,
+   "decompress_mbps": 184.78
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3178914,
+   "ratio": 0.5167,
+   "compress_mbps": 55.7,
+   "decompress_mbps": 191.91
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3174170,
+   "ratio": 0.5159,
+   "compress_mbps": 48.64,
+   "decompress_mbps": 193.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3172734,
+   "ratio": 0.5157,
+   "compress_mbps": 45.8,
+   "decompress_mbps": 193.57
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3171353,
+   "ratio": 0.5155,
+   "compress_mbps": 38.57,
+   "decompress_mbps": 193.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3171299,
+   "ratio": 0.5155,
+   "compress_mbps": 34.71,
+   "decompress_mbps": 193.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 123.53,
+   "decompress_mbps": 272.88
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 123.96,
+   "decompress_mbps": 275.8
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 123.58,
+   "decompress_mbps": 276.01
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 123.38,
+   "decompress_mbps": 273.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3654027,
+   "ratio": 0.3623,
+   "compress_mbps": 96.18,
+   "decompress_mbps": 277.93
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3652732,
+   "ratio": 0.3622,
+   "compress_mbps": 93.36,
+   "decompress_mbps": 277.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3652496,
+   "ratio": 0.3621,
+   "compress_mbps": 87.38,
+   "decompress_mbps": 277.61
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3652505,
+   "ratio": 0.3621,
+   "compress_mbps": 87.25,
+   "decompress_mbps": 277.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3652505,
+   "ratio": 0.3621,
+   "compress_mbps": 87.18,
+   "decompress_mbps": 274.43
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 99.53,
+   "decompress_mbps": 359.02
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 99.54,
+   "decompress_mbps": 357.84
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 98.86,
+   "decompress_mbps": 358.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 99.12,
+   "decompress_mbps": 358.87
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1892183,
+   "ratio": 0.2855,
+   "compress_mbps": 52.27,
+   "decompress_mbps": 357.11
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1837957,
+   "ratio": 0.2773,
+   "compress_mbps": 30.32,
+   "decompress_mbps": 366.73
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1826603,
+   "ratio": 0.2756,
+   "compress_mbps": 24.27,
+   "decompress_mbps": 366.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1818702,
+   "ratio": 0.2744,
+   "compress_mbps": 15.83,
+   "decompress_mbps": 365.68
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1818702,
+   "ratio": 0.2744,
+   "compress_mbps": 15.8,
+   "decompress_mbps": 366.33
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 144.08,
+   "decompress_mbps": 400.86
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 144.61,
+   "decompress_mbps": 403.43
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 144.91,
+   "decompress_mbps": 404.3
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 144.99,
+   "decompress_mbps": 403.33
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5501344,
+   "ratio": 0.2546,
+   "compress_mbps": 103.0,
+   "decompress_mbps": 408.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5464646,
+   "ratio": 0.2529,
+   "compress_mbps": 78.95,
+   "decompress_mbps": 412.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5429975,
+   "ratio": 0.2513,
+   "compress_mbps": 66.89,
+   "decompress_mbps": 413.55
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5419566,
+   "ratio": 0.2508,
+   "compress_mbps": 49.42,
+   "decompress_mbps": 412.12
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5417952,
+   "ratio": 0.2508,
+   "compress_mbps": 45.42,
+   "decompress_mbps": 413.22
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.25,
+   "decompress_mbps": 162.57
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.57,
+   "decompress_mbps": 162.43
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.38,
+   "decompress_mbps": 162.61
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.32,
+   "decompress_mbps": 162.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5450496,
+   "ratio": 0.7516,
+   "compress_mbps": 46.65,
+   "decompress_mbps": 165.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5440281,
+   "ratio": 0.7502,
+   "compress_mbps": 40.78,
+   "decompress_mbps": 152.94
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5439077,
+   "ratio": 0.75,
+   "compress_mbps": 40.35,
+   "decompress_mbps": 157.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5438787,
+   "ratio": 0.75,
+   "compress_mbps": 38.69,
+   "decompress_mbps": 161.6
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5438787,
+   "ratio": 0.75,
+   "compress_mbps": 39.68,
+   "decompress_mbps": 164.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 106.97,
+   "decompress_mbps": 315.78
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.82,
+   "decompress_mbps": 316.45
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.42,
+   "decompress_mbps": 319.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.71,
+   "decompress_mbps": 320.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12238874,
+   "ratio": 0.2952,
+   "compress_mbps": 72.07,
+   "decompress_mbps": 324.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12086531,
+   "ratio": 0.2915,
+   "compress_mbps": 53.46,
+   "decompress_mbps": 327.48
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12020742,
+   "ratio": 0.2899,
+   "compress_mbps": 46.3,
+   "decompress_mbps": 327.39
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 11987253,
+   "ratio": 0.2891,
+   "compress_mbps": 37.94,
+   "decompress_mbps": 328.74
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11987245,
+   "ratio": 0.2891,
+   "compress_mbps": 37.78,
+   "decompress_mbps": 324.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 61.03,
+   "decompress_mbps": 147.69
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 61.28,
+   "decompress_mbps": 147.25
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 61.19,
+   "decompress_mbps": 147.99
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 61.15,
+   "decompress_mbps": 147.99
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6244483,
+   "ratio": 0.7369,
+   "compress_mbps": 55.89,
+   "decompress_mbps": 149.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6244482,
+   "ratio": 0.7369,
+   "compress_mbps": 55.73,
+   "decompress_mbps": 149.73
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6244482,
+   "ratio": 0.7369,
+   "compress_mbps": 55.89,
+   "decompress_mbps": 149.78
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6244480,
+   "ratio": 0.7369,
+   "compress_mbps": 56.03,
+   "decompress_mbps": 149.93
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6244480,
+   "ratio": 0.7369,
+   "compress_mbps": 55.95,
+   "decompress_mbps": 149.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 230.99,
+   "decompress_mbps": 681.22
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 231.6,
+   "decompress_mbps": 669.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 231.88,
+   "decompress_mbps": 680.3
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 231.73,
+   "decompress_mbps": 679.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 716461,
+   "ratio": 0.134,
+   "compress_mbps": 165.89,
+   "decompress_mbps": 714.55
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 687053,
+   "ratio": 0.1285,
+   "compress_mbps": 124.71,
+   "decompress_mbps": 741.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 673597,
+   "ratio": 0.126,
+   "compress_mbps": 101.0,
+   "decompress_mbps": 757.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 662156,
+   "ratio": 0.1239,
+   "compress_mbps": 65.42,
+   "decompress_mbps": 760.55
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 661610,
+   "ratio": 0.1238,
+   "compress_mbps": 61.08,
+   "decompress_mbps": 762.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 73589,
+   "ratio": 0.4839,
+   "compress_mbps": 34.53,
+   "decompress_mbps": 57.57
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 69878,
+   "ratio": 0.4595,
+   "compress_mbps": 32.9,
+   "decompress_mbps": 58.57
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 66917,
+   "ratio": 0.44,
+   "compress_mbps": 27.28,
+   "decompress_mbps": 66.6
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 59388,
+   "ratio": 0.3905,
+   "compress_mbps": 31.75,
+   "decompress_mbps": 80.7
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 57062,
+   "ratio": 0.3752,
+   "compress_mbps": 22.74,
+   "decompress_mbps": 80.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 55472,
+   "ratio": 0.3647,
+   "compress_mbps": 16.38,
+   "decompress_mbps": 79.73
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 55265,
+   "ratio": 0.3634,
+   "compress_mbps": 14.32,
+   "decompress_mbps": 80.11
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 55168,
+   "ratio": 0.3627,
+   "compress_mbps": 11.95,
+   "decompress_mbps": 79.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 55168,
+   "ratio": 0.3627,
+   "compress_mbps": 11.97,
+   "decompress_mbps": 80.09
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 64551,
+   "ratio": 0.5157,
+   "compress_mbps": 32.72,
+   "decompress_mbps": 54.58
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 62089,
+   "ratio": 0.496,
+   "compress_mbps": 31.02,
+   "decompress_mbps": 58.34
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 58690,
+   "ratio": 0.4688,
+   "compress_mbps": 24.8,
+   "decompress_mbps": 59.71
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 53521,
+   "ratio": 0.4276,
+   "compress_mbps": 30.17,
+   "decompress_mbps": 80.38
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 51677,
+   "ratio": 0.4128,
+   "compress_mbps": 20.96,
+   "decompress_mbps": 78.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 50638,
+   "ratio": 0.4045,
+   "compress_mbps": 14.99,
+   "decompress_mbps": 84.28
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 50501,
+   "ratio": 0.4034,
+   "compress_mbps": 13.57,
+   "decompress_mbps": 80.06
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 50452,
+   "ratio": 0.403,
+   "compress_mbps": 12.62,
+   "decompress_mbps": 83.56
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 50452,
+   "ratio": 0.403,
+   "compress_mbps": 12.61,
+   "decompress_mbps": 83.29
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 9859,
+   "ratio": 0.4007,
+   "compress_mbps": 44.32,
+   "decompress_mbps": 113.78
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 10473,
+   "ratio": 0.4257,
+   "compress_mbps": 48.22,
+   "decompress_mbps": 149.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 10172,
+   "ratio": 0.4134,
+   "compress_mbps": 43.3,
+   "decompress_mbps": 152.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8692,
+   "ratio": 0.3533,
+   "compress_mbps": 41.91,
+   "decompress_mbps": 152.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8440,
+   "ratio": 0.343,
+   "compress_mbps": 36.02,
+   "decompress_mbps": 156.73
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 8385,
+   "ratio": 0.3408,
+   "compress_mbps": 32.13,
+   "decompress_mbps": 157.13
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 8366,
+   "ratio": 0.34,
+   "compress_mbps": 30.34,
+   "decompress_mbps": 151.47
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 8367,
+   "ratio": 0.3401,
+   "compress_mbps": 29.21,
+   "decompress_mbps": 158.02
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 8367,
+   "ratio": 0.3401,
+   "compress_mbps": 29.15,
+   "decompress_mbps": 155.98
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 4822,
+   "ratio": 0.4325,
+   "compress_mbps": 54.52,
+   "decompress_mbps": 188.53
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 4593,
+   "ratio": 0.4119,
+   "compress_mbps": 54.24,
+   "decompress_mbps": 193.47
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 4381,
+   "ratio": 0.3929,
+   "compress_mbps": 52.66,
+   "decompress_mbps": 199.66
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3725,
+   "ratio": 0.3341,
+   "compress_mbps": 52.59,
+   "decompress_mbps": 202.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3614,
+   "ratio": 0.3241,
+   "compress_mbps": 44.28,
+   "decompress_mbps": 208.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3578,
+   "ratio": 0.3209,
+   "compress_mbps": 39.76,
+   "decompress_mbps": 210.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3572,
+   "ratio": 0.3204,
+   "compress_mbps": 37.2,
+   "decompress_mbps": 210.06
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3568,
+   "ratio": 0.32,
+   "compress_mbps": 33.64,
+   "decompress_mbps": 209.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3568,
+   "ratio": 0.32,
+   "compress_mbps": 34.12,
+   "decompress_mbps": 210.14
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1738,
+   "ratio": 0.4671,
+   "compress_mbps": 30.63,
+   "decompress_mbps": 178.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1709,
+   "ratio": 0.4593,
+   "compress_mbps": 32.07,
+   "decompress_mbps": 179.56
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1694,
+   "ratio": 0.4553,
+   "compress_mbps": 31.49,
+   "decompress_mbps": 180.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1458,
+   "ratio": 0.3918,
+   "compress_mbps": 30.44,
+   "decompress_mbps": 188.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1441,
+   "ratio": 0.3873,
+   "compress_mbps": 29.17,
+   "decompress_mbps": 190.78
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.19,
+   "decompress_mbps": 192.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.94,
+   "decompress_mbps": 190.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.47,
+   "decompress_mbps": 192.63
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.85,
+   "decompress_mbps": 192.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 260073,
+   "ratio": 0.2526,
+   "compress_mbps": 53.47,
+   "decompress_mbps": 57.67
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 296764,
+   "ratio": 0.2882,
+   "compress_mbps": 49.71,
+   "decompress_mbps": 76.91
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 288989,
+   "ratio": 0.2806,
+   "compress_mbps": 38.04,
+   "decompress_mbps": 78.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 246442,
+   "ratio": 0.2393,
+   "compress_mbps": 54.21,
+   "decompress_mbps": 83.24
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 218888,
+   "ratio": 0.2126,
+   "compress_mbps": 40.33,
+   "decompress_mbps": 77.32
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 217830,
+   "ratio": 0.2115,
+   "compress_mbps": 24.23,
+   "decompress_mbps": 88.27
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 221437,
+   "ratio": 0.215,
+   "compress_mbps": 19.37,
+   "decompress_mbps": 87.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 219666,
+   "ratio": 0.2133,
+   "compress_mbps": 5.51,
+   "decompress_mbps": 85.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 219921,
+   "ratio": 0.2136,
+   "compress_mbps": 2.78,
+   "decompress_mbps": 87.37
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 194588,
+   "ratio": 0.456,
+   "compress_mbps": 34.89,
+   "decompress_mbps": 52.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 185757,
+   "ratio": 0.4353,
+   "compress_mbps": 33.46,
+   "decompress_mbps": 49.8
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 175850,
+   "ratio": 0.4121,
+   "compress_mbps": 27.59,
+   "decompress_mbps": 59.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 155951,
+   "ratio": 0.3654,
+   "compress_mbps": 32.39,
+   "decompress_mbps": 73.44
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 150274,
+   "ratio": 0.3521,
+   "compress_mbps": 23.26,
+   "decompress_mbps": 72.52
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 147958,
+   "ratio": 0.3467,
+   "compress_mbps": 16.81,
+   "decompress_mbps": 73.51
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 147522,
+   "ratio": 0.3457,
+   "compress_mbps": 15.18,
+   "decompress_mbps": 71.72
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 147331,
+   "ratio": 0.3452,
+   "compress_mbps": 13.61,
+   "decompress_mbps": 71.04
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 147328,
+   "ratio": 0.3452,
+   "compress_mbps": 13.61,
+   "decompress_mbps": 72.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 256904,
+   "ratio": 0.5331,
+   "compress_mbps": 30.48,
+   "decompress_mbps": 46.92
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 245675,
+   "ratio": 0.5098,
+   "compress_mbps": 29.14,
+   "decompress_mbps": 50.06
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 231519,
+   "ratio": 0.4805,
+   "compress_mbps": 23.07,
+   "decompress_mbps": 57.17
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 210028,
+   "ratio": 0.4359,
+   "compress_mbps": 27.9,
+   "decompress_mbps": 65.64
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 203312,
+   "ratio": 0.4219,
+   "compress_mbps": 18.75,
+   "decompress_mbps": 62.62
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 199287,
+   "ratio": 0.4136,
+   "compress_mbps": 12.87,
+   "decompress_mbps": 66.39
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 198474,
+   "ratio": 0.4119,
+   "compress_mbps": 11.21,
+   "decompress_mbps": 66.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 198080,
+   "ratio": 0.4111,
+   "compress_mbps": 8.86,
+   "decompress_mbps": 65.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 198080,
+   "ratio": 0.4111,
+   "compress_mbps": 8.91,
+   "decompress_mbps": 65.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 71229,
+   "ratio": 0.1388,
+   "compress_mbps": 83.77,
+   "decompress_mbps": 131.58
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 69946,
+   "ratio": 0.1363,
+   "compress_mbps": 80.79,
+   "decompress_mbps": 137.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 68538,
+   "ratio": 0.1335,
+   "compress_mbps": 71.18,
+   "decompress_mbps": 151.28
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 61320,
+   "ratio": 0.1195,
+   "compress_mbps": 66.7,
+   "decompress_mbps": 167.14
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 59993,
+   "ratio": 0.1169,
+   "compress_mbps": 57.62,
+   "decompress_mbps": 167.58
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 58637,
+   "ratio": 0.1143,
+   "compress_mbps": 41.62,
+   "decompress_mbps": 167.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 58209,
+   "ratio": 0.1134,
+   "compress_mbps": 35.62,
+   "decompress_mbps": 175.53
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 55749,
+   "ratio": 0.1086,
+   "compress_mbps": 19.34,
+   "decompress_mbps": 178.8
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 54927,
+   "ratio": 0.107,
+   "compress_mbps": 7.47,
+   "decompress_mbps": 178.91
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 16399,
+   "ratio": 0.4288,
+   "compress_mbps": 37.32,
+   "decompress_mbps": 88.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 15933,
+   "ratio": 0.4167,
+   "compress_mbps": 34.65,
+   "decompress_mbps": 90.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 15739,
+   "ratio": 0.4116,
+   "compress_mbps": 28.77,
+   "decompress_mbps": 87.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13834,
+   "ratio": 0.3618,
+   "compress_mbps": 32.3,
+   "decompress_mbps": 107.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13463,
+   "ratio": 0.3521,
+   "compress_mbps": 26.29,
+   "decompress_mbps": 110.38
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13353,
+   "ratio": 0.3492,
+   "compress_mbps": 19.08,
+   "decompress_mbps": 111.13
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13317,
+   "ratio": 0.3482,
+   "compress_mbps": 15.86,
+   "decompress_mbps": 111.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13255,
+   "ratio": 0.3466,
+   "compress_mbps": 8.41,
+   "decompress_mbps": 111.28
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13171,
+   "ratio": 0.3444,
+   "compress_mbps": 4.15,
+   "decompress_mbps": 113.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 2512,
+   "ratio": 0.5943,
+   "compress_mbps": 28.93,
+   "decompress_mbps": 159.45
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 2477,
+   "ratio": 0.586,
+   "compress_mbps": 29.81,
+   "decompress_mbps": 161.01
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 2452,
+   "ratio": 0.5801,
+   "compress_mbps": 30.92,
+   "decompress_mbps": 161.34
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 2110,
+   "ratio": 0.4992,
+   "compress_mbps": 29.19,
+   "decompress_mbps": 160.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.88,
+   "decompress_mbps": 169.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 29.34,
+   "decompress_mbps": 170.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.91,
+   "decompress_mbps": 169.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 29.08,
+   "decompress_mbps": 170.68
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.76,
+   "decompress_mbps": 162.67
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 5183792,
+   "ratio": 0.5086,
+   "compress_mbps": 31.94,
+   "decompress_mbps": 39.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4956750,
+   "ratio": 0.4863,
+   "compress_mbps": 30.27,
+   "decompress_mbps": 43.07
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4644095,
+   "ratio": 0.4556,
+   "compress_mbps": 24.33,
+   "decompress_mbps": 47.82
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4178564,
+   "ratio": 0.41,
+   "compress_mbps": 29.19,
+   "decompress_mbps": 60.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 4034632,
+   "ratio": 0.3958,
+   "compress_mbps": 20.02,
+   "decompress_mbps": 61.14
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3952244,
+   "ratio": 0.3878,
+   "compress_mbps": 14.05,
+   "decompress_mbps": 61.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3938822,
+   "ratio": 0.3864,
+   "compress_mbps": 12.28,
+   "decompress_mbps": 61.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3935171,
+   "ratio": 0.3861,
+   "compress_mbps": 10.81,
+   "decompress_mbps": 61.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3935171,
+   "ratio": 0.3861,
+   "compress_mbps": 10.75,
+   "decompress_mbps": 61.78
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 25320013,
+   "ratio": 0.4943,
+   "compress_mbps": 32.7,
+   "decompress_mbps": 34.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 24804084,
+   "ratio": 0.4843,
+   "compress_mbps": 31.11,
+   "decompress_mbps": 36.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 24241121,
+   "ratio": 0.4733,
+   "compress_mbps": 26.19,
+   "decompress_mbps": 37.28
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 20950547,
+   "ratio": 0.409,
+   "compress_mbps": 29.54,
+   "decompress_mbps": 44.04
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 20592289,
+   "ratio": 0.402,
+   "compress_mbps": 24.65,
+   "decompress_mbps": 45.47
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 20445232,
+   "ratio": 0.3992,
+   "compress_mbps": 18.85,
+   "decompress_mbps": 46.45
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 20407676,
+   "ratio": 0.3984,
+   "compress_mbps": 16.11,
+   "decompress_mbps": 46.66
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 20389473,
+   "ratio": 0.3981,
+   "compress_mbps": 10.25,
+   "decompress_mbps": 45.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 20386824,
+   "ratio": 0.398,
+   "compress_mbps": 6.88,
+   "decompress_mbps": 45.39
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3964698,
+   "ratio": 0.3976,
+   "compress_mbps": 38.8,
+   "decompress_mbps": 48.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3936391,
+   "ratio": 0.3948,
+   "compress_mbps": 36.31,
+   "decompress_mbps": 49.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3823540,
+   "ratio": 0.3835,
+   "compress_mbps": 28.05,
+   "decompress_mbps": 52.45
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3799601,
+   "ratio": 0.3811,
+   "compress_mbps": 33.08,
+   "decompress_mbps": 62.74
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3830938,
+   "ratio": 0.3842,
+   "compress_mbps": 22.72,
+   "decompress_mbps": 57.8
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3808303,
+   "ratio": 0.382,
+   "compress_mbps": 14.84,
+   "decompress_mbps": 58.01
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3802814,
+   "ratio": 0.3814,
+   "compress_mbps": 12.15,
+   "decompress_mbps": 57.78
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3800355,
+   "ratio": 0.3812,
+   "compress_mbps": 6.76,
+   "decompress_mbps": 57.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3799676,
+   "ratio": 0.3811,
+   "compress_mbps": 6.07,
+   "decompress_mbps": 58.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4899547,
+   "ratio": 0.146,
+   "compress_mbps": 96.81,
+   "decompress_mbps": 130.32
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4587004,
+   "ratio": 0.1367,
+   "compress_mbps": 96.43,
+   "decompress_mbps": 139.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 4229035,
+   "ratio": 0.126,
+   "compress_mbps": 90.78,
+   "decompress_mbps": 152.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3791322,
+   "ratio": 0.113,
+   "compress_mbps": 82.31,
+   "decompress_mbps": 162.11
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3449193,
+   "ratio": 0.1028,
+   "compress_mbps": 72.86,
+   "decompress_mbps": 166.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3269452,
+   "ratio": 0.0974,
+   "compress_mbps": 58.61,
+   "decompress_mbps": 171.28
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3211286,
+   "ratio": 0.0957,
+   "compress_mbps": 50.41,
+   "decompress_mbps": 168.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3101534,
+   "ratio": 0.0924,
+   "compress_mbps": 27.51,
+   "decompress_mbps": 171.08
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3058177,
+   "ratio": 0.0911,
+   "compress_mbps": 16.54,
+   "decompress_mbps": 179.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 4024327,
+   "ratio": 0.6541,
+   "compress_mbps": 23.3,
+   "decompress_mbps": 29.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3953722,
+   "ratio": 0.6427,
+   "compress_mbps": 22.26,
+   "decompress_mbps": 30.51
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3887921,
+   "ratio": 0.632,
+   "compress_mbps": 18.93,
+   "decompress_mbps": 30.66
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3320440,
+   "ratio": 0.5397,
+   "compress_mbps": 21.59,
+   "decompress_mbps": 37.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3279338,
+   "ratio": 0.533,
+   "compress_mbps": 18.04,
+   "decompress_mbps": 38.33
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3254309,
+   "ratio": 0.529,
+   "compress_mbps": 14.03,
+   "decompress_mbps": 38.11
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3250139,
+   "ratio": 0.5283,
+   "compress_mbps": 12.36,
+   "decompress_mbps": 37.71
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3247018,
+   "ratio": 0.5278,
+   "compress_mbps": 10.17,
+   "decompress_mbps": 37.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3246865,
+   "ratio": 0.5278,
+   "compress_mbps": 9.55,
+   "decompress_mbps": 38.02
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4471091,
+   "ratio": 0.4433,
+   "compress_mbps": 35.74,
+   "decompress_mbps": 69.37
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 4372105,
+   "ratio": 0.4335,
+   "compress_mbps": 34.44,
+   "decompress_mbps": 73.11
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 4305270,
+   "ratio": 0.4269,
+   "compress_mbps": 30.84,
+   "decompress_mbps": 74.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3920495,
+   "ratio": 0.3887,
+   "compress_mbps": 30.64,
+   "decompress_mbps": 66.2
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3853177,
+   "ratio": 0.382,
+   "compress_mbps": 26.77,
+   "decompress_mbps": 65.04
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3780878,
+   "ratio": 0.3749,
+   "compress_mbps": 23.5,
+   "decompress_mbps": 63.8
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3763880,
+   "ratio": 0.3732,
+   "compress_mbps": 20.18,
+   "decompress_mbps": 72.63
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3757719,
+   "ratio": 0.3726,
+   "compress_mbps": 18.28,
+   "decompress_mbps": 71.63
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3757719,
+   "ratio": 0.3726,
+   "compress_mbps": 18.37,
+   "decompress_mbps": 72.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2722387,
+   "ratio": 0.4108,
+   "compress_mbps": 38.5,
+   "decompress_mbps": 66.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2572544,
+   "ratio": 0.3882,
+   "compress_mbps": 37.5,
+   "decompress_mbps": 70.7
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2384328,
+   "ratio": 0.3598,
+   "compress_mbps": 29.7,
+   "decompress_mbps": 80.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2112060,
+   "ratio": 0.3187,
+   "compress_mbps": 36.54,
+   "decompress_mbps": 85.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1991581,
+   "ratio": 0.3005,
+   "compress_mbps": 25.62,
+   "decompress_mbps": 88.33
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1917866,
+   "ratio": 0.2894,
+   "compress_mbps": 15.14,
+   "decompress_mbps": 93.59
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1895353,
+   "ratio": 0.286,
+   "compress_mbps": 11.09,
+   "decompress_mbps": 90.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1880740,
+   "ratio": 0.2838,
+   "compress_mbps": 5.6,
+   "decompress_mbps": 91.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1880711,
+   "ratio": 0.2838,
+   "compress_mbps": 5.58,
+   "decompress_mbps": 91.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 7441483,
+   "ratio": 0.3444,
+   "compress_mbps": 45.31,
+   "decompress_mbps": 67.23
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 7229248,
+   "ratio": 0.3346,
+   "compress_mbps": 44.23,
+   "decompress_mbps": 69.05
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 7083451,
+   "ratio": 0.3278,
+   "compress_mbps": 39.55,
+   "decompress_mbps": 71.01
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 6189639,
+   "ratio": 0.2865,
+   "compress_mbps": 42.58,
+   "decompress_mbps": 92.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 6053058,
+   "ratio": 0.2802,
+   "compress_mbps": 35.44,
+   "decompress_mbps": 96.9
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5988137,
+   "ratio": 0.2771,
+   "compress_mbps": 28.74,
+   "decompress_mbps": 102.79
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5949908,
+   "ratio": 0.2754,
+   "compress_mbps": 25.39,
+   "decompress_mbps": 103.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5936656,
+   "ratio": 0.2748,
+   "compress_mbps": 19.35,
+   "decompress_mbps": 106.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5934701,
+   "ratio": 0.2747,
+   "compress_mbps": 18.09,
+   "decompress_mbps": 106.06
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 6335542,
+   "ratio": 0.8736,
+   "compress_mbps": 19.02,
+   "decompress_mbps": 31.37
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 6247260,
+   "ratio": 0.8615,
+   "compress_mbps": 17.95,
+   "decompress_mbps": 49.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 6064713,
+   "ratio": 0.8363,
+   "compress_mbps": 15.55,
+   "decompress_mbps": 56.91
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5568111,
+   "ratio": 0.7678,
+   "compress_mbps": 17.78,
+   "decompress_mbps": 60.28
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5544524,
+   "ratio": 0.7646,
+   "compress_mbps": 14.67,
+   "decompress_mbps": 65.44
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5513056,
+   "ratio": 0.7602,
+   "compress_mbps": 12.16,
+   "decompress_mbps": 62.98
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5508915,
+   "ratio": 0.7596,
+   "compress_mbps": 11.43,
+   "decompress_mbps": 64.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5508365,
+   "ratio": 0.7596,
+   "compress_mbps": 10.71,
+   "decompress_mbps": 64.32
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5508365,
+   "ratio": 0.7596,
+   "compress_mbps": 10.65,
+   "decompress_mbps": 64.32
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 16776095,
+   "ratio": 0.4046,
+   "compress_mbps": 38.53,
+   "decompress_mbps": 51.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 16032651,
+   "ratio": 0.3867,
+   "compress_mbps": 36.77,
+   "decompress_mbps": 55.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 15180334,
+   "ratio": 0.3662,
+   "compress_mbps": 31.71,
+   "decompress_mbps": 52.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 13261924,
+   "ratio": 0.3199,
+   "compress_mbps": 36.14,
+   "decompress_mbps": 67.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12706028,
+   "ratio": 0.3065,
+   "compress_mbps": 27.77,
+   "decompress_mbps": 72.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12464158,
+   "ratio": 0.3006,
+   "compress_mbps": 21.22,
+   "decompress_mbps": 72.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12375954,
+   "ratio": 0.2985,
+   "compress_mbps": 18.25,
+   "decompress_mbps": 70.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12321552,
+   "ratio": 0.2972,
+   "compress_mbps": 14.41,
+   "decompress_mbps": 70.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12320276,
+   "ratio": 0.2972,
+   "compress_mbps": 13.86,
+   "decompress_mbps": 70.47
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6799201,
+   "ratio": 0.8023,
+   "compress_mbps": 18.93,
+   "decompress_mbps": 18.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6800500,
+   "ratio": 0.8025,
+   "compress_mbps": 17.48,
+   "decompress_mbps": 18.29
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6803212,
+   "ratio": 0.8028,
+   "compress_mbps": 15.35,
+   "decompress_mbps": 18.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6264611,
+   "ratio": 0.7393,
+   "compress_mbps": 17.68,
+   "decompress_mbps": 25.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6217901,
+   "ratio": 0.7337,
+   "compress_mbps": 16.03,
+   "decompress_mbps": 24.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6201999,
+   "ratio": 0.7319,
+   "compress_mbps": 15.62,
+   "decompress_mbps": 24.92
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6201883,
+   "ratio": 0.7319,
+   "compress_mbps": 15.57,
+   "decompress_mbps": 24.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6201887,
+   "ratio": 0.7319,
+   "compress_mbps": 15.53,
+   "decompress_mbps": 25.08
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6201887,
+   "ratio": 0.7319,
+   "compress_mbps": 15.5,
+   "decompress_mbps": 25.13
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 1081679,
+   "ratio": 0.2024,
+   "compress_mbps": 75.64,
+   "decompress_mbps": 107.31
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 1001890,
+   "ratio": 0.1874,
+   "compress_mbps": 74.66,
+   "decompress_mbps": 116.68
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 921722,
+   "ratio": 0.1724,
+   "compress_mbps": 67.17,
+   "decompress_mbps": 127.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 849263,
+   "ratio": 0.1589,
+   "compress_mbps": 65.29,
+   "decompress_mbps": 141.45
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 771964,
+   "ratio": 0.1444,
+   "compress_mbps": 55.0,
+   "decompress_mbps": 142.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 728098,
+   "ratio": 0.1362,
+   "compress_mbps": 42.74,
+   "decompress_mbps": 149.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 713635,
+   "ratio": 0.1335,
+   "compress_mbps": 37.31,
+   "decompress_mbps": 149.43
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 699093,
+   "ratio": 0.1308,
+   "compress_mbps": 27.08,
+   "decompress_mbps": 145.77
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 698459,
+   "ratio": 0.1307,
+   "compress_mbps": 25.24,
+   "decompress_mbps": 150.48
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 62797,
+   "ratio": 0.4129,
+   "compress_mbps": 68.56,
+   "decompress_mbps": 158.42
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 59605,
+   "ratio": 0.3919,
+   "compress_mbps": 57.55,
+   "decompress_mbps": 183.76
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 57675,
+   "ratio": 0.3792,
+   "compress_mbps": 49.31,
+   "decompress_mbps": 171.74
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56500,
+   "ratio": 0.3715,
+   "compress_mbps": 42.67,
+   "decompress_mbps": 133.64
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 56440,
+   "ratio": 0.3711,
+   "compress_mbps": 42.15,
+   "decompress_mbps": 142.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 55443,
+   "ratio": 0.3645,
+   "compress_mbps": 35.41,
+   "decompress_mbps": 138.32
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 55373,
+   "ratio": 0.3641,
+   "compress_mbps": 34.36,
+   "decompress_mbps": 137
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 55352,
+   "ratio": 0.3639,
+   "compress_mbps": 33.41,
+   "decompress_mbps": 182.41
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 55352,
+   "ratio": 0.3639,
+   "compress_mbps": 33.5,
+   "decompress_mbps": 129.92
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 55063,
+   "ratio": 0.4399,
+   "compress_mbps": 63.55,
+   "decompress_mbps": 163.9
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 52932,
+   "ratio": 0.4229,
+   "compress_mbps": 54.4,
+   "decompress_mbps": 120.17
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51597,
+   "ratio": 0.4122,
+   "compress_mbps": 46.63,
+   "decompress_mbps": 93.11
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50780,
+   "ratio": 0.4057,
+   "compress_mbps": 37.77,
+   "decompress_mbps": 86.8
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 50767,
+   "ratio": 0.4056,
+   "compress_mbps": 39.45,
+   "decompress_mbps": 88.09
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 50160,
+   "ratio": 0.4007,
+   "compress_mbps": 32.07,
+   "decompress_mbps": 118.41
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 33.01,
+   "decompress_mbps": 92.32
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 31.73,
+   "decompress_mbps": 86.87
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 31.75,
+   "decompress_mbps": 124.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8730,
+   "ratio": 0.3548,
+   "compress_mbps": 43,
+   "decompress_mbps": 35.73
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8457,
+   "ratio": 0.3437,
+   "compress_mbps": 74.58,
+   "decompress_mbps": 53.62
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8353,
+   "ratio": 0.3395,
+   "compress_mbps": 39.6,
+   "decompress_mbps": 45.98
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8301,
+   "ratio": 0.3374,
+   "compress_mbps": 71.04,
+   "decompress_mbps": 49.17
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8212,
+   "ratio": 0.3338,
+   "compress_mbps": 36.39,
+   "decompress_mbps": 43.68
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 8172,
+   "ratio": 0.3322,
+   "compress_mbps": 58.86,
+   "decompress_mbps": 47.79
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 53.96,
+   "decompress_mbps": 46.46
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 59.01,
+   "decompress_mbps": 46.76
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 54.5,
+   "decompress_mbps": 49.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3475,
+   "ratio": 0.3117,
+   "compress_mbps": 77.94,
+   "decompress_mbps": 58.2
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3305,
+   "ratio": 0.2964,
+   "compress_mbps": 63.71,
+   "decompress_mbps": 51.69
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3225,
+   "ratio": 0.2892,
+   "compress_mbps": 72.96,
+   "decompress_mbps": 67.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3192,
+   "ratio": 0.2863,
+   "compress_mbps": 71.43,
+   "decompress_mbps": 66.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3180,
+   "ratio": 0.2852,
+   "compress_mbps": 71.91,
+   "decompress_mbps": 61.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 62.79,
+   "decompress_mbps": 60.69
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 52.9,
+   "decompress_mbps": 64.49
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 69.05,
+   "decompress_mbps": 64.73
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 67.52,
+   "decompress_mbps": 60.86
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1275,
+   "ratio": 0.3426,
+   "compress_mbps": 30.33,
+   "decompress_mbps": 25.75
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1247,
+   "ratio": 0.3351,
+   "compress_mbps": 26.62,
+   "decompress_mbps": 26.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1239,
+   "ratio": 0.333,
+   "compress_mbps": 28.08,
+   "decompress_mbps": 24.32
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1238,
+   "ratio": 0.3327,
+   "compress_mbps": 27.91,
+   "decompress_mbps": 26.5
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1239,
+   "ratio": 0.333,
+   "compress_mbps": 23.23,
+   "decompress_mbps": 26.4
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 33.51,
+   "decompress_mbps": 26.22
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 26.3,
+   "decompress_mbps": 26.34
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 24.78,
+   "decompress_mbps": 26.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 21.78,
+   "decompress_mbps": 28.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 226284,
+   "ratio": 0.2197,
+   "compress_mbps": 134.49,
+   "decompress_mbps": 255.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 221369,
+   "ratio": 0.215,
+   "compress_mbps": 99.6,
+   "decompress_mbps": 268.5
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 218607,
+   "ratio": 0.2123,
+   "compress_mbps": 89,
+   "decompress_mbps": 272.02
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 217919,
+   "ratio": 0.2116,
+   "compress_mbps": 80.85,
+   "decompress_mbps": 276.89
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 217919,
+   "ratio": 0.2116,
+   "compress_mbps": 81.27,
+   "decompress_mbps": 277.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 217312,
+   "ratio": 0.211,
+   "compress_mbps": 54.76,
+   "decompress_mbps": 270.88
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 215966,
+   "ratio": 0.2097,
+   "compress_mbps": 40.6,
+   "decompress_mbps": 269.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 215930,
+   "ratio": 0.2097,
+   "compress_mbps": 19.55,
+   "decompress_mbps": 274.47
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 215912,
+   "ratio": 0.2097,
+   "compress_mbps": 15.7,
+   "decompress_mbps": 308.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 167622,
+   "ratio": 0.3928,
+   "compress_mbps": 62.33,
+   "decompress_mbps": 106.11
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 158003,
+   "ratio": 0.3702,
+   "compress_mbps": 49.14,
+   "decompress_mbps": 88.59
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 152928,
+   "ratio": 0.3584,
+   "compress_mbps": 49.6,
+   "decompress_mbps": 96.98
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 149886,
+   "ratio": 0.3512,
+   "compress_mbps": 38.56,
+   "decompress_mbps": 119.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 149767,
+   "ratio": 0.3509,
+   "compress_mbps": 40.53,
+   "decompress_mbps": 85.64
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 147818,
+   "ratio": 0.3464,
+   "compress_mbps": 34.71,
+   "decompress_mbps": 94.25
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 147733,
+   "ratio": 0.3462,
+   "compress_mbps": 32.03,
+   "decompress_mbps": 99.55
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 147709,
+   "ratio": 0.3461,
+   "compress_mbps": 31.41,
+   "decompress_mbps": 99.42
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 147705,
+   "ratio": 0.3461,
+   "compress_mbps": 33.45,
+   "decompress_mbps": 89.22
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 222866,
+   "ratio": 0.4625,
+   "compress_mbps": 71.4,
+   "decompress_mbps": 143.74
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 212925,
+   "ratio": 0.4419,
+   "compress_mbps": 58.24,
+   "decompress_mbps": 157.21
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 206913,
+   "ratio": 0.4294,
+   "compress_mbps": 40.37,
+   "decompress_mbps": 119.73
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 202875,
+   "ratio": 0.421,
+   "compress_mbps": 35.81,
+   "decompress_mbps": 112.43
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 202867,
+   "ratio": 0.421,
+   "compress_mbps": 35.22,
+   "decompress_mbps": 176.5
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 199818,
+   "ratio": 0.4147,
+   "compress_mbps": 29.94,
+   "decompress_mbps": 122.03
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 199664,
+   "ratio": 0.4144,
+   "compress_mbps": 29.08,
+   "decompress_mbps": 164.03
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 199634,
+   "ratio": 0.4143,
+   "compress_mbps": 28.55,
+   "decompress_mbps": 113.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 199634,
+   "ratio": 0.4143,
+   "compress_mbps": 28.96,
+   "decompress_mbps": 160.17
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60580,
+   "ratio": 0.118,
+   "compress_mbps": 135.13,
+   "decompress_mbps": 168.22
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 59663,
+   "ratio": 0.1163,
+   "compress_mbps": 125.37,
+   "decompress_mbps": 145.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 59465,
+   "ratio": 0.1159,
+   "compress_mbps": 117.64,
+   "decompress_mbps": 329.46
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 59353,
+   "ratio": 0.1156,
+   "compress_mbps": 112.4,
+   "decompress_mbps": 158.61
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 58830,
+   "ratio": 0.1146,
+   "compress_mbps": 106.94,
+   "decompress_mbps": 138.94
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 57884,
+   "ratio": 0.1128,
+   "compress_mbps": 71.04,
+   "decompress_mbps": 140.49
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 57206,
+   "ratio": 0.1115,
+   "compress_mbps": 57.86,
+   "decompress_mbps": 137.88
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 56545,
+   "ratio": 0.1102,
+   "compress_mbps": 30.93,
+   "decompress_mbps": 137.12
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 56454,
+   "ratio": 0.11,
+   "compress_mbps": 12.82,
+   "decompress_mbps": 137.07
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14194,
+   "ratio": 0.3712,
+   "compress_mbps": 62.96,
+   "decompress_mbps": 62.62
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13770,
+   "ratio": 0.3601,
+   "compress_mbps": 44.68,
+   "decompress_mbps": 52.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13611,
+   "ratio": 0.3559,
+   "compress_mbps": 60.61,
+   "decompress_mbps": 48.72
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13534,
+   "ratio": 0.3539,
+   "compress_mbps": 57.34,
+   "decompress_mbps": 60.12
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13527,
+   "ratio": 0.3537,
+   "compress_mbps": 57.3,
+   "decompress_mbps": 55.11
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13438,
+   "ratio": 0.3514,
+   "compress_mbps": 37.2,
+   "decompress_mbps": 58.23
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13419,
+   "ratio": 0.3509,
+   "compress_mbps": 50.17,
+   "decompress_mbps": 60.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13404,
+   "ratio": 0.3505,
+   "compress_mbps": 41.25,
+   "decompress_mbps": 60.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13390,
+   "ratio": 0.3502,
+   "compress_mbps": 24.99,
+   "decompress_mbps": 60.66
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1832,
+   "ratio": 0.4334,
+   "compress_mbps": 33.47,
+   "decompress_mbps": 24.8
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1776,
+   "ratio": 0.4202,
+   "compress_mbps": 28.92,
+   "decompress_mbps": 28.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1764,
+   "ratio": 0.4173,
+   "compress_mbps": 29.3,
+   "decompress_mbps": 25.73
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1763,
+   "ratio": 0.4171,
+   "compress_mbps": 37.31,
+   "decompress_mbps": 29.49
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 27.55,
+   "decompress_mbps": 29.7
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 28.12,
+   "decompress_mbps": 27.83
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 26.98,
+   "decompress_mbps": 27.73
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 23.43,
+   "decompress_mbps": 29.45
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 21.87,
+   "decompress_mbps": 28.32
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4462632,
+   "ratio": 0.4378,
+   "compress_mbps": 57.87,
+   "decompress_mbps": 125.17
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4244833,
+   "ratio": 0.4165,
+   "compress_mbps": 48.15,
+   "decompress_mbps": 147.15
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4112285,
+   "ratio": 0.4035,
+   "compress_mbps": 40.82,
+   "decompress_mbps": 139.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4020435,
+   "ratio": 0.3945,
+   "compress_mbps": 36.37,
+   "decompress_mbps": 142.4
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 4019177,
+   "ratio": 0.3943,
+   "compress_mbps": 36.45,
+   "decompress_mbps": 142.97
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3956464,
+   "ratio": 0.3882,
+   "compress_mbps": 30.24,
+   "decompress_mbps": 159.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3953310,
+   "ratio": 0.3879,
+   "compress_mbps": 29.41,
+   "decompress_mbps": 146.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3952872,
+   "ratio": 0.3878,
+   "compress_mbps": 29.15,
+   "decompress_mbps": 161.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3952872,
+   "ratio": 0.3878,
+   "compress_mbps": 29.91,
+   "decompress_mbps": 158.9
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20177423,
+   "ratio": 0.3939,
+   "compress_mbps": 79.22,
+   "decompress_mbps": 165.46
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19759467,
+   "ratio": 0.3858,
+   "compress_mbps": 69.86,
+   "decompress_mbps": 153.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19583171,
+   "ratio": 0.3823,
+   "compress_mbps": 62.32,
+   "decompress_mbps": 168.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19479125,
+   "ratio": 0.3803,
+   "compress_mbps": 54.79,
+   "decompress_mbps": 170.19
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19423693,
+   "ratio": 0.3792,
+   "compress_mbps": 52.87,
+   "decompress_mbps": 155.75
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19337683,
+   "ratio": 0.3775,
+   "compress_mbps": 35.86,
+   "decompress_mbps": 158.01
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19323922,
+   "ratio": 0.3773,
+   "compress_mbps": 31.01,
+   "decompress_mbps": 162.6
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19314797,
+   "ratio": 0.3771,
+   "compress_mbps": 25.05,
+   "decompress_mbps": 170.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19312663,
+   "ratio": 0.377,
+   "compress_mbps": 10.78,
+   "decompress_mbps": 170.64
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3762978,
+   "ratio": 0.3774,
+   "compress_mbps": 73.55,
+   "decompress_mbps": 158.73
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3711615,
+   "ratio": 0.3723,
+   "compress_mbps": 61.61,
+   "decompress_mbps": 156.01
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3663131,
+   "ratio": 0.3674,
+   "compress_mbps": 54.17,
+   "decompress_mbps": 162.95
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3631512,
+   "ratio": 0.3642,
+   "compress_mbps": 47.67,
+   "decompress_mbps": 162.23
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3630867,
+   "ratio": 0.3642,
+   "compress_mbps": 47.3,
+   "decompress_mbps": 136.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3615953,
+   "ratio": 0.3627,
+   "compress_mbps": 36.72,
+   "decompress_mbps": 183.9
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3615518,
+   "ratio": 0.3626,
+   "compress_mbps": 34.5,
+   "decompress_mbps": 166.79
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3613845,
+   "ratio": 0.3625,
+   "compress_mbps": 29.37,
+   "decompress_mbps": 167.22
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3614283,
+   "ratio": 0.3625,
+   "compress_mbps": 25.49,
+   "decompress_mbps": 152.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4418800,
+   "ratio": 0.1317,
+   "compress_mbps": 147.78,
+   "decompress_mbps": 255.76
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4026774,
+   "ratio": 0.12,
+   "compress_mbps": 133.75,
+   "decompress_mbps": 246.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3837798,
+   "ratio": 0.1144,
+   "compress_mbps": 127.06,
+   "decompress_mbps": 265.57
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3751023,
+   "ratio": 0.1118,
+   "compress_mbps": 119.47,
+   "decompress_mbps": 276.82
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3643468,
+   "ratio": 0.1086,
+   "compress_mbps": 109.94,
+   "decompress_mbps": 278.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3379481,
+   "ratio": 0.1007,
+   "compress_mbps": 71.5,
+   "decompress_mbps": 283.02
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3354082,
+   "ratio": 0.1,
+   "compress_mbps": 63.54,
+   "decompress_mbps": 278.98
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3330028,
+   "ratio": 0.0992,
+   "compress_mbps": 48.52,
+   "decompress_mbps": 294.14
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3327482,
+   "ratio": 0.0992,
+   "compress_mbps": 38.14,
+   "decompress_mbps": 281.8
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3233790,
+   "ratio": 0.5256,
+   "compress_mbps": 49.01,
+   "decompress_mbps": 104.92
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3184644,
+   "ratio": 0.5176,
+   "compress_mbps": 43.61,
+   "decompress_mbps": 93.6
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3160521,
+   "ratio": 0.5137,
+   "compress_mbps": 39.95,
+   "decompress_mbps": 118.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3141929,
+   "ratio": 0.5107,
+   "compress_mbps": 36.7,
+   "decompress_mbps": 111.6
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3138514,
+   "ratio": 0.5101,
+   "compress_mbps": 36.34,
+   "decompress_mbps": 96.01
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3126843,
+   "ratio": 0.5082,
+   "compress_mbps": 31.55,
+   "decompress_mbps": 95.28
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3126796,
+   "ratio": 0.5082,
+   "compress_mbps": 29.22,
+   "decompress_mbps": 93.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3126322,
+   "ratio": 0.5082,
+   "compress_mbps": 25.65,
+   "decompress_mbps": 95.56
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3126286,
+   "ratio": 0.5082,
+   "compress_mbps": 22.12,
+   "decompress_mbps": 94.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4076349,
+   "ratio": 0.4042,
+   "compress_mbps": 70.62,
+   "decompress_mbps": 128.6
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3914739,
+   "ratio": 0.3881,
+   "compress_mbps": 65.68,
+   "decompress_mbps": 162.69
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3845160,
+   "ratio": 0.3812,
+   "compress_mbps": 62.94,
+   "decompress_mbps": 190.14
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3822047,
+   "ratio": 0.379,
+   "compress_mbps": 61.07,
+   "decompress_mbps": 175.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3799472,
+   "ratio": 0.3767,
+   "compress_mbps": 56.83,
+   "decompress_mbps": 195.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3783861,
+   "ratio": 0.3752,
+   "compress_mbps": 54.95,
+   "decompress_mbps": 154.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3783432,
+   "ratio": 0.3751,
+   "compress_mbps": 54.44,
+   "decompress_mbps": 195.71
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3783342,
+   "ratio": 0.3751,
+   "compress_mbps": 54.44,
+   "decompress_mbps": 152.64
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3783342,
+   "ratio": 0.3751,
+   "compress_mbps": 54.41,
+   "decompress_mbps": 153.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2261112,
+   "ratio": 0.3412,
+   "compress_mbps": 63.14,
+   "decompress_mbps": 144.01
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2128691,
+   "ratio": 0.3212,
+   "compress_mbps": 51.99,
+   "decompress_mbps": 119.21
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2049023,
+   "ratio": 0.3092,
+   "compress_mbps": 42.59,
+   "decompress_mbps": 136.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1990249,
+   "ratio": 0.3003,
+   "compress_mbps": 36.52,
+   "decompress_mbps": 119.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1975224,
+   "ratio": 0.298,
+   "compress_mbps": 35.45,
+   "decompress_mbps": 187.46
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1910262,
+   "ratio": 0.2882,
+   "compress_mbps": 26.28,
+   "decompress_mbps": 116.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1902923,
+   "ratio": 0.2871,
+   "compress_mbps": 24,
+   "decompress_mbps": 193.41
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1900964,
+   "ratio": 0.2868,
+   "compress_mbps": 22.36,
+   "decompress_mbps": 150.61
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1900958,
+   "ratio": 0.2868,
+   "compress_mbps": 22.83,
+   "decompress_mbps": 141.37
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6016919,
+   "ratio": 0.2785,
+   "compress_mbps": 102.33,
+   "decompress_mbps": 220.56
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5767272,
+   "ratio": 0.2669,
+   "compress_mbps": 90.9,
+   "decompress_mbps": 177.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5669548,
+   "ratio": 0.2624,
+   "compress_mbps": 81.47,
+   "decompress_mbps": 209.95
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5619947,
+   "ratio": 0.2601,
+   "compress_mbps": 73.58,
+   "decompress_mbps": 212.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5586034,
+   "ratio": 0.2585,
+   "compress_mbps": 69.19,
+   "decompress_mbps": 216.46
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5540130,
+   "ratio": 0.2564,
+   "compress_mbps": 59.45,
+   "decompress_mbps": 218.47
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5537271,
+   "ratio": 0.2563,
+   "compress_mbps": 50.37,
+   "decompress_mbps": 215.76
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5530686,
+   "ratio": 0.256,
+   "compress_mbps": 39.81,
+   "decompress_mbps": 229.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5529823,
+   "ratio": 0.2559,
+   "compress_mbps": 37.98,
+   "decompress_mbps": 218.14
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5602819,
+   "ratio": 0.7726,
+   "compress_mbps": 43.77,
+   "decompress_mbps": 122.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5504019,
+   "ratio": 0.759,
+   "compress_mbps": 39.83,
+   "decompress_mbps": 116.35
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5452816,
+   "ratio": 0.7519,
+   "compress_mbps": 36.31,
+   "decompress_mbps": 101.11
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5425752,
+   "ratio": 0.7482,
+   "compress_mbps": 33.34,
+   "decompress_mbps": 111.95
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5425752,
+   "ratio": 0.7482,
+   "compress_mbps": 33.33,
+   "decompress_mbps": 134.03
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5407602,
+   "ratio": 0.7457,
+   "compress_mbps": 29.93,
+   "decompress_mbps": 117.04
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5406417,
+   "ratio": 0.7455,
+   "compress_mbps": 28.96,
+   "decompress_mbps": 101.72
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5406380,
+   "ratio": 0.7455,
+   "compress_mbps": 29.09,
+   "decompress_mbps": 101.95
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5406380,
+   "ratio": 0.7455,
+   "compress_mbps": 29.06,
+   "decompress_mbps": 122.69
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 14342407,
+   "ratio": 0.3459,
+   "compress_mbps": 80.69,
+   "decompress_mbps": 148.42
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13424966,
+   "ratio": 0.3238,
+   "compress_mbps": 69.28,
+   "decompress_mbps": 152.62
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13061399,
+   "ratio": 0.315,
+   "compress_mbps": 61.33,
+   "decompress_mbps": 154.49
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12877207,
+   "ratio": 0.3106,
+   "compress_mbps": 55.43,
+   "decompress_mbps": 148.12
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12671090,
+   "ratio": 0.3056,
+   "compress_mbps": 51.73,
+   "decompress_mbps": 148.74
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12511088,
+   "ratio": 0.3018,
+   "compress_mbps": 43.72,
+   "decompress_mbps": 155.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12503313,
+   "ratio": 0.3016,
+   "compress_mbps": 42.4,
+   "decompress_mbps": 157.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12502263,
+   "ratio": 0.3016,
+   "compress_mbps": 42.05,
+   "decompress_mbps": 158.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12502263,
+   "ratio": 0.3016,
+   "compress_mbps": 42.14,
+   "decompress_mbps": 158.28
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6022390,
+   "ratio": 0.7107,
+   "compress_mbps": 49.65,
+   "decompress_mbps": 97.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 5997124,
+   "ratio": 0.7077,
+   "compress_mbps": 44.68,
+   "decompress_mbps": 113.66
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 5979254,
+   "ratio": 0.7056,
+   "compress_mbps": 41.54,
+   "decompress_mbps": 116.97
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 5967955,
+   "ratio": 0.7042,
+   "compress_mbps": 39.36,
+   "decompress_mbps": 110.22
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 5967953,
+   "ratio": 0.7042,
+   "compress_mbps": 39.23,
+   "decompress_mbps": 117.4
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5965386,
+   "ratio": 0.7039,
+   "compress_mbps": 39.35,
+   "decompress_mbps": 117.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 39.62,
+   "decompress_mbps": 117.2
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 39.1,
+   "decompress_mbps": 98.58
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 40.18,
+   "decompress_mbps": 98.47
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 985606,
+   "ratio": 0.1844,
+   "compress_mbps": 93.37,
+   "decompress_mbps": 141.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 852636,
+   "ratio": 0.1595,
+   "compress_mbps": 89.07,
+   "decompress_mbps": 238.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 814293,
+   "ratio": 0.1523,
+   "compress_mbps": 81.69,
+   "decompress_mbps": 223.79
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 788388,
+   "ratio": 0.1475,
+   "compress_mbps": 79.24,
+   "decompress_mbps": 251.87
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 749390,
+   "ratio": 0.1402,
+   "compress_mbps": 74.77,
+   "decompress_mbps": 224.33
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 706892,
+   "ratio": 0.1322,
+   "compress_mbps": 60.77,
+   "decompress_mbps": 269.34
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 705695,
+   "ratio": 0.132,
+   "compress_mbps": 58.98,
+   "decompress_mbps": 181.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 703904,
+   "ratio": 0.1317,
+   "compress_mbps": 56.3,
+   "decompress_mbps": 170.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 703900,
+   "ratio": 0.1317,
+   "compress_mbps": 56.44,
+   "decompress_mbps": 180.91
+  }
+ ]
 }


### PR DESCRIPTION
This PR adds `Huffman.Spec.computeCodeLengthsN`, an `Array Nat` twin of the spec `computeCodeLengths`, and routes the hot `dynamicCodeLengths` path through it, so the per-split-block Huffman code-length construction no longer pays the `O(n²)` `List.set`/`List.length` churn that `assignLengths` incurred (the `setTR`/`lengthTR` cluster the profiler put at ~14% of L6 mozilla, plus its allocator/reference-count traffic). The array twin makes symbol→length assignment `O(n)` via `Array.setIfInBounds`, and returns the lengths as an `Array` directly. The spec `List` pipeline (`assignLengths`, `fixKraftList`, `computeCodeLengths`, `limitedPairs`, and the #2536 completeness theorems) stays untouched as the reference; `computeCodeLengthsN_toList` proves the array pipeline read back as a list is exactly the spec `List`, so every downstream property (length, `ValidLengths`, completeness, nonzero) transfers verbatim and the compressed output is byte-identical. The one perturbed spec proof (`emitDynBlock_spec`) is re-proved through the same correspondence lemma; no theorem statement changed and there is no `sorry`, `native_decide`, or `implemented_by` trust gap — the fast path is on the verified route. The swap also covers the L9/L10 per-region refits and the split sizing pass, since both go through `sizedTrees` → `dynamicCodeLengths`.

Measured before/after on Silesia + Canterbury (`compress_mbps`, native, same machine `chungus2`), `max |Δratio| = 0.000000` (byte-identical):

| member | L6 before → after | speedup |
|---|---|---|
| mozilla | 17.33 → 22.98 | **1.33x** |
| x-ray | 9.98 → 13.90 | **1.39x** |
| ooffice | 17.80 → 21.42 | 1.20x |
| samba | 29.45 → 33.50 | 1.14x |
| mr | 20.92 → 23.33 | 1.12x |
| dickens (text) | 22.87 → 23.41 | 1.02x |

The win lands exactly where the issue predicted: heterogeneous, heavily-split members at L5–L8 (+14–42%), flat on text, and L1–L5 sit at ~1.00x (they split less, so the code-length build is not hot there — a clean control that the AFTER binary is not uniformly faster). L9/L10 refits also improve (mozilla 1.06x/1.04x, sao 1.19x/1.11x). A per-block microbench (`bench/ZipHuffBench.lean`) over Canterbury measures the isolated build 3.4–4.3x faster with byte-identical lengths on every file.

Closes https://github.com/kim-em/lean-zip/issues/2761

🤖 Prepared with Claude Code