### PR TITLE
bench: migrate canonical benchmark machine to chungus2

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -20,6 +20,19 @@ the external-language comparators (see below), then [`plot.py`](plot.py) (writes
 the SVGs). Ratios are deterministic; throughput is a **median-of-5 snapshot of
 the machine recorded in the JSON `meta`** — commit the JSON and SVGs together.
 
+> **Benchmark machine: chungus2 (since 2026-07-05).** The canonical machine moved
+> from `chungus` to `chungus2`. The two are indistinguishable on throughput —
+> within ~0.3% across every version-stable comparator, and byte-identical on ratio
+> — so historical numbers stay directly comparable. `go` and `js` each run on
+> their **newest** release (`nix-shell -p go` → go 1.26.3; `nodejs_latest` → node
+> v26, ~+22% JS compress over the old default v24), so those two curves track the
+> compiler version rather than the machine; js in particular carries large V8
+> run-to-run variance and is indicative only. Full analysis:
+> [`results/cross-machine-chungus-to-chungus2.md`](results/cross-machine-chungus-to-chungus2.md);
+> the last `chungus` snapshot is preserved under
+> [`results/archive/`](results/archive/) and the comparison is reproducible via
+> [`cross_machine.py`](cross_machine.py).
+
 ## Compressors compared
 
 The honest comparison group for a pure-Lean codec is other **language-native**

--- a/bench/comparators/build_all.sh
+++ b/bench/comparators/build_all.sh
@@ -14,8 +14,11 @@ echo "[go] building (pure-Go compress/flate)…"
 ( cd go && nix-shell -p go --run "go build -o bench-go main.go" ) \
   && echo "[go] ok" || echo "[go] FAILED — skipping"
 
+# `nodejs_latest` (not the older default `nodejs`) so JS runs on the newest V8 —
+# each language deserves its best current release. On a 2026-07 channel this is
+# node v26, ~+22% JS compress over v24. `go` likewise takes `-p go` (newest).
 echo "[js] installing fflate (pure-JS)…"
-( cd js && nix-shell -p nodejs --run "npm install --no-audit --no-fund --silent" ) \
+( cd js && nix-shell -p nodejs_latest --run "npm install --no-audit --no-fund --silent" ) \
   && echo "[js] ok" || echo "[js] FAILED — skipping"
 
 # Zig 0.14.1 specifically: the 0.15 stdlib `flate.Compress` encoder is an

--- a/bench/cross_machine.py
+++ b/bench/cross_machine.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Cross-machine consistency report for the Track D dashboard.
+
+Compares two `bench-report` result JSONs (an OLD machine and a NEW machine) and
+emits a Markdown report on how the two machines relate, per compressor and per
+metric. Used when migrating the canonical benchmark machine (e.g. chungus →
+chungus2) to decide whether the move is sound.
+
+Usage:
+    python3 bench/cross_machine.py OLD.json NEW.json > report.md
+
+What it checks
+--------------
+* **Compression ratio** is deterministic and machine-independent, so for the
+  *same code* it must be byte-identical across machines. A per-compressor
+  `max |Δratio|` therefore separates two effects:
+    - external comparators (go/js/zig/ocaml/zlib/miniz_oxide/libdeflate) run the
+      *same* third-party code on both machines → any ratio delta is version drift
+      in the pinned toolchain, and should be ~0;
+    - `native` (lean-zip) may legitimately differ if the two snapshots are at
+      different commits — that is a *code* delta, not a machine delta, and is
+      called out separately so it is not mistaken for machine inconsistency.
+* **Throughput** (`compress_mbps`, `decompress_mbps`): the geomean of
+  NEW/OLD per compressor is the machine speed factor. If it is roughly uniform
+  across compressors, the two machines are consistently related (one is ~X%
+  faster); large per-compressor spread is the signal that the machines are NOT
+  cleanly comparable and the move needs scrutiny.
+
+Only `(compressor, pattern, level)` cells present in BOTH inputs are compared.
+"""
+import json
+import math
+import sys
+
+
+def load(path):
+    d = json.load(open(path))
+    rows = d.get("results", d.get("rows", []))
+    idx = {}
+    for r in rows:
+        idx[(r["compressor"], r["pattern"], r["level"])] = r
+    return d.get("meta", {}), idx
+
+
+def geomean(xs):
+    xs = [x for x in xs if x and x > 0]
+    if not xs:
+        return None
+    return math.exp(sum(math.log(x) for x in xs) / len(xs))
+
+
+def main():
+    old_path, new_path = sys.argv[1], sys.argv[2]
+    om, oi = load(old_path)
+    nm, ni = load(new_path)
+    common = sorted(set(oi) & set(ni))
+    comps = sorted({k[0] for k in common})
+
+    print("# Cross-machine benchmark consistency\n")
+    print(f"- **OLD**: `{om.get('machine','?')}` @ `{om.get('git_commit','?')}` "
+          f"({om.get('date','?')}) — `{old_path}`")
+    print(f"- **NEW**: `{nm.get('machine','?')}` @ `{nm.get('git_commit','?')}` "
+          f"({nm.get('date','?')}) — `{new_path}`")
+    print(f"- Compared cells present in both: **{len(common)}** "
+          f"across {len(comps)} compressors\n")
+    same_commit = om.get("git_commit") == nm.get("git_commit")
+    if not same_commit:
+        print("> **Note:** the two snapshots are at *different commits*, so the "
+              "`native` rows reflect a code delta on top of the machine delta. "
+              "For a clean machine comparison read the external comparators "
+              "(same third-party code on both machines); treat `native` "
+              "throughput as machine × code.\n")
+
+    # Throughput speed factor (NEW / OLD), geomean per compressor.
+    print("## Throughput: NEW / OLD (geomean over shared cells)\n")
+    print("| compressor | cells | compress× | decompress× |")
+    print("|---|---|---|---|")
+    for c in comps:
+        keys = [k for k in common if k[0] == c]
+        cz = geomean([ni[k]["compress_mbps"] / oi[k]["compress_mbps"]
+                      for k in keys
+                      if oi[k].get("compress_mbps") and ni[k].get("compress_mbps")])
+        dz = geomean([ni[k]["decompress_mbps"] / oi[k]["decompress_mbps"]
+                      for k in keys
+                      if oi[k].get("decompress_mbps") and ni[k].get("decompress_mbps")])
+        cs = f"{cz:.3f}x" if cz else "—"
+        ds = f"{dz:.3f}x" if dz else "—"
+        print(f"| {c} | {len(keys)} | {cs} | {ds} |")
+
+    # External-only summary (the clean machine factor).
+    ext = [c for c in comps if c != "native"]
+    ext_keys = [k for k in common if k[0] in ext]
+    ecz = geomean([ni[k]["compress_mbps"] / oi[k]["compress_mbps"]
+                   for k in ext_keys
+                   if oi[k].get("compress_mbps") and ni[k].get("compress_mbps")])
+    edz = geomean([ni[k]["decompress_mbps"] / oi[k]["decompress_mbps"]
+                   for k in ext_keys
+                   if oi[k].get("decompress_mbps") and ni[k].get("decompress_mbps")])
+    print(f"\n**External comparators (same code, clean machine factor): "
+          f"compress {ecz:.3f}x, decompress {edz:.3f}x.** "
+          f"A tight cluster around these means the machines are consistently "
+          f"related; wide spread means they are not cleanly comparable.\n")
+
+    # Ratio consistency.
+    print("## Compression ratio consistency (deterministic → machine-independent)\n")
+    print("| compressor | cells | max \\|Δratio\\| | cells with Δ≠0 |")
+    print("|---|---|---|---|")
+    for c in comps:
+        keys = [k for k in common if k[0] == c]
+        deltas = [abs(ni[k]["ratio"] - oi[k]["ratio"]) for k in keys
+                  if oi[k].get("ratio") is not None and ni[k].get("ratio") is not None]
+        mx = max(deltas) if deltas else 0.0
+        nz = sum(1 for d in deltas if d > 1e-9)
+        print(f"| {c} | {len(keys)} | {mx:.6f} | {nz} |")
+    print("\nFor every *external* compressor `max |Δratio|` should be `0.000000` "
+          "(same code, deterministic output). A nonzero value flags pinned-"
+          "toolchain version drift. `native` may differ iff the snapshots are at "
+          "different commits (a code delta, expected).")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pab730e26a5)">
+   <g clip-path="url(#p490df6c679)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEklEQVR4nO3Yz4rk1R2H4a6emkGGZkgU/w0hiGBW2bvwGtzkQnIFuYtcQSCQlVsJyTK7XIIkIkJGMc2MM7Y9bXdN/dxlL7yHbyye5wo+xYFT7+/sjs//sp3x83JzNb1gnZsX0wuW2O5upycss3v01vSENe6/Nr1gnfPz6QVr3N1ML1hnd5pntj17Mj1hmdM8MQCAQQILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/+LscnrDEnfHm+kJy7z7i/enJyxzsb0zPWGJ3fdPpycs84+Xn01PWOJXD96anrDM4Xg7PWGJq1ene+/fHg/TE5b48NGvpycs4wULACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYrsXP3yyTY9Y4eXhanrCMm8eH05PWOdwO71gjavL6QXrvP2b6QVLXG3X0xOWOdX78c3tYnrCMk/Onk5PWOLx5bfTE5bxggUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx/cWzy+kNS1zsH0xPWOfm6+kFy2xXz6cnrHE8Ti9YZvfwm+kJS5zyHXKxfzQ9YY0Hr00vWObxy9vpCUts119NT1jGCxYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGy/XX49vYGf6nicXgD/s/3n8+kJa5z7/vzZcTfyf8QNAgAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAALH97//75fSGJZ7dvJqesMw/n7yYnrDMp7/7aHrCEu88fG96wjK//dOfpycs8fEHr09PWObfz26mJ/AT/fVv/5qesMT1H/8wPWEZL1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ2x2Of9+mR6zw6niYnrDM+e50u/jezfX0hDXu7acXrPP90+kFSxx/+Xh6wjLbdpyesMS9E34zuNtO8z/t/uE0f9fZmRcsAICcwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiO3P726nNyxxvjvhdvzms+kFy2zX301PWONwmF6wzO6Nd6cnLHF+wmd23O+nJ6xx+eX0gmXu/3A1PWGJ7bvn0xOWOeEKAQCYIbAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGI/Aho0jca+rSBPAAAAAElFTkSuQmCC" id="imageca4fadaaa1" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDUlEQVR4nO3YvYpdVQCG4TkzZzQxowTFGA0EQUvBShvt7b0Qr8DGa/AORLAXwcLaxlJsFAUJIaBCYv5mJpPzYyF4Be9imc3zXMG3Wex93rNWu/tf7Q94tpw/mr1gnCfLfLb9xfnsCcOsXro2e8IYz78we8E4q8PZC8Z4utz3bKlntr97e/aEYZZ5YgAAEwksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY+tbq7uwNQ1xsz2dPGOb61TdnTxjmZHdt9oQhVmcPZk8Y5vuzn2dPGOKN516dPWGY7W4ze8IQDzensycMs9lvZ08Y4r0Xb8yeMIwbLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIitT46vzt4wxG69mz1hmJODS7MnjPP3rdkLhtifPZg9YZj3b34we8IQp5vlntnjhT7b2yfvzJ4wzMVqM3vCEPvff5w9YRg3WAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABBbXz46mb1hiPPt6ewJ46wW3MWXXpq9YIjVgs/seLOZPWGIJZ/ZlfUy37M/Lu7MnjDMZncxe8IQN65cnT1hmOV+QQAAJhFYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEFttf/psP3sE/Ge3m70A/nXo/+czx/eD/xFfEACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIitP/nr1uwNQzx4sp09YZgf7jycPWGYbz7+cPaEIV67fHP2hGHe/eLL2ROG+Oitl2dPGOa3e2ezJwxxeX00e8IwX3/7y+wJQ5x+/unsCcO4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDYarP7bj97xAjb3Wb2hGEOV8vt4qPz09kTxjhaz14wzuO7sxcMsb16ffaEYXb73ewJQxyvlvuePd0v8zfteLPM5zo4cIMFAJATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsfXh04vZG4Y4PFzPnjDOn7/OXjDM/tH92RPG2GxmLxhm9crrsycMcbTdzZ4wztFC/1vfuz17wTDHZw9mTxhi/3Ch3/wDN1gAADmBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQ+wfth4K8R0QyZwAAAABJRU5ErkJggg==" id="image21944d7de8" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m139c1d456f" d="M 0 0 
+       <path id="m70d0eb3e4b" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m139c1d456f" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m139c1d456f" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m139c1d456f" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m139c1d456f" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m139c1d456f" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m139c1d456f" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m139c1d456f" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m139c1d456f" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m139c1d456f" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m139c1d456f" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m139c1d456f" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m70d0eb3e4b" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m62cb93c2dd" d="M 0 0 
+       <path id="m07a2dc99fe" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m62cb93c2dd" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m07a2dc99fe" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m62cb93c2dd" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m07a2dc99fe" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m62cb93c2dd" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m07a2dc99fe" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m62cb93c2dd" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m07a2dc99fe" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m62cb93c2dd" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m07a2dc99fe" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m62cb93c2dd" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m07a2dc99fe" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m62cb93c2dd" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m07a2dc99fe" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m62cb93c2dd" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m07a2dc99fe" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,64 +1303,37 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -15 -->
+    <!-- -14 -->
     <g transform="translate(109.993485 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- -10 -->
-    <g transform="translate(149.244284 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -65 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
      <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
 z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- -87 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+   <g id="text_21">
+    <!-- -8 -->
+    <g transform="translate(151.312096 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1401,6 +1374,55 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -64 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -87 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
 L 3525 4397 
@@ -1420,27 +1442,6 @@ z
    <g id="text_24">
     <!-- -94 -->
     <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
@@ -1455,15 +1456,15 @@ z
     </g>
    </g>
    <g id="text_26">
-    <!-- -11 -->
+    <!-- -10 -->
     <g transform="translate(345.498276 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +5 -->
+    <!-- +7 -->
     <g transform="translate(385.266027 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1483,7 +1484,7 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1541,79 +1542,39 @@ z
     </g>
    </g>
    <g id="text_35">
-    <!-- -17 -->
+    <!-- -18 -->
     <g transform="translate(266.996679 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- -46 -->
+    <!-- -45 -->
     <g transform="translate(306.247477 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_37">
-    <!-- +6 -->
+    <!-- +7 -->
     <g transform="translate(346.015229 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_38">
-    <!-- +9 -->
-    <g transform="translate(385.266027 104.25537) scale(0.065 -0.065)">
+    <!-- +10 -->
+    <g transform="translate(383.198215 104.25537) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- -4 -->
+    <!-- -3 -->
     <g transform="translate(426.067685 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_40">
-    <!-- +12 -->
-    <g transform="translate(461.699812 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_41">
-    <!-- -17 -->
-    <g transform="translate(502.50147 104.25537) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_42">
-    <!-- +229 -->
-    <g transform="translate(106.374813 139.606222) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_43">
-    <!-- +249 -->
-    <g transform="translate(145.625612 139.606222) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_44">
-    <!-- +303 -->
-    <g transform="translate(184.87641 139.606222) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1648,26 +1609,67 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_40">
+    <!-- +12 -->
+    <g transform="translate(461.699812 104.25537) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_41">
+    <!-- -17 -->
+    <g transform="translate(502.50147 104.25537) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_42">
+    <!-- +230 -->
+    <g transform="translate(106.374813 139.606222) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_43">
+    <!-- +248 -->
+    <g transform="translate(145.625612 139.606222) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_44">
+    <!-- +301 -->
+    <g transform="translate(184.87641 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_45">
-    <!-- +74 -->
+    <!-- +73 -->
     <g transform="translate(226.195021 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_46">
-    <!-- +25 -->
+    <!-- +26 -->
     <g transform="translate(265.44582 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_47">
@@ -1680,39 +1682,39 @@ z
     </g>
    </g>
    <g id="text_48">
-    <!-- +230 -->
+    <!-- +233 -->
     <g transform="translate(341.879604 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +267 -->
+    <!-- +272 -->
     <g transform="translate(381.130402 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +267 -->
+    <!-- +262 -->
     <g transform="translate(420.381201 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +394 -->
+    <!-- +397 -->
     <g transform="translate(459.631999 139.606222) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
@@ -1766,12 +1768,11 @@ z
     </g>
    </g>
    <g id="text_58">
-    <!-- -100 -->
-    <g transform="translate(304.179665 174.957073) scale(0.065 -0.065)">
+    <!-- -99 -->
+    <g transform="translate(306.247477 174.957073) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(163.330078 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_59">
@@ -1818,179 +1819,177 @@ z
     </g>
    </g>
    <g id="text_64">
+    <!-- +19 -->
+    <g transform="translate(108.442626 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_65">
+    <!-- +37 -->
+    <g transform="translate(147.693424 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_66">
+    <!-- -9 -->
+    <g transform="translate(190.562895 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_67">
+    <!-- -40 -->
+    <g transform="translate(227.74588 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_68">
     <!-- -58 -->
-    <g transform="translate(109.993485 210.307924) scale(0.065 -0.065)">
+    <g transform="translate(266.996679 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_65">
-    <!-- -48 -->
-    <g transform="translate(149.244284 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_66">
-    <!-- -67 -->
-    <g transform="translate(188.495082 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_67">
-    <!-- -90 -->
-    <g transform="translate(227.74588 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_68">
-    <!-- -94 -->
-    <g transform="translate(266.996679 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
    <g id="text_69">
-    <!-- -44 -->
+    <!-- -16 -->
     <g transform="translate(306.247477 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_70">
-    <!-- -34 -->
-    <g transform="translate(345.498276 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    <!-- +29 -->
+    <g transform="translate(343.947416 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_71">
-    <!-- -22 -->
-    <g transform="translate(384.749074 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    <!-- +34 -->
+    <g transform="translate(383.198215 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_72">
-    <!-- -11 -->
-    <g transform="translate(423.999873 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    <!-- +48 -->
+    <g transform="translate(422.449013 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_73">
-    <!-- -34 -->
-    <g transform="translate(463.250671 210.307924) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    <!-- +58 -->
+    <g transform="translate(461.699812 210.307924) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_74">
-    <!-- -94 -->
+    <!-- -60 -->
     <g transform="translate(502.50147 210.307924) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_75">
-    <!-- +26 -->
-    <g transform="translate(108.442626 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_76">
-    <!-- +45 -->
-    <g transform="translate(147.693424 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_77">
-    <!-- -30 -->
-    <g transform="translate(188.495082 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_75">
+    <!-- +39 -->
+    <g transform="translate(108.442626 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_76">
+    <!-- +41 -->
+    <g transform="translate(147.693424 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_77">
+    <!-- -15 -->
+    <g transform="translate(188.495082 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_78">
-    <!-- -39 -->
+    <!-- -59 -->
     <g transform="translate(227.74588 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_79">
-    <!-- -68 -->
+    <!-- -81 -->
     <g transform="translate(266.996679 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_80">
-    <!-- -12 -->
-    <g transform="translate(306.247477 245.658775) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    <!-- +10 -->
+    <g transform="translate(304.696618 245.658775) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_81">
-    <!-- +25 -->
+    <!-- +32 -->
     <g transform="translate(343.947416 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_82">
-    <!-- +46 -->
+    <!-- +55 -->
     <g transform="translate(383.198215 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_83">
-    <!-- -27 -->
-    <g transform="translate(423.999873 245.658775) scale(0.065 -0.065)">
+    <!-- -8 -->
+    <g transform="translate(426.067685 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_84">
-    <!-- +54 -->
+    <!-- +13 -->
     <g transform="translate(461.699812 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_85">
-    <!-- -80 -->
+    <!-- -86 -->
     <g transform="translate(502.50147 245.658775) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_86">
@@ -2002,85 +2001,85 @@ z
     </g>
    </g>
    <g id="text_87">
-    <!-- +79 -->
+    <!-- +77 -->
     <g transform="translate(147.693424 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_88">
-    <!-- +26 -->
+    <!-- +25 -->
     <g transform="translate(186.944223 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_89">
-    <!-- -18 -->
+    <!-- -19 -->
     <g transform="translate(227.74588 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_90">
-    <!-- -43 -->
+    <!-- -41 -->
     <g transform="translate(266.996679 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_91">
-    <!-- +114 -->
+    <!-- +113 -->
     <g transform="translate(302.628805 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_92">
-    <!-- +68 -->
+    <!-- +69 -->
     <g transform="translate(343.947416 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_93">
-    <!-- +77 -->
+    <!-- +75 -->
     <g transform="translate(383.198215 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_94">
-    <!-- +97 -->
+    <!-- +96 -->
     <g transform="translate(422.449013 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_95">
-    <!-- +107 -->
+    <!-- +105 -->
     <g transform="translate(459.631999 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_96">
-    <!-- -52 -->
+    <!-- -53 -->
     <g transform="translate(502.50147 281.009626) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_97">
@@ -2092,19 +2091,19 @@ z
     </g>
    </g>
    <g id="text_98">
-    <!-- -35 -->
+    <!-- -34 -->
     <g transform="translate(149.244284 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_99">
-    <!-- -54 -->
+    <!-- -53 -->
     <g transform="translate(188.495082 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_100">
@@ -2124,51 +2123,51 @@ z
     </g>
    </g>
    <g id="text_102">
-    <!-- -52 -->
+    <!-- -51 -->
     <g transform="translate(306.247477 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_103">
-    <!-- -37 -->
+    <!-- -36 -->
     <g transform="translate(345.498276 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_104">
-    <!-- -34 -->
+    <!-- -33 -->
     <g transform="translate(384.749074 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_105">
-    <!-- -47 -->
-    <g transform="translate(423.999873 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_106">
-    <!-- -43 -->
-    <g transform="translate(463.250671 316.360477) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_105">
+    <!-- -46 -->
+    <g transform="translate(423.999873 316.360477) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_106">
+    <!-- -42 -->
+    <g transform="translate(463.250671 316.360477) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_107">
-    <!-- -86 -->
+    <!-- -85 -->
     <g transform="translate(502.50147 316.360477) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
@@ -2182,23 +2181,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image6aca13501e" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image71cda7bb84" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m1a62f86dd3" d="M 0 0 
+       <path id="mdd03cddc87" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1a62f86dd3" x="547.779688" y="277.001573" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd03cddc87" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
       <!-- −3 -->
-      <g transform="translate(554.779688 280.800792) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 280.093124) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2216,12 +2215,12 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m1a62f86dd3" x="547.779688" y="248.280684" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd03cddc87" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
       <!-- −2 -->
-      <g transform="translate(554.779688 252.079903) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 251.608124) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2230,12 +2229,12 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1a62f86dd3" x="547.779688" y="219.559794" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd03cddc87" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
       <!-- −1 -->
-      <g transform="translate(554.779688 223.359013) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 223.123124) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2244,7 +2243,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m1a62f86dd3" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd03cddc87" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2257,12 +2256,12 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1a62f86dd3" x="547.779688" y="162.118015" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd03cddc87" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
       <!-- 1 -->
-      <g transform="translate(554.779688 165.917234) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 166.153123) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2270,12 +2269,12 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m1a62f86dd3" x="547.779688" y="133.397125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd03cddc87" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
       <!-- 2 -->
-      <g transform="translate(554.779688 137.196344) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 137.668123) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2283,12 +2282,12 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1a62f86dd3" x="547.779688" y="104.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdd03cddc87" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
       <!-- 3 -->
-      <g transform="translate(554.779688 108.475455) scale(0.1 -0.1)">
+      <g transform="translate(554.779688 109.183123) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2944,8 +2943,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-05T08:48:39Z  ·  Linux chungus x86_64  ·  commit 7e98994a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.762578 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.687734 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3014,14 +3013,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3041,128 +3040,129 @@ z
     <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
     <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
     <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.792969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.580078 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.367188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.941406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3761.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.314453 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.693359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3988.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.917969 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4211.03125 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4334.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.308594 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.6875 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4556.001953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.181641 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.804688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.591797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.214844 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.837891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.625 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.248047 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.332031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.195312 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.947266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.734375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.185547 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.367188 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.746094 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.601562 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.457031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.666016 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5992.029297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.441406 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.964844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.224609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.503906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.769531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.148438 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.427734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6691.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.382812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.564453 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.773438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.464844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.365234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.644531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.853516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.818359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.388672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.488281 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.484375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7520.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.371094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.566406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.945312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.728516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.828125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7867.037109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.820312 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2107.714844 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2139.501953 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2325.927734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2503.173828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.960938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2566.748047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2598.535156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2630.322266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2662.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2717.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2778.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2875.683594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pab730e26a5">
+  <clipPath id="p490df6c679">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mf47ca16301" d="M 0 0 
+       <path id="mc852c6beca" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf47ca16301" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc852c6beca" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mf47ca16301" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc852c6beca" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mf47ca16301" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc852c6beca" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf47ca16301" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc852c6beca" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf47ca16301" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc852c6beca" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf47ca16301" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc852c6beca" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf47ca16301" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc852c6beca" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -852,23 +852,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 347.796763 
-L 637.2 347.796763 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 347.786382 
+L 637.2 347.786382 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m6af20f0217" d="M 0 0 
+       <path id="m69a621b2e9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6af20f0217" x="49.078125" y="347.796763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69a621b2e9" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 351.595982) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 351.585601) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -893,18 +893,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 238.680056 
-L 637.2 238.680056 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 238.646289 
+L 637.2 238.646289 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6af20f0217" x="49.078125" y="238.680056" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69a621b2e9" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 242.479274) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 242.445508) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -913,18 +913,18 @@ L 637.2 238.680056
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 129.563348 
-L 637.2 129.563348 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 129.506196 
+L 637.2 129.506196 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m6af20f0217" x="49.078125" y="129.563348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69a621b2e9" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 133.362567) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 133.305415) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -933,330 +933,330 @@ L 637.2 129.563348
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 404.851571 
-L 637.2 404.851571 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 404.853417 
+L 637.2 404.853417 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m7c8c97a1cb" d="M 0 0 
+       <path id="m52b97157d8" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="404.851571" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 391.218667 
-L 637.2 391.218667 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 391.217592 
+L 637.2 391.217592 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="391.218667" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 380.644165 
-L 637.2 380.644165 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.640824 
+L 637.2 380.640824 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="380.644165" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 372.004168 
-L 637.2 372.004168 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 371.998975 
+L 637.2 371.998975 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="372.004168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 364.699155 
-L 637.2 364.699155 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 364.692396 
+L 637.2 364.692396 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="364.699155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 358.371265 
-L 637.2 358.371265 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 358.36315 
+L 637.2 358.36315 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="358.371265" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 352.78967 
-L 637.2 352.78967 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 352.780359 
+L 637.2 352.780359 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="352.78967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 314.949361 
-L 637.2 314.949361 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 314.93194 
+L 637.2 314.93194 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="314.949361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 295.734863 
-L 637.2 295.734863 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 295.713324 
+L 637.2 295.713324 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="295.734863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 282.101959 
-L 637.2 282.101959 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 282.077499 
+L 637.2 282.077499 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="282.101959" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 271.527458 
-L 637.2 271.527458 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.500731 
+L 637.2 271.500731 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="271.527458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 262.887461 
-L 637.2 262.887461 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.858882 
+L 637.2 262.858882 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="262.887461" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 255.582447 
-L 637.2 255.582447 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.552304 
+L 637.2 255.552304 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="255.582447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 249.254557 
-L 637.2 249.254557 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.223057 
+L 637.2 249.223057 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="249.254557" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 243.672962 
-L 637.2 243.672962 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.640266 
+L 637.2 243.640266 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="243.672962" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 205.832653 
-L 637.2 205.832653 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.791848 
+L 637.2 205.791848 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="205.832653" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 186.618155 
-L 637.2 186.618155 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 186.573231 
+L 637.2 186.573231 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="186.618155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 172.985251 
-L 637.2 172.985251 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 172.937406 
+L 637.2 172.937406 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="172.985251" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 162.41075 
-L 637.2 162.41075 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 162.360638 
+L 637.2 162.360638 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="162.41075" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 153.770753 
-L 637.2 153.770753 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 153.71879 
+L 637.2 153.71879 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="153.770753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 146.46574 
-L 637.2 146.46574 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.412211 
+L 637.2 146.412211 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="146.46574" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 140.137849 
-L 637.2 140.137849 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 140.082964 
+L 637.2 140.082964 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="140.137849" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 134.556255 
-L 637.2 134.556255 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 134.500173 
+L 637.2 134.500173 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="134.556255" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_67">
-      <path d="M 49.078125 96.715946 
-L 637.2 96.715946 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 96.651755 
+L 637.2 96.651755 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="96.715946" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_69">
-      <path d="M 49.078125 77.501447 
-L 637.2 77.501447 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 77.433138 
+L 637.2 77.433138 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="77.501447" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_71">
-      <path d="M 49.078125 63.868544 
-L 637.2 63.868544 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 63.797313 
+L 637.2 63.797313 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="63.868544" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_73">
-      <path d="M 49.078125 53.294042 
-L 637.2 53.294042 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 53.220545 
+L 637.2 53.220545 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m7c8c97a1cb" x="49.078125" y="53.294042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m52b97157d8" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 160.489547) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 160.316466) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 302.043257) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 301.905418) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,1488 +1732,1488 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m458a51683f" d="M -2.5 2.5 
+     <path id="m8201a32ea5" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1218df302b)">
-     <use xlink:href="#m458a51683f" x="355.479835" y="95.25942" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m458a51683f" x="308.273931" y="102.64095" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m458a51683f" x="271.230161" y="116.240058" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m458a51683f" x="217.83458" y="119.978674" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m458a51683f" x="177.077692" y="138.359262" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m458a51683f" x="162.880539" y="157.659557" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m458a51683f" x="160.741445" y="165.081439" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m458a51683f" x="153.966678" y="183.30847" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m458a51683f" x="151.589614" y="194.354473" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3aaf15e627)">
+     <use xlink:href="#m8201a32ea5" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8201a32ea5" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8201a32ea5" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8201a32ea5" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8201a32ea5" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8201a32ea5" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8201a32ea5" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8201a32ea5" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8201a32ea5" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
-    <path d="M 355.479835 95.25942 
-L 354.496379 95.425534 
-L 353.512922 95.591068 
-L 352.529466 95.756025 
-L 351.54601 95.920411 
-L 350.562553 96.084228 
-L 349.579097 96.247481 
-L 348.595641 96.410174 
-L 347.612184 96.572309 
-L 346.628728 96.733892 
-L 345.645272 96.894926 
-L 344.661815 97.055415 
-L 343.678359 97.215362 
-L 342.694903 97.37477 
-L 341.711446 97.533645 
-L 340.72799 97.691988 
-L 339.744534 97.849804 
-L 338.761077 98.007097 
-L 337.777621 98.163869 
-L 336.794165 98.320124 
-L 335.810708 98.475865 
-L 334.827252 98.631097 
-L 333.843796 98.785821 
-L 332.860339 98.940042 
-L 331.876883 99.093763 
-L 330.893427 99.246987 
-L 329.90997 99.399717 
-L 328.926514 99.551956 
-L 327.943058 99.703708 
-L 326.959601 99.854975 
-L 325.976145 100.005761 
-L 324.992689 100.156069 
-L 324.009232 100.305902 
-L 323.025776 100.455262 
-L 322.04232 100.604153 
-L 321.058863 100.752577 
-L 320.075407 100.900539 
-L 319.091951 101.048039 
-L 318.108494 101.195082 
-L 317.125038 101.341671 
-L 316.141582 101.487807 
-L 315.158125 101.633494 
-L 314.174669 101.778734 
-L 313.191213 101.923531 
-L 312.207756 102.067886 
-L 311.2243 102.211803 
-L 310.240844 102.355284 
-L 309.257387 102.498333 
-L 308.273931 102.64095 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 355.479835 95.382063 
+L 354.496379 95.547954 
+L 353.512922 95.713267 
+L 352.529466 95.878005 
+L 351.54601 96.042172 
+L 350.562553 96.205773 
+L 349.579097 96.368811 
+L 348.595641 96.53129 
+L 347.612184 96.693214 
+L 346.628728 96.854587 
+L 345.645272 97.015412 
+L 344.661815 97.175694 
+L 343.678359 97.335435 
+L 342.694903 97.49464 
+L 341.711446 97.653312 
+L 340.72799 97.811454 
+L 339.744534 97.969071 
+L 338.761077 98.126165 
+L 337.777621 98.28274 
+L 336.794165 98.4388 
+L 335.810708 98.594347 
+L 334.827252 98.749386 
+L 333.843796 98.903919 
+L 332.860339 99.057951 
+L 331.876883 99.211483 
+L 330.893427 99.364519 
+L 329.90997 99.517063 
+L 328.926514 99.669118 
+L 327.943058 99.820686 
+L 326.959601 99.971771 
+L 325.976145 100.122377 
+L 324.992689 100.272505 
+L 324.009232 100.422159 
+L 323.025776 100.571342 
+L 322.04232 100.720057 
+L 321.058863 100.868307 
+L 320.075407 101.016095 
+L 319.091951 101.163423 
+L 318.108494 101.310295 
+L 317.125038 101.456713 
+L 316.141582 101.60268 
+L 315.158125 101.7482 
+L 314.174669 101.893273 
+L 313.191213 102.037904 
+L 312.207756 102.182095 
+L 311.2243 102.325849 
+L 310.240844 102.469168 
+L 309.257387 102.612055 
+L 308.273931 102.754513 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
-    <path d="M 308.273931 102.64095 
-L 307.502186 102.96797 
-L 306.730441 103.292748 
-L 305.958695 103.615315 
-L 305.18695 103.935702 
-L 304.415205 104.253937 
-L 303.64346 104.570049 
-L 302.871714 104.884067 
-L 302.099969 105.196017 
-L 301.328224 105.505928 
-L 300.556479 105.813824 
-L 299.784734 106.119734 
-L 299.012988 106.423681 
-L 298.241243 106.725691 
-L 297.469498 107.025788 
-L 296.697753 107.323997 
-L 295.926008 107.620342 
-L 295.154262 107.914844 
-L 294.382517 108.207528 
-L 293.610772 108.498415 
-L 292.839027 108.787527 
-L 292.067281 109.074886 
-L 291.295536 109.360513 
-L 290.523791 109.644429 
-L 289.752046 109.926655 
-L 288.980301 110.207209 
-L 288.208555 110.486112 
-L 287.43681 110.763383 
-L 286.665065 111.039041 
-L 285.89332 111.313105 
-L 285.121575 111.585594 
-L 284.349829 111.856524 
-L 283.578084 112.125914 
-L 282.806339 112.393781 
-L 282.034594 112.660143 
-L 281.262849 112.925016 
-L 280.491103 113.188417 
-L 279.719358 113.450362 
-L 278.947613 113.710867 
-L 278.175868 113.969947 
-L 277.404122 114.227619 
-L 276.632377 114.483897 
-L 275.860632 114.738797 
-L 275.088887 114.992333 
-L 274.317142 115.24452 
-L 273.545396 115.495372 
-L 272.773651 115.744903 
-L 272.001906 115.993127 
-L 271.230161 116.240058 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 308.273931 102.754513 
+L 307.502186 103.086339 
+L 306.730441 103.415859 
+L 305.958695 103.743103 
+L 305.18695 104.068104 
+L 304.415205 104.390891 
+L 303.64346 104.711495 
+L 302.871714 105.029945 
+L 302.099969 105.34627 
+L 301.328224 105.660497 
+L 300.556479 105.972656 
+L 299.784734 106.282772 
+L 299.012988 106.590872 
+L 298.241243 106.896982 
+L 297.469498 107.201128 
+L 296.697753 107.503335 
+L 295.926008 107.803627 
+L 295.154262 108.102029 
+L 294.382517 108.398564 
+L 293.610772 108.693255 
+L 292.839027 108.986126 
+L 292.067281 109.277198 
+L 291.295536 109.566493 
+L 290.523791 109.854034 
+L 289.752046 110.13984 
+L 288.980301 110.423934 
+L 288.208555 110.706335 
+L 287.43681 110.987063 
+L 286.665065 111.266139 
+L 285.89332 111.543581 
+L 285.121575 111.819408 
+L 284.349829 112.09364 
+L 283.578084 112.366294 
+L 282.806339 112.637389 
+L 282.034594 112.906942 
+L 281.262849 113.17497 
+L 280.491103 113.441492 
+L 279.719358 113.706523 
+L 278.947613 113.970081 
+L 278.175868 114.232181 
+L 277.404122 114.49284 
+L 276.632377 114.752074 
+L 275.860632 115.009897 
+L 275.088887 115.266326 
+L 274.317142 115.521374 
+L 273.545396 115.775058 
+L 272.773651 116.027391 
+L 272.001906 116.278388 
+L 271.230161 116.528062 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
-    <path d="M 271.230161 116.240058 
-L 270.117753 116.321031 
-L 269.005345 116.401867 
-L 267.892937 116.482564 
-L 266.780529 116.563125 
-L 265.668121 116.643548 
-L 264.555713 116.723836 
-L 263.443305 116.803987 
-L 262.330897 116.884004 
-L 261.218489 116.963885 
-L 260.106081 117.043632 
-L 258.993673 117.123245 
-L 257.881265 117.202725 
-L 256.768858 117.282071 
-L 255.65645 117.361285 
-L 254.544042 117.440367 
-L 253.431634 117.519317 
-L 252.319226 117.598135 
-L 251.206818 117.676823 
-L 250.09441 117.75538 
-L 248.982002 117.833808 
-L 247.869594 117.912105 
-L 246.757186 117.990274 
-L 245.644778 118.068313 
-L 244.53237 118.146225 
-L 243.419962 118.224009 
-L 242.307554 118.301665 
-L 241.195146 118.379194 
-L 240.082738 118.456596 
-L 238.97033 118.533872 
-L 237.857923 118.611023 
-L 236.745515 118.688048 
-L 235.633107 118.764948 
-L 234.520699 118.841723 
-L 233.408291 118.918375 
-L 232.295883 118.994902 
-L 231.183475 119.071306 
-L 230.071067 119.147587 
-L 228.958659 119.223746 
-L 227.846251 119.299782 
-L 226.733843 119.375697 
-L 225.621435 119.45149 
-L 224.509027 119.527162 
-L 223.396619 119.602713 
-L 222.284211 119.678144 
-L 221.171803 119.753456 
-L 220.059395 119.828647 
-L 218.946988 119.90372 
-L 217.83458 119.978674 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 271.230161 116.528062 
+L 270.117753 116.603356 
+L 269.005345 116.67853 
+L 267.892937 116.753584 
+L 266.780529 116.82852 
+L 265.668121 116.903338 
+L 264.555713 116.978038 
+L 263.443305 117.052621 
+L 262.330897 117.127086 
+L 261.218489 117.201434 
+L 260.106081 117.275666 
+L 258.993673 117.349782 
+L 257.881265 117.423783 
+L 256.768858 117.497667 
+L 255.65645 117.571437 
+L 254.544042 117.645093 
+L 253.431634 117.718634 
+L 252.319226 117.792061 
+L 251.206818 117.865374 
+L 250.09441 117.938574 
+L 248.982002 118.011662 
+L 247.869594 118.084637 
+L 246.757186 118.157499 
+L 245.644778 118.23025 
+L 244.53237 118.302889 
+L 243.419962 118.375418 
+L 242.307554 118.447835 
+L 241.195146 118.520142 
+L 240.082738 118.592339 
+L 238.97033 118.664426 
+L 237.857923 118.736403 
+L 236.745515 118.808272 
+L 235.633107 118.880031 
+L 234.520699 118.951682 
+L 233.408291 119.023225 
+L 232.295883 119.09466 
+L 231.183475 119.165988 
+L 230.071067 119.237208 
+L 228.958659 119.308322 
+L 227.846251 119.379329 
+L 226.733843 119.45023 
+L 225.621435 119.521025 
+L 224.509027 119.591714 
+L 223.396619 119.662298 
+L 222.284211 119.732777 
+L 221.171803 119.803152 
+L 220.059395 119.873422 
+L 218.946988 119.943588 
+L 217.83458 120.013651 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
-    <path d="M 217.83458 119.978674 
-L 216.985478 120.444182 
-L 216.136376 120.905161 
-L 215.287274 121.361699 
-L 214.438172 121.813881 
-L 213.58907 122.261789 
-L 212.739969 122.705503 
-L 211.890867 123.145101 
-L 211.041765 123.580658 
-L 210.192663 124.012249 
-L 209.343561 124.439944 
-L 208.494459 124.863814 
-L 207.645358 125.283926 
-L 206.796256 125.700347 
-L 205.947154 126.11314 
-L 205.098052 126.522368 
-L 204.24895 126.928093 
-L 203.399848 127.330373 
-L 202.550747 127.729267 
-L 201.701645 128.124832 
-L 200.852543 128.517122 
-L 200.003441 128.906191 
-L 199.154339 129.292092 
-L 198.305237 129.674876 
-L 197.456136 130.054592 
-L 196.607034 130.431291 
-L 195.757932 130.805018 
-L 194.90883 131.175821 
-L 194.059728 131.543745 
-L 193.210626 131.908835 
-L 192.361525 132.271133 
-L 191.512423 132.630683 
-L 190.663321 132.987525 
-L 189.814219 133.3417 
-L 188.965117 133.693247 
-L 188.116016 134.042206 
-L 187.266914 134.388615 
-L 186.417812 134.732509 
-L 185.56871 135.073925 
-L 184.719608 135.4129 
-L 183.870506 135.749467 
-L 183.021405 136.08366 
-L 182.172303 136.415513 
-L 181.323201 136.745059 
-L 180.474099 137.072328 
-L 179.624997 137.397353 
-L 178.775895 137.720164 
-L 177.926794 138.04079 
-L 177.077692 138.359262 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 217.83458 120.013651 
+L 216.985478 120.480366 
+L 216.136376 120.942531 
+L 215.287274 121.400234 
+L 214.438172 121.853558 
+L 213.58907 122.302588 
+L 212.739969 122.747404 
+L 211.890867 123.188085 
+L 211.041765 123.624706 
+L 210.192663 124.057341 
+L 209.343561 124.486064 
+L 208.494459 124.910943 
+L 207.645358 125.332048 
+L 206.796256 125.749444 
+L 205.947154 126.163197 
+L 205.098052 126.57337 
+L 204.24895 126.980023 
+L 203.399848 127.383217 
+L 202.550747 127.783011 
+L 201.701645 128.17946 
+L 200.852543 128.572621 
+L 200.003441 128.962548 
+L 199.154339 129.349293 
+L 198.305237 129.732908 
+L 197.456136 130.113443 
+L 196.607034 130.490947 
+L 195.757932 130.865469 
+L 194.90883 131.237054 
+L 194.059728 131.605749 
+L 193.210626 131.971598 
+L 192.361525 132.334646 
+L 191.512423 132.694933 
+L 190.663321 133.052503 
+L 189.814219 133.407395 
+L 188.965117 133.75965 
+L 188.116016 134.109306 
+L 187.266914 134.456402 
+L 186.417812 134.800974 
+L 185.56871 135.14306 
+L 184.719608 135.482694 
+L 183.870506 135.819912 
+L 183.021405 136.154748 
+L 182.172303 136.487235 
+L 181.323201 136.817406 
+L 180.474099 137.145293 
+L 179.624997 137.470928 
+L 178.775895 137.79434 
+L 177.926794 138.115561 
+L 177.077692 138.43462 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
-    <path d="M 177.077692 138.359262 
-L 176.781918 138.852998 
-L 176.486144 139.341643 
-L 176.19037 139.8253 
-L 175.894596 140.304071 
-L 175.598822 140.778053 
-L 175.303048 141.247341 
-L 175.007274 141.712028 
-L 174.7115 142.172202 
-L 174.415726 142.62795 
-L 174.119951 143.079357 
-L 173.824177 143.526505 
-L 173.528403 143.969473 
-L 173.232629 144.408339 
-L 172.936855 144.843177 
-L 172.641081 145.274062 
-L 172.345307 145.701064 
-L 172.049533 146.124253 
-L 171.753759 146.543697 
-L 171.457985 146.95946 
-L 171.162211 147.371607 
-L 170.866437 147.780201 
-L 170.570663 148.185302 
-L 170.274889 148.586969 
-L 169.979115 148.98526 
-L 169.683341 149.380232 
-L 169.387567 149.771939 
-L 169.091793 150.160434 
-L 168.796019 150.545771 
-L 168.500245 150.927999 
-L 168.204471 151.307169 
-L 167.908697 151.68333 
-L 167.612923 152.056528 
-L 167.317149 152.42681 
-L 167.021375 152.794221 
-L 166.725601 153.158805 
-L 166.429827 153.520606 
-L 166.134053 153.879665 
-L 165.838279 154.236025 
-L 165.542505 154.589724 
-L 165.246731 154.940804 
-L 164.950957 155.289301 
-L 164.655183 155.635254 
-L 164.359409 155.9787 
-L 164.063635 156.319675 
-L 163.767861 156.658214 
-L 163.472087 156.994351 
-L 163.176313 157.328121 
-L 162.880539 157.659557 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 177.077692 138.43462 
+L 176.781918 138.929688 
+L 176.486144 139.419639 
+L 176.19037 139.904577 
+L 175.894596 140.384603 
+L 175.598822 140.859818 
+L 175.303048 141.330314 
+L 175.007274 141.796187 
+L 174.7115 142.257525 
+L 174.415726 142.714416 
+L 174.119951 143.166945 
+L 173.824177 143.615195 
+L 173.528403 144.059245 
+L 173.232629 144.499173 
+L 172.936855 144.935056 
+L 172.641081 145.366967 
+L 172.345307 145.794978 
+L 172.049533 146.219159 
+L 171.753759 146.639577 
+L 171.457985 147.056299 
+L 171.162211 147.469389 
+L 170.866437 147.87891 
+L 170.570663 148.284923 
+L 170.274889 148.687487 
+L 169.979115 149.086662 
+L 169.683341 149.482503 
+L 169.387567 149.875065 
+L 169.091793 150.264403 
+L 168.796019 150.650569 
+L 168.500245 151.033614 
+L 168.204471 151.413588 
+L 167.908697 151.790541 
+L 167.612923 152.164519 
+L 167.317149 152.53557 
+L 167.021375 152.903738 
+L 166.725601 153.269069 
+L 166.429827 153.631606 
+L 166.134053 153.991391 
+L 165.838279 154.348465 
+L 165.542505 154.70287 
+L 165.246731 155.054644 
+L 164.950957 155.403827 
+L 164.655183 155.750456 
+L 164.359409 156.094568 
+L 164.063635 156.436201 
+L 163.767861 156.775388 
+L 163.472087 157.112166 
+L 163.176313 157.446568 
+L 162.880539 157.778627 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
-    <path d="M 162.880539 157.659557 
-L 162.835974 157.82665 
-L 162.79141 157.993157 
-L 162.746845 158.15908 
-L 162.702281 158.324425 
-L 162.657716 158.489194 
-L 162.613152 158.653393 
-L 162.568588 158.817025 
-L 162.524023 158.980093 
-L 162.479459 159.142603 
-L 162.434894 159.304557 
-L 162.39033 159.465959 
-L 162.345765 159.626814 
-L 162.301201 159.787124 
-L 162.256636 159.946894 
-L 162.212072 160.106127 
-L 162.167508 160.264827 
-L 162.122943 160.422997 
-L 162.078379 160.580641 
-L 162.033814 160.737763 
-L 161.98925 160.894365 
-L 161.944685 161.050451 
-L 161.900121 161.206025 
-L 161.855556 161.361089 
-L 161.810992 161.515648 
-L 161.766428 161.669705 
-L 161.721863 161.823262 
-L 161.677299 161.976324 
-L 161.632734 162.128892 
-L 161.58817 162.280971 
-L 161.543605 162.432564 
-L 161.499041 162.583673 
-L 161.454477 162.734302 
-L 161.409912 162.884453 
-L 161.365348 163.034131 
-L 161.320783 163.183337 
-L 161.276219 163.332074 
-L 161.231654 163.480347 
-L 161.18709 163.628157 
-L 161.142525 163.775507 
-L 161.097961 163.9224 
-L 161.053397 164.06884 
-L 161.008832 164.214828 
-L 160.964268 164.360368 
-L 160.919703 164.505463 
-L 160.875139 164.650114 
-L 160.830574 164.794326 
-L 160.78601 164.9381 
-L 160.741445 165.081439 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 162.880539 157.778627 
+L 162.835974 157.945624 
+L 162.79141 158.112034 
+L 162.746845 158.277863 
+L 162.702281 158.443113 
+L 162.657716 158.607789 
+L 162.613152 158.771895 
+L 162.568588 158.935435 
+L 162.524023 159.098413 
+L 162.479459 159.260832 
+L 162.434894 159.422696 
+L 162.39033 159.58401 
+L 162.345765 159.744776 
+L 162.301201 159.904999 
+L 162.256636 160.064682 
+L 162.212072 160.223829 
+L 162.167508 160.382444 
+L 162.122943 160.540529 
+L 162.078379 160.698089 
+L 162.033814 160.855127 
+L 161.98925 161.011646 
+L 161.944685 161.16765 
+L 161.900121 161.323143 
+L 161.855556 161.478127 
+L 161.810992 161.632606 
+L 161.766428 161.786583 
+L 161.721863 161.940061 
+L 161.677299 162.093044 
+L 161.632734 162.245535 
+L 161.58817 162.397537 
+L 161.543605 162.549053 
+L 161.499041 162.700087 
+L 161.454477 162.85064 
+L 161.409912 163.000717 
+L 161.365348 163.15032 
+L 161.320783 163.299452 
+L 161.276219 163.448117 
+L 161.231654 163.596317 
+L 161.18709 163.744055 
+L 161.142525 163.891334 
+L 161.097961 164.038157 
+L 161.053397 164.184526 
+L 161.008832 164.330445 
+L 160.964268 164.475915 
+L 160.919703 164.620941 
+L 160.875139 164.765525 
+L 160.830574 164.909668 
+L 160.78601 165.053375 
+L 160.741445 165.196647 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
-    <path d="M 160.741445 165.081439 
-L 160.600304 165.542285 
-L 160.459163 165.998692 
-L 160.318022 166.450746 
-L 160.176881 166.898528 
-L 160.03574 167.342119 
-L 159.894599 167.781595 
-L 159.753458 168.217034 
-L 159.612317 168.648508 
-L 159.471176 169.076088 
-L 159.330035 169.499846 
-L 159.188894 169.919847 
-L 159.047754 170.336159 
-L 158.906613 170.748845 
-L 158.765472 171.157968 
-L 158.624331 171.56359 
-L 158.48319 171.965769 
-L 158.342049 172.364563 
-L 158.200908 172.76003 
-L 158.059767 173.152223 
-L 157.918626 173.541198 
-L 157.777485 173.927005 
-L 157.636344 174.309697 
-L 157.495203 174.689324 
-L 157.354062 175.065933 
-L 157.212921 175.439573 
-L 157.07178 175.810289 
-L 156.930639 176.178129 
-L 156.789498 176.543135 
-L 156.648357 176.905351 
-L 156.507216 177.264819 
-L 156.366075 177.621582 
-L 156.224934 177.975678 
-L 156.083793 178.327148 
-L 155.942652 178.676031 
-L 155.801511 179.022364 
-L 155.66037 179.366184 
-L 155.519229 179.707527 
-L 155.378088 180.04643 
-L 155.236947 180.382926 
-L 155.095806 180.717049 
-L 154.954665 181.048833 
-L 154.813524 181.37831 
-L 154.672383 181.705513 
-L 154.531242 182.030471 
-L 154.390101 182.353217 
-L 154.24896 182.673779 
-L 154.107819 182.992187 
-L 153.966678 183.30847 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 160.741445 165.196647 
+L 160.600304 165.656931 
+L 160.459163 166.112787 
+L 160.318022 166.564301 
+L 160.176881 167.011555 
+L 160.03574 167.454628 
+L 159.894599 167.893598 
+L 159.753458 168.328539 
+L 159.612317 168.759526 
+L 159.471176 169.186629 
+L 159.330035 169.609917 
+L 159.188894 170.029459 
+L 159.047754 170.445321 
+L 158.906613 170.857565 
+L 158.765472 171.266255 
+L 158.624331 171.671451 
+L 158.48319 172.073212 
+L 158.342049 172.471597 
+L 158.200908 172.866661 
+L 158.059767 173.258459 
+L 157.918626 173.647046 
+L 157.777485 174.032472 
+L 157.636344 174.41479 
+L 157.495203 174.794049 
+L 157.354062 175.170297 
+L 157.212921 175.543582 
+L 157.07178 175.91395 
+L 156.930639 176.281447 
+L 156.789498 176.646116 
+L 156.648357 177.008001 
+L 156.507216 177.367144 
+L 156.366075 177.723586 
+L 156.224934 178.077368 
+L 156.083793 178.428529 
+L 155.942652 178.777107 
+L 155.801511 179.123141 
+L 155.66037 179.466666 
+L 155.519229 179.80772 
+L 155.378088 180.146337 
+L 155.236947 180.482552 
+L 155.095806 180.8164 
+L 154.954665 181.147912 
+L 154.813524 181.477122 
+L 154.672383 181.804061 
+L 154.531242 182.12876 
+L 154.390101 182.45125 
+L 154.24896 182.771561 
+L 154.107819 183.089721 
+L 153.966678 183.405761 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
-    <path d="M 153.966678 183.30847 
-L 153.917156 183.566921 
-L 153.867633 183.823969 
-L 153.818111 184.079631 
-L 153.768589 184.333921 
-L 153.719067 184.586854 
-L 153.669545 184.838444 
-L 153.620023 185.088705 
-L 153.5705 185.337651 
-L 153.520978 185.585297 
-L 153.471456 185.831655 
-L 153.421934 186.076739 
-L 153.372412 186.320562 
-L 153.322889 186.563137 
-L 153.273367 186.804476 
-L 153.223845 187.044593 
-L 153.174323 187.283499 
-L 153.124801 187.521207 
-L 153.075279 187.757728 
-L 153.025756 187.993075 
-L 152.976234 188.227258 
-L 152.926712 188.460291 
-L 152.87719 188.692182 
-L 152.827668 188.922945 
-L 152.778146 189.152589 
-L 152.728623 189.381126 
-L 152.679101 189.608566 
-L 152.629579 189.834919 
-L 152.580057 190.060197 
-L 152.530535 190.284409 
-L 152.481013 190.507564 
-L 152.43149 190.729674 
-L 152.381968 190.950748 
-L 152.332446 191.170795 
-L 152.282924 191.389825 
-L 152.233402 191.607848 
-L 152.18388 191.824872 
-L 152.134357 192.040906 
-L 152.084835 192.255961 
-L 152.035313 192.470043 
-L 151.985791 192.683163 
-L 151.936269 192.895329 
-L 151.886747 193.106549 
-L 151.837224 193.316832 
-L 151.787702 193.526186 
-L 151.73818 193.734619 
-L 151.688658 193.942139 
-L 151.639136 194.148754 
-L 151.589614 194.354473 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 153.966678 183.405761 
+L 153.917156 183.665156 
+L 153.867633 183.923139 
+L 153.818111 184.179726 
+L 153.768589 184.434932 
+L 153.719067 184.68877 
+L 153.669545 184.941257 
+L 153.620023 185.192405 
+L 153.5705 185.44223 
+L 153.520978 185.690745 
+L 153.471456 185.937964 
+L 153.421934 186.1839 
+L 153.372412 186.428567 
+L 153.322889 186.671977 
+L 153.273367 186.914144 
+L 153.223845 187.155079 
+L 153.174323 187.394796 
+L 153.124801 187.633307 
+L 153.075279 187.870624 
+L 153.025756 188.106758 
+L 152.976234 188.341722 
+L 152.926712 188.575527 
+L 152.87719 188.808184 
+L 152.827668 189.039705 
+L 152.778146 189.2701 
+L 152.728623 189.499381 
+L 152.679101 189.727558 
+L 152.629579 189.954642 
+L 152.580057 190.180643 
+L 152.530535 190.405572 
+L 152.481013 190.629439 
+L 152.43149 190.852253 
+L 152.381968 191.074024 
+L 152.332446 191.294763 
+L 152.282924 191.514478 
+L 152.233402 191.73318 
+L 152.18388 191.950877 
+L 152.134357 192.167579 
+L 152.084835 192.383295 
+L 152.035313 192.598033 
+L 151.985791 192.811803 
+L 151.936269 193.024614 
+L 151.886747 193.236473 
+L 151.837224 193.447389 
+L 151.787702 193.657371 
+L 151.73818 193.866427 
+L 151.688658 194.074564 
+L 151.639136 194.281792 
+L 151.589614 194.488118 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="mb565d4ecf5" d="M 0 -2.5 
+     <path id="mf4758b086d" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1218df302b)">
-     <use xlink:href="#mb565d4ecf5" x="531.649087" y="75.906758" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb565d4ecf5" x="283.721324" y="98.757435" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb565d4ecf5" x="218.882044" y="120.902897" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb565d4ecf5" x="187.447228" y="126.710903" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb565d4ecf5" x="176.342474" y="138.212475" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb565d4ecf5" x="163.054314" y="161.207386" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb565d4ecf5" x="162.210539" y="168.678909" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb565d4ecf5" x="159.303811" y="175.634901" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mb565d4ecf5" x="157.793928" y="179.408171" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3aaf15e627)">
+     <use xlink:href="#mf4758b086d" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4758b086d" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4758b086d" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4758b086d" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4758b086d" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4758b086d" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4758b086d" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4758b086d" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf4758b086d" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
-    <path d="M 531.649087 75.906758 
-L 526.483926 76.51458 
-L 521.318764 77.114705 
-L 516.153602 77.707324 
-L 510.988441 78.292624 
-L 505.823279 78.870784 
-L 500.658117 79.441974 
-L 495.492955 80.006362 
-L 490.327794 80.564107 
-L 485.162632 81.115363 
-L 479.99747 81.660281 
-L 474.832308 82.199004 
-L 469.667147 82.731672 
-L 464.501985 83.258419 
-L 459.336823 83.779375 
-L 454.171662 84.294666 
-L 449.0065 84.804414 
-L 443.841338 85.308738 
-L 438.676176 85.807751 
-L 433.511015 86.301563 
-L 428.345853 86.790283 
-L 423.180691 87.274015 
-L 418.015529 87.752858 
-L 412.850368 88.226911 
-L 407.685206 88.696269 
-L 402.520044 89.161024 
-L 397.354882 89.621265 
-L 392.189721 90.077079 
-L 387.024559 90.528551 
-L 381.859397 90.975762 
-L 376.694236 91.418792 
-L 371.529074 91.857718 
-L 366.363912 92.292616 
-L 361.19875 92.72356 
-L 356.033589 93.15062 
-L 350.868427 93.573865 
-L 345.703265 93.993364 
-L 340.538103 94.409182 
-L 335.372942 94.821383 
-L 330.20778 95.23003 
-L 325.042618 95.635182 
-L 319.877457 96.036901 
-L 314.712295 96.435242 
-L 309.547133 96.830263 
-L 304.381971 97.222018 
-L 299.21681 97.610561 
-L 294.051648 97.995945 
-L 288.886486 98.37822 
-L 283.721324 98.757435 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 531.649087 75.963093 
+L 526.483926 76.577767 
+L 521.318764 77.184572 
+L 516.153602 77.783707 
+L 510.988441 78.375363 
+L 505.823279 78.959724 
+L 500.658117 79.536969 
+L 495.492955 80.107268 
+L 490.327794 80.670788 
+L 485.162632 81.227686 
+L 479.99747 81.778117 
+L 474.832308 82.322229 
+L 469.667147 82.860166 
+L 464.501985 83.392067 
+L 459.336823 83.918064 
+L 454.171662 84.438289 
+L 449.0065 84.952866 
+L 443.841338 85.461916 
+L 438.676176 85.965557 
+L 433.511015 86.463903 
+L 428.345853 86.957064 
+L 423.180691 87.445147 
+L 418.015529 87.928255 
+L 412.850368 88.406488 
+L 407.685206 88.879945 
+L 402.520044 89.348719 
+L 397.354882 89.812902 
+L 392.189721 90.272584 
+L 387.024559 90.72785 
+L 381.859397 91.178785 
+L 376.694236 91.62547 
+L 371.529074 92.067985 
+L 366.363912 92.506407 
+L 361.19875 92.940811 
+L 356.033589 93.37127 
+L 350.868427 93.797855 
+L 345.703265 94.220634 
+L 340.538103 94.639676 
+L 335.372942 95.055046 
+L 330.20778 95.466807 
+L 325.042618 95.875022 
+L 319.877457 96.279752 
+L 314.712295 96.681055 
+L 309.547133 97.078988 
+L 304.381971 97.473609 
+L 299.21681 97.864971 
+L 294.051648 98.253128 
+L 288.886486 98.638133 
+L 283.721324 99.020035 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
-    <path d="M 283.721324 98.757435 
-L 282.370506 99.341933 
-L 281.019688 99.91931 
-L 279.668869 100.489736 
-L 278.318051 101.053378 
-L 276.967233 101.610394 
-L 275.616414 102.16094 
-L 274.265596 102.705162 
-L 272.914778 103.243206 
-L 271.563959 103.775209 
-L 270.213141 104.301306 
-L 268.862323 104.821626 
-L 267.511504 105.336296 
-L 266.160686 105.845436 
-L 264.809868 106.349163 
-L 263.459049 106.847593 
-L 262.108231 107.340835 
-L 260.757413 107.828995 
-L 259.406594 108.312179 
-L 258.055776 108.790485 
-L 256.704958 109.264012 
-L 255.354139 109.732854 
-L 254.003321 110.197103 
-L 252.652503 110.656848 
-L 251.301684 111.112175 
-L 249.950866 111.563169 
-L 248.600048 112.009912 
-L 247.249229 112.452482 
-L 245.898411 112.890957 
-L 244.547593 113.325413 
-L 243.196774 113.755921 
-L 241.845956 114.182554 
-L 240.495138 114.60538 
-L 239.144319 115.024467 
-L 237.793501 115.43988 
-L 236.442683 115.851683 
-L 235.091864 116.259938 
-L 233.741046 116.664706 
-L 232.390228 117.066046 
-L 231.039409 117.464016 
-L 229.688591 117.858671 
-L 228.337773 118.250067 
-L 226.986954 118.638257 
-L 225.636136 119.023292 
-L 224.285318 119.405225 
-L 222.934499 119.784103 
-L 221.583681 120.159977 
-L 220.232863 120.532893 
-L 218.882044 120.902897 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 283.721324 99.020035 
+L 282.370506 99.601348 
+L 281.019688 100.175618 
+L 279.668869 100.743013 
+L 278.318051 101.303696 
+L 276.967233 101.857824 
+L 275.616414 102.405549 
+L 274.265596 102.947017 
+L 272.914778 103.482369 
+L 271.563959 104.011743 
+L 270.213141 104.535269 
+L 268.862323 105.053075 
+L 267.511504 105.565286 
+L 266.160686 106.072022 
+L 264.809868 106.573396 
+L 263.459049 107.069523 
+L 262.108231 107.560511 
+L 260.757413 108.046465 
+L 259.406594 108.527487 
+L 258.055776 109.003677 
+L 256.704958 109.47513 
+L 255.354139 109.94194 
+L 254.003321 110.404197 
+L 252.652503 110.86199 
+L 251.301684 111.315403 
+L 249.950866 111.76452 
+L 248.600048 112.209422 
+L 247.249229 112.650186 
+L 245.898411 113.08689 
+L 244.547593 113.519607 
+L 243.196774 113.948409 
+L 241.845956 114.373366 
+L 240.495138 114.794548 
+L 239.144319 115.212019 
+L 237.793501 115.625846 
+L 236.442683 116.036092 
+L 235.091864 116.442816 
+L 233.741046 116.846081 
+L 232.390228 117.245943 
+L 231.039409 117.642461 
+L 229.688591 118.035689 
+L 228.337773 118.425681 
+L 226.986954 118.812491 
+L 225.636136 119.196169 
+L 224.285318 119.576767 
+L 222.934499 119.954333 
+L 221.583681 120.328916 
+L 220.232863 120.700561 
+L 218.882044 121.069315 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
-    <path d="M 218.882044 120.902897 
-L 218.227152 121.03145 
-L 217.57226 121.159655 
-L 216.917368 121.287514 
-L 216.262476 121.415029 
-L 215.607584 121.542202 
-L 214.952692 121.669035 
-L 214.2978 121.795529 
-L 213.642908 121.921687 
-L 212.988016 122.047509 
-L 212.333124 122.172998 
-L 211.678232 122.298156 
-L 211.02334 122.422984 
-L 210.368448 122.547484 
-L 209.713556 122.671658 
-L 209.058664 122.795508 
-L 208.403772 122.919034 
-L 207.74888 123.04224 
-L 207.093988 123.165126 
-L 206.439096 123.287694 
-L 205.784204 123.409946 
-L 205.129312 123.531883 
-L 204.47442 123.653507 
-L 203.819528 123.77482 
-L 203.164636 123.895824 
-L 202.509744 124.016519 
-L 201.854852 124.136907 
-L 201.19996 124.25699 
-L 200.545068 124.37677 
-L 199.890176 124.496248 
-L 199.235284 124.615426 
-L 198.580392 124.734304 
-L 197.9255 124.852885 
-L 197.270608 124.97117 
-L 196.615716 125.08916 
-L 195.960824 125.206858 
-L 195.305932 125.324264 
-L 194.65104 125.441379 
-L 193.996148 125.558206 
-L 193.341256 125.674746 
-L 192.686364 125.791 
-L 192.031472 125.906969 
-L 191.37658 126.022655 
-L 190.721688 126.13806 
-L 190.066796 126.253184 
-L 189.411904 126.368029 
-L 188.757012 126.482596 
-L 188.10212 126.596887 
-L 187.447228 126.710903 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 218.882044 121.069315 
+L 218.227152 121.203269 
+L 217.57226 121.336846 
+L 216.917368 121.470048 
+L 216.262476 121.602877 
+L 215.607584 121.735334 
+L 214.952692 121.867422 
+L 214.2978 121.999143 
+L 213.642908 122.130499 
+L 212.988016 122.261492 
+L 212.333124 122.392124 
+L 211.678232 122.522397 
+L 211.02334 122.652313 
+L 210.368448 122.781874 
+L 209.713556 122.911082 
+L 209.058664 123.039938 
+L 208.403772 123.168445 
+L 207.74888 123.296605 
+L 207.093988 123.424418 
+L 206.439096 123.551889 
+L 205.784204 123.679017 
+L 205.129312 123.805805 
+L 204.47442 123.932255 
+L 203.819528 124.058369 
+L 203.164636 124.184148 
+L 202.509744 124.309594 
+L 201.854852 124.434709 
+L 201.19996 124.559494 
+L 200.545068 124.683952 
+L 199.890176 124.808084 
+L 199.235284 124.931892 
+L 198.580392 125.055377 
+L 197.9255 125.178541 
+L 197.270608 125.301387 
+L 196.615716 125.423914 
+L 195.960824 125.546126 
+L 195.305932 125.668023 
+L 194.65104 125.789608 
+L 193.996148 125.910881 
+L 193.341256 126.031845 
+L 192.686364 126.152501 
+L 192.031472 126.272851 
+L 191.37658 126.392896 
+L 190.721688 126.512638 
+L 190.066796 126.632078 
+L 189.411904 126.751217 
+L 188.757012 126.870058 
+L 188.10212 126.988602 
+L 187.447228 127.10685 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
-    <path d="M 187.447228 126.710903 
-L 187.215878 126.981327 
-L 186.984529 127.250216 
-L 186.75318 127.517588 
-L 186.521831 127.783461 
-L 186.290482 128.047849 
-L 186.059133 128.310771 
-L 185.827784 128.572242 
-L 185.596435 128.832279 
-L 185.365086 129.090896 
-L 185.133737 129.34811 
-L 184.902388 129.603935 
-L 184.671039 129.858386 
-L 184.43969 130.111478 
-L 184.208341 130.363226 
-L 183.976992 130.613644 
-L 183.745643 130.862745 
-L 183.514294 131.110544 
-L 183.282945 131.357053 
-L 183.051596 131.602287 
-L 182.820247 131.846259 
-L 182.588898 132.08898 
-L 182.357549 132.330465 
-L 182.1262 132.570726 
-L 181.894851 132.809775 
-L 181.663502 133.047623 
-L 181.432153 133.284284 
-L 181.200804 133.519769 
-L 180.969455 133.75409 
-L 180.738106 133.987258 
-L 180.506757 134.219284 
-L 180.275408 134.450179 
-L 180.044058 134.679955 
-L 179.812709 134.908622 
-L 179.58136 135.136191 
-L 179.350011 135.362673 
-L 179.118662 135.588077 
-L 178.887313 135.812414 
-L 178.655964 136.035694 
-L 178.424615 136.257928 
-L 178.193266 136.479123 
-L 177.961917 136.699291 
-L 177.730568 136.918441 
-L 177.499219 137.136582 
-L 177.26787 137.353724 
-L 177.036521 137.569875 
-L 176.805172 137.785045 
-L 176.573823 137.999242 
-L 176.342474 138.212475 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 187.447228 127.10685 
+L 187.215878 127.370806 
+L 186.984529 127.6333 
+L 186.75318 127.894348 
+L 186.521831 128.153967 
+L 186.290482 128.412171 
+L 186.059133 128.668976 
+L 185.827784 128.924397 
+L 185.596435 129.17845 
+L 185.365086 129.431147 
+L 185.133737 129.682505 
+L 184.902388 129.932537 
+L 184.671039 130.181257 
+L 184.43969 130.428678 
+L 184.208341 130.674815 
+L 183.976992 130.91968 
+L 183.745643 131.163287 
+L 183.514294 131.405648 
+L 183.282945 131.646776 
+L 183.051596 131.886684 
+L 182.820247 132.125383 
+L 182.588898 132.362887 
+L 182.357549 132.599206 
+L 182.1262 132.834353 
+L 181.894851 133.068339 
+L 181.663502 133.301176 
+L 181.432153 133.532874 
+L 181.200804 133.763445 
+L 180.969455 133.992901 
+L 180.738106 134.22125 
+L 180.506757 134.448505 
+L 180.275408 134.674676 
+L 180.044058 134.899772 
+L 179.812709 135.123805 
+L 179.58136 135.346784 
+L 179.350011 135.568718 
+L 179.118662 135.789619 
+L 178.887313 136.009494 
+L 178.655964 136.228355 
+L 178.424615 136.446209 
+L 178.193266 136.663067 
+L 177.961917 136.878937 
+L 177.730568 137.093828 
+L 177.499219 137.307749 
+L 177.26787 137.52071 
+L 177.036521 137.732718 
+L 176.805172 137.943781 
+L 176.573823 138.153909 
+L 176.342474 138.36311 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
-    <path d="M 176.342474 138.212475 
-L 176.065637 138.825109 
-L 175.788801 139.429924 
-L 175.511964 140.027117 
-L 175.235127 140.616878 
-L 174.958291 141.199389 
-L 174.681454 141.774826 
-L 174.404617 142.34336 
-L 174.127781 142.905154 
-L 173.850944 143.460366 
-L 173.574107 144.009148 
-L 173.297271 144.551648 
-L 173.020434 145.088007 
-L 172.743597 145.618364 
-L 172.466761 146.142851 
-L 172.189924 146.661596 
-L 171.913087 147.174724 
-L 171.636251 147.682356 
-L 171.359414 148.184607 
-L 171.082577 148.681591 
-L 170.805741 149.173417 
-L 170.528904 149.660191 
-L 170.252067 150.142016 
-L 169.975231 150.618991 
-L 169.698394 151.091213 
-L 169.421557 151.558776 
-L 169.144721 152.02177 
-L 168.867884 152.480285 
-L 168.591047 152.934406 
-L 168.314211 153.384216 
-L 168.037374 153.829797 
-L 167.760537 154.271227 
-L 167.483701 154.708583 
-L 167.206864 155.14194 
-L 166.930027 155.57137 
-L 166.653191 155.996943 
-L 166.376354 156.418728 
-L 166.099517 156.836792 
-L 165.82268 157.251201 
-L 165.545844 157.662017 
-L 165.269007 158.069302 
-L 164.99217 158.473116 
-L 164.715334 158.873518 
-L 164.438497 159.270566 
-L 164.16166 159.664314 
-L 163.884824 160.054818 
-L 163.607987 160.442131 
-L 163.33115 160.826303 
-L 163.054314 161.207386 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 176.342474 138.36311 
+L 176.065637 138.974179 
+L 175.788801 139.577469 
+L 175.511964 140.173178 
+L 175.235127 140.761492 
+L 174.958291 141.342594 
+L 174.681454 141.916657 
+L 174.404617 142.483852 
+L 174.127781 143.044339 
+L 173.850944 143.598275 
+L 173.574107 144.145813 
+L 173.297271 144.687098 
+L 173.020434 145.222272 
+L 172.743597 145.75147 
+L 172.466761 146.274825 
+L 172.189924 146.792464 
+L 171.913087 147.304512 
+L 171.636251 147.811086 
+L 171.359414 148.312304 
+L 171.082577 148.808278 
+L 170.805741 149.299115 
+L 170.528904 149.784921 
+L 170.252067 150.265799 
+L 169.975231 150.741847 
+L 169.698394 151.213161 
+L 169.421557 151.679835 
+L 169.144721 152.141959 
+L 168.867884 152.599621 
+L 168.591047 153.052906 
+L 168.314211 153.501898 
+L 168.037374 153.946676 
+L 167.760537 154.387319 
+L 167.483701 154.823904 
+L 167.206864 155.256503 
+L 166.930027 155.685191 
+L 166.653191 156.110036 
+L 166.376354 156.531106 
+L 166.099517 156.948469 
+L 165.82268 157.362189 
+L 165.545844 157.772329 
+L 165.269007 158.178951 
+L 164.99217 158.582114 
+L 164.715334 158.981877 
+L 164.438497 159.378296 
+L 164.16166 159.771427 
+L 163.884824 160.161325 
+L 163.607987 160.548041 
+L 163.33115 160.931628 
+L 163.054314 161.312135 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
-    <path d="M 163.054314 161.207386 
-L 163.036735 161.375685 
-L 163.019157 161.543389 
-L 163.001578 161.710502 
-L 162.983999 161.877027 
-L 162.966421 162.042969 
-L 162.948842 162.208332 
-L 162.931263 162.37312 
-L 162.913685 162.537337 
-L 162.896106 162.700987 
-L 162.878527 162.864073 
-L 162.860949 163.0266 
-L 162.84337 163.188572 
-L 162.825791 163.349992 
-L 162.808213 163.510864 
-L 162.790634 163.671192 
-L 162.773056 163.83098 
-L 162.755477 163.99023 
-L 162.737898 164.148947 
-L 162.72032 164.307134 
-L 162.702741 164.464795 
-L 162.685162 164.621933 
-L 162.667584 164.778551 
-L 162.650005 164.934654 
-L 162.632426 165.090244 
-L 162.614848 165.245325 
-L 162.597269 165.399901 
-L 162.579691 165.553973 
-L 162.562112 165.707546 
-L 162.544533 165.860624 
-L 162.526955 166.013208 
-L 162.509376 166.165303 
-L 162.491797 166.316911 
-L 162.474219 166.468035 
-L 162.45664 166.61868 
-L 162.439061 166.768846 
-L 162.421483 166.918539 
-L 162.403904 167.06776 
-L 162.386326 167.216513 
-L 162.368747 167.3648 
-L 162.351168 167.512624 
-L 162.33359 167.659989 
-L 162.316011 167.806898 
-L 162.298432 167.953352 
-L 162.280854 168.099355 
-L 162.263275 168.244909 
-L 162.245696 168.390018 
-L 162.228118 168.534683 
-L 162.210539 168.678909 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 163.054314 161.312135 
+L 163.036735 161.47971 
+L 163.019157 161.646695 
+L 163.001578 161.813093 
+L 162.983999 161.978909 
+L 162.966421 162.144147 
+L 162.948842 162.308811 
+L 162.931263 162.472905 
+L 162.913685 162.636433 
+L 162.896106 162.799399 
+L 162.878527 162.961806 
+L 162.860949 163.123659 
+L 162.84337 163.284961 
+L 162.825791 163.445716 
+L 162.808213 163.605927 
+L 162.790634 163.765599 
+L 162.773056 163.924735 
+L 162.755477 164.083338 
+L 162.737898 164.241412 
+L 162.72032 164.398961 
+L 162.702741 164.555988 
+L 162.685162 164.712497 
+L 162.667584 164.86849 
+L 162.650005 165.023972 
+L 162.632426 165.178945 
+L 162.614848 165.333413 
+L 162.597269 165.48738 
+L 162.579691 165.640848 
+L 162.562112 165.79382 
+L 162.544533 165.946301 
+L 162.526955 166.098293 
+L 162.509376 166.249798 
+L 162.491797 166.400821 
+L 162.474219 166.551365 
+L 162.45664 166.701432 
+L 162.439061 166.851025 
+L 162.421483 167.000147 
+L 162.403904 167.148802 
+L 162.386326 167.296992 
+L 162.368747 167.44472 
+L 162.351168 167.59199 
+L 162.33359 167.738803 
+L 162.316011 167.885162 
+L 162.298432 168.031072 
+L 162.280854 168.176533 
+L 162.263275 168.321549 
+L 162.245696 168.466124 
+L 162.228118 168.610258 
+L 162.210539 168.753955 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
-    <path d="M 162.210539 168.678909 
-L 162.149982 168.834745 
-L 162.089425 168.99007 
-L 162.028869 169.144888 
-L 161.968312 169.299201 
-L 161.907755 169.453014 
-L 161.847198 169.606329 
-L 161.786641 169.759149 
-L 161.726084 169.911479 
-L 161.665528 170.06332 
-L 161.604971 170.214676 
-L 161.544414 170.365551 
-L 161.483857 170.515947 
-L 161.4233 170.665866 
-L 161.362743 170.815313 
-L 161.302187 170.964291 
-L 161.24163 171.112801 
-L 161.181073 171.260847 
-L 161.120516 171.408433 
-L 161.059959 171.55556 
-L 160.999402 171.702232 
-L 160.938846 171.848451 
-L 160.878289 171.99422 
-L 160.817732 172.139543 
-L 160.757175 172.284421 
-L 160.696618 172.428857 
-L 160.636061 172.572855 
-L 160.575504 172.716416 
-L 160.514948 172.859544 
-L 160.454391 173.002241 
-L 160.393834 173.144509 
-L 160.333277 173.286352 
-L 160.27272 173.427771 
-L 160.212163 173.56877 
-L 160.151607 173.70935 
-L 160.09105 173.849514 
-L 160.030493 173.989265 
-L 159.969936 174.128606 
-L 159.909379 174.267537 
-L 159.848822 174.406063 
-L 159.788266 174.544185 
-L 159.727709 174.681905 
-L 159.667152 174.819226 
-L 159.606595 174.956151 
-L 159.546038 175.092681 
-L 159.485481 175.228819 
-L 159.424925 175.364567 
-L 159.364368 175.499927 
-L 159.303811 175.634901 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 162.210539 168.753955 
+L 162.149982 168.910833 
+L 162.089425 169.067193 
+L 162.028869 169.223039 
+L 161.968312 169.378374 
+L 161.907755 169.533202 
+L 161.847198 169.687525 
+L 161.786641 169.841348 
+L 161.726084 169.994673 
+L 161.665528 170.147504 
+L 161.604971 170.299844 
+L 161.544414 170.451696 
+L 161.483857 170.603062 
+L 161.4233 170.753947 
+L 161.362743 170.904353 
+L 161.302187 171.054284 
+L 161.24163 171.203741 
+L 161.181073 171.352729 
+L 161.120516 171.50125 
+L 161.059959 171.649307 
+L 160.999402 171.796903 
+L 160.938846 171.94404 
+L 160.878289 172.090723 
+L 160.817732 172.236953 
+L 160.757175 172.382733 
+L 160.696618 172.528066 
+L 160.636061 172.672955 
+L 160.575504 172.817403 
+L 160.514948 172.961411 
+L 160.454391 173.104983 
+L 160.393834 173.248122 
+L 160.333277 173.39083 
+L 160.27272 173.533109 
+L 160.212163 173.674963 
+L 160.151607 173.816393 
+L 160.09105 173.957403 
+L 160.030493 174.097994 
+L 159.969936 174.23817 
+L 159.909379 174.377932 
+L 159.848822 174.517283 
+L 159.788266 174.656226 
+L 159.727709 174.794763 
+L 159.667152 174.932896 
+L 159.606595 175.070627 
+L 159.546038 175.20796 
+L 159.485481 175.344896 
+L 159.424925 175.481437 
+L 159.364368 175.617586 
+L 159.303811 175.753345 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
-    <path d="M 159.303811 175.634901 
-L 159.272355 175.716655 
-L 159.240899 175.798268 
-L 159.209443 175.87974 
-L 159.177987 175.961073 
-L 159.146531 176.042266 
-L 159.115076 176.12332 
-L 159.08362 176.204236 
-L 159.052164 176.285014 
-L 159.020708 176.365655 
-L 158.989252 176.446159 
-L 158.957796 176.526526 
-L 158.92634 176.606757 
-L 158.894884 176.686852 
-L 158.863428 176.766813 
-L 158.831973 176.846638 
-L 158.800517 176.92633 
-L 158.769061 177.005887 
-L 158.737605 177.085311 
-L 158.706149 177.164603 
-L 158.674693 177.243762 
-L 158.643237 177.322788 
-L 158.611781 177.401684 
-L 158.580325 177.480448 
-L 158.54887 177.559081 
-L 158.517414 177.637585 
-L 158.485958 177.715958 
-L 158.454502 177.794202 
-L 158.423046 177.872317 
-L 158.39159 177.950303 
-L 158.360134 178.028162 
-L 158.328678 178.105892 
-L 158.297222 178.183496 
-L 158.265767 178.260972 
-L 158.234311 178.338322 
-L 158.202855 178.415546 
-L 158.171399 178.492644 
-L 158.139943 178.569617 
-L 158.108487 178.646466 
-L 158.077031 178.72319 
-L 158.045575 178.799789 
-L 158.014119 178.876266 
-L 157.982664 178.952619 
-L 157.951208 179.028849 
-L 157.919752 179.104956 
-L 157.888296 179.180942 
-L 157.85684 179.256806 
-L 157.825384 179.332549 
-L 157.793928 179.408171 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 159.303811 175.753345 
+L 159.272355 175.834382 
+L 159.240899 175.915281 
+L 159.209443 175.996041 
+L 159.177987 176.076664 
+L 159.146531 176.15715 
+L 159.115076 176.2375 
+L 159.08362 176.317714 
+L 159.052164 176.397792 
+L 159.020708 176.477736 
+L 158.989252 176.557544 
+L 158.957796 176.637219 
+L 158.92634 176.71676 
+L 158.894884 176.796167 
+L 158.863428 176.875442 
+L 158.831973 176.954584 
+L 158.800517 177.033595 
+L 158.769061 177.112474 
+L 158.737605 177.191222 
+L 158.706149 177.269839 
+L 158.674693 177.348326 
+L 158.643237 177.426683 
+L 158.611781 177.504911 
+L 158.580325 177.58301 
+L 158.54887 177.660981 
+L 158.517414 177.738824 
+L 158.485958 177.816539 
+L 158.454502 177.894126 
+L 158.423046 177.971587 
+L 158.39159 178.048922 
+L 158.360134 178.126131 
+L 158.328678 178.203214 
+L 158.297222 178.280172 
+L 158.265767 178.357005 
+L 158.234311 178.433714 
+L 158.202855 178.510299 
+L 158.171399 178.58676 
+L 158.139943 178.663098 
+L 158.108487 178.739313 
+L 158.077031 178.815407 
+L 158.045575 178.891378 
+L 158.014119 178.967227 
+L 157.982664 179.042956 
+L 157.951208 179.118563 
+L 157.919752 179.19405 
+L 157.888296 179.269417 
+L 157.85684 179.344665 
+L 157.825384 179.419793 
+L 157.793928 179.494802 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="ma006064a17" d="M -0 3.535534 
+     <path id="ma8de32e618" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1218df302b)">
-     <use xlink:href="#ma006064a17" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="203.775848" y="81.892474" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="186.982691" y="88.798621" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="179.779306" y="91.094902" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="157.610419" y="99.337194" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="148.722526" y="107.793132" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="144.388162" y="121.197738" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="127.071247" y="144.456083" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="124.491988" y="152.059912" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="92.613662" y="207.455314" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="87.348715" y="224.984992" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma006064a17" x="86.053433" y="241.561213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3aaf15e627)">
+     <use xlink:href="#ma8de32e618" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#ma8de32e618" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
     <path d="M 251.559581 64.890426 
-L 250.564087 65.314605 
-L 249.568592 65.735021 
-L 248.573098 66.15174 
-L 247.577604 66.564826 
-L 246.582109 66.974343 
-L 245.586615 67.380351 
-L 244.59112 67.78291 
-L 243.595626 68.182078 
-L 242.600131 68.577912 
-L 241.604637 68.970467 
-L 240.609142 69.359797 
-L 239.613648 69.745954 
-L 238.618153 70.12899 
-L 237.622659 70.508955 
-L 236.627165 70.885897 
-L 235.63167 71.259865 
-L 234.636176 71.630905 
-L 233.640681 71.999062 
-L 232.645187 72.364381 
-L 231.649692 72.726905 
-L 230.654198 73.086677 
-L 229.658703 73.443739 
-L 228.663209 73.79813 
-L 227.667715 74.14989 
-L 226.67222 74.499059 
-L 225.676726 74.845673 
-L 224.681231 75.189771 
-L 223.685737 75.531388 
-L 222.690242 75.87056 
-L 221.694748 76.207322 
-L 220.699253 76.541708 
-L 219.703759 76.873751 
-L 218.708264 77.203483 
-L 217.71277 77.530937 
-L 216.717276 77.856143 
-L 215.721781 78.179134 
-L 214.726287 78.499937 
-L 213.730792 78.818584 
-L 212.735298 79.135102 
-L 211.739803 79.44952 
-L 210.744309 79.761866 
-L 209.748814 80.072166 
-L 208.75332 80.380448 
-L 207.757825 80.686737 
-L 206.762331 80.99106 
-L 205.766837 81.29344 
-L 204.771342 81.593904 
-L 203.775848 81.892474 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 250.564087 65.310389 
+L 249.568592 65.726663 
+L 248.573098 66.139314 
+L 247.577604 66.548402 
+L 246.582109 66.953991 
+L 245.586615 67.356138 
+L 244.59112 67.754902 
+L 243.595626 68.150339 
+L 242.600131 68.542504 
+L 241.604637 68.931451 
+L 240.609142 69.317233 
+L 239.613648 69.6999 
+L 238.618153 70.079502 
+L 237.622659 70.456089 
+L 236.627165 70.829707 
+L 235.63167 71.200403 
+L 234.636176 71.568222 
+L 233.640681 71.933209 
+L 232.645187 72.295407 
+L 231.649692 72.654858 
+L 230.654198 73.011604 
+L 229.658703 73.365685 
+L 228.663209 73.71714 
+L 227.667715 74.066008 
+L 226.67222 74.412328 
+L 225.676726 74.756135 
+L 224.681231 75.097467 
+L 223.685737 75.436358 
+L 222.690242 75.772844 
+L 221.694748 76.106957 
+L 220.699253 76.438732 
+L 219.703759 76.7682 
+L 218.708264 77.095395 
+L 217.71277 77.420346 
+L 216.717276 77.743085 
+L 215.721781 78.06364 
+L 214.726287 78.382043 
+L 213.730792 78.698321 
+L 212.735298 79.012502 
+L 211.739803 79.324615 
+L 210.744309 79.634686 
+L 209.748814 79.942742 
+L 208.75332 80.248808 
+L 207.757825 80.552911 
+L 206.762331 80.855075 
+L 205.766837 81.155325 
+L 204.771342 81.453685 
+L 203.775848 81.750179 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
-    <path d="M 203.775848 81.892474 
-L 203.42599 82.047112 
-L 203.076133 82.201247 
-L 202.726275 82.354882 
-L 202.376418 82.508021 
-L 202.026561 82.660666 
-L 201.676703 82.812821 
-L 201.326846 82.96449 
-L 200.976988 83.115674 
-L 200.627131 83.266378 
-L 200.277273 83.416604 
-L 199.927416 83.566355 
-L 199.577559 83.715634 
-L 199.227701 83.864445 
-L 198.877844 84.01279 
-L 198.527986 84.160672 
-L 198.178129 84.308094 
-L 197.828271 84.455058 
-L 197.478414 84.601569 
-L 197.128557 84.747627 
-L 196.778699 84.893237 
-L 196.428842 85.038401 
-L 196.078984 85.183122 
-L 195.729127 85.327402 
-L 195.37927 85.471244 
-L 195.029412 85.614651 
-L 194.679555 85.757625 
-L 194.329697 85.900169 
-L 193.97984 86.042285 
-L 193.629982 86.183977 
-L 193.280125 86.325246 
-L 192.930268 86.466095 
-L 192.58041 86.606527 
-L 192.230553 86.746544 
-L 191.880695 86.886149 
-L 191.530838 87.025344 
-L 191.18098 87.16413 
-L 190.831123 87.302512 
-L 190.481266 87.440491 
-L 190.131408 87.578069 
-L 189.781551 87.715248 
-L 189.431693 87.852032 
-L 189.081836 87.988422 
-L 188.731978 88.124421 
-L 188.382121 88.260031 
-L 188.032264 88.395253 
-L 187.682406 88.530091 
-L 187.332549 88.664546 
-L 186.982691 88.798621 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 203.775848 81.750179 
+L 203.42599 81.897358 
+L 203.076133 82.044081 
+L 202.726275 82.190351 
+L 202.376418 82.336171 
+L 202.026561 82.481544 
+L 201.676703 82.626473 
+L 201.326846 82.77096 
+L 200.976988 82.915007 
+L 200.627131 83.058618 
+L 200.277273 83.201796 
+L 199.927416 83.344542 
+L 199.577559 83.486859 
+L 199.227701 83.628751 
+L 198.877844 83.770219 
+L 198.527986 83.911266 
+L 198.178129 84.051895 
+L 197.828271 84.192107 
+L 197.478414 84.331906 
+L 197.128557 84.471294 
+L 196.778699 84.610274 
+L 196.428842 84.748846 
+L 196.078984 84.887015 
+L 195.729127 85.024783 
+L 195.37927 85.162151 
+L 195.029412 85.299122 
+L 194.679555 85.435699 
+L 194.329697 85.571883 
+L 193.97984 85.707677 
+L 193.629982 85.843083 
+L 193.280125 85.978103 
+L 192.930268 86.11274 
+L 192.58041 86.246995 
+L 192.230553 86.380871 
+L 191.880695 86.51437 
+L 191.530838 86.647495 
+L 191.18098 86.780246 
+L 190.831123 86.912627 
+L 190.481266 87.044638 
+L 190.131408 87.176284 
+L 189.781551 87.307564 
+L 189.431693 87.438482 
+L 189.081836 87.56904 
+L 188.731978 87.699239 
+L 188.382121 87.829081 
+L 188.032264 87.958568 
+L 187.682406 88.087703 
+L 187.332549 88.216487 
+L 186.982691 88.344921 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
-    <path d="M 186.982691 88.798621 
-L 186.832621 88.847613 
-L 186.68255 88.896554 
-L 186.53248 88.945445 
-L 186.382409 88.994286 
-L 186.232339 89.043076 
-L 186.082268 89.091816 
-L 185.932198 89.140505 
-L 185.782127 89.189145 
-L 185.632057 89.237735 
-L 185.481986 89.286276 
-L 185.331916 89.334766 
-L 185.181845 89.383207 
-L 185.031774 89.431599 
-L 184.881704 89.479941 
-L 184.731633 89.528234 
-L 184.581563 89.576477 
-L 184.431492 89.624672 
-L 184.281422 89.672818 
-L 184.131351 89.720914 
-L 183.981281 89.768963 
-L 183.83121 89.816962 
-L 183.68114 89.864913 
-L 183.531069 89.912815 
-L 183.380999 89.960669 
-L 183.230928 90.008475 
-L 183.080858 90.056232 
-L 182.930787 90.103942 
-L 182.780717 90.151603 
-L 182.630646 90.199217 
-L 182.480575 90.246783 
-L 182.330505 90.294301 
-L 182.180434 90.341771 
-L 182.030364 90.389194 
-L 181.880293 90.43657 
-L 181.730223 90.483898 
-L 181.580152 90.531179 
-L 181.430082 90.578413 
-L 181.280011 90.6256 
-L 181.129941 90.67274 
-L 180.97987 90.719833 
-L 180.8298 90.766879 
-L 180.679729 90.813879 
-L 180.529659 90.860832 
-L 180.379588 90.907739 
-L 180.229518 90.954599 
-L 180.079447 91.001413 
-L 179.929376 91.048181 
-L 179.779306 91.094902 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 186.982691 88.344921 
+L 186.832621 88.402778 
+L 186.68255 88.460563 
+L 186.53248 88.518279 
+L 186.382409 88.575924 
+L 186.232339 88.633499 
+L 186.082268 88.691004 
+L 185.932198 88.74844 
+L 185.782127 88.805806 
+L 185.632057 88.863103 
+L 185.481986 88.92033 
+L 185.331916 88.977489 
+L 185.181845 89.034578 
+L 185.031774 89.091599 
+L 184.881704 89.148552 
+L 184.731633 89.205436 
+L 184.581563 89.262252 
+L 184.431492 89.319 
+L 184.281422 89.37568 
+L 184.131351 89.432293 
+L 183.981281 89.488837 
+L 183.83121 89.545315 
+L 183.68114 89.601725 
+L 183.531069 89.658068 
+L 183.380999 89.714345 
+L 183.230928 89.770554 
+L 183.080858 89.826697 
+L 182.930787 89.882774 
+L 182.780717 89.938784 
+L 182.630646 89.994728 
+L 182.480575 90.050607 
+L 182.330505 90.106419 
+L 182.180434 90.162166 
+L 182.030364 90.217847 
+L 181.880293 90.273463 
+L 181.730223 90.329014 
+L 181.580152 90.3845 
+L 181.430082 90.439921 
+L 181.280011 90.495277 
+L 181.129941 90.550568 
+L 180.97987 90.605796 
+L 180.8298 90.660959 
+L 180.679729 90.716057 
+L 180.529659 90.771092 
+L 180.379588 90.826063 
+L 180.229518 90.88097 
+L 180.079447 90.935814 
+L 179.929376 90.990595 
+L 179.779306 91.045312 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
-    <path d="M 179.779306 91.094902 
-L 179.317454 91.282084 
-L 178.855602 91.46853 
-L 178.39375 91.654245 
-L 177.931899 91.839235 
-L 177.470047 92.023506 
-L 177.008195 92.207063 
-L 176.546343 92.389911 
-L 176.084491 92.572057 
-L 175.62264 92.753505 
-L 175.160788 92.934262 
-L 174.698936 93.114331 
-L 174.237084 93.293719 
-L 173.775232 93.47243 
-L 173.31338 93.65047 
-L 172.851529 93.827844 
-L 172.389677 94.004556 
-L 171.927825 94.180611 
-L 171.465973 94.356015 
-L 171.004121 94.530772 
-L 170.54227 94.704887 
-L 170.080418 94.878365 
-L 169.618566 95.05121 
-L 169.156714 95.223427 
-L 168.694862 95.39502 
-L 168.23301 95.565994 
-L 167.771159 95.736353 
-L 167.309307 95.906102 
-L 166.847455 96.075246 
-L 166.385603 96.243787 
-L 165.923751 96.411732 
-L 165.4619 96.579083 
-L 165.000048 96.745845 
-L 164.538196 96.912023 
-L 164.076344 97.07762 
-L 163.614492 97.24264 
-L 163.15264 97.407088 
-L 162.690789 97.570967 
-L 162.228937 97.734281 
-L 161.767085 97.897034 
-L 161.305233 98.05923 
-L 160.843381 98.220873 
-L 160.38153 98.381967 
-L 159.919678 98.542515 
-L 159.457826 98.70252 
-L 158.995974 98.861987 
-L 158.534122 99.02092 
-L 158.07227 99.179321 
-L 157.610419 99.337194 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 179.779306 91.045312 
+L 179.317454 91.235147 
+L 178.855602 91.424226 
+L 178.39375 91.612553 
+L 177.931899 91.800134 
+L 177.470047 91.986976 
+L 177.008195 92.173085 
+L 176.546343 92.358466 
+L 176.084491 92.543124 
+L 175.62264 92.727066 
+L 175.160788 92.910297 
+L 174.698936 93.092822 
+L 174.237084 93.274647 
+L 173.775232 93.455778 
+L 173.31338 93.636218 
+L 172.851529 93.815975 
+L 172.389677 93.995052 
+L 171.927825 94.173455 
+L 171.465973 94.35119 
+L 171.004121 94.52826 
+L 170.54227 94.704671 
+L 170.080418 94.880428 
+L 169.618566 95.055536 
+L 169.156714 95.229999 
+L 168.694862 95.403823 
+L 168.23301 95.577011 
+L 167.771159 95.749569 
+L 167.309307 95.921501 
+L 166.847455 96.092812 
+L 166.385603 96.263505 
+L 165.923751 96.433586 
+L 165.4619 96.603059 
+L 165.000048 96.771929 
+L 164.538196 96.940198 
+L 164.076344 97.107873 
+L 163.614492 97.274956 
+L 163.15264 97.441453 
+L 162.690789 97.607366 
+L 162.228937 97.772701 
+L 161.767085 97.937462 
+L 161.305233 98.101651 
+L 160.843381 98.265274 
+L 160.38153 98.428334 
+L 159.919678 98.590835 
+L 159.457826 98.75278 
+L 158.995974 98.914174 
+L 158.534122 99.075021 
+L 158.07227 99.235323 
+L 157.610419 99.395085 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
-    <path d="M 157.610419 99.337194 
-L 157.425254 99.529664 
-L 157.24009 99.721354 
-L 157.054925 99.912273 
-L 156.869761 100.102425 
-L 156.684597 100.291818 
-L 156.499432 100.480456 
-L 156.314268 100.668347 
-L 156.129103 100.855496 
-L 155.943939 101.041908 
-L 155.758774 101.22759 
-L 155.57361 101.412547 
-L 155.388446 101.596785 
-L 155.203281 101.78031 
-L 155.018117 101.963127 
-L 154.832952 102.145241 
-L 154.647788 102.326658 
-L 154.462623 102.507383 
-L 154.277459 102.687422 
-L 154.092295 102.866779 
-L 153.90713 103.045459 
-L 153.721966 103.223469 
-L 153.536801 103.400812 
-L 153.351637 103.577495 
-L 153.166472 103.753521 
-L 152.981308 103.928895 
-L 152.796144 104.103623 
-L 152.610979 104.277709 
-L 152.425815 104.451158 
-L 152.24065 104.623974 
-L 152.055486 104.796163 
-L 151.870321 104.967728 
-L 151.685157 105.138674 
-L 151.499993 105.309005 
-L 151.314828 105.478727 
-L 151.129664 105.647843 
-L 150.944499 105.816358 
-L 150.759335 105.984275 
-L 150.57417 106.1516 
-L 150.389006 106.318335 
-L 150.203842 106.484487 
-L 150.018677 106.650057 
-L 149.833513 106.815052 
-L 149.648348 106.979473 
-L 149.463184 107.143327 
-L 149.27802 107.306615 
-L 149.092855 107.469343 
-L 148.907691 107.631514 
-L 148.722526 107.793132 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 157.610419 99.395085 
+L 157.425254 99.587874 
+L 157.24009 99.779881 
+L 157.054925 99.971113 
+L 156.869761 100.161577 
+L 156.684597 100.351279 
+L 156.499432 100.540224 
+L 156.314268 100.72842 
+L 156.129103 100.915871 
+L 155.943939 101.102583 
+L 155.758774 101.288563 
+L 155.57361 101.473817 
+L 155.388446 101.658348 
+L 155.203281 101.842165 
+L 155.018117 102.025271 
+L 154.832952 102.207673 
+L 154.647788 102.389375 
+L 154.462623 102.570383 
+L 154.277459 102.750703 
+L 154.092295 102.93034 
+L 153.90713 103.109298 
+L 153.721966 103.287583 
+L 153.536801 103.4652 
+L 153.351637 103.642154 
+L 153.166472 103.818449 
+L 152.981308 103.994092 
+L 152.796144 104.169086 
+L 152.610979 104.343436 
+L 152.425815 104.517148 
+L 152.24065 104.690225 
+L 152.055486 104.862672 
+L 151.870321 105.034494 
+L 151.685157 105.205696 
+L 151.499993 105.376281 
+L 151.314828 105.546255 
+L 151.129664 105.715621 
+L 150.944499 105.884385 
+L 150.759335 106.052549 
+L 150.57417 106.220119 
+L 150.389006 106.387099 
+L 150.203842 106.553493 
+L 150.018677 106.719304 
+L 149.833513 106.884538 
+L 149.648348 107.049197 
+L 149.463184 107.213286 
+L 149.27802 107.37681 
+L 149.092855 107.539771 
+L 148.907691 107.702174 
+L 148.722526 107.864022 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
-    <path d="M 148.722526 107.793132 
-L 148.632227 108.1148 
-L 148.541928 108.4343 
-L 148.451628 108.75166 
-L 148.361329 109.066908 
-L 148.27103 109.380074 
-L 148.180731 109.691183 
-L 148.090431 110.000263 
-L 148.000132 110.307341 
-L 147.909833 110.612441 
-L 147.819534 110.91559 
-L 147.729234 111.216811 
-L 147.638935 111.51613 
-L 147.548636 111.813571 
-L 147.458337 112.109156 
-L 147.368038 112.402908 
-L 147.277738 112.694852 
-L 147.187439 112.985007 
-L 147.09714 113.273397 
-L 147.006841 113.560042 
-L 146.916541 113.844964 
-L 146.826242 114.128183 
-L 146.735943 114.40972 
-L 146.645644 114.689593 
-L 146.555344 114.967824 
-L 146.465045 115.244431 
-L 146.374746 115.519432 
-L 146.284447 115.792847 
-L 146.194147 116.064693 
-L 146.103848 116.334988 
-L 146.013549 116.603751 
-L 145.92325 116.870998 
-L 145.83295 117.136746 
-L 145.742651 117.401013 
-L 145.652352 117.663814 
-L 145.562053 117.925165 
-L 145.471753 118.185083 
-L 145.381454 118.443583 
-L 145.291155 118.700681 
-L 145.200856 118.956392 
-L 145.110556 119.21073 
-L 145.020257 119.46371 
-L 144.929958 119.715347 
-L 144.839659 119.965655 
-L 144.749359 120.214647 
-L 144.65906 120.462338 
-L 144.568761 120.708742 
-L 144.478462 120.95387 
-L 144.388162 121.197738 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 148.722526 107.864022 
+L 148.632227 108.184834 
+L 148.541928 108.503489 
+L 148.451628 108.820016 
+L 148.361329 109.134444 
+L 148.27103 109.446799 
+L 148.180731 109.75711 
+L 148.090431 110.065402 
+L 148.000132 110.371702 
+L 147.909833 110.676035 
+L 147.819534 110.978427 
+L 147.729234 111.278902 
+L 147.638935 111.577484 
+L 147.548636 111.874197 
+L 147.458337 112.169064 
+L 147.368038 112.462108 
+L 147.277738 112.753351 
+L 147.187439 113.042816 
+L 147.09714 113.330524 
+L 147.006841 113.616496 
+L 146.916541 113.900753 
+L 146.826242 114.183315 
+L 146.735943 114.464203 
+L 146.645644 114.743436 
+L 146.555344 115.021034 
+L 146.465045 115.297015 
+L 146.374746 115.571399 
+L 146.284447 115.844203 
+L 146.194147 116.115447 
+L 146.103848 116.385147 
+L 146.013549 116.653321 
+L 145.92325 116.919986 
+L 145.83295 117.18516 
+L 145.742651 117.448858 
+L 145.652352 117.711098 
+L 145.562053 117.971894 
+L 145.471753 118.231263 
+L 145.381454 118.489221 
+L 145.291155 118.745783 
+L 145.200856 119.000963 
+L 145.110556 119.254777 
+L 145.020257 119.507239 
+L 144.929958 119.758363 
+L 144.839659 120.008164 
+L 144.749359 120.256655 
+L 144.65906 120.50385 
+L 144.568761 120.749763 
+L 144.478462 120.994407 
+L 144.388162 121.237794 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
-    <path d="M 144.388162 121.197738 
-L 144.027393 121.819197 
-L 143.666624 122.432611 
-L 143.305855 123.038187 
-L 142.945086 123.636122 
-L 142.584317 124.226606 
-L 142.223548 124.809823 
-L 141.862779 125.385949 
-L 141.50201 125.955155 
-L 141.141241 126.517606 
-L 140.780472 127.073458 
-L 140.419703 127.622867 
-L 140.058934 128.165979 
-L 139.698165 128.702936 
-L 139.337395 129.233878 
-L 138.976626 129.758937 
-L 138.615857 130.278242 
-L 138.255088 130.791918 
-L 137.894319 131.300085 
-L 137.53355 131.802861 
-L 137.172781 132.300359 
-L 136.812012 132.792688 
-L 136.451243 133.279955 
-L 136.090474 133.762262 
-L 135.729705 134.23971 
-L 135.368936 134.712396 
-L 135.008167 135.180413 
-L 134.647398 135.643853 
-L 134.286629 136.102805 
-L 133.92586 136.557355 
-L 133.56509 137.007586 
-L 133.204321 137.45358 
-L 132.843552 137.895415 
-L 132.482783 138.333169 
-L 132.122014 138.766916 
-L 131.761245 139.196729 
-L 131.400476 139.622679 
-L 131.039707 140.044834 
-L 130.678938 140.463262 
-L 130.318169 140.878027 
-L 129.9574 141.289194 
-L 129.596631 141.696824 
-L 129.235862 142.100977 
-L 128.875093 142.501713 
-L 128.514324 142.899088 
-L 128.153555 143.293159 
-L 127.792786 143.68398 
-L 127.432016 144.071604 
-L 127.071247 144.456083 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 144.388162 121.237794 
+L 144.027393 121.861388 
+L 143.666624 122.476883 
+L 143.305855 123.084489 
+L 142.945086 123.684404 
+L 142.584317 124.276821 
+L 142.223548 124.861925 
+L 141.862779 125.439894 
+L 141.50201 126.010901 
+L 141.141241 126.575111 
+L 140.780472 127.132683 
+L 140.419703 127.683773 
+L 140.058934 128.228529 
+L 139.698165 128.767095 
+L 139.337395 129.29961 
+L 138.976626 129.826209 
+L 138.615857 130.347022 
+L 138.255088 130.862174 
+L 137.894319 131.371788 
+L 137.53355 131.875981 
+L 137.172781 132.374867 
+L 136.812012 132.868556 
+L 136.451243 133.357157 
+L 136.090474 133.840772 
+L 135.729705 134.319503 
+L 135.368936 134.793447 
+L 135.008167 135.262698 
+L 134.647398 135.72735 
+L 134.286629 136.187491 
+L 133.92586 136.643207 
+L 133.56509 137.094584 
+L 133.204321 137.541703 
+L 132.843552 137.984644 
+L 132.482783 138.423484 
+L 132.122014 138.858298 
+L 131.761245 139.289159 
+L 131.400476 139.716139 
+L 131.039707 140.139307 
+L 130.678938 140.558731 
+L 130.318169 140.974476 
+L 129.9574 141.386606 
+L 129.596631 141.795183 
+L 129.235862 142.200268 
+L 128.875093 142.601921 
+L 128.514324 143.000199 
+L 128.153555 143.395158 
+L 127.792786 143.786853 
+L 127.432016 144.175338 
+L 127.071247 144.560664 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
-    <path d="M 127.071247 144.456083 
-L 127.017513 144.627603 
-L 126.963778 144.798504 
-L 126.910044 144.96879 
-L 126.856309 145.138467 
-L 126.802575 145.307539 
-L 126.74884 145.47601 
-L 126.695105 145.643883 
-L 126.641371 145.811165 
-L 126.587636 145.977858 
-L 126.533902 146.143966 
-L 126.480167 146.309494 
-L 126.426433 146.474446 
-L 126.372698 146.638826 
-L 126.318963 146.802638 
-L 126.265229 146.965886 
-L 126.211494 147.128572 
-L 126.15776 147.290703 
-L 126.104025 147.45228 
-L 126.050291 147.613309 
-L 125.996556 147.773792 
-L 125.942822 147.933734 
-L 125.889087 148.093137 
-L 125.835352 148.252006 
-L 125.781618 148.410345 
-L 125.727883 148.568156 
-L 125.674149 148.725443 
-L 125.620414 148.88221 
-L 125.56668 149.03846 
-L 125.512945 149.194197 
-L 125.45921 149.349423 
-L 125.405476 149.504143 
-L 125.351741 149.658359 
-L 125.298007 149.812075 
-L 125.244272 149.965294 
-L 125.190538 150.118019 
-L 125.136803 150.270253 
-L 125.083068 150.422 
-L 125.029334 150.573263 
-L 124.975599 150.724044 
-L 124.921865 150.874347 
-L 124.86813 151.024175 
-L 124.814396 151.173531 
-L 124.760661 151.322417 
-L 124.706926 151.470837 
-L 124.653192 151.618794 
-L 124.599457 151.76629 
-L 124.545723 151.913329 
-L 124.491988 152.059912 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 127.071247 144.560664 
+L 127.017513 144.730211 
+L 126.963778 144.899153 
+L 126.910044 145.067495 
+L 126.856309 145.235241 
+L 126.802575 145.402396 
+L 126.74884 145.568963 
+L 126.695105 145.734947 
+L 126.641371 145.900352 
+L 126.587636 146.065182 
+L 126.533902 146.22944 
+L 126.480167 146.393131 
+L 126.426433 146.556259 
+L 126.372698 146.718827 
+L 126.318963 146.88084 
+L 126.265229 147.042301 
+L 126.211494 147.203213 
+L 126.15776 147.363581 
+L 126.104025 147.523409 
+L 126.050291 147.682699 
+L 125.996556 147.841456 
+L 125.942822 147.999683 
+L 125.889087 148.157383 
+L 125.835352 148.31456 
+L 125.781618 148.471218 
+L 125.727883 148.62736 
+L 125.674149 148.782989 
+L 125.620414 148.938109 
+L 125.56668 149.092723 
+L 125.512945 149.246834 
+L 125.45921 149.400446 
+L 125.405476 149.553561 
+L 125.351741 149.706184 
+L 125.298007 149.858317 
+L 125.244272 150.009962 
+L 125.190538 150.161125 
+L 125.136803 150.311806 
+L 125.083068 150.462011 
+L 125.029334 150.61174 
+L 124.975599 150.760999 
+L 124.921865 150.909788 
+L 124.86813 151.058113 
+L 124.814396 151.205974 
+L 124.760661 151.353376 
+L 124.706926 151.50032 
+L 124.653192 151.646811 
+L 124.599457 151.79285 
+L 124.545723 151.93844 
+L 124.491988 152.083585 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
-    <path d="M 124.491988 152.059912 
-L 123.827856 154.201178 
-L 123.163725 156.249859 
-L 122.499593 158.21363 
-L 121.835461 160.099252 
-L 121.171329 161.912706 
-L 120.507197 163.659314 
-L 119.843066 165.343829 
-L 119.178934 166.970515 
-L 118.514802 168.54321 
-L 117.85067 170.065385 
-L 117.186538 171.540184 
-L 116.522407 172.970467 
-L 115.858275 174.358843 
-L 115.194143 175.707698 
-L 114.530011 177.01922 
-L 113.86588 178.29542 
-L 113.201748 179.538151 
-L 112.537616 180.749123 
-L 111.873484 181.92992 
-L 111.209352 183.082008 
-L 110.545221 184.206751 
-L 109.881089 185.305417 
-L 109.216957 186.379187 
-L 108.552825 187.429165 
-L 107.888693 188.456382 
-L 107.224562 189.461805 
-L 106.56043 190.446338 
-L 105.896298 191.410833 
-L 105.232166 192.356089 
-L 104.568034 193.282858 
-L 103.903903 194.191849 
-L 103.239771 195.083732 
-L 102.575639 195.959139 
-L 101.911507 196.818668 
-L 101.247375 197.662884 
-L 100.583244 198.492323 
-L 99.919112 199.307494 
-L 99.25498 200.10888 
-L 98.590848 200.896939 
-L 97.926717 201.672106 
-L 97.262585 202.434797 
-L 96.598453 203.185408 
-L 95.934321 203.924315 
-L 95.270189 204.651876 
-L 94.606058 205.368437 
-L 93.941926 206.074323 
-L 93.277794 206.769849 
-L 92.613662 207.455314 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 124.491988 152.083585 
+L 123.827856 154.234707 
+L 123.163725 156.292427 
+L 122.499593 158.26452 
+L 121.835461 160.157828 
+L 121.171329 161.978406 
+L 120.507197 163.731635 
+L 119.843066 165.422321 
+L 119.178934 167.054773 
+L 118.514802 168.632868 
+L 117.85067 170.160111 
+L 117.186538 171.639677 
+L 116.522407 173.074453 
+L 115.858275 174.467071 
+L 115.194143 175.819938 
+L 114.530011 177.13526 
+L 113.86588 178.415065 
+L 113.201748 179.661221 
+L 112.537616 180.875453 
+L 111.873484 182.059354 
+L 111.209352 183.214404 
+L 110.545221 184.341975 
+L 109.881089 185.443344 
+L 109.216957 186.519702 
+L 108.552825 187.572159 
+L 107.888693 188.601754 
+L 107.224562 189.609459 
+L 106.56043 190.596185 
+L 105.896298 191.562788 
+L 105.232166 192.510073 
+L 104.568034 193.438796 
+L 103.903903 194.349671 
+L 103.239771 195.243371 
+L 102.575639 196.120532 
+L 101.911507 196.981755 
+L 101.247375 197.827608 
+L 100.583244 198.658632 
+L 99.919112 199.475336 
+L 99.25498 200.278205 
+L 98.590848 201.067702 
+L 97.926717 201.844263 
+L 97.262585 202.608307 
+L 96.598453 203.36023 
+L 95.934321 204.10041 
+L 95.270189 204.829209 
+L 94.606058 205.546972 
+L 93.941926 206.254028 
+L 93.277794 206.950691 
+L 92.613662 207.637263 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
-    <path d="M 92.613662 207.455314 
-L 92.503976 207.895174 
-L 92.394289 208.330988 
-L 92.284603 208.762831 
-L 92.174917 209.190775 
-L 92.06523 209.614888 
-L 91.955544 210.035239 
-L 91.845857 210.451895 
-L 91.736171 210.864919 
-L 91.626485 211.274374 
-L 91.516798 211.680322 
-L 91.407112 212.082821 
-L 91.297425 212.481931 
-L 91.187739 212.877708 
-L 91.078053 213.270206 
-L 90.968366 213.659481 
-L 90.85868 214.045583 
-L 90.748993 214.428566 
-L 90.639307 214.808478 
-L 90.529621 215.185368 
-L 90.419934 215.559285 
-L 90.310248 215.930274 
-L 90.200562 216.298382 
-L 90.090875 216.663652 
-L 89.981189 217.026128 
-L 89.871502 217.385853 
-L 89.761816 217.742867 
-L 89.65213 218.097212 
-L 89.542443 218.448928 
-L 89.432757 218.798051 
-L 89.32307 219.144622 
-L 89.213384 219.488677 
-L 89.103698 219.830251 
-L 88.994011 220.169381 
-L 88.884325 220.506102 
-L 88.774638 220.840446 
-L 88.664952 221.172449 
-L 88.555266 221.502141 
-L 88.445579 221.829556 
-L 88.335893 222.154724 
-L 88.226206 222.477676 
-L 88.11652 222.798442 
-L 88.006834 223.117051 
-L 87.897147 223.433533 
-L 87.787461 223.747915 
-L 87.677774 224.060225 
-L 87.568088 224.37049 
-L 87.458402 224.678737 
-L 87.348715 224.984992 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 92.613662 207.637263 
+L 92.503976 208.085817 
+L 92.394289 208.530165 
+L 92.284603 208.970387 
+L 92.174917 209.406557 
+L 92.06523 209.838751 
+L 91.955544 210.267039 
+L 91.845857 210.691491 
+L 91.736171 211.112177 
+L 91.626485 211.529162 
+L 91.516798 211.94251 
+L 91.407112 212.352285 
+L 91.297425 212.758547 
+L 91.187739 213.161357 
+L 91.078053 213.560772 
+L 90.968366 213.95685 
+L 90.85868 214.349646 
+L 90.748993 214.739213 
+L 90.639307 215.125605 
+L 90.529621 215.508872 
+L 90.419934 215.889065 
+L 90.310248 216.266232 
+L 90.200562 216.640422 
+L 90.090875 217.011681 
+L 89.981189 217.380055 
+L 89.871502 217.745588 
+L 89.761816 218.108323 
+L 89.65213 218.468304 
+L 89.542443 218.825571 
+L 89.432757 219.180166 
+L 89.32307 219.532127 
+L 89.213384 219.881494 
+L 89.103698 220.228305 
+L 88.994011 220.572597 
+L 88.884325 220.914406 
+L 88.774638 221.253768 
+L 88.664952 221.590717 
+L 88.555266 221.925288 
+L 88.445579 222.257514 
+L 88.335893 222.587427 
+L 88.226206 222.91506 
+L 88.11652 223.240444 
+L 88.006834 223.563609 
+L 87.897147 223.884586 
+L 87.787461 224.203404 
+L 87.677774 224.520091 
+L 87.568088 224.834677 
+L 87.458402 225.147189 
+L 87.348715 225.457654 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
-    <path d="M 87.348715 224.984992 
-L 87.32173 225.396639 
-L 87.294745 225.804741 
-L 87.26776 226.209358 
-L 87.240775 226.61055 
-L 87.21379 227.008374 
-L 87.186805 227.402886 
-L 87.15982 227.794141 
-L 87.132835 228.182192 
-L 87.10585 228.567091 
-L 87.078865 228.948889 
-L 87.05188 229.327635 
-L 87.024895 229.703379 
-L 86.99791 230.076167 
-L 86.970925 230.446044 
-L 86.94394 230.813058 
-L 86.916955 231.177251 
-L 86.889969 231.538666 
-L 86.862984 231.897345 
-L 86.835999 232.253331 
-L 86.809014 232.606662 
-L 86.782029 232.957378 
-L 86.755044 233.305517 
-L 86.728059 233.651118 
-L 86.701074 233.994216 
-L 86.674089 234.334849 
-L 86.647104 234.67305 
-L 86.620119 235.008854 
-L 86.593134 235.342296 
-L 86.566149 235.673408 
-L 86.539164 236.002223 
-L 86.512179 236.328771 
-L 86.485194 236.653085 
-L 86.458209 236.975195 
-L 86.431224 237.295129 
-L 86.404239 237.612919 
-L 86.377254 237.928591 
-L 86.350269 238.242174 
-L 86.323283 238.553697 
-L 86.296298 238.863184 
-L 86.269313 239.170664 
-L 86.242328 239.476161 
-L 86.215343 239.779701 
-L 86.188358 240.08131 
-L 86.161373 240.381011 
-L 86.134388 240.678828 
-L 86.107403 240.974786 
-L 86.080418 241.268907 
-L 86.053433 241.561213 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 87.348715 225.457654 
+L 87.32173 225.868806 
+L 87.294745 226.276422 
+L 87.26776 226.680563 
+L 87.240775 227.081287 
+L 87.21379 227.478652 
+L 87.186805 227.872713 
+L 87.15982 228.263525 
+L 87.132835 228.651141 
+L 87.10585 229.035613 
+L 87.078865 229.416991 
+L 87.05188 229.795326 
+L 87.024895 230.170664 
+L 86.99791 230.543053 
+L 86.970925 230.91254 
+L 86.94394 231.279168 
+L 86.916955 231.642983 
+L 86.889969 232.004026 
+L 86.862984 232.36234 
+L 86.835999 232.717965 
+L 86.809014 233.070942 
+L 86.782029 233.42131 
+L 86.755044 233.769107 
+L 86.728059 234.114371 
+L 86.701074 234.457138 
+L 86.674089 234.797444 
+L 86.647104 235.135324 
+L 86.620119 235.470813 
+L 86.593134 235.803943 
+L 86.566149 236.134749 
+L 86.539164 236.463262 
+L 86.512179 236.789513 
+L 86.485194 237.113535 
+L 86.458209 237.435356 
+L 86.431224 237.755007 
+L 86.404239 238.072517 
+L 86.377254 238.387914 
+L 86.350269 238.701227 
+L 86.323283 239.012481 
+L 86.296298 239.321706 
+L 86.269313 239.628926 
+L 86.242328 239.934167 
+L 86.215343 240.237456 
+L 86.188358 240.538816 
+L 86.161373 240.838272 
+L 86.134388 241.135848 
+L 86.107403 241.431568 
+L 86.080418 241.725454 
+L 86.053433 242.017529 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="me5bb776e6d" d="M -0 2.5 
+     <path id="m56c2750bfe" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1218df302b)">
-     <use xlink:href="#me5bb776e6d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3aaf15e627)">
+     <use xlink:href="#m56c2750bfe" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m8cc897ea4d" d="M -0.833333 2.5 
+     <path id="mcac27d6d46" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,437 +3228,437 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1218df302b)">
-     <use xlink:href="#m8cc897ea4d" x="362.865999" y="178.157653" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cc897ea4d" x="278.798176" y="181.06557" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cc897ea4d" x="251.17632" y="188.680634" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cc897ea4d" x="200.806828" y="186.322161" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cc897ea4d" x="169.803221" y="202.757761" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cc897ea4d" x="161.916638" y="211.158991" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cc897ea4d" x="158.697104" y="214.041592" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cc897ea4d" x="154.26679" y="230.364582" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8cc897ea4d" x="153.096464" y="236.337782" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3aaf15e627)">
+     <use xlink:href="#mcac27d6d46" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcac27d6d46" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcac27d6d46" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcac27d6d46" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcac27d6d46" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcac27d6d46" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcac27d6d46" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcac27d6d46" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcac27d6d46" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
-    <path d="M 362.865999 178.157653 
-L 361.114586 178.220091 
-L 359.363173 178.282447 
-L 357.61176 178.344721 
-L 355.860347 178.406913 
-L 354.108934 178.469023 
-L 352.357521 178.531052 
-L 350.606108 178.593 
-L 348.854695 178.654867 
-L 347.103282 178.716654 
-L 345.351869 178.77836 
-L 343.600456 178.839986 
-L 341.849043 178.901532 
-L 340.09763 178.962998 
-L 338.346217 179.024384 
-L 336.594804 179.085691 
-L 334.843391 179.146919 
-L 333.091978 179.208067 
-L 331.340565 179.269137 
-L 329.589152 179.330129 
-L 327.837739 179.391042 
-L 326.086326 179.451876 
-L 324.334913 179.512633 
-L 322.5835 179.573312 
-L 320.832087 179.633913 
-L 319.080674 179.694437 
-L 317.329262 179.754884 
-L 315.577849 179.815254 
-L 313.826436 179.875547 
-L 312.075023 179.935763 
-L 310.32361 179.995903 
-L 308.572197 180.055966 
-L 306.820784 180.115954 
-L 305.069371 180.175866 
-L 303.317958 180.235702 
-L 301.566545 180.295463 
-L 299.815132 180.355148 
-L 298.063719 180.414758 
-L 296.312306 180.474294 
-L 294.560893 180.533755 
-L 292.80948 180.593141 
-L 291.058067 180.652453 
-L 289.306654 180.711691 
-L 287.555241 180.770854 
-L 285.803828 180.829944 
-L 284.052415 180.888961 
-L 282.301002 180.947904 
-L 280.549589 181.006774 
-L 278.798176 181.06557 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 362.865999 115.428618 
+L 361.114586 115.595904 
+L 359.363173 115.762601 
+L 357.61176 115.928714 
+L 355.860347 116.094247 
+L 354.108934 116.259204 
+L 352.357521 116.423589 
+L 350.606108 116.587405 
+L 348.854695 116.750658 
+L 347.103282 116.91335 
+L 345.351869 117.075485 
+L 343.600456 117.237068 
+L 341.849043 117.398102 
+L 340.09763 117.558591 
+L 338.346217 117.718538 
+L 336.594804 117.877947 
+L 334.843391 118.036822 
+L 333.091978 118.195166 
+L 331.340565 118.352983 
+L 329.589152 118.510276 
+L 327.837739 118.667049 
+L 326.086326 118.823305 
+L 324.334913 118.979047 
+L 322.5835 119.13428 
+L 320.832087 119.289006 
+L 319.080674 119.443228 
+L 317.329262 119.59695 
+L 315.577849 119.750176 
+L 313.826436 119.902907 
+L 312.075023 120.055148 
+L 310.32361 120.206902 
+L 308.572197 120.358171 
+L 306.820784 120.508959 
+L 305.069371 120.659269 
+L 303.317958 120.809104 
+L 301.566545 120.958466 
+L 299.815132 121.10736 
+L 298.063719 121.255787 
+L 296.312306 121.403751 
+L 294.560893 121.551254 
+L 292.80948 121.6983 
+L 291.058067 121.844891 
+L 289.306654 121.99103 
+L 287.555241 122.136719 
+L 285.803828 122.281963 
+L 284.052415 122.426763 
+L 282.301002 122.571121 
+L 280.549589 122.715042 
+L 278.798176 122.858526 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
-    <path d="M 278.798176 181.06557 
-L 278.222721 181.237364 
-L 277.647265 181.408536 
-L 277.07181 181.579093 
-L 276.496355 181.749038 
-L 275.920899 181.918376 
-L 275.345444 182.087111 
-L 274.769989 182.255247 
-L 274.194533 182.422788 
-L 273.619078 182.58974 
-L 273.043623 182.756105 
-L 272.468168 182.921889 
-L 271.892712 183.087094 
-L 271.317257 183.251725 
-L 270.741802 183.415787 
-L 270.166346 183.579282 
-L 269.590891 183.742215 
-L 269.015436 183.904591 
-L 268.43998 184.066411 
-L 267.864525 184.227681 
-L 267.28907 184.388404 
-L 266.713614 184.548583 
-L 266.138159 184.708223 
-L 265.562704 184.867328 
-L 264.987248 185.025899 
-L 264.411793 185.183942 
-L 263.836338 185.341459 
-L 263.260882 185.498455 
-L 262.685427 185.654932 
-L 262.109972 185.810895 
-L 261.534516 185.966345 
-L 260.959061 186.121288 
-L 260.383606 186.275725 
-L 259.80815 186.429661 
-L 259.232695 186.583098 
-L 258.65724 186.73604 
-L 258.081784 186.888491 
-L 257.506329 187.040452 
-L 256.930874 187.191927 
-L 256.355418 187.34292 
-L 255.779963 187.493434 
-L 255.204508 187.64347 
-L 254.629052 187.793034 
-L 254.053597 187.942126 
-L 253.478142 188.090751 
-L 252.902686 188.238912 
-L 252.327231 188.386611 
-L 251.751776 188.53385 
-L 251.17632 188.680634 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 278.798176 122.858526 
+L 278.222721 122.977606 
+L 277.647265 123.096388 
+L 277.07181 123.214873 
+L 276.496355 123.333063 
+L 275.920899 123.450958 
+L 275.345444 123.568561 
+L 274.769989 123.685873 
+L 274.194533 123.802895 
+L 273.619078 123.91963 
+L 273.043623 124.036077 
+L 272.468168 124.152239 
+L 271.892712 124.268117 
+L 271.317257 124.383712 
+L 270.741802 124.499026 
+L 270.166346 124.614061 
+L 269.590891 124.728816 
+L 269.015436 124.843295 
+L 268.43998 124.957498 
+L 267.864525 125.071426 
+L 267.28907 125.185081 
+L 266.713614 125.298464 
+L 266.138159 125.411577 
+L 265.562704 125.52442 
+L 264.987248 125.636996 
+L 264.411793 125.749304 
+L 263.836338 125.861347 
+L 263.260882 125.973126 
+L 262.685427 126.084642 
+L 262.109972 126.195896 
+L 261.534516 126.30689 
+L 260.959061 126.417624 
+L 260.383606 126.528101 
+L 259.80815 126.63832 
+L 259.232695 126.748283 
+L 258.65724 126.857993 
+L 258.081784 126.967448 
+L 257.506329 127.076652 
+L 256.930874 127.185605 
+L 256.355418 127.294307 
+L 255.779963 127.402761 
+L 255.204508 127.510968 
+L 254.629052 127.618928 
+L 254.053597 127.726642 
+L 253.478142 127.834113 
+L 252.902686 127.94134 
+L 252.327231 128.048325 
+L 251.751776 128.155069 
+L 251.17632 128.261574 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
-    <path d="M 251.17632 188.680634 
-L 250.126956 188.632677 
-L 249.077592 188.584672 
-L 248.028227 188.536619 
-L 246.978863 188.488516 
-L 245.929498 188.440365 
-L 244.880134 188.392164 
-L 243.830769 188.343915 
-L 242.781405 188.295616 
-L 241.732041 188.247269 
-L 240.682676 188.198871 
-L 239.633312 188.150425 
-L 238.583947 188.101928 
-L 237.534583 188.053382 
-L 236.485218 188.004787 
-L 235.435854 187.956141 
-L 234.38649 187.907445 
-L 233.337125 187.858699 
-L 232.287761 187.809904 
-L 231.238396 187.761057 
-L 230.189032 187.712161 
-L 229.139667 187.663214 
-L 228.090303 187.614216 
-L 227.040939 187.565167 
-L 225.991574 187.516068 
-L 224.94221 187.466918 
-L 223.892845 187.417717 
-L 222.843481 187.368464 
-L 221.794116 187.319161 
-L 220.744752 187.269806 
-L 219.695388 187.220399 
-L 218.646023 187.170941 
-L 217.596659 187.121432 
-L 216.547294 187.07187 
-L 215.49793 187.022257 
-L 214.448565 186.972592 
-L 213.399201 186.922874 
-L 212.349836 186.873105 
-L 211.300472 186.823283 
-L 210.251108 186.773408 
-L 209.201743 186.723481 
-L 208.152379 186.673502 
-L 207.103014 186.623469 
-L 206.05365 186.573384 
-L 205.004285 186.523246 
-L 203.954921 186.473055 
-L 202.905557 186.42281 
-L 201.856192 186.372512 
-L 200.806828 186.322161 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 251.17632 128.261574 
+L 250.126956 128.331857 
+L 249.077592 128.402036 
+L 248.028227 128.472111 
+L 246.978863 128.542083 
+L 245.929498 128.611951 
+L 244.880134 128.681717 
+L 243.830769 128.751381 
+L 242.781405 128.820942 
+L 241.732041 128.890401 
+L 240.682676 128.959758 
+L 239.633312 129.029014 
+L 238.583947 129.098169 
+L 237.534583 129.167224 
+L 236.485218 129.236178 
+L 235.435854 129.305031 
+L 234.38649 129.373785 
+L 233.337125 129.442439 
+L 232.287761 129.510994 
+L 231.238396 129.57945 
+L 230.189032 129.647807 
+L 229.139667 129.716066 
+L 228.090303 129.784227 
+L 227.040939 129.85229 
+L 225.991574 129.920255 
+L 224.94221 129.988123 
+L 223.892845 130.055893 
+L 222.843481 130.123567 
+L 221.794116 130.191145 
+L 220.744752 130.258626 
+L 219.695388 130.326012 
+L 218.646023 130.393302 
+L 217.596659 130.460496 
+L 216.547294 130.527595 
+L 215.49793 130.594599 
+L 214.448565 130.661509 
+L 213.399201 130.728325 
+L 212.349836 130.795046 
+L 211.300472 130.861674 
+L 210.251108 130.928208 
+L 209.201743 130.994649 
+L 208.152379 131.060997 
+L 207.103014 131.127252 
+L 206.05365 131.193414 
+L 205.004285 131.259485 
+L 203.954921 131.325463 
+L 202.905557 131.39135 
+L 201.856192 131.457145 
+L 200.806828 131.522849 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
-    <path d="M 200.806828 186.322161 
-L 200.160919 186.729693 
-L 199.515011 187.133751 
-L 198.869102 187.534392 
-L 198.223194 187.931675 
-L 197.577285 188.325655 
-L 196.931377 188.716386 
-L 196.285468 189.103922 
-L 195.63956 189.488314 
-L 194.993652 189.869614 
-L 194.347743 190.24787 
-L 193.701835 190.62313 
-L 193.055926 190.995443 
-L 192.410018 191.364853 
-L 191.764109 191.731405 
-L 191.118201 192.095145 
-L 190.472292 192.456113 
-L 189.826384 192.814353 
-L 189.180475 193.169905 
-L 188.534567 193.522809 
-L 187.888658 193.873104 
-L 187.24275 194.220829 
-L 186.596841 194.566021 
-L 185.950933 194.908717 
-L 185.305024 195.248952 
-L 184.659116 195.586762 
-L 184.013208 195.922181 
-L 183.367299 196.255242 
-L 182.721391 196.585979 
-L 182.075482 196.914424 
-L 181.429574 197.240608 
-L 180.783665 197.564562 
-L 180.137757 197.886316 
-L 179.491848 198.205901 
-L 178.84594 198.523345 
-L 178.200031 198.838676 
-L 177.554123 199.151924 
-L 176.908214 199.463114 
-L 176.262306 199.772274 
-L 175.616397 200.07943 
-L 174.970489 200.384608 
-L 174.32458 200.687833 
-L 173.678672 200.98913 
-L 173.032764 201.288524 
-L 172.386855 201.586038 
-L 171.740947 201.881696 
-L 171.095038 202.175521 
-L 170.44913 202.467535 
-L 169.803221 202.757761 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 200.806828 131.522849 
+L 200.160919 131.929576 
+L 199.515011 132.332842 
+L 198.869102 132.732707 
+L 198.223194 133.129226 
+L 197.577285 133.522456 
+L 196.931377 133.91245 
+L 196.285468 134.299262 
+L 195.63956 134.682942 
+L 194.993652 135.063541 
+L 194.347743 135.441109 
+L 193.701835 135.815693 
+L 193.055926 136.18734 
+L 192.410018 136.556095 
+L 191.764109 136.922004 
+L 191.118201 137.28511 
+L 190.472292 137.645455 
+L 189.826384 138.003081 
+L 189.180475 138.35803 
+L 188.534567 138.71034 
+L 187.888658 139.06005 
+L 187.24275 139.4072 
+L 186.596841 139.751825 
+L 185.950933 140.093962 
+L 185.305024 140.433648 
+L 184.659116 140.770917 
+L 184.013208 141.105803 
+L 183.367299 141.438339 
+L 182.721391 141.768558 
+L 182.075482 142.096493 
+L 181.429574 142.422175 
+L 180.783665 142.745634 
+L 180.137757 143.066901 
+L 179.491848 143.386004 
+L 178.84594 143.702974 
+L 178.200031 144.017839 
+L 177.554123 144.330625 
+L 176.908214 144.641361 
+L 176.262306 144.950073 
+L 175.616397 145.256788 
+L 174.970489 145.56153 
+L 174.32458 145.864326 
+L 173.678672 146.165199 
+L 173.032764 146.464175 
+L 172.386855 146.761277 
+L 171.740947 147.056528 
+L 171.095038 147.349951 
+L 170.44913 147.64157 
+L 169.803221 147.931404 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
-    <path d="M 169.803221 202.757761 
-L 169.638917 202.948874 
-L 169.474614 203.13922 
-L 169.31031 203.328804 
-L 169.146006 203.517632 
-L 168.981702 203.705712 
-L 168.817398 203.893047 
-L 168.653094 204.079645 
-L 168.488791 204.265512 
-L 168.324487 204.450652 
-L 168.160183 204.635071 
-L 167.995879 204.818776 
-L 167.831575 205.001771 
-L 167.667272 205.184062 
-L 167.502968 205.365655 
-L 167.338664 205.546555 
-L 167.17436 205.726766 
-L 167.010056 205.906295 
-L 166.845752 206.085147 
-L 166.681449 206.263325 
-L 166.517145 206.440837 
-L 166.352841 206.617686 
-L 166.188537 206.793877 
-L 166.024233 206.969416 
-L 165.85993 207.144307 
-L 165.695626 207.318555 
-L 165.531322 207.492165 
-L 165.367018 207.66514 
-L 165.202714 207.837487 
-L 165.03841 208.009209 
-L 164.874107 208.180312 
-L 164.709803 208.350798 
-L 164.545499 208.520674 
-L 164.381195 208.689943 
-L 164.216891 208.858609 
-L 164.052588 209.026677 
-L 163.888284 209.194151 
-L 163.72398 209.361035 
-L 163.559676 209.527334 
-L 163.395372 209.693051 
-L 163.231068 209.858191 
-L 163.066765 210.022757 
-L 162.902461 210.186754 
-L 162.738157 210.350185 
-L 162.573853 210.513054 
-L 162.409549 210.675366 
-L 162.245246 210.837123 
-L 162.080942 210.99833 
-L 161.916638 211.158991 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 169.803221 147.931404 
+L 169.638917 148.23622 
+L 169.474614 148.539088 
+L 169.31031 148.840032 
+L 169.146006 149.139078 
+L 168.981702 149.436249 
+L 168.817398 149.731569 
+L 168.653094 150.02506 
+L 168.488791 150.316745 
+L 168.324487 150.606646 
+L 168.160183 150.894784 
+L 167.995879 151.181182 
+L 167.831575 151.465859 
+L 167.667272 151.748837 
+L 167.502968 152.030136 
+L 167.338664 152.309775 
+L 167.17436 152.587774 
+L 167.010056 152.864151 
+L 166.845752 153.138927 
+L 166.681449 153.412119 
+L 166.517145 153.683745 
+L 166.352841 153.953824 
+L 166.188537 154.222372 
+L 166.024233 154.489408 
+L 165.85993 154.754947 
+L 165.695626 155.019007 
+L 165.531322 155.281605 
+L 165.367018 155.542755 
+L 165.202714 155.802474 
+L 165.03841 156.060779 
+L 164.874107 156.317683 
+L 164.709803 156.573202 
+L 164.545499 156.827351 
+L 164.381195 157.080144 
+L 164.216891 157.331597 
+L 164.052588 157.581722 
+L 163.888284 157.830535 
+L 163.72398 158.078048 
+L 163.559676 158.324276 
+L 163.395372 158.569231 
+L 163.231068 158.812927 
+L 163.066765 159.055376 
+L 162.902461 159.296591 
+L 162.738157 159.536585 
+L 162.573853 159.77537 
+L 162.409549 160.012958 
+L 162.245246 160.249361 
+L 162.080942 160.484591 
+L 161.916638 160.718659 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
-    <path d="M 161.916638 211.158991 
-L 161.849564 211.220869 
-L 161.782491 211.282666 
-L 161.715417 211.344383 
-L 161.648343 211.406019 
-L 161.58127 211.467576 
-L 161.514196 211.529052 
-L 161.447123 211.590449 
-L 161.380049 211.651766 
-L 161.312975 211.713005 
-L 161.245902 211.774164 
-L 161.178828 211.835244 
-L 161.111755 211.896246 
-L 161.044681 211.957169 
-L 160.977607 212.018014 
-L 160.910534 212.078781 
-L 160.84346 212.13947 
-L 160.776386 212.200082 
-L 160.709313 212.260616 
-L 160.642239 212.321073 
-L 160.575166 212.381453 
-L 160.508092 212.441756 
-L 160.441018 212.501983 
-L 160.373945 212.562133 
-L 160.306871 212.622206 
-L 160.239797 212.682204 
-L 160.172724 212.742126 
-L 160.10565 212.801972 
-L 160.038577 212.861743 
-L 159.971503 212.921438 
-L 159.904429 212.981058 
-L 159.837356 213.040604 
-L 159.770282 213.100074 
-L 159.703209 213.15947 
-L 159.636135 213.218792 
-L 159.569061 213.278039 
-L 159.501988 213.337213 
-L 159.434914 213.396313 
-L 159.36784 213.455339 
-L 159.300767 213.514292 
-L 159.233693 213.573171 
-L 159.16662 213.631978 
-L 159.099546 213.690711 
-L 159.032472 213.749372 
-L 158.965399 213.80796 
-L 158.898325 213.866476 
-L 158.831251 213.92492 
-L 158.764178 213.983292 
-L 158.697104 214.041592 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 161.916638 160.718659 
+L 161.849564 160.875236 
+L 161.782491 161.031297 
+L 161.715417 161.186847 
+L 161.648343 161.341888 
+L 161.58127 161.496423 
+L 161.514196 161.650456 
+L 161.447123 161.80399 
+L 161.380049 161.957028 
+L 161.312975 162.109574 
+L 161.245902 162.26163 
+L 161.178828 162.413201 
+L 161.111755 162.564288 
+L 161.044681 162.714895 
+L 160.977607 162.865025 
+L 160.910534 163.014681 
+L 160.84346 163.163866 
+L 160.776386 163.312582 
+L 160.709313 163.460834 
+L 160.642239 163.608624 
+L 160.575166 163.755954 
+L 160.508092 163.902827 
+L 160.441018 164.049247 
+L 160.373945 164.195216 
+L 160.306871 164.340737 
+L 160.239797 164.485812 
+L 160.172724 164.630445 
+L 160.10565 164.774637 
+L 160.038577 164.918393 
+L 159.971503 165.061714 
+L 159.904429 165.204602 
+L 159.837356 165.347061 
+L 159.770282 165.489094 
+L 159.703209 165.630702 
+L 159.636135 165.771888 
+L 159.569061 165.912655 
+L 159.501988 166.053005 
+L 159.434914 166.192941 
+L 159.36784 166.332464 
+L 159.300767 166.471579 
+L 159.233693 166.610286 
+L 159.16662 166.748588 
+L 159.099546 166.886488 
+L 159.032472 167.023989 
+L 158.965399 167.161091 
+L 158.898325 167.297798 
+L 158.831251 167.434112 
+L 158.764178 167.570034 
+L 158.697104 167.705569 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
-    <path d="M 158.697104 214.041592 
-L 158.604806 214.445838 
-L 158.512508 214.846665 
-L 158.42021 215.244129 
-L 158.327911 215.638288 
-L 158.235613 216.029196 
-L 158.143315 216.416905 
-L 158.051017 216.801468 
-L 157.958718 217.182935 
-L 157.86642 217.561356 
-L 157.774122 217.936779 
-L 157.681824 218.309252 
-L 157.589526 218.678819 
-L 157.497227 219.045527 
-L 157.404929 219.409419 
-L 157.312631 219.770537 
-L 157.220333 220.128925 
-L 157.128034 220.484623 
-L 157.035736 220.83767 
-L 156.943438 221.188107 
-L 156.85114 221.535972 
-L 156.758842 221.881301 
-L 156.666543 222.224133 
-L 156.574245 222.564502 
-L 156.481947 222.902443 
-L 156.389649 223.237992 
-L 156.29735 223.571181 
-L 156.205052 223.902044 
-L 156.112754 224.230614 
-L 156.020456 224.55692 
-L 155.928158 224.880995 
-L 155.835859 225.202869 
-L 155.743561 225.522572 
-L 155.651263 225.840132 
-L 155.558965 226.155578 
-L 155.466666 226.468939 
-L 155.374368 226.78024 
-L 155.28207 227.089511 
-L 155.189772 227.396775 
-L 155.097474 227.702061 
-L 155.005175 228.005392 
-L 154.912877 228.306794 
-L 154.820579 228.606292 
-L 154.728281 228.903908 
-L 154.635982 229.199667 
-L 154.543684 229.493591 
-L 154.451386 229.785704 
-L 154.359088 230.076027 
-L 154.26679 230.364582 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 158.697104 167.705569 
+L 158.604806 168.024921 
+L 158.512508 168.342136 
+L 158.42021 168.657242 
+L 158.327911 168.970267 
+L 158.235613 169.281238 
+L 158.143315 169.590182 
+L 158.051017 169.897126 
+L 157.958718 170.202095 
+L 157.86642 170.505114 
+L 157.774122 170.806208 
+L 157.681824 171.105402 
+L 157.589526 171.402719 
+L 157.497227 171.698183 
+L 157.404929 171.991816 
+L 157.312631 172.283642 
+L 157.220333 172.573681 
+L 157.128034 172.861957 
+L 157.035736 173.14849 
+L 156.943438 173.433301 
+L 156.85114 173.716411 
+L 156.758842 173.997841 
+L 156.666543 174.277609 
+L 156.574245 174.555735 
+L 156.481947 174.832239 
+L 156.389649 175.107139 
+L 156.29735 175.380455 
+L 156.205052 175.652203 
+L 156.112754 175.922402 
+L 156.020456 176.191069 
+L 155.928158 176.458223 
+L 155.835859 176.723878 
+L 155.743561 176.988054 
+L 155.651263 177.250765 
+L 155.558965 177.512028 
+L 155.466666 177.771859 
+L 155.374368 178.030273 
+L 155.28207 178.287286 
+L 155.189772 178.542913 
+L 155.097474 178.797169 
+L 155.005175 179.050068 
+L 154.912877 179.301625 
+L 154.820579 179.551854 
+L 154.728281 179.800769 
+L 154.635982 180.048383 
+L 154.543684 180.294711 
+L 154.451386 180.539765 
+L 154.359088 180.783558 
+L 154.26679 181.026105 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
-    <path d="M 154.26679 230.364582 
-L 154.242408 230.497021 
-L 154.218026 230.629091 
-L 154.193644 230.760794 
-L 154.169262 230.892133 
-L 154.144881 231.023108 
-L 154.120499 231.153722 
-L 154.096117 231.283977 
-L 154.071735 231.413875 
-L 154.047354 231.543418 
-L 154.022972 231.672608 
-L 153.99859 231.801447 
-L 153.974208 231.929936 
-L 153.949826 232.058078 
-L 153.925445 232.185874 
-L 153.901063 232.313327 
-L 153.876681 232.440438 
-L 153.852299 232.567208 
-L 153.827918 232.693641 
-L 153.803536 232.819737 
-L 153.779154 232.945498 
-L 153.754772 233.070927 
-L 153.730391 233.196024 
-L 153.706009 233.320792 
-L 153.681627 233.445233 
-L 153.657245 233.569347 
-L 153.632863 233.693137 
-L 153.608482 233.816605 
-L 153.5841 233.939752 
-L 153.559718 234.06258 
-L 153.535336 234.18509 
-L 153.510955 234.307284 
-L 153.486573 234.429164 
-L 153.462191 234.550732 
-L 153.437809 234.671988 
-L 153.413427 234.792935 
-L 153.389046 234.913574 
-L 153.364664 235.033906 
-L 153.340282 235.153934 
-L 153.3159 235.273659 
-L 153.291519 235.393081 
-L 153.267137 235.512204 
-L 153.242755 235.631028 
-L 153.218373 235.749555 
-L 153.193992 235.867786 
-L 153.16961 235.985723 
-L 153.145228 236.103367 
-L 153.120846 236.220719 
-L 153.096464 236.337782 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 154.26679 181.026105 
+L 154.242408 181.280687 
+L 154.218026 181.53391 
+L 154.193644 181.785787 
+L 154.169262 182.036332 
+L 154.144881 182.28556 
+L 154.120499 182.533485 
+L 154.096117 182.780119 
+L 154.071735 183.025477 
+L 154.047354 183.269571 
+L 154.022972 183.512415 
+L 153.99859 183.754021 
+L 153.974208 183.994401 
+L 153.949826 184.233569 
+L 153.925445 184.471536 
+L 153.901063 184.708314 
+L 153.876681 184.943915 
+L 153.852299 185.178351 
+L 153.827918 185.411633 
+L 153.803536 185.643772 
+L 153.779154 185.87478 
+L 153.754772 186.104668 
+L 153.730391 186.333446 
+L 153.706009 186.561125 
+L 153.681627 186.787716 
+L 153.657245 187.013229 
+L 153.632863 187.237674 
+L 153.608482 187.461061 
+L 153.5841 187.6834 
+L 153.559718 187.904701 
+L 153.535336 188.124974 
+L 153.510955 188.344228 
+L 153.486573 188.562472 
+L 153.462191 188.779716 
+L 153.437809 188.995969 
+L 153.413427 189.211239 
+L 153.389046 189.425537 
+L 153.364664 189.638869 
+L 153.340282 189.851246 
+L 153.3159 190.062676 
+L 153.291519 190.273167 
+L 153.267137 190.482727 
+L 153.242755 190.691365 
+L 153.218373 190.899088 
+L 153.193992 191.105905 
+L 153.16961 191.311823 
+L 153.145228 191.516851 
+L 153.120846 191.720996 
+L 153.096464 191.924265 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="me8075b117d" d="M -1.25 2.5 
+     <path id="me4b4cede54" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,437 +3673,437 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1218df302b)">
-     <use xlink:href="#me8075b117d" x="301.619021" y="144.650944" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8075b117d" x="250.236474" y="147.192871" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8075b117d" x="225.418659" y="152.799409" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8075b117d" x="212.328936" y="158.91628" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8075b117d" x="209.030149" y="156.82091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8075b117d" x="197.547749" y="167.982576" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8075b117d" x="194.819287" y="169.49094" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8075b117d" x="193.12279" y="177.004847" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me8075b117d" x="192.79794" y="181.853352" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3aaf15e627)">
+     <use xlink:href="#me4b4cede54" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4cede54" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4cede54" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4cede54" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4cede54" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4cede54" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4cede54" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4cede54" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4cede54" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
-    <path d="M 301.619021 144.650944 
-L 300.548551 144.705316 
-L 299.478081 144.759625 
-L 298.407612 144.813872 
-L 297.337142 144.868057 
-L 296.266672 144.922181 
-L 295.196202 144.976242 
-L 294.125733 145.030242 
-L 293.055263 145.08418 
-L 291.984793 145.138057 
-L 290.914323 145.191873 
-L 289.843854 145.245628 
-L 288.773384 145.299322 
-L 287.702914 145.352955 
-L 286.632445 145.406528 
-L 285.561975 145.46004 
-L 284.491505 145.513492 
-L 283.421035 145.566883 
-L 282.350566 145.620215 
-L 281.280096 145.673486 
-L 280.209626 145.726698 
-L 279.139157 145.77985 
-L 278.068687 145.832942 
-L 276.998217 145.885975 
-L 275.927747 145.938949 
-L 274.857278 145.991863 
-L 273.786808 146.044719 
-L 272.716338 146.097516 
-L 271.645868 146.150253 
-L 270.575399 146.202933 
-L 269.504929 146.255553 
-L 268.434459 146.308116 
-L 267.36399 146.36062 
-L 266.29352 146.413066 
-L 265.22305 146.465454 
-L 264.15258 146.517784 
-L 263.082111 146.570057 
-L 262.011641 146.622272 
-L 260.941171 146.674429 
-L 259.870702 146.726529 
-L 258.800232 146.778572 
-L 257.729762 146.830558 
-L 256.659292 146.882487 
-L 255.588823 146.934359 
-L 254.518353 146.986174 
-L 253.447883 147.037933 
-L 252.377414 147.089635 
-L 251.306944 147.141281 
-L 250.236474 147.192871 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 301.619021 150.561849 
+L 300.548551 150.697498 
+L 299.478081 150.83276 
+L 298.407612 150.967636 
+L 297.337142 151.102131 
+L 296.266672 151.236244 
+L 295.196202 151.36998 
+L 294.125733 151.503339 
+L 293.055263 151.636324 
+L 291.984793 151.768936 
+L 290.914323 151.901179 
+L 289.843854 152.033054 
+L 288.773384 152.164563 
+L 287.702914 152.295708 
+L 286.632445 152.426491 
+L 285.561975 152.556915 
+L 284.491505 152.68698 
+L 283.421035 152.81669 
+L 282.350566 152.946045 
+L 281.280096 153.075049 
+L 280.209626 153.203702 
+L 279.139157 153.332007 
+L 278.068687 153.459966 
+L 276.998217 153.58758 
+L 275.927747 153.714852 
+L 274.857278 153.841783 
+L 273.786808 153.968375 
+L 272.716338 154.094629 
+L 271.645868 154.220548 
+L 270.575399 154.346134 
+L 269.504929 154.471387 
+L 268.434459 154.596311 
+L 267.36399 154.720906 
+L 266.29352 154.845175 
+L 265.22305 154.969118 
+L 264.15258 155.092738 
+L 263.082111 155.216037 
+L 262.011641 155.339016 
+L 260.941171 155.461677 
+L 259.870702 155.584021 
+L 258.800232 155.70605 
+L 257.729762 155.827765 
+L 256.659292 155.949169 
+L 255.588823 156.070263 
+L 254.518353 156.191048 
+L 253.447883 156.311526 
+L 252.377414 156.431699 
+L 251.306944 156.551567 
+L 250.236474 156.671134 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
-    <path d="M 250.236474 147.192871 
-L 249.719436 147.316702 
-L 249.202398 147.44021 
-L 248.685361 147.563397 
-L 248.168323 147.686265 
-L 247.651285 147.808815 
-L 247.134247 147.93105 
-L 246.617209 148.052969 
-L 246.100172 148.174576 
-L 245.583134 148.295871 
-L 245.066096 148.416857 
-L 244.549058 148.537535 
-L 244.03202 148.657906 
-L 243.514982 148.777972 
-L 242.997945 148.897735 
-L 242.480907 149.017196 
-L 241.963869 149.136356 
-L 241.446831 149.255218 
-L 240.929793 149.373782 
-L 240.412756 149.49205 
-L 239.895718 149.610024 
-L 239.37868 149.727705 
-L 238.861642 149.845095 
-L 238.344604 149.962194 
-L 237.827566 150.079005 
-L 237.310529 150.195528 
-L 236.793491 150.311766 
-L 236.276453 150.427719 
-L 235.759415 150.543389 
-L 235.242377 150.658778 
-L 234.72534 150.773886 
-L 234.208302 150.888715 
-L 233.691264 151.003267 
-L 233.174226 151.117542 
-L 232.657188 151.231543 
-L 232.14015 151.34527 
-L 231.623113 151.458725 
-L 231.106075 151.571909 
-L 230.589037 151.684823 
-L 230.071999 151.797468 
-L 229.554961 151.909847 
-L 229.037924 152.02196 
-L 228.520886 152.133808 
-L 228.003848 152.245392 
-L 227.48681 152.356715 
-L 226.969772 152.467777 
-L 226.452735 152.578579 
-L 225.935697 152.689122 
-L 225.418659 152.799409 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 250.236474 156.671134 
+L 249.719436 156.76189 
+L 249.202398 156.852473 
+L 248.685361 156.942883 
+L 248.168323 157.033121 
+L 247.651285 157.123188 
+L 247.134247 157.213084 
+L 246.617209 157.302809 
+L 246.100172 157.392365 
+L 245.583134 157.481752 
+L 245.066096 157.570971 
+L 244.549058 157.660022 
+L 244.03202 157.748907 
+L 243.514982 157.837624 
+L 242.997945 157.926177 
+L 242.480907 158.014564 
+L 241.963869 158.102786 
+L 241.446831 158.190845 
+L 240.929793 158.27874 
+L 240.412756 158.366473 
+L 239.895718 158.454043 
+L 239.37868 158.541452 
+L 238.861642 158.6287 
+L 238.344604 158.715788 
+L 237.827566 158.802716 
+L 237.310529 158.889485 
+L 236.793491 158.976096 
+L 236.276453 159.062548 
+L 235.759415 159.148843 
+L 235.242377 159.234982 
+L 234.72534 159.320964 
+L 234.208302 159.40679 
+L 233.691264 159.492461 
+L 233.174226 159.577978 
+L 232.657188 159.66334 
+L 232.14015 159.74855 
+L 231.623113 159.833606 
+L 231.106075 159.91851 
+L 230.589037 160.003262 
+L 230.071999 160.087863 
+L 229.554961 160.172313 
+L 229.037924 160.256613 
+L 228.520886 160.340763 
+L 228.003848 160.424764 
+L 227.48681 160.508616 
+L 226.969772 160.592321 
+L 226.452735 160.675878 
+L 225.935697 160.759287 
+L 225.418659 160.842551 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
-    <path d="M 225.418659 152.799409 
-L 225.145956 152.935239 
-L 224.873254 153.070681 
-L 224.600551 153.205737 
-L 224.327849 153.340409 
-L 224.055146 153.474699 
-L 223.782444 153.60861 
-L 223.509741 153.742144 
-L 223.237038 153.875302 
-L 222.964336 154.008087 
-L 222.691633 154.140502 
-L 222.418931 154.272547 
-L 222.146228 154.404225 
-L 221.873526 154.535539 
-L 221.600823 154.66649 
-L 221.328121 154.797079 
-L 221.055418 154.92731 
-L 220.782715 155.057184 
-L 220.510013 155.186703 
-L 220.23731 155.315869 
-L 219.964608 155.444684 
-L 219.691905 155.57315 
-L 219.419203 155.701268 
-L 219.1465 155.829041 
-L 218.873798 155.956471 
-L 218.601095 156.083558 
-L 218.328392 156.210306 
-L 218.05569 156.336715 
-L 217.782987 156.462789 
-L 217.510285 156.588528 
-L 217.237582 156.713934 
-L 216.96488 156.839009 
-L 216.692177 156.963754 
-L 216.419475 157.088173 
-L 216.146772 157.212265 
-L 215.874069 157.336034 
-L 215.601367 157.45948 
-L 215.328664 157.582605 
-L 215.055962 157.705411 
-L 214.783259 157.8279 
-L 214.510557 157.950073 
-L 214.237854 158.071932 
-L 213.965152 158.193478 
-L 213.692449 158.314713 
-L 213.419746 158.435639 
-L 213.147044 158.556257 
-L 212.874341 158.676569 
-L 212.601639 158.796576 
-L 212.328936 158.91628 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 225.418659 160.842551 
+L 225.145956 160.853856 
+L 224.873254 160.86516 
+L 224.600551 160.87646 
+L 224.327849 160.887758 
+L 224.055146 160.899053 
+L 223.782444 160.910345 
+L 223.509741 160.921635 
+L 223.237038 160.932922 
+L 222.964336 160.944206 
+L 222.691633 160.955488 
+L 222.418931 160.966767 
+L 222.146228 160.978043 
+L 221.873526 160.989316 
+L 221.600823 161.000587 
+L 221.328121 161.011855 
+L 221.055418 161.023121 
+L 220.782715 161.034384 
+L 220.510013 161.045644 
+L 220.23731 161.056901 
+L 219.964608 161.068156 
+L 219.691905 161.079408 
+L 219.419203 161.090658 
+L 219.1465 161.101905 
+L 218.873798 161.113149 
+L 218.601095 161.12439 
+L 218.328392 161.135629 
+L 218.05569 161.146865 
+L 217.782987 161.158099 
+L 217.510285 161.169329 
+L 217.237582 161.180558 
+L 216.96488 161.191783 
+L 216.692177 161.203006 
+L 216.419475 161.214226 
+L 216.146772 161.225444 
+L 215.874069 161.236658 
+L 215.601367 161.247871 
+L 215.328664 161.25908 
+L 215.055962 161.270287 
+L 214.783259 161.281491 
+L 214.510557 161.292693 
+L 214.237854 161.303892 
+L 213.965152 161.315088 
+L 213.692449 161.326282 
+L 213.419746 161.337473 
+L 213.147044 161.348661 
+L 212.874341 161.359847 
+L 212.601639 161.37103 
+L 212.328936 161.382211 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
-    <path d="M 212.328936 158.91628 
-L 212.260212 158.873558 
-L 212.191487 158.830798 
-L 212.122762 158.787999 
-L 212.054037 158.745162 
-L 211.985313 158.702285 
-L 211.916588 158.65937 
-L 211.847863 158.616416 
-L 211.779138 158.573423 
-L 211.710414 158.530391 
-L 211.641689 158.48732 
-L 211.572964 158.444209 
-L 211.504239 158.40106 
-L 211.435515 158.357871 
-L 211.36679 158.314642 
-L 211.298065 158.271374 
-L 211.229341 158.228067 
-L 211.160616 158.18472 
-L 211.091891 158.141333 
-L 211.023166 158.097907 
-L 210.954442 158.05444 
-L 210.885717 158.010934 
-L 210.816992 157.967388 
-L 210.748267 157.923802 
-L 210.679543 157.880176 
-L 210.610818 157.836509 
-L 210.542093 157.792802 
-L 210.473369 157.749055 
-L 210.404644 157.705267 
-L 210.335919 157.661439 
-L 210.267194 157.617571 
-L 210.19847 157.573661 
-L 210.129745 157.529711 
-L 210.06102 157.485721 
-L 209.992295 157.441689 
-L 209.923571 157.397616 
-L 209.854846 157.353503 
-L 209.786121 157.309348 
-L 209.717396 157.265152 
-L 209.648672 157.220915 
-L 209.579947 157.176636 
-L 209.511222 157.132316 
-L 209.442498 157.087955 
-L 209.373773 157.043552 
-L 209.305048 156.999107 
-L 209.236323 156.954621 
-L 209.167599 156.910092 
-L 209.098874 156.865522 
-L 209.030149 156.82091 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 212.328936 161.382211 
+L 212.260212 161.488914 
+L 212.191487 161.595378 
+L 212.122762 161.701603 
+L 212.054037 161.807591 
+L 211.985313 161.913342 
+L 211.916588 162.018858 
+L 211.847863 162.124139 
+L 211.779138 162.229187 
+L 211.710414 162.334003 
+L 211.641689 162.438588 
+L 211.572964 162.542942 
+L 211.504239 162.647067 
+L 211.435515 162.750964 
+L 211.36679 162.854633 
+L 211.298065 162.958076 
+L 211.229341 163.061294 
+L 211.160616 163.164288 
+L 211.091891 163.267059 
+L 211.023166 163.369607 
+L 210.954442 163.471933 
+L 210.885717 163.57404 
+L 210.816992 163.675926 
+L 210.748267 163.777595 
+L 210.679543 163.879045 
+L 210.610818 163.980279 
+L 210.542093 164.081298 
+L 210.473369 164.182101 
+L 210.404644 164.28269 
+L 210.335919 164.383067 
+L 210.267194 164.483231 
+L 210.19847 164.583184 
+L 210.129745 164.682927 
+L 210.06102 164.78246 
+L 209.992295 164.881785 
+L 209.923571 164.980902 
+L 209.854846 165.079812 
+L 209.786121 165.178516 
+L 209.717396 165.277016 
+L 209.648672 165.37531 
+L 209.579947 165.473402 
+L 209.511222 165.571291 
+L 209.442498 165.668978 
+L 209.373773 165.766464 
+L 209.305048 165.86375 
+L 209.236323 165.960837 
+L 209.167599 166.057725 
+L 209.098874 166.154416 
+L 209.030149 166.25091 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
-    <path d="M 209.030149 156.82091 
-L 208.790932 157.08239 
-L 208.551716 157.342435 
-L 208.312499 157.60106 
-L 208.073282 157.858282 
-L 207.834066 158.114115 
-L 207.594849 158.368575 
-L 207.355632 158.621675 
-L 207.116416 158.873431 
-L 206.877199 159.123857 
-L 206.637982 159.372966 
-L 206.398766 159.620772 
-L 206.159549 159.867289 
-L 205.920332 160.112531 
-L 205.681116 160.356509 
-L 205.441899 160.599239 
-L 205.202682 160.840731 
-L 204.963466 161.080999 
-L 204.724249 161.320055 
-L 204.485032 161.55791 
-L 204.245816 161.794578 
-L 204.006599 162.03007 
-L 203.767382 162.264398 
-L 203.528166 162.497572 
-L 203.288949 162.729605 
-L 203.049732 162.960507 
-L 202.810516 163.19029 
-L 202.571299 163.418963 
-L 202.332082 163.646539 
-L 202.092866 163.873027 
-L 201.853649 164.098437 
-L 201.614432 164.322781 
-L 201.375216 164.546067 
-L 201.135999 164.768307 
-L 200.896782 164.989508 
-L 200.657566 165.209683 
-L 200.418349 165.428839 
-L 200.179132 165.646986 
-L 199.939916 165.864133 
-L 199.700699 166.08029 
-L 199.461482 166.295465 
-L 199.222266 166.509668 
-L 198.983049 166.722907 
-L 198.743832 166.935191 
-L 198.504616 167.146528 
-L 198.265399 167.356927 
-L 198.026182 167.566396 
-L 197.786966 167.774943 
-L 197.547749 167.982576 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 209.030149 166.25091 
+L 208.790932 166.364843 
+L 208.551716 166.478503 
+L 208.312499 166.591891 
+L 208.073282 166.705008 
+L 207.834066 166.817856 
+L 207.594849 166.930436 
+L 207.355632 167.04275 
+L 207.116416 167.154797 
+L 206.877199 167.266581 
+L 206.637982 167.378102 
+L 206.398766 167.48936 
+L 206.159549 167.600359 
+L 205.920332 167.711097 
+L 205.681116 167.821578 
+L 205.441899 167.931802 
+L 205.202682 168.04177 
+L 204.963466 168.151484 
+L 204.724249 168.260944 
+L 204.485032 168.370152 
+L 204.245816 168.479109 
+L 204.006599 168.587816 
+L 203.767382 168.696275 
+L 203.528166 168.804485 
+L 203.288949 168.91245 
+L 203.049732 169.020169 
+L 202.810516 169.127643 
+L 202.571299 169.234875 
+L 202.332082 169.341864 
+L 202.092866 169.448613 
+L 201.853649 169.555121 
+L 201.614432 169.661391 
+L 201.375216 169.767423 
+L 201.135999 169.873219 
+L 200.896782 169.978779 
+L 200.657566 170.084104 
+L 200.418349 170.189196 
+L 200.179132 170.294055 
+L 199.939916 170.398683 
+L 199.700699 170.50308 
+L 199.461482 170.607248 
+L 199.222266 170.711188 
+L 198.983049 170.8149 
+L 198.743832 170.918385 
+L 198.504616 171.021645 
+L 198.265399 171.124681 
+L 198.026182 171.227493 
+L 197.786966 171.330083 
+L 197.547749 171.432451 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
-    <path d="M 197.547749 167.982576 
-L 197.490906 168.014495 
-L 197.434063 168.046392 
-L 197.37722 168.078268 
-L 197.320377 168.110123 
-L 197.263534 168.141956 
-L 197.206691 168.173768 
-L 197.149848 168.205558 
-L 197.093005 168.237327 
-L 197.036162 168.269075 
-L 196.979319 168.300802 
-L 196.922476 168.332507 
-L 196.865633 168.364192 
-L 196.80879 168.395855 
-L 196.751947 168.427497 
-L 196.695104 168.459117 
-L 196.638261 168.490717 
-L 196.581418 168.522296 
-L 196.524576 168.553853 
-L 196.467733 168.58539 
-L 196.41089 168.616906 
-L 196.354047 168.6484 
-L 196.297204 168.679874 
-L 196.240361 168.711327 
-L 196.183518 168.742759 
-L 196.126675 168.77417 
-L 196.069832 168.805561 
-L 196.012989 168.83693 
-L 195.956146 168.868279 
-L 195.899303 168.899607 
-L 195.84246 168.930915 
-L 195.785617 168.962201 
-L 195.728774 168.993468 
-L 195.671931 169.024713 
-L 195.615088 169.055938 
-L 195.558245 169.087142 
-L 195.501402 169.118326 
-L 195.444559 169.14949 
-L 195.387716 169.180632 
-L 195.330873 169.211755 
-L 195.27403 169.242857 
-L 195.217187 169.273938 
-L 195.160344 169.305 
-L 195.103501 169.33604 
-L 195.046658 169.367061 
-L 194.989815 169.398061 
-L 194.932972 169.429041 
-L 194.876129 169.460001 
-L 194.819287 169.49094 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 197.547749 171.432451 
+L 197.490906 171.512489 
+L 197.434063 171.592391 
+L 197.37722 171.67216 
+L 197.320377 171.751794 
+L 197.263534 171.831294 
+L 197.206691 171.910662 
+L 197.149848 171.989897 
+L 197.093005 172.068999 
+L 197.036162 172.14797 
+L 196.979319 172.226809 
+L 196.922476 172.305518 
+L 196.865633 172.384096 
+L 196.80879 172.462544 
+L 196.751947 172.540862 
+L 196.695104 172.619051 
+L 196.638261 172.697112 
+L 196.581418 172.775044 
+L 196.524576 172.852848 
+L 196.467733 172.930524 
+L 196.41089 173.008074 
+L 196.354047 173.085497 
+L 196.297204 173.162793 
+L 196.240361 173.239964 
+L 196.183518 173.317009 
+L 196.126675 173.39393 
+L 196.069832 173.470725 
+L 196.012989 173.547397 
+L 195.956146 173.623944 
+L 195.899303 173.700368 
+L 195.84246 173.77667 
+L 195.785617 173.852848 
+L 195.728774 173.928904 
+L 195.671931 174.004839 
+L 195.615088 174.080652 
+L 195.558245 174.156344 
+L 195.501402 174.231915 
+L 195.444559 174.307366 
+L 195.387716 174.382697 
+L 195.330873 174.457908 
+L 195.27403 174.533001 
+L 195.217187 174.607974 
+L 195.160344 174.68283 
+L 195.103501 174.757567 
+L 195.046658 174.832186 
+L 194.989815 174.906688 
+L 194.932972 174.981074 
+L 194.876129 175.055342 
+L 194.819287 175.129495 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
-    <path d="M 194.819287 169.49094 
-L 194.783943 169.66027 
-L 194.748599 169.828997 
-L 194.713256 169.997126 
-L 194.677912 170.16466 
-L 194.642568 170.331604 
-L 194.607224 170.497962 
-L 194.571881 170.663738 
-L 194.536537 170.828936 
-L 194.501193 170.99356 
-L 194.46585 171.157614 
-L 194.430506 171.321102 
-L 194.395162 171.484028 
-L 194.359819 171.646396 
-L 194.324475 171.808209 
-L 194.289131 171.969472 
-L 194.253788 172.130188 
-L 194.218444 172.290361 
-L 194.1831 172.449994 
-L 194.147757 172.609091 
-L 194.112413 172.767656 
-L 194.077069 172.925692 
-L 194.041726 173.083203 
-L 194.006382 173.240192 
-L 193.971038 173.396663 
-L 193.935695 173.552618 
-L 193.900351 173.708062 
-L 193.865007 173.862998 
-L 193.829664 174.017429 
-L 193.79432 174.171359 
-L 193.758976 174.32479 
-L 193.723633 174.477725 
-L 193.688289 174.630169 
-L 193.652945 174.782124 
-L 193.617602 174.933594 
-L 193.582258 175.08458 
-L 193.546914 175.235088 
-L 193.511571 175.385118 
-L 193.476227 175.534675 
-L 193.440883 175.683762 
-L 193.40554 175.832381 
-L 193.370196 175.980536 
-L 193.334852 176.128228 
-L 193.299509 176.275462 
-L 193.264165 176.42224 
-L 193.228821 176.568565 
-L 193.193478 176.714439 
-L 193.158134 176.859866 
-L 193.12279 177.004847 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 194.819287 175.129495 
+L 194.783943 175.273863 
+L 194.748599 175.417793 
+L 194.713256 175.561288 
+L 194.677912 175.704349 
+L 194.642568 175.84698 
+L 194.607224 175.989182 
+L 194.571881 176.13096 
+L 194.536537 176.272315 
+L 194.501193 176.413249 
+L 194.46585 176.553765 
+L 194.430506 176.693867 
+L 194.395162 176.833555 
+L 194.359819 176.972833 
+L 194.324475 177.111703 
+L 194.289131 177.250167 
+L 194.253788 177.388228 
+L 194.218444 177.525887 
+L 194.1831 177.663149 
+L 194.147757 177.800014 
+L 194.112413 177.936484 
+L 194.077069 178.072563 
+L 194.041726 178.208253 
+L 194.006382 178.343555 
+L 193.971038 178.478472 
+L 193.935695 178.613006 
+L 193.900351 178.747159 
+L 193.865007 178.880934 
+L 193.829664 179.014332 
+L 193.79432 179.147356 
+L 193.758976 179.280007 
+L 193.723633 179.412289 
+L 193.688289 179.544202 
+L 193.652945 179.675749 
+L 193.617602 179.806932 
+L 193.582258 179.937753 
+L 193.546914 180.068214 
+L 193.511571 180.198316 
+L 193.476227 180.328063 
+L 193.440883 180.457455 
+L 193.40554 180.586496 
+L 193.370196 180.715185 
+L 193.334852 180.843527 
+L 193.299509 180.971521 
+L 193.264165 181.099172 
+L 193.228821 181.226479 
+L 193.193478 181.353445 
+L 193.158134 181.480072 
+L 193.12279 181.606362 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
-    <path d="M 193.12279 177.004847 
-L 193.116023 177.111087 
-L 193.109255 177.217089 
-L 193.102487 177.322854 
-L 193.095719 177.428384 
-L 193.088952 177.533679 
-L 193.082184 177.638741 
-L 193.075416 177.74357 
-L 193.068649 177.848168 
-L 193.061881 177.952536 
-L 193.055113 178.056675 
-L 193.048345 178.160585 
-L 193.041578 178.264267 
-L 193.03481 178.367724 
-L 193.028042 178.470954 
-L 193.021274 178.573961 
-L 193.014507 178.676744 
-L 193.007739 178.779305 
-L 193.000971 178.881644 
-L 192.994204 178.983763 
-L 192.987436 179.085662 
-L 192.980668 179.187342 
-L 192.9739 179.288805 
-L 192.967133 179.390051 
-L 192.960365 179.491081 
-L 192.953597 179.591896 
-L 192.94683 179.692497 
-L 192.940062 179.792886 
-L 192.933294 179.893061 
-L 192.926526 179.993026 
-L 192.919759 180.09278 
-L 192.912991 180.192325 
-L 192.906223 180.29166 
-L 192.899456 180.390789 
-L 192.892688 180.48971 
-L 192.88592 180.588425 
-L 192.879152 180.686935 
-L 192.872385 180.78524 
-L 192.865617 180.883342 
-L 192.858849 180.981242 
-L 192.852082 181.078939 
-L 192.845314 181.176436 
-L 192.838546 181.273732 
-L 192.831778 181.370829 
-L 192.825011 181.467728 
-L 192.818243 181.564429 
-L 192.811475 181.660932 
-L 192.804707 181.75724 
-L 192.79794 181.853352 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 193.12279 181.606362 
+L 193.116023 181.783765 
+L 193.109255 181.960508 
+L 193.102487 182.136593 
+L 193.095719 182.312027 
+L 193.088952 182.486814 
+L 193.082184 182.660959 
+L 193.075416 182.834466 
+L 193.068649 183.00734 
+L 193.061881 183.179587 
+L 193.055113 183.351209 
+L 193.048345 183.522213 
+L 193.041578 183.692601 
+L 193.03481 183.86238 
+L 193.028042 184.031552 
+L 193.021274 184.200123 
+L 193.014507 184.368096 
+L 193.007739 184.535477 
+L 193.000971 184.702268 
+L 192.994204 184.868474 
+L 192.987436 185.0341 
+L 192.980668 185.199149 
+L 192.9739 185.363625 
+L 192.967133 185.527532 
+L 192.960365 185.690875 
+L 192.953597 185.853656 
+L 192.94683 186.015881 
+L 192.940062 186.177552 
+L 192.933294 186.338673 
+L 192.926526 186.499249 
+L 192.919759 186.659282 
+L 192.912991 186.818777 
+L 192.906223 186.977738 
+L 192.899456 187.136166 
+L 192.892688 187.294067 
+L 192.88592 187.451444 
+L 192.879152 187.6083 
+L 192.872385 187.764639 
+L 192.865617 187.920463 
+L 192.858849 188.075778 
+L 192.852082 188.230584 
+L 192.845314 188.384887 
+L 192.838546 188.538689 
+L 192.831778 188.691994 
+L 192.825011 188.844804 
+L 192.818243 188.997124 
+L 192.811475 189.148955 
+L 192.804707 189.300302 
+L 192.79794 189.451167 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="mfa8147e441" d="M 0 -2.5 
+     <path id="m737e32427b" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,437 +4116,437 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p1218df302b)">
-     <use xlink:href="#mfa8147e441" x="206.45578" y="118.264704" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfa8147e441" x="206.45578" y="117.943158" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfa8147e441" x="206.45578" y="118.023409" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfa8147e441" x="206.45578" y="118.008666" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfa8147e441" x="171.767499" y="133.507746" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfa8147e441" x="163.54283" y="144.396316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfa8147e441" x="160.174881" y="150.295858" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfa8147e441" x="154.179217" y="168.595905" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mfa8147e441" x="152.4406" y="178.324207" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p3aaf15e627)">
+     <use xlink:href="#m737e32427b" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m737e32427b" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m737e32427b" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m737e32427b" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m737e32427b" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m737e32427b" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m737e32427b" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m737e32427b" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m737e32427b" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
-    <path d="M 206.45578 118.264704 
-L 206.45578 118.258027 
-L 206.45578 118.25135 
-L 206.45578 118.244671 
-L 206.45578 118.237992 
-L 206.45578 118.231311 
-L 206.45578 118.22463 
-L 206.45578 118.217948 
-L 206.45578 118.211264 
-L 206.45578 118.20458 
-L 206.45578 118.197895 
-L 206.45578 118.191209 
-L 206.45578 118.184522 
-L 206.45578 118.177834 
-L 206.45578 118.171145 
-L 206.45578 118.164455 
-L 206.45578 118.157764 
-L 206.45578 118.151072 
-L 206.45578 118.14438 
-L 206.45578 118.137686 
-L 206.45578 118.130992 
-L 206.45578 118.124296 
-L 206.45578 118.1176 
-L 206.45578 118.110902 
-L 206.45578 118.104204 
-L 206.45578 118.097504 
-L 206.45578 118.090804 
-L 206.45578 118.084103 
-L 206.45578 118.077401 
-L 206.45578 118.070698 
-L 206.45578 118.063994 
-L 206.45578 118.057289 
-L 206.45578 118.050583 
-L 206.45578 118.043876 
-L 206.45578 118.037168 
-L 206.45578 118.030459 
-L 206.45578 118.023749 
-L 206.45578 118.017039 
-L 206.45578 118.010327 
-L 206.45578 118.003614 
-L 206.45578 117.996901 
-L 206.45578 117.990186 
-L 206.45578 117.983471 
-L 206.45578 117.976754 
-L 206.45578 117.970037 
-L 206.45578 117.963319 
-L 206.45578 117.9566 
-L 206.45578 117.949879 
-L 206.45578 117.943158 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 206.45578 118.584066 
+L 206.45578 118.577315 
+L 206.45578 118.570564 
+L 206.45578 118.563811 
+L 206.45578 118.557058 
+L 206.45578 118.550303 
+L 206.45578 118.543548 
+L 206.45578 118.536792 
+L 206.45578 118.530034 
+L 206.45578 118.523276 
+L 206.45578 118.516517 
+L 206.45578 118.509757 
+L 206.45578 118.502995 
+L 206.45578 118.496233 
+L 206.45578 118.48947 
+L 206.45578 118.482706 
+L 206.45578 118.475941 
+L 206.45578 118.469175 
+L 206.45578 118.462408 
+L 206.45578 118.45564 
+L 206.45578 118.448871 
+L 206.45578 118.442102 
+L 206.45578 118.435331 
+L 206.45578 118.428559 
+L 206.45578 118.421786 
+L 206.45578 118.415013 
+L 206.45578 118.408238 
+L 206.45578 118.401462 
+L 206.45578 118.394686 
+L 206.45578 118.387908 
+L 206.45578 118.381129 
+L 206.45578 118.37435 
+L 206.45578 118.367569 
+L 206.45578 118.360788 
+L 206.45578 118.354006 
+L 206.45578 118.347222 
+L 206.45578 118.340438 
+L 206.45578 118.333652 
+L 206.45578 118.326866 
+L 206.45578 118.320079 
+L 206.45578 118.31329 
+L 206.45578 118.306501 
+L 206.45578 118.299711 
+L 206.45578 118.29292 
+L 206.45578 118.286128 
+L 206.45578 118.279335 
+L 206.45578 118.27254 
+L 206.45578 118.265745 
+L 206.45578 118.258949 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
-    <path d="M 206.45578 117.943158 
-L 206.45578 117.944831 
-L 206.45578 117.946505 
-L 206.45578 117.948178 
-L 206.45578 117.949851 
-L 206.45578 117.951524 
-L 206.45578 117.953197 
-L 206.45578 117.95487 
-L 206.45578 117.956543 
-L 206.45578 117.958216 
-L 206.45578 117.959888 
-L 206.45578 117.961561 
-L 206.45578 117.963234 
-L 206.45578 117.964906 
-L 206.45578 117.966579 
-L 206.45578 117.968251 
-L 206.45578 117.969924 
-L 206.45578 117.971596 
-L 206.45578 117.973268 
-L 206.45578 117.97494 
-L 206.45578 117.976612 
-L 206.45578 117.978285 
-L 206.45578 117.979957 
-L 206.45578 117.981629 
-L 206.45578 117.983301 
-L 206.45578 117.984972 
-L 206.45578 117.986644 
-L 206.45578 117.988316 
-L 206.45578 117.989988 
-L 206.45578 117.991659 
-L 206.45578 117.993331 
-L 206.45578 117.995002 
-L 206.45578 117.996674 
-L 206.45578 117.998345 
-L 206.45578 118.000017 
-L 206.45578 118.001688 
-L 206.45578 118.003359 
-L 206.45578 118.00503 
-L 206.45578 118.006701 
-L 206.45578 118.008372 
-L 206.45578 118.010043 
-L 206.45578 118.011714 
-L 206.45578 118.013385 
-L 206.45578 118.015056 
-L 206.45578 118.016727 
-L 206.45578 118.018397 
-L 206.45578 118.020068 
-L 206.45578 118.021738 
-L 206.45578 118.023409 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 206.45578 118.258949 
+L 206.45578 118.269429 
+L 206.45578 118.279906 
+L 206.45578 118.29038 
+L 206.45578 118.300853 
+L 206.45578 118.311323 
+L 206.45578 118.32179 
+L 206.45578 118.332256 
+L 206.45578 118.342719 
+L 206.45578 118.35318 
+L 206.45578 118.363638 
+L 206.45578 118.374094 
+L 206.45578 118.384548 
+L 206.45578 118.395 
+L 206.45578 118.405449 
+L 206.45578 118.415896 
+L 206.45578 118.426341 
+L 206.45578 118.436783 
+L 206.45578 118.447223 
+L 206.45578 118.457661 
+L 206.45578 118.468096 
+L 206.45578 118.47853 
+L 206.45578 118.48896 
+L 206.45578 118.499389 
+L 206.45578 118.509815 
+L 206.45578 118.520239 
+L 206.45578 118.530661 
+L 206.45578 118.54108 
+L 206.45578 118.551498 
+L 206.45578 118.561912 
+L 206.45578 118.572325 
+L 206.45578 118.582735 
+L 206.45578 118.593143 
+L 206.45578 118.603549 
+L 206.45578 118.613952 
+L 206.45578 118.624353 
+L 206.45578 118.634752 
+L 206.45578 118.645149 
+L 206.45578 118.655543 
+L 206.45578 118.665935 
+L 206.45578 118.676325 
+L 206.45578 118.686712 
+L 206.45578 118.697097 
+L 206.45578 118.70748 
+L 206.45578 118.717861 
+L 206.45578 118.728239 
+L 206.45578 118.738615 
+L 206.45578 118.748989 
+L 206.45578 118.759361 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
-    <path d="M 206.45578 118.023409 
-L 206.45578 118.023102 
-L 206.45578 118.022795 
-L 206.45578 118.022488 
-L 206.45578 118.022181 
-L 206.45578 118.021873 
-L 206.45578 118.021566 
-L 206.45578 118.021259 
-L 206.45578 118.020952 
-L 206.45578 118.020645 
-L 206.45578 118.020338 
-L 206.45578 118.020031 
-L 206.45578 118.019724 
-L 206.45578 118.019417 
-L 206.45578 118.019109 
-L 206.45578 118.018802 
-L 206.45578 118.018495 
-L 206.45578 118.018188 
-L 206.45578 118.017881 
-L 206.45578 118.017574 
-L 206.45578 118.017267 
-L 206.45578 118.016959 
-L 206.45578 118.016652 
-L 206.45578 118.016345 
-L 206.45578 118.016038 
-L 206.45578 118.015731 
-L 206.45578 118.015424 
-L 206.45578 118.015117 
-L 206.45578 118.014809 
-L 206.45578 118.014502 
-L 206.45578 118.014195 
-L 206.45578 118.013888 
-L 206.45578 118.013581 
-L 206.45578 118.013274 
-L 206.45578 118.012966 
-L 206.45578 118.012659 
-L 206.45578 118.012352 
-L 206.45578 118.012045 
-L 206.45578 118.011738 
-L 206.45578 118.011431 
-L 206.45578 118.011123 
-L 206.45578 118.010816 
-L 206.45578 118.010509 
-L 206.45578 118.010202 
-L 206.45578 118.009895 
-L 206.45578 118.009588 
-L 206.45578 118.00928 
-L 206.45578 118.008973 
-L 206.45578 118.008666 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 206.45578 118.759361 
+L 206.45578 118.748494 
+L 206.45578 118.737626 
+L 206.45578 118.726755 
+L 206.45578 118.715881 
+L 206.45578 118.705005 
+L 206.45578 118.694127 
+L 206.45578 118.683246 
+L 206.45578 118.672362 
+L 206.45578 118.661476 
+L 206.45578 118.650587 
+L 206.45578 118.639696 
+L 206.45578 118.628803 
+L 206.45578 118.617907 
+L 206.45578 118.607008 
+L 206.45578 118.596107 
+L 206.45578 118.585203 
+L 206.45578 118.574297 
+L 206.45578 118.563389 
+L 206.45578 118.552477 
+L 206.45578 118.541564 
+L 206.45578 118.530648 
+L 206.45578 118.519729 
+L 206.45578 118.508808 
+L 206.45578 118.497884 
+L 206.45578 118.486958 
+L 206.45578 118.476029 
+L 206.45578 118.465098 
+L 206.45578 118.454164 
+L 206.45578 118.443228 
+L 206.45578 118.432289 
+L 206.45578 118.421348 
+L 206.45578 118.410404 
+L 206.45578 118.399457 
+L 206.45578 118.388509 
+L 206.45578 118.377557 
+L 206.45578 118.366603 
+L 206.45578 118.355647 
+L 206.45578 118.344687 
+L 206.45578 118.333726 
+L 206.45578 118.322762 
+L 206.45578 118.311795 
+L 206.45578 118.300826 
+L 206.45578 118.289854 
+L 206.45578 118.27888 
+L 206.45578 118.267903 
+L 206.45578 118.256924 
+L 206.45578 118.245942 
+L 206.45578 118.234957 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
-    <path d="M 206.45578 118.008666 
-L 205.733108 118.389096 
-L 205.010435 118.766496 
-L 204.287763 119.140915 
-L 203.56509 119.512398 
-L 202.842418 119.880992 
-L 202.119745 120.246742 
-L 201.397073 120.609689 
-L 200.6744 120.969879 
-L 199.951728 121.327351 
-L 199.229055 121.682147 
-L 198.506383 122.034306 
-L 197.78371 122.383867 
-L 197.061038 122.730869 
-L 196.338365 123.075348 
-L 195.615693 123.417342 
-L 194.89302 123.756885 
-L 194.170348 124.094012 
-L 193.447675 124.428758 
-L 192.725003 124.761156 
-L 192.00233 125.091239 
-L 191.279657 125.419038 
-L 190.556985 125.744585 
-L 189.834312 126.067912 
-L 189.11164 126.389047 
-L 188.388967 126.708021 
-L 187.666295 127.024862 
-L 186.943622 127.339598 
-L 186.22095 127.652258 
-L 185.498277 127.962869 
-L 184.775605 128.271457 
-L 184.052932 128.578049 
-L 183.33026 128.88267 
-L 182.607587 129.185345 
-L 181.884915 129.486099 
-L 181.162242 129.784957 
-L 180.43957 130.081941 
-L 179.716897 130.377076 
-L 178.994225 130.670385 
-L 178.271552 130.961889 
-L 177.54888 131.25161 
-L 176.826207 131.539572 
-L 176.103535 131.825794 
-L 175.380862 132.110298 
-L 174.658189 132.393103 
-L 173.935517 132.674231 
-L 173.212844 132.953702 
-L 172.490172 133.231533 
-L 171.767499 133.507746 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 206.45578 118.234957 
+L 205.733108 118.625841 
+L 205.010435 119.013527 
+L 204.287763 119.398069 
+L 203.56509 119.779515 
+L 202.842418 120.157917 
+L 202.119745 120.533321 
+L 201.397073 120.905775 
+L 200.6744 121.275326 
+L 199.951728 121.642017 
+L 199.229055 122.005894 
+L 198.506383 122.366998 
+L 197.78371 122.725372 
+L 197.061038 123.081057 
+L 196.338365 123.434093 
+L 195.615693 123.784518 
+L 194.89302 124.132372 
+L 194.170348 124.477692 
+L 193.447675 124.820514 
+L 192.725003 125.160874 
+L 192.00233 125.498808 
+L 191.279657 125.834349 
+L 190.556985 126.167532 
+L 189.834312 126.498389 
+L 189.11164 126.826952 
+L 188.388967 127.153254 
+L 187.666295 127.477325 
+L 186.943622 127.799195 
+L 186.22095 128.118894 
+L 185.498277 128.436451 
+L 184.775605 128.751895 
+L 184.052932 129.065253 
+L 183.33026 129.376553 
+L 182.607587 129.685822 
+L 181.884915 129.993087 
+L 181.162242 130.298372 
+L 180.43957 130.601703 
+L 179.716897 130.903106 
+L 178.994225 131.202604 
+L 178.271552 131.500222 
+L 177.54888 131.795983 
+L 176.826207 132.089909 
+L 176.103535 132.382024 
+L 175.380862 132.67235 
+L 174.658189 132.960908 
+L 173.935517 133.247721 
+L 173.212844 133.532808 
+L 172.490172 133.816191 
+L 171.767499 134.097889 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
-    <path d="M 171.767499 133.507746 
-L 171.596152 133.762085 
-L 171.424805 134.015066 
-L 171.253458 134.266703 
-L 171.08211 134.517012 
-L 170.910763 134.766005 
-L 170.739416 135.013697 
-L 170.568068 135.260101 
-L 170.396721 135.505231 
-L 170.225374 135.749099 
-L 170.054027 135.991718 
-L 169.882679 136.233102 
-L 169.711332 136.473262 
-L 169.539985 136.712212 
-L 169.368637 136.949962 
-L 169.19729 137.186526 
-L 169.025943 137.421914 
-L 168.854596 137.65614 
-L 168.683248 137.889213 
-L 168.511901 138.121145 
-L 168.340554 138.351948 
-L 168.169206 138.581632 
-L 167.997859 138.810209 
-L 167.826512 139.037688 
-L 167.655165 139.26408 
-L 167.483817 139.489396 
-L 167.31247 139.713646 
-L 167.141123 139.936839 
-L 166.969775 140.158986 
-L 166.798428 140.380097 
-L 166.627081 140.600181 
-L 166.455734 140.819247 
-L 166.284386 141.037306 
-L 166.113039 141.254365 
-L 165.941692 141.470435 
-L 165.770344 141.685525 
-L 165.598997 141.899642 
-L 165.42765 142.112796 
-L 165.256303 142.324996 
-L 165.084955 142.53625 
-L 164.913608 142.746566 
-L 164.742261 142.955953 
-L 164.570913 143.164419 
-L 164.399566 143.371972 
-L 164.228219 143.57862 
-L 164.056872 143.78437 
-L 163.885524 143.989231 
-L 163.714177 144.193211 
-L 163.54283 144.396316 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 171.767499 134.097889 
+L 171.596152 134.34384 
+L 171.424805 134.58852 
+L 171.253458 134.831944 
+L 171.08211 135.074124 
+L 170.910763 135.315074 
+L 170.739416 135.554804 
+L 170.568068 135.793328 
+L 170.396721 136.030658 
+L 170.225374 136.266805 
+L 170.054027 136.501782 
+L 169.882679 136.7356 
+L 169.711332 136.96827 
+L 169.539985 137.199803 
+L 169.368637 137.430211 
+L 169.19729 137.659504 
+L 169.025943 137.887693 
+L 168.854596 138.114789 
+L 168.683248 138.340802 
+L 168.511901 138.565743 
+L 168.340554 138.789621 
+L 168.169206 139.012446 
+L 167.997859 139.234229 
+L 167.826512 139.45498 
+L 167.655165 139.674706 
+L 167.483817 139.893419 
+L 167.31247 140.111128 
+L 167.141123 140.32784 
+L 166.969775 140.543567 
+L 166.798428 140.758316 
+L 166.627081 140.972097 
+L 166.455734 141.184918 
+L 166.284386 141.396787 
+L 166.113039 141.607714 
+L 165.941692 141.817706 
+L 165.770344 142.026772 
+L 165.598997 142.23492 
+L 165.42765 142.442157 
+L 165.256303 142.648493 
+L 165.084955 142.853934 
+L 164.913608 143.058489 
+L 164.742261 143.262165 
+L 164.570913 143.464969 
+L 164.399566 143.666909 
+L 164.228219 143.867993 
+L 164.056872 144.068227 
+L 163.885524 144.267619 
+L 163.714177 144.466175 
+L 163.54283 144.663903 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
-    <path d="M 163.54283 144.396316 
-L 163.472664 144.527021 
-L 163.402498 144.657366 
-L 163.332333 144.787354 
-L 163.262167 144.916986 
-L 163.192002 145.046264 
-L 163.121836 145.175191 
-L 163.051671 145.303768 
-L 162.981505 145.431997 
-L 162.911339 145.55988 
-L 162.841174 145.687419 
-L 162.771008 145.814616 
-L 162.700843 145.941472 
-L 162.630677 146.067989 
-L 162.560511 146.19417 
-L 162.490346 146.320015 
-L 162.42018 146.445527 
-L 162.350015 146.570708 
-L 162.279849 146.695559 
-L 162.209683 146.820081 
-L 162.139518 146.944278 
-L 162.069352 147.068149 
-L 161.999187 147.191698 
-L 161.929021 147.314926 
-L 161.858855 147.437834 
-L 161.78869 147.560424 
-L 161.718524 147.682697 
-L 161.648359 147.804656 
-L 161.578193 147.926302 
-L 161.508027 148.047636 
-L 161.437862 148.168661 
-L 161.367696 148.289377 
-L 161.297531 148.409787 
-L 161.227365 148.529891 
-L 161.157199 148.649692 
-L 161.087034 148.76919 
-L 161.016868 148.888388 
-L 160.946703 149.007287 
-L 160.876537 149.125889 
-L 160.806372 149.244194 
-L 160.736206 149.362205 
-L 160.66604 149.479922 
-L 160.595875 149.597348 
-L 160.525709 149.714484 
-L 160.455544 149.831331 
-L 160.385378 149.94789 
-L 160.315212 150.064163 
-L 160.245047 150.180152 
-L 160.174881 150.295858 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 163.54283 144.663903 
+L 163.472664 144.816985 
+L 163.402498 144.969575 
+L 163.332333 145.121674 
+L 163.262167 145.273287 
+L 163.192002 145.424417 
+L 163.121836 145.575066 
+L 163.051671 145.725238 
+L 162.981505 145.874936 
+L 162.911339 146.024163 
+L 162.841174 146.172921 
+L 162.771008 146.321213 
+L 162.700843 146.469044 
+L 162.630677 146.616414 
+L 162.560511 146.763328 
+L 162.490346 146.909788 
+L 162.42018 147.055797 
+L 162.350015 147.201357 
+L 162.279849 147.346472 
+L 162.209683 147.491143 
+L 162.139518 147.635375 
+L 162.069352 147.779169 
+L 161.999187 147.922528 
+L 161.929021 148.065455 
+L 161.858855 148.207952 
+L 161.78869 148.350022 
+L 161.718524 148.491667 
+L 161.648359 148.632891 
+L 161.578193 148.773694 
+L 161.508027 148.914081 
+L 161.437862 149.054054 
+L 161.367696 149.193614 
+L 161.297531 149.332764 
+L 161.227365 149.471507 
+L 161.157199 149.609845 
+L 161.087034 149.747781 
+L 161.016868 149.885316 
+L 160.946703 150.022454 
+L 160.876537 150.159196 
+L 160.806372 150.295544 
+L 160.736206 150.431501 
+L 160.66604 150.56707 
+L 160.595875 150.702252 
+L 160.525709 150.837049 
+L 160.455544 150.971464 
+L 160.385378 151.105499 
+L 160.315212 151.239156 
+L 160.245047 151.372438 
+L 160.174881 151.505345 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
-    <path d="M 160.174881 150.295858 
-L 160.049972 150.758919 
-L 159.925062 151.217498 
-L 159.800152 151.671683 
-L 159.675242 152.121555 
-L 159.550333 152.567198 
-L 159.425423 153.008688 
-L 159.300513 153.446103 
-L 159.175604 153.879518 
-L 159.050694 154.309005 
-L 158.925784 154.734634 
-L 158.800875 155.156474 
-L 158.675965 155.574592 
-L 158.551055 155.989053 
-L 158.426146 156.399921 
-L 158.301236 156.807257 
-L 158.176326 157.211122 
-L 158.051417 157.611574 
-L 157.926507 158.00867 
-L 157.801597 158.402467 
-L 157.676688 158.793018 
-L 157.551778 159.180376 
-L 157.426868 159.564594 
-L 157.301959 159.945722 
-L 157.177049 160.323809 
-L 157.052139 160.698903 
-L 156.92723 161.071052 
-L 156.80232 161.440301 
-L 156.67741 161.806695 
-L 156.552501 162.170278 
-L 156.427591 162.531092 
-L 156.302681 162.88918 
-L 156.177772 163.244583 
-L 156.052862 163.59734 
-L 155.927952 163.94749 
-L 155.803043 164.295072 
-L 155.678133 164.640124 
-L 155.553223 164.982681 
-L 155.428313 165.322779 
-L 155.303404 165.660454 
-L 155.178494 165.99574 
-L 155.053584 166.328671 
-L 154.928675 166.659279 
-L 154.803765 166.987596 
-L 154.678855 167.313654 
-L 154.553946 167.637484 
-L 154.429036 167.959116 
-L 154.304126 168.27858 
-L 154.179217 168.595905 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 160.174881 151.505345 
+L 160.049972 151.953237 
+L 159.925062 152.396937 
+L 159.800152 152.836521 
+L 159.675242 153.272066 
+L 159.550333 153.703645 
+L 159.425423 154.13133 
+L 159.300513 154.555191 
+L 159.175604 154.975295 
+L 159.050694 155.391708 
+L 158.925784 155.804494 
+L 158.800875 156.213717 
+L 158.675965 156.619437 
+L 158.551055 157.021713 
+L 158.426146 157.420604 
+L 158.301236 157.816166 
+L 158.176326 158.208455 
+L 158.051417 158.597523 
+L 157.926507 158.983424 
+L 157.801597 159.366208 
+L 157.676688 159.745925 
+L 157.551778 160.122625 
+L 157.426868 160.496355 
+L 157.301959 160.867161 
+L 157.177049 161.235088 
+L 157.052139 161.600182 
+L 156.92723 161.962484 
+L 156.80232 162.322039 
+L 156.67741 162.678887 
+L 156.552501 163.033068 
+L 156.427591 163.384622 
+L 156.302681 163.733588 
+L 156.177772 164.080003 
+L 156.052862 164.423905 
+L 155.927952 164.76533 
+L 155.803043 165.104313 
+L 155.678133 165.440889 
+L 155.553223 165.775091 
+L 155.428313 166.106954 
+L 155.303404 166.43651 
+L 155.178494 166.76379 
+L 155.053584 167.088825 
+L 154.928675 167.411647 
+L 154.803765 167.732285 
+L 154.678855 168.050769 
+L 154.553946 168.367127 
+L 154.429036 168.681387 
+L 154.304126 168.993578 
+L 154.179217 169.303726 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
-    <path d="M 154.179217 168.595905 
-L 154.142996 168.820349 
-L 154.106774 169.043734 
-L 154.070553 169.266071 
-L 154.034332 169.48737 
-L 153.998111 169.707641 
-L 153.96189 169.926892 
-L 153.925669 170.145133 
-L 153.889447 170.362374 
-L 153.853226 170.578624 
-L 153.817005 170.793892 
-L 153.780784 171.008186 
-L 153.744563 171.221515 
-L 153.708342 171.433888 
-L 153.67212 171.645314 
-L 153.635899 171.8558 
-L 153.599678 172.065356 
-L 153.563457 172.273989 
-L 153.527236 172.481708 
-L 153.491014 172.68852 
-L 153.454793 172.894434 
-L 153.418572 173.099457 
-L 153.382351 173.303596 
-L 153.34613 173.50686 
-L 153.309909 173.709256 
-L 153.273687 173.910791 
-L 153.237466 174.111472 
-L 153.201245 174.311308 
-L 153.165024 174.510304 
-L 153.128803 174.708468 
-L 153.092582 174.905807 
-L 153.05636 175.102327 
-L 153.020139 175.298036 
-L 152.983918 175.49294 
-L 152.947697 175.687045 
-L 152.911476 175.880359 
-L 152.875255 176.072888 
-L 152.839033 176.264637 
-L 152.802812 176.455614 
-L 152.766591 176.645824 
-L 152.73037 176.835273 
-L 152.694149 177.023969 
-L 152.657928 177.211915 
-L 152.621706 177.39912 
-L 152.585485 177.585588 
-L 152.549264 177.771325 
-L 152.513043 177.956336 
-L 152.476822 178.140629 
-L 152.4406 178.324207 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 154.179217 169.303726 
+L 154.142996 169.516824 
+L 154.106774 169.728968 
+L 154.070553 169.940167 
+L 154.034332 170.15043 
+L 153.998111 170.359763 
+L 153.96189 170.568177 
+L 153.925669 170.775677 
+L 153.889447 170.982274 
+L 153.853226 171.187974 
+L 153.817005 171.392785 
+L 153.780784 171.596715 
+L 153.744563 171.799771 
+L 153.708342 172.001961 
+L 153.67212 172.203292 
+L 153.635899 172.403772 
+L 153.599678 172.603407 
+L 153.563457 172.802205 
+L 153.527236 173.000172 
+L 153.491014 173.197317 
+L 153.454793 173.393644 
+L 153.418572 173.589162 
+L 153.382351 173.783877 
+L 153.34613 173.977795 
+L 153.309909 174.170923 
+L 153.273687 174.363267 
+L 153.237466 174.554834 
+L 153.201245 174.745629 
+L 153.165024 174.93566 
+L 153.128803 175.124932 
+L 153.092582 175.313451 
+L 153.05636 175.501224 
+L 153.020139 175.688255 
+L 152.983918 175.874551 
+L 152.947697 176.060118 
+L 152.911476 176.244961 
+L 152.875255 176.429087 
+L 152.839033 176.612499 
+L 152.802812 176.795205 
+L 152.766591 176.977209 
+L 152.73037 177.158517 
+L 152.694149 177.339134 
+L 152.657928 177.519066 
+L 152.621706 177.698317 
+L 152.585485 177.876892 
+L 152.549264 178.054798 
+L 152.513043 178.232038 
+L 152.476822 178.408618 
+L 152.4406 178.584542 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m87d12b9912" d="M 0 -2.5 
+     <path id="m318fe77cb1" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,433 +4555,433 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1218df302b)">
-     <use xlink:href="#m87d12b9912" x="610.467188" y="173.595159" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87d12b9912" x="592.067397" y="175.027997" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87d12b9912" x="534.807821" y="181.390376" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87d12b9912" x="327.802209" y="176.703263" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87d12b9912" x="275.83761" y="187.043834" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87d12b9912" x="258.25125" y="199.15685" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87d12b9912" x="256.777056" y="204.107569" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87d12b9912" x="248.769854" y="218.250617" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87d12b9912" x="246.264594" y="228.00198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3aaf15e627)">
+     <use xlink:href="#m318fe77cb1" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318fe77cb1" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318fe77cb1" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318fe77cb1" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318fe77cb1" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318fe77cb1" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318fe77cb1" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318fe77cb1" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m318fe77cb1" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
-    <path d="M 610.467188 173.595159 
-L 610.083859 173.625456 
-L 609.70053 173.655734 
-L 609.317201 173.685992 
-L 608.933872 173.716231 
-L 608.550543 173.746451 
-L 608.167214 173.776651 
-L 607.783885 173.806832 
-L 607.400556 173.836994 
-L 607.017227 173.867137 
-L 606.633898 173.897261 
-L 606.250569 173.927365 
-L 605.86724 173.957451 
-L 605.483911 173.987517 
-L 605.100582 174.017564 
-L 604.717253 174.047592 
-L 604.333924 174.077601 
-L 603.950595 174.107592 
-L 603.567266 174.137563 
-L 603.183937 174.167515 
-L 602.800608 174.197449 
-L 602.417279 174.227363 
-L 602.03395 174.257259 
-L 601.650621 174.287135 
-L 601.267292 174.316993 
-L 600.883963 174.346832 
-L 600.500634 174.376653 
-L 600.117305 174.406454 
-L 599.733976 174.436237 
-L 599.350647 174.466001 
-L 598.967318 174.495747 
-L 598.583989 174.525474 
-L 598.20066 174.555182 
-L 597.817331 174.584871 
-L 597.434002 174.614542 
-L 597.050673 174.644195 
-L 596.667344 174.673829 
-L 596.284015 174.703444 
-L 595.900686 174.733041 
-L 595.517357 174.762619 
-L 595.134028 174.792179 
-L 594.750699 174.821721 
-L 594.367371 174.851244 
-L 593.984042 174.880748 
-L 593.600713 174.910235 
-L 593.217384 174.939703 
-L 592.834055 174.969152 
-L 592.450726 174.998584 
-L 592.067397 175.027997 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467188 172.829682 
+L 610.083859 172.849333 
+L 609.70053 172.868975 
+L 609.317201 172.888609 
+L 608.933872 172.908235 
+L 608.550543 172.927853 
+L 608.167214 172.947463 
+L 607.783885 172.967065 
+L 607.400556 172.986659 
+L 607.017227 173.006244 
+L 606.633898 173.025822 
+L 606.250569 173.045391 
+L 605.86724 173.064953 
+L 605.483911 173.084506 
+L 605.100582 173.104051 
+L 604.717253 173.123588 
+L 604.333924 173.143117 
+L 603.950595 173.162638 
+L 603.567266 173.182151 
+L 603.183937 173.201656 
+L 602.800608 173.221153 
+L 602.417279 173.240642 
+L 602.03395 173.260123 
+L 601.650621 173.279596 
+L 601.267292 173.299061 
+L 600.883963 173.318518 
+L 600.500634 173.337967 
+L 600.117305 173.357408 
+L 599.733976 173.376841 
+L 599.350647 173.396266 
+L 598.967318 173.415683 
+L 598.583989 173.435092 
+L 598.20066 173.454493 
+L 597.817331 173.473887 
+L 597.434002 173.493272 
+L 597.050673 173.512649 
+L 596.667344 173.532019 
+L 596.284015 173.551381 
+L 595.900686 173.570734 
+L 595.517357 173.59008 
+L 595.134028 173.609418 
+L 594.750699 173.628748 
+L 594.367371 173.64807 
+L 593.984042 173.667384 
+L 593.600713 173.686691 
+L 593.217384 173.705989 
+L 592.834055 173.72528 
+L 592.450726 173.744563 
+L 592.067397 173.763838 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
-    <path d="M 592.067397 175.027997 
-L 590.874489 175.169645 
-L 589.681581 175.31087 
-L 588.488673 175.451676 
-L 587.295765 175.592065 
-L 586.102857 175.732039 
-L 584.90995 175.8716 
-L 583.717042 176.010752 
-L 582.524134 176.149497 
-L 581.331226 176.287837 
-L 580.138318 176.425773 
-L 578.94541 176.56331 
-L 577.752503 176.700449 
-L 576.559595 176.837191 
-L 575.366687 176.973541 
-L 574.173779 177.109499 
-L 572.980871 177.245068 
-L 571.787963 177.380251 
-L 570.595056 177.515049 
-L 569.402148 177.649464 
-L 568.20924 177.7835 
-L 567.016332 177.917157 
-L 565.823424 178.050439 
-L 564.630516 178.183346 
-L 563.437609 178.315882 
-L 562.244701 178.448048 
-L 561.051793 178.579847 
-L 559.858885 178.71128 
-L 558.665977 178.84235 
-L 557.473069 178.973058 
-L 556.280162 179.103407 
-L 555.087254 179.233398 
-L 553.894346 179.363033 
-L 552.701438 179.492315 
-L 551.50853 179.621245 
-L 550.315622 179.749826 
-L 549.122715 179.878058 
-L 547.929807 180.005944 
-L 546.736899 180.133486 
-L 545.543991 180.260686 
-L 544.351083 180.387545 
-L 543.158175 180.514066 
-L 541.965268 180.640249 
-L 540.77236 180.766098 
-L 539.579452 180.891613 
-L 538.386544 181.016797 
-L 537.193636 181.14165 
-L 536.000728 181.266176 
-L 534.807821 181.390376 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 592.067397 173.763838 
+L 590.874489 173.911651 
+L 589.681581 174.059005 
+L 588.488673 174.205903 
+L 587.295765 174.352346 
+L 586.102857 174.498339 
+L 584.90995 174.643883 
+L 583.717042 174.788982 
+L 582.524134 174.933638 
+L 581.331226 175.077854 
+L 580.138318 175.221632 
+L 578.94541 175.364975 
+L 577.752503 175.507887 
+L 576.559595 175.650368 
+L 575.366687 175.792423 
+L 574.173779 175.934053 
+L 572.980871 176.075262 
+L 571.787963 176.21605 
+L 570.595056 176.356422 
+L 569.402148 176.49638 
+L 568.20924 176.635925 
+L 567.016332 176.775061 
+L 565.823424 176.913789 
+L 564.630516 177.052113 
+L 563.437609 177.190034 
+L 562.244701 177.327555 
+L 561.051793 177.464678 
+L 559.858885 177.601406 
+L 558.665977 177.73774 
+L 557.473069 177.873684 
+L 556.280162 178.009238 
+L 555.087254 178.144406 
+L 553.894346 178.27919 
+L 552.701438 178.413591 
+L 551.50853 178.547613 
+L 550.315622 178.681256 
+L 549.122715 178.814524 
+L 547.929807 178.947418 
+L 546.736899 179.079941 
+L 545.543991 179.212094 
+L 544.351083 179.34388 
+L 543.158175 179.4753 
+L 541.965268 179.606357 
+L 540.77236 179.737052 
+L 539.579452 179.867389 
+L 538.386544 179.997367 
+L 537.193636 180.126991 
+L 536.000728 180.25626 
+L 534.807821 180.385179 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
-    <path d="M 534.807821 181.390376 
-L 530.495204 181.29731 
-L 526.182587 181.204061 
-L 521.86997 181.110628 
-L 517.557353 181.017011 
-L 513.244736 180.923208 
-L 508.932119 180.829219 
-L 504.619502 180.735044 
-L 500.306885 180.640681 
-L 495.994268 180.54613 
-L 491.681651 180.451389 
-L 487.369035 180.356459 
-L 483.056418 180.261339 
-L 478.743801 180.166027 
-L 474.431184 180.070523 
-L 470.118567 179.974826 
-L 465.80595 179.878935 
-L 461.493333 179.78285 
-L 457.180716 179.68657 
-L 452.868099 179.590094 
-L 448.555482 179.493421 
-L 444.242865 179.39655 
-L 439.930249 179.299481 
-L 435.617632 179.202213 
-L 431.305015 179.104745 
-L 426.992398 179.007075 
-L 422.679781 178.909204 
-L 418.367164 178.811131 
-L 414.054547 178.712854 
-L 409.74193 178.614373 
-L 405.429313 178.515687 
-L 401.116696 178.416794 
-L 396.804079 178.317696 
-L 392.491462 178.218389 
-L 388.178846 178.118874 
-L 383.866229 178.019149 
-L 379.553612 177.919214 
-L 375.240995 177.819068 
-L 370.928378 177.71871 
-L 366.615761 177.618139 
-L 362.303144 177.517354 
-L 357.990527 177.416354 
-L 353.67791 177.315138 
-L 349.365293 177.213706 
-L 345.052676 177.112057 
-L 340.74006 177.010188 
-L 336.427443 176.9081 
-L 332.114826 176.805792 
-L 327.802209 176.703263 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 534.807821 180.385179 
+L 530.495204 180.30112 
+L 526.182587 180.216911 
+L 521.86997 180.132553 
+L 517.557353 180.048044 
+L 513.244736 179.963384 
+L 508.932119 179.878573 
+L 504.619502 179.79361 
+L 500.306885 179.708494 
+L 495.994268 179.623226 
+L 491.681651 179.537803 
+L 487.369035 179.452226 
+L 483.056418 179.366495 
+L 478.743801 179.280608 
+L 474.431184 179.194565 
+L 470.118567 179.108366 
+L 465.80595 179.02201 
+L 461.493333 178.935496 
+L 457.180716 178.848823 
+L 452.868099 178.761993 
+L 448.555482 178.675002 
+L 444.242865 178.587852 
+L 439.930249 178.500541 
+L 435.617632 178.413069 
+L 431.305015 178.325436 
+L 426.992398 178.23764 
+L 422.679781 178.149681 
+L 418.367164 178.061559 
+L 414.054547 177.973272 
+L 409.74193 177.884821 
+L 405.429313 177.796204 
+L 401.116696 177.707422 
+L 396.804079 177.618473 
+L 392.491462 177.529356 
+L 388.178846 177.440072 
+L 383.866229 177.350619 
+L 379.553612 177.260997 
+L 375.240995 177.171205 
+L 370.928378 177.081243 
+L 366.615761 176.99111 
+L 362.303144 176.900805 
+L 357.990527 176.810328 
+L 353.67791 176.719677 
+L 349.365293 176.628853 
+L 345.052676 176.537855 
+L 340.74006 176.446681 
+L 336.427443 176.355332 
+L 332.114826 176.263806 
+L 327.802209 176.172104 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
-    <path d="M 327.802209 176.703263 
-L 326.719613 176.943393 
-L 325.637017 177.182313 
-L 324.554421 177.420034 
-L 323.471826 177.656568 
-L 322.38923 177.891928 
-L 321.306634 178.126124 
-L 320.224038 178.359169 
-L 319.141442 178.591074 
-L 318.058846 178.821849 
-L 316.976251 179.051506 
-L 315.893655 179.280055 
-L 314.811059 179.507507 
-L 313.728463 179.733872 
-L 312.645867 179.959162 
-L 311.563272 180.183385 
-L 310.480676 180.406553 
-L 309.39808 180.628674 
-L 308.315484 180.84976 
-L 307.232888 181.069818 
-L 306.150292 181.28886 
-L 305.067697 181.506893 
-L 303.985101 181.723928 
-L 302.902505 181.939974 
-L 301.819909 182.155039 
-L 300.737313 182.369132 
-L 299.654718 182.582263 
-L 298.572122 182.794439 
-L 297.489526 183.00567 
-L 296.40693 183.215963 
-L 295.324334 183.425327 
-L 294.241738 183.633771 
-L 293.159143 183.841301 
-L 292.076547 184.047926 
-L 290.993951 184.253655 
-L 289.911355 184.458494 
-L 288.828759 184.662452 
-L 287.746164 184.865535 
-L 286.663568 185.067752 
-L 285.580972 185.26911 
-L 284.498376 185.469616 
-L 283.41578 185.669277 
-L 282.333184 185.8681 
-L 281.250589 186.066093 
-L 280.167993 186.263261 
-L 279.085397 186.459613 
-L 278.002801 186.655155 
-L 276.920205 186.849893 
-L 275.83761 187.043834 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 327.802209 176.172104 
+L 326.719613 176.417963 
+L 325.637017 176.662553 
+L 324.554421 176.905888 
+L 323.471826 177.14798 
+L 322.38923 177.388842 
+L 321.306634 177.628486 
+L 320.224038 177.866924 
+L 319.141442 178.104169 
+L 318.058846 178.340233 
+L 316.976251 178.575126 
+L 315.893655 178.808861 
+L 314.811059 179.04145 
+L 313.728463 179.272902 
+L 312.645867 179.50323 
+L 311.563272 179.732444 
+L 310.480676 179.960555 
+L 309.39808 180.187573 
+L 308.315484 180.41351 
+L 307.232888 180.638374 
+L 306.150292 180.862176 
+L 305.067697 181.084927 
+L 303.985101 181.306636 
+L 302.902505 181.527313 
+L 301.819909 181.746967 
+L 300.737313 181.965608 
+L 299.654718 182.183245 
+L 298.572122 182.399887 
+L 297.489526 182.615544 
+L 296.40693 182.830223 
+L 295.324334 183.043935 
+L 294.241738 183.256688 
+L 293.159143 183.46849 
+L 292.076547 183.679349 
+L 290.993951 183.889275 
+L 289.911355 184.098275 
+L 288.828759 184.306358 
+L 287.746164 184.513531 
+L 286.663568 184.719802 
+L 285.580972 184.92518 
+L 284.498376 185.129672 
+L 283.41578 185.333285 
+L 282.333184 185.536027 
+L 281.250589 185.737906 
+L 280.167993 185.938929 
+L 279.085397 186.139102 
+L 278.002801 186.338434 
+L 276.920205 186.536931 
+L 275.83761 186.734601 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
-    <path d="M 275.83761 187.043834 
-L 275.471227 187.330505 
-L 275.104845 187.615452 
-L 274.738462 187.898695 
-L 274.37208 188.180256 
-L 274.005697 188.460154 
-L 273.639315 188.738409 
-L 273.272932 189.015039 
-L 272.90655 189.290063 
-L 272.540167 189.563501 
-L 272.173785 189.83537 
-L 271.807402 190.105688 
-L 271.44102 190.374473 
-L 271.074637 190.641742 
-L 270.708255 190.907513 
-L 270.341872 191.1718 
-L 269.97549 191.434623 
-L 269.609107 191.695995 
-L 269.242725 191.955934 
-L 268.876342 192.214455 
-L 268.50996 192.471573 
-L 268.143577 192.727304 
-L 267.777195 192.981662 
-L 267.410812 193.234662 
-L 267.04443 193.486318 
-L 266.678047 193.736645 
-L 266.311665 193.985657 
-L 265.945282 194.233367 
-L 265.5789 194.479789 
-L 265.212517 194.724936 
-L 264.846135 194.968822 
-L 264.479753 195.211458 
-L 264.11337 195.452859 
-L 263.746988 195.693037 
-L 263.380605 195.932003 
-L 263.014223 196.16977 
-L 262.64784 196.40635 
-L 262.281458 196.641755 
-L 261.915075 196.875997 
-L 261.548693 197.109086 
-L 261.18231 197.341034 
-L 260.815928 197.571853 
-L 260.449545 197.801553 
-L 260.083163 198.030144 
-L 259.71678 198.257639 
-L 259.350398 198.484046 
-L 258.984015 198.709377 
-L 258.617633 198.933642 
-L 258.25125 199.15685 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 275.83761 186.734601 
+L 275.471227 187.019541 
+L 275.104845 187.302778 
+L 274.738462 187.584333 
+L 274.37208 187.864226 
+L 274.005697 188.142475 
+L 273.639315 188.4191 
+L 273.272932 188.694121 
+L 272.90655 188.967554 
+L 272.540167 189.23942 
+L 272.173785 189.509735 
+L 271.807402 189.778517 
+L 271.44102 190.045784 
+L 271.074637 190.311552 
+L 270.708255 190.575838 
+L 270.341872 190.838659 
+L 269.97549 191.10003 
+L 269.609107 191.359968 
+L 269.242725 191.618488 
+L 268.876342 191.875606 
+L 268.50996 192.131337 
+L 268.143577 192.385696 
+L 267.777195 192.638696 
+L 267.410812 192.890354 
+L 267.04443 193.140682 
+L 266.678047 193.389695 
+L 266.311665 193.637407 
+L 265.945282 193.883831 
+L 265.5789 194.128981 
+L 265.212517 194.372869 
+L 264.846135 194.615508 
+L 264.479753 194.856912 
+L 264.11337 195.097093 
+L 263.746988 195.336062 
+L 263.380605 195.573833 
+L 263.014223 195.810417 
+L 262.64784 196.045827 
+L 262.281458 196.280072 
+L 261.915075 196.513166 
+L 261.548693 196.745119 
+L 261.18231 196.975943 
+L 260.815928 197.205647 
+L 260.449545 197.434245 
+L 260.083163 197.661744 
+L 259.71678 197.888158 
+L 259.350398 198.113494 
+L 258.984015 198.337765 
+L 258.617633 198.560979 
+L 258.25125 198.783148 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
-    <path d="M 258.25125 199.15685 
-L 258.220538 199.265446 
-L 258.189826 199.373793 
-L 258.159113 199.481893 
-L 258.128401 199.589747 
-L 258.097688 199.697356 
-L 258.066976 199.804722 
-L 258.036264 199.911845 
-L 258.005551 200.018726 
-L 257.974839 200.125366 
-L 257.944127 200.231767 
-L 257.913414 200.33793 
-L 257.882702 200.443856 
-L 257.851989 200.549545 
-L 257.821277 200.654999 
-L 257.790565 200.760219 
-L 257.759852 200.865206 
-L 257.72914 200.969961 
-L 257.698427 201.074484 
-L 257.667715 201.178778 
-L 257.637003 201.282842 
-L 257.60629 201.386679 
-L 257.575578 201.490289 
-L 257.544866 201.593672 
-L 257.514153 201.696831 
-L 257.483441 201.799765 
-L 257.452728 201.902476 
-L 257.422016 202.004965 
-L 257.391304 202.107233 
-L 257.360591 202.209281 
-L 257.329879 202.31111 
-L 257.299167 202.41272 
-L 257.268454 202.514113 
-L 257.237742 202.615289 
-L 257.207029 202.71625 
-L 257.176317 202.816996 
-L 257.145605 202.917528 
-L 257.114892 203.017848 
-L 257.08418 203.117955 
-L 257.053467 203.217852 
-L 257.022755 203.317538 
-L 256.992043 203.417015 
-L 256.96133 203.516284 
-L 256.930618 203.615345 
-L 256.899906 203.7142 
-L 256.869193 203.812849 
-L 256.838481 203.911293 
-L 256.807768 204.009533 
-L 256.777056 204.107569 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 258.25125 198.783148 
+L 258.220538 198.891831 
+L 258.189826 199.000266 
+L 258.159113 199.108453 
+L 258.128401 199.216395 
+L 258.097688 199.32409 
+L 258.066976 199.431542 
+L 258.036264 199.538751 
+L 258.005551 199.645717 
+L 257.974839 199.752443 
+L 257.944127 199.858929 
+L 257.913414 199.965177 
+L 257.882702 200.071186 
+L 257.851989 200.17696 
+L 257.821277 200.282497 
+L 257.790565 200.3878 
+L 257.759852 200.49287 
+L 257.72914 200.597708 
+L 257.698427 200.702314 
+L 257.667715 200.806689 
+L 257.637003 200.910836 
+L 257.60629 201.014754 
+L 257.575578 201.118444 
+L 257.544866 201.221909 
+L 257.514153 201.325148 
+L 257.483441 201.428162 
+L 257.452728 201.530953 
+L 257.422016 201.633522 
+L 257.391304 201.735869 
+L 257.360591 201.837996 
+L 257.329879 201.939903 
+L 257.299167 202.041592 
+L 257.268454 202.143063 
+L 257.237742 202.244317 
+L 257.207029 202.345355 
+L 257.176317 202.446179 
+L 257.145605 202.546788 
+L 257.114892 202.647184 
+L 257.08418 202.747368 
+L 257.053467 202.847341 
+L 257.022755 202.947103 
+L 256.992043 203.046656 
+L 256.96133 203.146 
+L 256.930618 203.245136 
+L 256.899906 203.344066 
+L 256.869193 203.442789 
+L 256.838481 203.541307 
+L 256.807768 203.639621 
+L 256.777056 203.737732 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
-    <path d="M 256.777056 204.107569 
-L 256.610239 204.449667 
-L 256.443423 204.789314 
-L 256.276606 205.126543 
-L 256.109789 205.46139 
-L 255.942972 205.793887 
-L 255.776156 206.124067 
-L 255.609339 206.451963 
-L 255.442522 206.777605 
-L 255.275706 207.101025 
-L 255.108889 207.422253 
-L 254.942072 207.741318 
-L 254.775255 208.058249 
-L 254.608439 208.373075 
-L 254.441622 208.685822 
-L 254.274805 208.99652 
-L 254.107989 209.305193 
-L 253.941172 209.611869 
-L 253.774355 209.916573 
-L 253.607538 210.21933 
-L 253.440722 210.520166 
-L 253.273905 210.819103 
-L 253.107088 211.116167 
-L 252.940272 211.41138 
-L 252.773455 211.704766 
-L 252.606638 211.996346 
-L 252.439821 212.286143 
-L 252.273005 212.574179 
-L 252.106188 212.860474 
-L 251.939371 213.14505 
-L 251.772555 213.427928 
-L 251.605738 213.709127 
-L 251.438921 213.988667 
-L 251.272104 214.266568 
-L 251.105288 214.542849 
-L 250.938471 214.817528 
-L 250.771654 215.090625 
-L 250.604837 215.362156 
-L 250.438021 215.632141 
-L 250.271204 215.900596 
-L 250.104387 216.167539 
-L 249.937571 216.432986 
-L 249.770754 216.696955 
-L 249.603937 216.959462 
-L 249.43712 217.220523 
-L 249.270304 217.480153 
-L 249.103487 217.738369 
-L 248.93667 217.995185 
-L 248.769854 218.250617 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 256.777056 203.737732 
+L 256.610239 204.075938 
+L 256.443423 204.411748 
+L 256.276606 204.745196 
+L 256.109789 205.076314 
+L 255.942972 205.405136 
+L 255.776156 205.731691 
+L 255.609339 206.056013 
+L 255.442522 206.37813 
+L 255.275706 206.698073 
+L 255.108889 207.015871 
+L 254.942072 207.331553 
+L 254.775255 207.645146 
+L 254.608439 207.956677 
+L 254.441622 208.266175 
+L 254.274805 208.573664 
+L 254.107989 208.879172 
+L 253.941172 209.182724 
+L 253.774355 209.484343 
+L 253.607538 209.784056 
+L 253.440722 210.081885 
+L 253.273905 210.377854 
+L 253.107088 210.671987 
+L 252.940272 210.964306 
+L 252.773455 211.254833 
+L 252.606638 211.54359 
+L 252.439821 211.830599 
+L 252.273005 212.11588 
+L 252.106188 212.399455 
+L 251.939371 212.681343 
+L 251.772555 212.961564 
+L 251.605738 213.240139 
+L 251.438921 213.517086 
+L 251.272104 213.792424 
+L 251.105288 214.066172 
+L 250.938471 214.338348 
+L 250.771654 214.60897 
+L 250.604837 214.878056 
+L 250.438021 215.145622 
+L 250.271204 215.411687 
+L 250.104387 215.676267 
+L 249.937571 215.939378 
+L 249.770754 216.201036 
+L 249.603937 216.461258 
+L 249.43712 216.720059 
+L 249.270304 216.977455 
+L 249.103487 217.23346 
+L 248.93667 217.48809 
+L 248.769854 217.74136 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
-    <path d="M 248.769854 218.250617 
-L 248.717661 218.475648 
-L 248.665468 218.699615 
-L 248.613275 218.922528 
-L 248.561082 219.144398 
-L 248.508889 219.365234 
-L 248.456696 219.585046 
-L 248.404503 219.803843 
-L 248.35231 220.021634 
-L 248.300117 220.238429 
-L 248.247924 220.454236 
-L 248.195731 220.669065 
-L 248.143539 220.882925 
-L 248.091346 221.095824 
-L 248.039153 221.307771 
-L 247.98696 221.518774 
-L 247.934767 221.728842 
-L 247.882574 221.937982 
-L 247.830381 222.146204 
-L 247.778188 222.353515 
-L 247.725995 222.559922 
-L 247.673802 222.765435 
-L 247.621609 222.97006 
-L 247.569416 223.173806 
-L 247.517224 223.376679 
-L 247.465031 223.578687 
-L 247.412838 223.779838 
-L 247.360645 223.980139 
-L 247.308452 224.179597 
-L 247.256259 224.378218 
-L 247.204066 224.576011 
-L 247.151873 224.772981 
-L 247.09968 224.969137 
-L 247.047487 225.164483 
-L 246.995294 225.359028 
-L 246.943101 225.552777 
-L 246.890909 225.745737 
-L 246.838716 225.937915 
-L 246.786523 226.129317 
-L 246.73433 226.319949 
-L 246.682137 226.509816 
-L 246.629944 226.698927 
-L 246.577751 226.887285 
-L 246.525558 227.074898 
-L 246.473365 227.261771 
-L 246.421172 227.44791 
-L 246.368979 227.633321 
-L 246.316786 227.818009 
-L 246.264594 228.00198 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 248.769854 217.74136 
+L 248.717661 217.9727 
+L 248.665468 218.202917 
+L 248.613275 218.432021 
+L 248.561082 218.660023 
+L 248.508889 218.886934 
+L 248.456696 219.112763 
+L 248.404503 219.337522 
+L 248.35231 219.56122 
+L 248.300117 219.783867 
+L 248.247924 220.005473 
+L 248.195731 220.226048 
+L 248.143539 220.445601 
+L 248.091346 220.664142 
+L 248.039153 220.88168 
+L 247.98696 221.098224 
+L 247.934767 221.313783 
+L 247.882574 221.528366 
+L 247.830381 221.741982 
+L 247.778188 221.95464 
+L 247.725995 222.166348 
+L 247.673802 222.377115 
+L 247.621609 222.586948 
+L 247.569416 222.795857 
+L 247.517224 223.003849 
+L 247.465031 223.210932 
+L 247.412838 223.417115 
+L 247.360645 223.622404 
+L 247.308452 223.826809 
+L 247.256259 224.030335 
+L 247.204066 224.232992 
+L 247.151873 224.434785 
+L 247.09968 224.635723 
+L 247.047487 224.835813 
+L 246.995294 225.035062 
+L 246.943101 225.233476 
+L 246.890909 225.431064 
+L 246.838716 225.627831 
+L 246.786523 225.823785 
+L 246.73433 226.018932 
+L 246.682137 226.213279 
+L 246.629944 226.406832 
+L 246.577751 226.599599 
+L 246.525558 226.791584 
+L 246.473365 226.982795 
+L 246.421172 227.173237 
+L 246.368979 227.362918 
+L 246.316786 227.551842 
+L 246.264594 227.740017 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m5981f9bd68" d="M 0 3.5 
+      <path id="m1f5d4b9d96" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m5981f9bd68" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m1f5d4b9d96" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m458a51683f" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8201a32ea5" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#mb565d4ecf5" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf4758b086d" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#ma006064a17" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#ma8de32e618" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#me5bb776e6d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m56c2750bfe" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m8cc897ea4d" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcac27d6d46" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#me8075b117d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me4b4cede54" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#mfa8147e441" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m737e32427b" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m87d12b9912" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m318fe77cb1" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p1218df302b)">
-     <use xlink:href="#m5981f9bd68" x="289.669676" y="165.489547" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5981f9bd68" x="223.847406" y="174.912852" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5981f9bd68" x="212.215046" y="178.606113" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5981f9bd68" x="186.58897" y="187.613652" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5981f9bd68" x="169.057218" y="196.655998" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5981f9bd68" x="158.596848" y="208.686007" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5981f9bd68" x="152.867313" y="213.646933" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5981f9bd68" x="150.950891" y="216.085721" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5981f9bd68" x="115.225692" y="282.095177" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5981f9bd68" x="99.852312" y="307.043257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p3aaf15e627)">
+     <use xlink:href="#m1f5d4b9d96" x="289.669676" y="165.316466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1f5d4b9d96" x="223.847406" y="174.96204" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1f5d4b9d96" x="212.215046" y="178.482168" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1f5d4b9d96" x="186.58897" y="187.275824" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1f5d4b9d96" x="169.057218" y="196.198972" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1f5d4b9d96" x="158.596848" y="208.242379" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1f5d4b9d96" x="152.867313" y="213.428968" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1f5d4b9d96" x="150.950891" y="215.894006" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1f5d4b9d96" x="115.225692" y="281.749714" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1f5d4b9d96" x="99.852312" y="306.905418" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 165.489547 
-L 288.298379 165.706249 
-L 286.927082 165.921966 
-L 285.555784 166.136704 
-L 284.184487 166.350474 
-L 282.81319 166.563284 
-L 281.441892 166.775142 
-L 280.070595 166.986058 
-L 278.699298 167.196039 
-L 277.328 167.405093 
-L 275.956703 167.61323 
-L 274.585406 167.820456 
-L 273.214109 168.02678 
-L 271.842811 168.23221 
-L 270.471514 168.436753 
-L 269.100217 168.640417 
-L 267.728919 168.843209 
-L 266.357622 169.045137 
-L 264.986325 169.246208 
-L 263.615028 169.44643 
-L 262.24373 169.64581 
-L 260.872433 169.844354 
-L 259.501136 170.04207 
-L 258.129838 170.238964 
-L 256.758541 170.435044 
-L 255.387244 170.630315 
-L 254.015947 170.824785 
-L 252.644649 171.018461 
-L 251.273352 171.211348 
-L 249.902055 171.403453 
-L 248.530757 171.594783 
-L 247.15946 171.785343 
-L 245.788163 171.97514 
-L 244.416866 172.16418 
-L 243.045568 172.352469 
-L 241.674271 172.540013 
-L 240.302974 172.726817 
-L 238.931676 172.912888 
-L 237.560379 173.098231 
-L 236.189082 173.282852 
-L 234.817784 173.466757 
-L 233.446487 173.64995 
-L 232.07519 173.832438 
-L 230.703893 174.014227 
-L 229.332595 174.19532 
-L 227.961298 174.375724 
-L 226.590001 174.555444 
-L 225.218703 174.734485 
-L 223.847406 174.912852 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 165.316466 
+L 288.298379 165.5388 
+L 286.927082 165.760096 
+L 285.555784 165.980364 
+L 284.184487 166.199613 
+L 282.81319 166.417852 
+L 281.441892 166.635091 
+L 280.070595 166.851339 
+L 278.699298 167.066604 
+L 277.328 167.280897 
+L 275.956703 167.494225 
+L 274.585406 167.706597 
+L 273.214109 167.918022 
+L 271.842811 168.128508 
+L 270.471514 168.338064 
+L 269.100217 168.546697 
+L 267.728919 168.754416 
+L 266.357622 168.961228 
+L 264.986325 169.167142 
+L 263.615028 169.372166 
+L 262.24373 169.576306 
+L 260.872433 169.779571 
+L 259.501136 169.981968 
+L 258.129838 170.183504 
+L 256.758541 170.384187 
+L 255.387244 170.584024 
+L 254.015947 170.783022 
+L 252.644649 170.981188 
+L 251.273352 171.178529 
+L 249.902055 171.375052 
+L 248.530757 171.570763 
+L 247.15946 171.76567 
+L 245.788163 171.959778 
+L 244.416866 172.153095 
+L 243.045568 172.345626 
+L 241.674271 172.537379 
+L 240.302974 172.728359 
+L 238.931676 172.918572 
+L 237.560379 173.108026 
+L 236.189082 173.296725 
+L 234.817784 173.484676 
+L 233.446487 173.671884 
+L 232.07519 173.858356 
+L 230.703893 174.044097 
+L 229.332595 174.229113 
+L 227.961298 174.41341 
+L 226.590001 174.596993 
+L 225.218703 174.779868 
+L 223.847406 174.96204 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 174.912852 
-L 223.605065 174.992805 
-L 223.362724 175.072623 
-L 223.120384 175.152308 
-L 222.878043 175.231858 
-L 222.635702 175.311275 
-L 222.393361 175.39056 
-L 222.15102 175.469712 
-L 221.908679 175.548732 
-L 221.666339 175.62762 
-L 221.423998 175.706377 
-L 221.181657 175.785004 
-L 220.939316 175.8635 
-L 220.696975 175.941867 
-L 220.454635 176.020104 
-L 220.212294 176.098212 
-L 219.969953 176.176192 
-L 219.727612 176.254043 
-L 219.485271 176.331767 
-L 219.24293 176.409364 
-L 219.00059 176.486834 
-L 218.758249 176.564177 
-L 218.515908 176.641394 
-L 218.273567 176.718486 
-L 218.031226 176.795453 
-L 217.788885 176.872294 
-L 217.546545 176.949012 
-L 217.304204 177.025605 
-L 217.061863 177.102075 
-L 216.819522 177.178421 
-L 216.577181 177.254645 
-L 216.33484 177.330746 
-L 216.0925 177.406725 
-L 215.850159 177.482583 
-L 215.607818 177.558319 
-L 215.365477 177.633935 
-L 215.123136 177.70943 
-L 214.880795 177.784805 
-L 214.638455 177.86006 
-L 214.396114 177.935196 
-L 214.153773 178.010213 
-L 213.911432 178.085112 
-L 213.669091 178.159892 
-L 213.42675 178.234555 
-L 213.18441 178.3091 
-L 212.942069 178.383528 
-L 212.699728 178.457839 
-L 212.457387 178.532034 
-L 212.215046 178.606113 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 174.96204 
+L 223.605065 175.038107 
+L 223.362724 175.114051 
+L 223.120384 175.189875 
+L 222.878043 175.265577 
+L 222.635702 175.341159 
+L 222.393361 175.41662 
+L 222.15102 175.491961 
+L 221.908679 175.567183 
+L 221.666339 175.642286 
+L 221.423998 175.71727 
+L 221.181657 175.792135 
+L 220.939316 175.866882 
+L 220.696975 175.941512 
+L 220.454635 176.016024 
+L 220.212294 176.090419 
+L 219.969953 176.164698 
+L 219.727612 176.238861 
+L 219.485271 176.312907 
+L 219.24293 176.386838 
+L 219.00059 176.460655 
+L 218.758249 176.534356 
+L 218.515908 176.607943 
+L 218.273567 176.681415 
+L 218.031226 176.754774 
+L 217.788885 176.82802 
+L 217.546545 176.901153 
+L 217.304204 176.974173 
+L 217.061863 177.047081 
+L 216.819522 177.119876 
+L 216.577181 177.19256 
+L 216.33484 177.265133 
+L 216.0925 177.337595 
+L 215.850159 177.409946 
+L 215.607818 177.482187 
+L 215.365477 177.554318 
+L 215.123136 177.62634 
+L 214.880795 177.698252 
+L 214.638455 177.770055 
+L 214.396114 177.84175 
+L 214.153773 177.913336 
+L 213.911432 177.984815 
+L 213.669091 178.056185 
+L 213.42675 178.127449 
+L 213.18441 178.198605 
+L 212.942069 178.269655 
+L 212.699728 178.340599 
+L 212.457387 178.411436 
+L 212.215046 178.482168 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 178.606113 
-L 211.68117 178.812341 
-L 211.147293 179.017675 
-L 210.613417 179.222124 
-L 210.07954 179.425695 
-L 209.545663 179.628394 
-L 209.011787 179.830231 
-L 208.47791 180.031211 
-L 207.944034 180.231343 
-L 207.410157 180.430633 
-L 206.87628 180.629088 
-L 206.342404 180.826716 
-L 205.808527 181.023523 
-L 205.274651 181.219516 
-L 204.740774 181.414701 
-L 204.206897 181.609086 
-L 203.673021 181.802677 
-L 203.139144 181.995481 
-L 202.605268 182.187503 
-L 202.071391 182.37875 
-L 201.537515 182.569228 
-L 201.003638 182.758944 
-L 200.469761 182.947904 
-L 199.935885 183.136113 
-L 199.402008 183.323577 
-L 198.868132 183.510303 
-L 198.334255 183.696296 
-L 197.800378 183.881562 
-L 197.266502 184.066106 
-L 196.732625 184.249934 
-L 196.198749 184.433052 
-L 195.664872 184.615465 
-L 195.130995 184.797179 
-L 194.597119 184.978199 
-L 194.063242 185.158529 
-L 193.529366 185.338176 
-L 192.995489 185.517145 
-L 192.461612 185.69544 
-L 191.927736 185.873067 
-L 191.393859 186.050031 
-L 190.859983 186.226336 
-L 190.326106 186.401988 
-L 189.79223 186.576991 
-L 189.258353 186.751351 
-L 188.724476 186.925071 
-L 188.1906 187.098156 
-L 187.656723 187.270612 
-L 187.122847 187.442442 
-L 186.58897 187.613652 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 178.482168 
+L 211.68117 178.683038 
+L 211.147293 178.883061 
+L 210.613417 179.082244 
+L 210.07954 179.280593 
+L 209.545663 179.478115 
+L 209.011787 179.674818 
+L 208.47791 179.870707 
+L 207.944034 180.065791 
+L 207.410157 180.260074 
+L 206.87628 180.453565 
+L 206.342404 180.646269 
+L 205.808527 180.838193 
+L 205.274651 181.029343 
+L 204.740774 181.219725 
+L 204.206897 181.409345 
+L 203.673021 181.59821 
+L 203.139144 181.786325 
+L 202.605268 181.973697 
+L 202.071391 182.160331 
+L 201.537515 182.346233 
+L 201.003638 182.531408 
+L 200.469761 182.715863 
+L 199.935885 182.899603 
+L 199.402008 183.082634 
+L 198.868132 183.26496 
+L 198.334255 183.446588 
+L 197.800378 183.627522 
+L 197.266502 183.807768 
+L 196.732625 183.987332 
+L 196.198749 184.166218 
+L 195.664872 184.344431 
+L 195.130995 184.521977 
+L 194.597119 184.69886 
+L 194.063242 184.875085 
+L 193.529366 185.050658 
+L 192.995489 185.225583 
+L 192.461612 185.399864 
+L 191.927736 185.573508 
+L 191.393859 185.746517 
+L 190.859983 185.918897 
+L 190.326106 186.090652 
+L 189.79223 186.261788 
+L 189.258353 186.432308 
+L 188.724476 186.602216 
+L 188.1906 186.771517 
+L 187.656723 186.940216 
+L 187.122847 187.108317 
+L 186.58897 187.275824 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 186.58897 187.613652 
-L 186.223725 187.820753 
-L 185.85848 188.026954 
-L 185.493235 188.232261 
-L 185.127991 188.436683 
-L 184.762746 188.640226 
-L 184.397501 188.842899 
-L 184.032256 189.044709 
-L 183.667011 189.245663 
-L 183.301766 189.445768 
-L 182.936522 189.645032 
-L 182.571277 189.843462 
-L 182.206032 190.041064 
-L 181.840787 190.237846 
-L 181.475542 190.433814 
-L 181.110297 190.628975 
-L 180.745053 190.823335 
-L 180.379808 191.016902 
-L 180.014563 191.209681 
-L 179.649318 191.401679 
-L 179.284073 191.592903 
-L 178.918828 191.783357 
-L 178.553584 191.97305 
-L 178.188339 192.161986 
-L 177.823094 192.350172 
-L 177.457849 192.537613 
-L 177.092604 192.724316 
-L 176.727359 192.910287 
-L 176.362115 193.09553 
-L 175.99687 193.280052 
-L 175.631625 193.463859 
-L 175.26638 193.646955 
-L 174.901135 193.829346 
-L 174.53589 194.011038 
-L 174.170645 194.192037 
-L 173.805401 194.372346 
-L 173.440156 194.551972 
-L 173.074911 194.73092 
-L 172.709666 194.909195 
-L 172.344421 195.086801 
-L 171.979176 195.263744 
-L 171.613932 195.440029 
-L 171.248687 195.615661 
-L 170.883442 195.790644 
-L 170.518197 195.964984 
-L 170.152952 196.138684 
-L 169.787707 196.31175 
-L 169.422463 196.484187 
-L 169.057218 196.655998 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.58897 187.275824 
+L 186.223725 187.479933 
+L 185.85848 187.683166 
+L 185.493235 187.885532 
+L 185.127991 188.087038 
+L 184.762746 188.287691 
+L 184.397501 188.487498 
+L 184.032256 188.686466 
+L 183.667011 188.884602 
+L 183.301766 189.081914 
+L 182.936522 189.278407 
+L 182.571277 189.47409 
+L 182.206032 189.668968 
+L 181.840787 189.863047 
+L 181.475542 190.056336 
+L 181.110297 190.248839 
+L 180.745053 190.440564 
+L 180.379808 190.631517 
+L 180.014563 190.821703 
+L 179.649318 191.011129 
+L 179.284073 191.199801 
+L 178.918828 191.387725 
+L 178.553584 191.574907 
+L 178.188339 191.761353 
+L 177.823094 191.947068 
+L 177.457849 192.132058 
+L 177.092604 192.31633 
+L 176.727359 192.499887 
+L 176.362115 192.682737 
+L 175.99687 192.864883 
+L 175.631625 193.046333 
+L 175.26638 193.227091 
+L 174.901135 193.407161 
+L 174.53589 193.586551 
+L 174.170645 193.765264 
+L 173.805401 193.943305 
+L 173.440156 194.120681 
+L 173.074911 194.297395 
+L 172.709666 194.473453 
+L 172.344421 194.648859 
+L 171.979176 194.823618 
+L 171.613932 194.997736 
+L 171.248687 195.171216 
+L 170.883442 195.344064 
+L 170.518197 195.516283 
+L 170.152952 195.687879 
+L 169.787707 195.858856 
+L 169.422463 196.029219 
+L 169.057218 196.198972 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 169.057218 196.655998 
-L 168.839293 196.940451 
-L 168.621369 197.223207 
-L 168.403445 197.504285 
-L 168.18552 197.783707 
-L 167.967596 198.06149 
-L 167.749672 198.337655 
-L 167.531747 198.612219 
-L 167.313823 198.885202 
-L 167.095898 199.156622 
-L 166.877974 199.426496 
-L 166.66005 199.694841 
-L 166.442125 199.961676 
-L 166.224201 200.227016 
-L 166.006277 200.490879 
-L 165.788352 200.753281 
-L 165.570428 201.014238 
-L 165.352503 201.273766 
-L 165.134579 201.53188 
-L 164.916655 201.788596 
-L 164.69873 202.043929 
-L 164.480806 202.297893 
-L 164.262882 202.550504 
-L 164.044957 202.801775 
-L 163.827033 203.051721 
-L 163.609108 203.300355 
-L 163.391184 203.547692 
-L 163.17326 203.793745 
-L 162.955335 204.038526 
-L 162.737411 204.28205 
-L 162.519487 204.524329 
-L 162.301562 204.765375 
-L 162.083638 205.005201 
-L 161.865713 205.24382 
-L 161.647789 205.481243 
-L 161.429865 205.717483 
-L 161.21194 205.952551 
-L 160.994016 206.186458 
-L 160.776092 206.419217 
-L 160.558167 206.650838 
-L 160.340243 206.881333 
-L 160.122318 207.110711 
-L 159.904394 207.338985 
-L 159.68647 207.566165 
-L 159.468545 207.79226 
-L 159.250621 208.017282 
-L 159.032697 208.241241 
-L 158.814772 208.464146 
-L 158.596848 208.686007 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 169.057218 196.198972 
+L 168.839293 196.483774 
+L 168.621369 196.766876 
+L 168.403445 197.048297 
+L 168.18552 197.328057 
+L 167.967596 197.606176 
+L 167.749672 197.882672 
+L 167.531747 198.157564 
+L 167.313823 198.430872 
+L 167.095898 198.702612 
+L 166.877974 198.972804 
+L 166.66005 199.241464 
+L 166.442125 199.50861 
+L 166.224201 199.774258 
+L 166.006277 200.038427 
+L 165.788352 200.30113 
+L 165.570428 200.562386 
+L 165.352503 200.82221 
+L 165.134579 201.080618 
+L 164.916655 201.337624 
+L 164.69873 201.593244 
+L 164.480806 201.847493 
+L 164.262882 202.100386 
+L 164.044957 202.351936 
+L 163.827033 202.602159 
+L 163.609108 202.851067 
+L 163.391184 203.098675 
+L 163.17326 203.344996 
+L 162.955335 203.590044 
+L 162.737411 203.833832 
+L 162.519487 204.076372 
+L 162.301562 204.317677 
+L 162.083638 204.55776 
+L 161.865713 204.796634 
+L 161.647789 205.034309 
+L 161.429865 205.270798 
+L 161.21194 205.506114 
+L 160.994016 205.740267 
+L 160.776092 205.973269 
+L 160.558167 206.205131 
+L 160.340243 206.435864 
+L 160.122318 206.66548 
+L 159.904394 206.893989 
+L 159.68647 207.121401 
+L 159.468545 207.347728 
+L 159.250621 207.572979 
+L 159.032697 207.797164 
+L 158.814772 208.020294 
+L 158.596848 208.242379 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 158.596848 208.686007 
-L 158.477483 208.794839 
-L 158.358117 208.90342 
-L 158.238752 209.011754 
-L 158.119387 209.11984 
-L 158.000021 209.227681 
-L 157.880656 209.335277 
-L 157.761291 209.442628 
-L 157.641925 209.549738 
-L 157.52256 209.656605 
-L 157.403195 209.763233 
-L 157.28383 209.869621 
-L 157.164464 209.97577 
-L 157.045099 210.081683 
-L 156.925734 210.187359 
-L 156.806368 210.2928 
-L 156.687003 210.398007 
-L 156.567638 210.50298 
-L 156.448272 210.607722 
-L 156.328907 210.712233 
-L 156.209542 210.816514 
-L 156.090177 210.920566 
-L 155.970811 211.02439 
-L 155.851446 211.127987 
-L 155.732081 211.231358 
-L 155.612715 211.334504 
-L 155.49335 211.437426 
-L 155.373985 211.540125 
-L 155.254619 211.642602 
-L 155.135254 211.744857 
-L 155.015889 211.846893 
-L 154.896524 211.948709 
-L 154.777158 212.050307 
-L 154.657793 212.151688 
-L 154.538428 212.252852 
-L 154.419062 212.353801 
-L 154.299697 212.454535 
-L 154.180332 212.555056 
-L 154.060966 212.655363 
-L 153.941601 212.755459 
-L 153.822236 212.855344 
-L 153.702871 212.955019 
-L 153.583505 213.054485 
-L 153.46414 213.153742 
-L 153.344775 213.252792 
-L 153.225409 213.351635 
-L 153.106044 213.450272 
-L 152.986679 213.548705 
-L 152.867313 213.646933 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.596848 208.242379 
+L 158.477483 208.356429 
+L 158.358117 208.470206 
+L 158.238752 208.58371 
+L 158.119387 208.696942 
+L 158.000021 208.809905 
+L 157.880656 208.9226 
+L 157.761291 209.035027 
+L 157.641925 209.147188 
+L 157.52256 209.259084 
+L 157.403195 209.370716 
+L 157.28383 209.482087 
+L 157.164464 209.593196 
+L 157.045099 209.704046 
+L 156.925734 209.814636 
+L 156.806368 209.92497 
+L 156.687003 210.035047 
+L 156.567638 210.144869 
+L 156.448272 210.254437 
+L 156.328907 210.363753 
+L 156.209542 210.472817 
+L 156.090177 210.581631 
+L 155.970811 210.690195 
+L 155.851446 210.798511 
+L 155.732081 210.906581 
+L 155.612715 211.014404 
+L 155.49335 211.121983 
+L 155.373985 211.229318 
+L 155.254619 211.336411 
+L 155.135254 211.443262 
+L 155.015889 211.549873 
+L 154.896524 211.656245 
+L 154.777158 211.762378 
+L 154.657793 211.868275 
+L 154.538428 211.973935 
+L 154.419062 212.07936 
+L 154.299697 212.184551 
+L 154.180332 212.28951 
+L 154.060966 212.394236 
+L 153.941601 212.498732 
+L 153.822236 212.602998 
+L 153.702871 212.707035 
+L 153.583505 212.810844 
+L 153.46414 212.914426 
+L 153.344775 213.017782 
+L 153.225409 213.120914 
+L 153.106044 213.223821 
+L 152.986679 213.326506 
+L 152.867313 213.428968 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 152.867313 213.646933 
-L 152.827388 213.699043 
-L 152.787463 213.751095 
-L 152.747537 213.80309 
-L 152.707612 213.855028 
-L 152.667686 213.90691 
-L 152.627761 213.958734 
-L 152.587835 214.010502 
-L 152.54791 214.062214 
-L 152.507984 214.113869 
-L 152.468059 214.165468 
-L 152.428133 214.21701 
-L 152.388208 214.268497 
-L 152.348282 214.319928 
-L 152.308357 214.371303 
-L 152.268432 214.422622 
-L 152.228506 214.473886 
-L 152.188581 214.525095 
-L 152.148655 214.576248 
-L 152.10873 214.627346 
-L 152.068804 214.678389 
-L 152.028879 214.729378 
-L 151.988953 214.780311 
-L 151.949028 214.83119 
-L 151.909102 214.882014 
-L 151.869177 214.932783 
-L 151.829252 214.983499 
-L 151.789326 215.03416 
-L 151.749401 215.084767 
-L 151.709475 215.13532 
-L 151.66955 215.185819 
-L 151.629624 215.236264 
-L 151.589699 215.286656 
-L 151.549773 215.336994 
-L 151.509848 215.387279 
-L 151.469922 215.437511 
-L 151.429997 215.487689 
-L 151.390072 215.537814 
-L 151.350146 215.587886 
-L 151.310221 215.637906 
-L 151.270295 215.687872 
-L 151.23037 215.737787 
-L 151.190444 215.787648 
-L 151.150519 215.837457 
-L 151.110593 215.887214 
-L 151.070668 215.936919 
-L 151.030742 215.986571 
-L 150.990817 216.036172 
-L 150.950891 216.085721 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 152.867313 213.428968 
+L 152.827388 213.481653 
+L 152.787463 213.534279 
+L 152.747537 213.586846 
+L 152.707612 213.639356 
+L 152.667686 213.691807 
+L 152.627761 213.7442 
+L 152.587835 213.796536 
+L 152.54791 213.848814 
+L 152.507984 213.901034 
+L 152.468059 213.953197 
+L 152.428133 214.005302 
+L 152.388208 214.05735 
+L 152.348282 214.109341 
+L 152.308357 214.161275 
+L 152.268432 214.213152 
+L 152.228506 214.264973 
+L 152.188581 214.316737 
+L 152.148655 214.368444 
+L 152.10873 214.420095 
+L 152.068804 214.47169 
+L 152.028879 214.523229 
+L 151.988953 214.574712 
+L 151.949028 214.626139 
+L 151.909102 214.67751 
+L 151.869177 214.728826 
+L 151.829252 214.780086 
+L 151.789326 214.83129 
+L 151.749401 214.88244 
+L 151.709475 214.933534 
+L 151.66955 214.984573 
+L 151.629624 215.035558 
+L 151.589699 215.086488 
+L 151.549773 215.137362 
+L 151.509848 215.188183 
+L 151.469922 215.238949 
+L 151.429997 215.289661 
+L 151.390072 215.340318 
+L 151.350146 215.390921 
+L 151.310221 215.441471 
+L 151.270295 215.491966 
+L 151.23037 215.542408 
+L 151.190444 215.592796 
+L 151.150519 215.643131 
+L 151.110593 215.693412 
+L 151.070668 215.74364 
+L 151.030742 215.793815 
+L 150.990817 215.843937 
+L 150.950891 215.894006 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 216.085721 
-L 150.206616 218.983402 
-L 149.462341 221.714063 
-L 148.718066 224.295912 
-L 147.973791 226.744334 
-L 147.229517 229.072445 
-L 146.485242 231.291516 
-L 145.740967 233.411307 
-L 144.996692 235.440322 
-L 144.252417 237.386017 
-L 143.508142 239.254967 
-L 142.763867 241.052995 
-L 142.019592 242.785289 
-L 141.275317 244.456486 
-L 140.531042 246.070749 
-L 139.786767 247.631831 
-L 139.042492 249.143123 
-L 138.298217 250.607703 
-L 137.553942 252.028374 
-L 136.809667 253.407691 
-L 136.065392 254.747993 
-L 135.321117 256.051429 
-L 134.576842 257.31997 
-L 133.832567 258.555438 
-L 133.088292 259.759513 
-L 132.344017 260.93375 
-L 131.599742 262.079594 
-L 130.855467 263.198384 
-L 130.111192 264.291369 
-L 129.366917 265.359713 
-L 128.622642 266.404501 
-L 127.878367 267.426751 
-L 127.134092 268.427415 
-L 126.389817 269.407384 
-L 125.645542 270.367499 
-L 124.901267 271.308546 
-L 124.156992 272.23127 
-L 123.412717 273.136369 
-L 122.668442 274.024505 
-L 121.924167 274.896302 
-L 121.179892 275.75235 
-L 120.435617 276.593208 
-L 119.691342 277.419406 
-L 118.947067 278.231446 
-L 118.202792 279.029805 
-L 117.458517 279.814937 
-L 116.714242 280.587272 
-L 115.969967 281.347222 
-L 115.225692 282.095177 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 150.950891 215.894006 
+L 150.206616 218.779081 
+L 149.462341 221.498578 
+L 148.718066 224.070474 
+L 147.973791 226.509972 
+L 147.229517 228.830036 
+L 146.485242 231.041819 
+L 145.740967 233.154978 
+L 144.996692 235.177934 
+L 144.252417 237.118074 
+L 143.508142 238.981914 
+L 142.763867 240.775227 
+L 142.019592 242.503157 
+L 141.275317 244.170305 
+L 140.531042 245.780801 
+L 139.786767 247.338371 
+L 139.042492 248.846382 
+L 138.298217 250.30789 
+L 137.553942 251.725679 
+L 136.809667 253.102288 
+L 136.065392 254.440042 
+L 135.321117 255.741074 
+L 134.576842 257.007346 
+L 133.832567 258.240669 
+L 133.088292 259.442712 
+L 132.344017 260.615024 
+L 131.599742 261.759039 
+L 130.855467 262.876093 
+L 130.111192 263.967425 
+L 129.366917 265.034195 
+L 128.622642 266.077483 
+L 127.878367 267.098302 
+L 127.134092 268.097598 
+L 126.389817 269.07626 
+L 125.645542 270.035124 
+L 124.901267 270.974974 
+L 124.156992 271.896551 
+L 123.412717 272.80055 
+L 122.668442 273.68763 
+L 121.924167 274.558413 
+L 121.179892 275.413487 
+L 120.435617 276.253408 
+L 119.691342 277.078704 
+L 118.947067 277.889876 
+L 118.202792 278.687399 
+L 117.458517 279.471725 
+L 116.714242 280.243283 
+L 115.969967 281.002483 
+L 115.225692 281.749714 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.225692 282.095177 
-L 114.905413 282.774383 
-L 114.585134 283.443993 
-L 114.264856 284.104272 
-L 113.944577 284.755478 
-L 113.624298 285.397856 
-L 113.304019 286.031643 
-L 112.983741 286.657065 
-L 112.663462 287.27434 
-L 112.343183 287.883679 
-L 112.022904 288.485281 
-L 111.702626 289.079342 
-L 111.382347 289.666048 
-L 111.062068 290.245578 
-L 110.741789 290.818108 
-L 110.421511 291.383802 
-L 110.101232 291.942823 
-L 109.780953 292.495327 
-L 109.460674 293.041463 
-L 109.140396 293.581377 
-L 108.820117 294.115208 
-L 108.499838 294.643093 
-L 108.17956 295.165162 
-L 107.859281 295.681543 
-L 107.539002 296.192357 
-L 107.218723 296.697724 
-L 106.898445 297.197758 
-L 106.578166 297.692571 
-L 106.257887 298.182271 
-L 105.937608 298.666962 
-L 105.61733 299.146745 
-L 105.297051 299.62172 
-L 104.976772 300.091982 
-L 104.656493 300.557622 
-L 104.336215 301.018732 
-L 104.015936 301.475398 
-L 103.695657 301.927706 
-L 103.375378 302.375737 
-L 103.0551 302.819572 
-L 102.734821 303.259288 
-L 102.414542 303.694962 
-L 102.094264 304.126667 
-L 101.773985 304.554475 
-L 101.453706 304.978455 
-L 101.133427 305.398675 
-L 100.813149 305.815202 
-L 100.49287 306.2281 
-L 100.172591 306.637431 
-L 99.852312 307.043257 
-" clip-path="url(#p1218df302b)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.225692 281.749714 
+L 114.905413 282.436114 
+L 114.585134 283.112715 
+L 114.264856 283.779794 
+L 113.944577 284.437614 
+L 113.624298 285.08643 
+L 113.304019 285.726485 
+L 112.983741 286.358011 
+L 112.663462 286.981234 
+L 112.343183 287.596369 
+L 112.022904 288.203622 
+L 111.702626 288.803194 
+L 111.382347 289.395277 
+L 111.062068 289.980054 
+L 110.741789 290.557705 
+L 110.421511 291.128401 
+L 110.101232 291.692307 
+L 109.780953 292.249583 
+L 109.460674 292.800383 
+L 109.140396 293.344856 
+L 108.820117 293.883146 
+L 108.499838 294.415391 
+L 108.17956 294.941726 
+L 107.859281 295.46228 
+L 107.539002 295.977179 
+L 107.218723 296.486545 
+L 106.898445 296.990496 
+L 106.578166 297.489144 
+L 106.257887 297.982602 
+L 105.937608 298.470974 
+L 105.61733 298.954367 
+L 105.297051 299.432879 
+L 104.976772 299.906609 
+L 104.656493 300.37565 
+L 104.336215 300.840096 
+L 104.015936 301.300035 
+L 103.695657 301.755554 
+L 103.375378 302.206736 
+L 103.0551 302.653665 
+L 102.734821 303.096418 
+L 102.414542 303.535074 
+L 102.094264 303.969708 
+L 101.773985 304.400393 
+L 101.453706 304.827199 
+L 101.133427 305.250196 
+L 100.813149 305.669452 
+L 100.49287 306.085032 
+L 100.172591 306.497 
+L 99.852312 306.905418 
+" clip-path="url(#p3aaf15e627)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-05T08:48:39Z  ·  Linux chungus x86_64  ·  commit 7e98994a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.762578 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.687734 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6316,36 +6316,6 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
 L 1344 2619 
 L 1344 1825 
@@ -6403,6 +6373,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6443,14 +6443,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6470,128 +6470,129 @@ z
     <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
     <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
     <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.792969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.580078 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.367188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.941406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3761.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.314453 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.693359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3988.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.917969 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4211.03125 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4334.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.308594 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.6875 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4556.001953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.181641 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.804688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.591797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.214844 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.837891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.625 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.248047 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.332031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.195312 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.947266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.734375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.185547 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.367188 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.746094 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.601562 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.457031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.666016 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5992.029297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.441406 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.964844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.224609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.503906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.769531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.148438 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.427734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6691.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.382812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.564453 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.773438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.464844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.365234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.644531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.853516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.818359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.388672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.488281 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.484375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7520.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.371094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.566406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.945312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.728516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.828125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7867.037109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.820312 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2107.714844 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2139.501953 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2325.927734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2503.173828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.960938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2566.748047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2598.535156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2630.322266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2662.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2717.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2778.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2875.683594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1218df302b">
+  <clipPath id="p3aaf15e627">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p0fca095c35)">
+   <g clip-path="url(#pf3eb7f8b4c)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="image7afb966de4" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="image0386cedcdb" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m0e6e5b8348" d="M 0 0 
+       <path id="mb46beef313" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0e6e5b8348" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m0e6e5b8348" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m0e6e5b8348" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0e6e5b8348" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m0e6e5b8348" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0e6e5b8348" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m0e6e5b8348" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0e6e5b8348" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m0e6e5b8348" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0e6e5b8348" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m0e6e5b8348" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb46beef313" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m669c6d5dfa" d="M 0 0 
+       <path id="m5eb75f3fcd" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m669c6d5dfa" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m669c6d5dfa" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m669c6d5dfa" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m669c6d5dfa" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m669c6d5dfa" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m669c6d5dfa" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m669c6d5dfa" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m669c6d5dfa" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5eb75f3fcd" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagef5bffe6e19" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imageeba73428b3" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m1fd5c73579" d="M 0 0 
+       <path id="mbc98d845d9" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1fd5c73579" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbc98d845d9" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m1fd5c73579" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbc98d845d9" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1fd5c73579" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbc98d845d9" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m1fd5c73579" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbc98d845d9" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1fd5c73579" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbc98d845d9" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m1fd5c73579" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbc98d845d9" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1fd5c73579" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbc98d845d9" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m1fd5c73579" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbc98d845d9" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1fd5c73579" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbc98d845d9" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-05T08:48:39Z  ·  Linux chungus x86_64  ·  commit 7e98994a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(18.762578 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.687734 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2952,14 +2952,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2979,128 +2979,129 @@ z
     <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
     <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
     <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.792969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.580078 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.367188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.941406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3761.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.314453 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.693359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3988.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.917969 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4211.03125 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4334.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.308594 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.6875 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4556.001953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.181641 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.804688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.591797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.214844 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.837891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.625 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.248047 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.332031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.195312 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.947266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.734375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.185547 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.367188 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.746094 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.601562 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.457031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.666016 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5992.029297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.441406 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.964844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.224609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.503906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.769531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.148438 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.427734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6691.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.382812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.564453 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.773438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.464844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.365234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.644531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.853516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.818359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.388672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.488281 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.484375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7520.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.371094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.566406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.945312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.728516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.828125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7867.037109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.820312 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2107.714844 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2139.501953 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2325.927734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2503.173828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.960938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2566.748047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2598.535156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2630.322266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2662.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2717.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2778.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2875.683594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p0fca095c35">
+  <clipPath id="pf3eb7f8b4c">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.874844pt" height="386.202469pt" viewBox="0 0 570.874844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.024531pt" height="386.202469pt" viewBox="0 0 575.024531 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.874844 386.202469 
-L 570.874844 0 
+L 575.024531 386.202469 
+L 575.024531 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.562422 104.1264 
-L 292.187422 104.1264 
-L 292.187422 74.7432 
-L 187.562422 74.7432 
+    <path d="M 189.637266 104.1264 
+L 294.262266 104.1264 
+L 294.262266 74.7432 
+L 189.637266 74.7432 
 z
-" clip-path="url(#p08b2821584)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.187422 104.1264 
-L 396.812422 104.1264 
-L 396.812422 74.7432 
-L 292.187422 74.7432 
+    <path d="M 294.262266 104.1264 
+L 398.887266 104.1264 
+L 398.887266 74.7432 
+L 294.262266 74.7432 
 z
-" clip-path="url(#p08b2821584)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.812422 104.1264 
-L 501.437422 104.1264 
-L 501.437422 74.7432 
-L 396.812422 74.7432 
+    <path d="M 398.887266 104.1264 
+L 503.512266 104.1264 
+L 503.512266 74.7432 
+L 398.887266 74.7432 
 z
-" clip-path="url(#p08b2821584)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.562422 133.5096 
-L 292.187422 133.5096 
-L 292.187422 104.1264 
-L 187.562422 104.1264 
+    <path d="M 189.637266 133.5096 
+L 294.262266 133.5096 
+L 294.262266 104.1264 
+L 189.637266 104.1264 
 z
-" clip-path="url(#p08b2821584)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.187422 133.5096 
-L 396.812422 133.5096 
-L 396.812422 104.1264 
-L 292.187422 104.1264 
+    <path d="M 294.262266 133.5096 
+L 398.887266 133.5096 
+L 398.887266 104.1264 
+L 294.262266 104.1264 
 z
-" clip-path="url(#p08b2821584)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.812422 133.5096 
-L 501.437422 133.5096 
-L 501.437422 104.1264 
-L 396.812422 104.1264 
+    <path d="M 398.887266 133.5096 
+L 503.512266 133.5096 
+L 503.512266 104.1264 
+L 398.887266 104.1264 
 z
-" clip-path="url(#p08b2821584)" style="fill: #fdb365; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.562422 162.8928 
-L 292.187422 162.8928 
-L 292.187422 133.5096 
-L 187.562422 133.5096 
+    <path d="M 189.637266 162.8928 
+L 294.262266 162.8928 
+L 294.262266 133.5096 
+L 189.637266 133.5096 
 z
-" clip-path="url(#p08b2821584)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.187422 162.8928 
-L 396.812422 162.8928 
-L 396.812422 133.5096 
-L 292.187422 133.5096 
+    <path d="M 294.262266 162.8928 
+L 398.887266 162.8928 
+L 398.887266 133.5096 
+L 294.262266 133.5096 
 z
-" clip-path="url(#p08b2821584)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.812422 162.8928 
-L 501.437422 162.8928 
-L 501.437422 133.5096 
-L 396.812422 133.5096 
+    <path d="M 398.887266 162.8928 
+L 503.512266 162.8928 
+L 503.512266 133.5096 
+L 398.887266 133.5096 
 z
-" clip-path="url(#p08b2821584)" style="fill: #b9e176; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.562422 192.276 
-L 292.187422 192.276 
-L 292.187422 162.8928 
-L 187.562422 162.8928 
+    <path d="M 189.637266 192.276 
+L 294.262266 192.276 
+L 294.262266 162.8928 
+L 189.637266 162.8928 
 z
-" clip-path="url(#p08b2821584)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.187422 192.276 
-L 396.812422 192.276 
-L 396.812422 162.8928 
-L 292.187422 162.8928 
+    <path d="M 294.262266 192.276 
+L 398.887266 192.276 
+L 398.887266 162.8928 
+L 294.262266 162.8928 
 z
-" clip-path="url(#p08b2821584)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.812422 192.276 
-L 501.437422 192.276 
-L 501.437422 162.8928 
-L 396.812422 162.8928 
+    <path d="M 398.887266 192.276 
+L 503.512266 192.276 
+L 503.512266 162.8928 
+L 398.887266 162.8928 
 z
-" clip-path="url(#p08b2821584)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.562422 221.6592 
-L 292.187422 221.6592 
-L 292.187422 192.276 
-L 187.562422 192.276 
+    <path d="M 189.637266 221.6592 
+L 294.262266 221.6592 
+L 294.262266 192.276 
+L 189.637266 192.276 
 z
-" clip-path="url(#p08b2821584)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.187422 221.6592 
-L 396.812422 221.6592 
-L 396.812422 192.276 
-L 292.187422 192.276 
+    <path d="M 294.262266 221.6592 
+L 398.887266 221.6592 
+L 398.887266 192.276 
+L 294.262266 192.276 
 z
-" clip-path="url(#p08b2821584)" style="fill: #fdc574; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.812422 221.6592 
-L 501.437422 221.6592 
-L 501.437422 192.276 
-L 396.812422 192.276 
+    <path d="M 398.887266 221.6592 
+L 503.512266 221.6592 
+L 503.512266 192.276 
+L 398.887266 192.276 
 z
-" clip-path="url(#p08b2821584)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.562422 251.0424 
-L 292.187422 251.0424 
-L 292.187422 221.6592 
-L 187.562422 221.6592 
+    <path d="M 189.637266 251.0424 
+L 294.262266 251.0424 
+L 294.262266 221.6592 
+L 189.637266 221.6592 
 z
-" clip-path="url(#p08b2821584)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.187422 251.0424 
-L 396.812422 251.0424 
-L 396.812422 221.6592 
-L 292.187422 221.6592 
+    <path d="M 294.262266 251.0424 
+L 398.887266 251.0424 
+L 398.887266 221.6592 
+L 294.262266 221.6592 
 z
-" clip-path="url(#p08b2821584)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.812422 251.0424 
-L 501.437422 251.0424 
-L 501.437422 221.6592 
-L 396.812422 221.6592 
+    <path d="M 398.887266 251.0424 
+L 503.512266 251.0424 
+L 503.512266 221.6592 
+L 398.887266 221.6592 
 z
-" clip-path="url(#p08b2821584)" style="fill: #ec5c3b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.562422 280.4256 
-L 292.187422 280.4256 
-L 292.187422 251.0424 
-L 187.562422 251.0424 
+    <path d="M 189.637266 280.4256 
+L 294.262266 280.4256 
+L 294.262266 251.0424 
+L 189.637266 251.0424 
 z
-" clip-path="url(#p08b2821584)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.187422 280.4256 
-L 396.812422 280.4256 
-L 396.812422 251.0424 
-L 292.187422 251.0424 
+    <path d="M 294.262266 280.4256 
+L 398.887266 280.4256 
+L 398.887266 251.0424 
+L 294.262266 251.0424 
 z
-" clip-path="url(#p08b2821584)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.812422 280.4256 
-L 501.437422 280.4256 
-L 501.437422 251.0424 
-L 396.812422 251.0424 
+    <path d="M 398.887266 280.4256 
+L 503.512266 280.4256 
+L 503.512266 251.0424 
+L 398.887266 251.0424 
 z
-" clip-path="url(#p08b2821584)" style="fill: #f16640; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.562422 309.8088 
-L 292.187422 309.8088 
-L 292.187422 280.4256 
-L 187.562422 280.4256 
+    <path d="M 189.637266 309.8088 
+L 294.262266 309.8088 
+L 294.262266 280.4256 
+L 189.637266 280.4256 
 z
-" clip-path="url(#p08b2821584)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.187422 309.8088 
-L 396.812422 309.8088 
-L 396.812422 280.4256 
-L 292.187422 280.4256 
+    <path d="M 294.262266 309.8088 
+L 398.887266 309.8088 
+L 398.887266 280.4256 
+L 294.262266 280.4256 
 z
-" clip-path="url(#p08b2821584)" style="fill: #f67f4b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.812422 309.8088 
-L 501.437422 309.8088 
-L 501.437422 280.4256 
-L 396.812422 280.4256 
+    <path d="M 398.887266 309.8088 
+L 503.512266 309.8088 
+L 503.512266 280.4256 
+L 398.887266 280.4256 
 z
-" clip-path="url(#p08b2821584)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.562422 339.192 
-L 292.187422 339.192 
-L 292.187422 309.8088 
-L 187.562422 309.8088 
+    <path d="M 189.637266 339.192 
+L 294.262266 339.192 
+L 294.262266 309.8088 
+L 189.637266 309.8088 
 z
-" clip-path="url(#p08b2821584)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.187422 339.192 
-L 396.812422 339.192 
-L 396.812422 309.8088 
-L 292.187422 309.8088 
+    <path d="M 294.262266 339.192 
+L 398.887266 339.192 
+L 398.887266 309.8088 
+L 294.262266 309.8088 
 z
-" clip-path="url(#p08b2821584)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.812422 339.192 
-L 501.437422 339.192 
-L 501.437422 309.8088 
-L 396.812422 309.8088 
+    <path d="M 398.887266 339.192 
+L 503.512266 339.192 
+L 503.512266 309.8088 
+L 398.887266 309.8088 
 z
-" clip-path="url(#p08b2821584)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p6e2f4a2ee9)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.549688 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.624531 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.833906 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.90875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.406016 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.480859 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.757734 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.832578 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.487422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.562266 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(228.423672 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(336.864922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.939766 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(441.489922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.564766 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.125547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.200391 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(228.423672 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(339.409922 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.484766 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1201,16 +1201,16 @@ z
     </g>
    </g>
    <g id="text_12">
-    <!-- 281 -->
-    <g transform="translate(441.489922 121.0255) scale(0.08 -0.08)">
+    <!-- 283 -->
+    <g transform="translate(443.564766 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(128.388672 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(130.463516 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(228.423672 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,23 +1244,90 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(339.409922 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.484766 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 700 -->
-    <g transform="translate(441.489922 150.4087) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+    <!-- 692 -->
+    <g transform="translate(443.564766 150.4087) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
-    <!-- miniz_oxide -->
-    <g transform="translate(111.694922 179.68065) scale(0.08 -0.08)">
+    <!-- Go compress/flate -->
+    <g transform="translate(100.893516 179.7919) scale(0.08 -0.08)">
      <defs>
+      <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-6d" d="M 3328 2828 
 Q 3544 3216 3844 3400 
 Q 4144 3584 4550 3584 
@@ -1291,6 +1358,105 @@ Q 2666 3584 2933 3390
 Q 3200 3197 3328 2828 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2f" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-47"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(77.490234 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(138.671875 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(170.458984 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(225.439453 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(286.621094 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(384.033203 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(447.509766 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(486.373047 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(547.896484 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(599.996094 0)"/>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(652.095703 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(685.787109 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(720.992188 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(748.775391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(810.054688 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 0.299 -->
+    <g transform="translate(230.498516 179.7919) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 52 -->
+    <g transform="translate(341.484766 179.7919) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 323 -->
+    <g transform="translate(443.564766 179.7919) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- miniz_oxide -->
+    <g transform="translate(113.769766 209.06385) scale(0.08 -0.08)">
+     <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
 L 2938 0 
@@ -1315,27 +1481,6 @@ L 3263 -1509
 L -63 -1509 
 L -63 -1063 
 L 3263 -1063 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6f" d="M 1959 3097 
-Q 1497 3097 1228 2736 
-Q 959 2375 959 1747 
-Q 959 1119 1226 758 
-Q 1494 397 1959 397 
-Q 2419 397 2687 759 
-Q 2956 1122 2956 1747 
-Q 2956 2369 2687 2733 
-Q 2419 3097 1959 3097 
-z
-M 1959 3584 
-Q 2709 3584 3137 3096 
-Q 3566 2609 3566 1747 
-Q 3566 888 3137 398 
-Q 2709 -91 1959 -91 
-Q 1206 -91 779 398 
-Q 353 888 353 1747 
-Q 353 2609 779 3096 
-Q 1206 3584 1959 3584 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-78" d="M 3513 3500 
@@ -1367,9 +1512,9 @@ z
      <use xlink:href="#DejaVuSans-65" transform="translate(527.34375 0)"/>
     </g>
    </g>
-   <g id="text_18">
+   <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(228.423672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1377,24 +1522,24 @@ z
      <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
     </g>
    </g>
-   <g id="text_19">
+   <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(339.409922 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.484766 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_20">
-    <!-- 730 -->
-    <g transform="translate(441.489922 179.7919) scale(0.08 -0.08)">
+   <g id="text_24">
+    <!-- 729 -->
+    <g transform="translate(443.564766 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
-   <g id="text_21">
+   <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(119.851172 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(121.926016 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1452,9 +1597,9 @@ z
      <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
     </g>
    </g>
-   <g id="text_22">
+   <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(228.423672 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1462,9 +1607,9 @@ z
      <use xlink:href="#DejaVuSans-37" transform="translate(222.65625 0)"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- 44 -->
-    <g transform="translate(339.409922 209.1751) scale(0.08 -0.08)">
+   <g id="text_27">
+    <!-- 41 -->
+    <g transform="translate(341.484766 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1487,20 +1632,19 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- 119 -->
-    <g transform="translate(441.489922 209.1751) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
     </g>
    </g>
-   <g id="text_25">
+   <g id="text_28">
+    <!-- 80 -->
+    <g transform="translate(446.109766 238.5583) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-38"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
     <!-- OCaml decompress -->
-    <g transform="translate(96.311797 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(98.386641 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -1544,70 +1688,6 @@ Q 3056 4750 3426 4639
 Q 3797 4528 4122 4306 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-63" d="M 3122 3366 
-L 3122 2828 
-Q 2878 2963 2633 3030 
-Q 2388 3097 2138 3097 
-Q 1578 3097 1268 2742 
-Q 959 2388 959 1747 
-Q 959 1106 1268 751 
-Q 1578 397 2138 397 
-Q 2388 397 2633 464 
-Q 2878 531 3122 666 
-L 3122 134 
-Q 2881 22 2623 -34 
-Q 2366 -91 2075 -91 
-Q 1284 -91 818 406 
-Q 353 903 353 1747 
-Q 353 2603 823 3093 
-Q 1294 3584 2113 3584 
-Q 2378 3584 2631 3529 
-Q 2884 3475 3122 3366 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525 
-L 1159 -1331 
-L 581 -1331 
-L 581 3500 
-L 1159 3500 
-L 1159 2969 
-Q 1341 3281 1617 3432 
-Q 1894 3584 2278 3584 
-Q 2916 3584 3314 3078 
-Q 3713 2572 3713 1747 
-Q 3713 922 3314 415 
-Q 2916 -91 2278 -91 
-Q 1894 -91 1617 61 
-Q 1341 213 1159 525 
-z
-M 3116 1747 
-Q 3116 2381 2855 2742 
-Q 2594 3103 2138 3103 
-Q 1681 3103 1420 2742 
-Q 1159 2381 1159 1747 
-Q 1159 1113 1420 752 
-Q 1681 391 2138 391 
-Q 2594 391 2855 752 
-Q 3116 1113 3116 1747 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-72" d="M 2631 2963 
-Q 2534 3019 2420 3045 
-Q 2306 3072 2169 3072 
-Q 1681 3072 1420 2755 
-Q 1159 2438 1159 1844 
-L 1159 0 
-L 581 0 
-L 581 3500 
-L 1159 3500 
-L 1159 2956 
-Q 1341 3275 1631 3429 
-Q 1922 3584 2338 3584 
-Q 2397 3584 2469 3576 
-Q 2541 3569 2628 3553 
-L 2631 2963 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-4f"/>
      <use xlink:href="#DejaVuSans-43" transform="translate(78.710938 0)"/>
@@ -1627,9 +1707,9 @@ z
      <use xlink:href="#DejaVuSans-73" transform="translate(921.333984 0)"/>
     </g>
    </g>
-   <g id="text_26">
+   <g id="text_30">
     <!-- 0.321 -->
-    <g transform="translate(228.423672 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1637,24 +1717,24 @@ z
      <use xlink:href="#DejaVuSans-31" transform="translate(222.65625 0)"/>
     </g>
    </g>
-   <g id="text_27">
+   <g id="text_31">
     <!-- 23 -->
-    <g transform="translate(339.409922 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.484766 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_28">
+   <g id="text_32">
     <!-- 117 -->
-    <g transform="translate(441.489922 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(443.564766 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
-   <g id="text_29">
+   <g id="text_33">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.196797 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.271641 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1761,9 +1841,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-29" transform="translate(880.615234 0)"/>
     </g>
    </g>
-   <g id="text_30">
+   <g id="text_34">
     <!-- 0.298 -->
-    <g transform="translate(227.223047 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.297891 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1892,9 +1972,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-38" transform="translate(246.728516 0)"/>
     </g>
    </g>
-   <g id="text_31">
+   <g id="text_35">
     <!-- 19 -->
-    <g transform="translate(338.933672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(341.008516 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1915,9 +1995,9 @@ z
      <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
     </g>
    </g>
-   <g id="text_32">
-    <!-- 136 -->
-    <g transform="translate(440.775547 267.9415) scale(0.08 -0.08)">
+   <g id="text_36">
+    <!-- 137 -->
+    <g transform="translate(442.850391 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516 
 Q 3453 2394 3698 2092 
@@ -1951,125 +2031,25 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
-    </g>
-   </g>
-   <g id="text_33">
-    <!-- Go compress/flate -->
-    <g transform="translate(98.818672 297.3247) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2f" d="M 1625 4666 
-L 2156 4666 
-L 531 -594 
-L 0 -594 
-L 1625 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-47"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(77.490234 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(138.671875 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(170.458984 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(225.439453 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(286.621094 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(384.033203 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(447.509766 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(486.373047 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(547.896484 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(599.996094 0)"/>
-     <use xlink:href="#DejaVuSans-2f" transform="translate(652.095703 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(685.787109 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(720.992188 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(748.775391 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(810.054688 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- 0.299 -->
-    <g transform="translate(228.423672 297.3247) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-30"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(159.033203 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(222.65625 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- 18 -->
-    <g transform="translate(339.409922 297.3247) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- 88 -->
-    <g transform="translate(444.034922 297.3247) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.533047 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.607891 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2080,7 +2060,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(228.423672 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2090,13 +2070,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(341.954922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.029766 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.124922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.199766 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2112,7 +2092,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(134.946172 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(137.021016 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2251,6 +2231,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2295,7 +2305,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-05T08:48:39Z  ·  Linux chungus x86_64  ·  commit 7e98994a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2436,14 +2446,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2463,129 +2473,130 @@ z
     <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
     <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
     <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.792969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.580078 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.367188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.941406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3761.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.314453 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.693359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3988.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.917969 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4211.03125 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4334.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.308594 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.6875 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4556.001953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.181641 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.804688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.591797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.214844 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.837891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.625 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.248047 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.332031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.195312 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.947266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.734375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.185547 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.367188 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.746094 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.601562 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.457031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.666016 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5992.029297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.441406 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.964844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.224609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.503906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.769531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.148438 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.427734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6691.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.382812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.564453 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.773438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.464844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.365234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.644531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.853516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.818359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.388672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.488281 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.484375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7520.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.371094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.566406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.945312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.728516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.828125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7867.037109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.820312 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2107.714844 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2139.501953 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2325.927734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2503.173828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.960938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2566.748047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2598.535156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2630.322266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2662.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2717.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2778.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2875.683594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p08b2821584">
-   <rect x="82.937422" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p6e2f4a2ee9">
+   <rect x="85.012266" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pffbdfc23f1)">
+   <g clip-path="url(#p3ffefac427)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ8UlEQVR4nO3Yv46cZx2GYc/uZB0chxjsOAlIFg0JTZAiqGg4AwoOgzJt+pSpaek5ASoQFRJCIFGELo6hII4SERwse2c9yxGkst77t/50XUfwjL4/7/3N7vjFby6vbdnhyfQCnsfxYnrBWruT6QVrXZxPL1jrxq3pBWs9/Xp6wVqnZ9MLeB5bvz/PbkwvWGrjpx8AAFeNAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILX/y+H+9Ial9ien0xOWOl5eTk9Y6u6rd6cnLHX/v/+cnrDWxj9x33751vSEpQ7Xz6YnLPXXhx9PT1jqx3d+OD1hqadnx+kJS+12j6cnLLXx4wEAgKtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9vde/cH0hqVuXb87PWGpz5/8a3rCUt97vO1vpJu3352esNTpbj89YanjteP0hKVev3ZnesJSF3fOpycs9caNe9MTljoct339Xjnf9vtl26c7AABXjgAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC13+223aCPDl9OT1jqW6c3pycs9ez2d6cnLPXvr/42PWGpr8+fTE9Y6iff+en0hKXOT6cXrPW/w6PpCTyH/zx9OD1hret3pxcste36BADgyhGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkds/++P7l9IiljsfpBfDNTnwDvtC8X15sW3/+tn5/un4vtI1fPQAArhoBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBAav/Gn/8xvWGpk/22G/vhx59PT1jq1796b3rCUh/+6bPpCUv9/N5r0xOW+u0fPpmesNQHv3xnesJSH/3+wfSEpX7x3lvTE5Z68NXT6QlL/ez7r0xPWGrbdQYAwJUjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSu8Oz311Oj1jp9OJiesJaJ/vpBWtdPJlesNbZjekFa+02/o17eZxesNbB8/dCe7bt8++w2/bz99LG+2XjpwMAAFeNAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILU/Xh6nNyx1+sX96QlrffvN6QVrPXo4vWCt6zenF6z10svTC9ba+u/78sH0grXe/NH0grXOH08vWGr/6d+nJ6x1+63pBUv5BxQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAg9X/x+HqsNPX6lAAAAABJRU5ErkJggg==" id="imagec86a2683d8" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ80lEQVR4nO3YsY6cVx2H4ezOeLM2kuXYYoWjCAkahChQIllRboProKLlGrgBOkougIKGggIpNCldEREbJCskVmJZzrA7u8tFROf9m0/PcwW/T2e+mXfOyc3Xf7h9Z8su30wvWOvkdHrBWjfH6QVrbf38jpfTC9a692B6wVr/fT29gO9jdza9YK2tfz7vnE8vWGrjv34AALxtBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9Z8dn0xuWOruzn56w1OF4OT1hqcf335+esNQXr55PT1jqeHI9PWGpn999OD1hqeO759MTlvr3639NT1jq4u7F9ISlDmfH6QlLnbzzZnrCUm5AAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1P7i3sX0hqUe/+Cn0xOW+vLNs+kJS/3osO3/SPcf/XJ6wlJnu/PpCUtd3xynJyy19fPb/POdbvv59qcfTE9Y6vxwmJ6w1LZ/3QEAeOsIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUvt3d/emNyz18vBiesJSWz+/6/ceTk9Y6vk3n01PWOr11WF6wlJP3nsyPWGpy9vj9ISlvnj1+fSEpX7x6KPpCUt9+uJv0xOW+vCH2z4/N6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqZPrv/7mdnrEUjc30wv4PrZ+fqf+A8KYrb9/vj//vx2P0wuW2vjpAQDwthGgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk9hefPp3esNTubDc9Yakvn/5nesJSv//1h9MTlvrd37d9fp98cH96wlJ//Mvn0xOW+u2vfjY9Yak//ePb6QlL/eTB3ekJS7387mp6wlIfP743PWEpN6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDq5Or6z7fTI1baXV1OT1hrdza9YK3jYXrBWvvz6QVr7fbTC9a6vZlesNbVxt+/k43fwZxu+/27Otn2+3fneJyesNTG3z4AAN42AhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgNT+5vZmesNSu6/+OT1hrQfvTy9Y69WL6QVrnd+fXrDWnfPpBWtt/flePptesNbDH08vWOvwanrBUvvnT6cnrPXo8fSCpdyAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKT+B169eLPa5stFAAAAAElFTkSuQmCC" id="imagef150d98969" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mb5ba2376dc" d="M 0 0 
+       <path id="m58cb58d4a1" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb5ba2376dc" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb5ba2376dc" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m58cb58d4a1" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mf9cf67213d" d="M 0 0 
+       <path id="mc068637832" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf9cf67213d" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc068637832" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf9cf67213d" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc068637832" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mf9cf67213d" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc068637832" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mf9cf67213d" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc068637832" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mf9cf67213d" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc068637832" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf9cf67213d" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc068637832" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mf9cf67213d" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc068637832" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf9cf67213d" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc068637832" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +8 -->
+    <!-- +9 -->
     <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1154,6 +1154,154 @@ L 678 2272
 L 2419 2272 
 L 2419 4013 
 L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -50 -->
+    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -20 -->
+    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -48 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-38" d="M 2034 2216 
@@ -1196,105 +1344,9 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -48 -->
-    <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -21 -->
-    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -47 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_25">
@@ -1348,11 +1400,27 @@ z
     </g>
    </g>
    <g id="text_27">
-    <!-- -12 -->
+    <!-- -13 -->
     <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1364,71 +1432,74 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- -1 -->
-    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+    <!-- -13 -->
+    <g transform="translate(432.725974 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -19 -->
+    <!-- -21 -->
     <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
     <!-- -72 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- -41 -->
+    <!-- -40 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
-    <!-- +6 -->
+    <!-- +7 -->
     <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_34">
+    <!-- -13 -->
+    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- -5 -->
+    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_36">
+    <!-- -16 -->
+    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1461,58 +1532,9 @@ Q 3103 4656 3366 4563
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_34">
-    <!-- -11 -->
-    <g transform="translate(150.784184 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_35">
-    <!-- -6 -->
-    <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_36">
-    <!-- -15 -->
-    <g transform="translate(231.338981 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_37">
@@ -1523,32 +1545,33 @@ z
     </g>
    </g>
    <g id="text_38">
-    <!-- +1 -->
-    <g transform="translate(312.410731 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    <!-- -0 -->
+    <g transform="translate(313.961591 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_39">
-    <!-- -3 -->
+    <!-- -4 -->
     <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_40">
-    <!-- -13 -->
+    <!-- -12 -->
     <g transform="translate(392.448575 106.389018) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_41">
-    <!-- +1 -->
-    <g transform="translate(433.242927 106.389018) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    <!-- -10 -->
+    <g transform="translate(432.725974 106.389018) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_42">
@@ -1583,125 +1606,102 @@ z
     </g>
    </g>
    <g id="text_46">
-    <!-- +252 -->
+    <!-- +250 -->
     <g transform="translate(147.165512 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_47">
-    <!-- +305 -->
+    <!-- +302 -->
     <g transform="translate(187.44291 143.2248) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_48">
-    <!-- +133 -->
+    <!-- +131 -->
     <g transform="translate(227.720309 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_49">
-    <!-- +238 -->
+    <!-- +230 -->
     <g transform="translate(267.997708 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_50">
-    <!-- +189 -->
+    <!-- +184 -->
     <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_51">
-    <!-- +281 -->
+    <!-- +280 -->
     <g transform="translate(348.552505 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_52">
-    <!-- +152 -->
+    <!-- +153 -->
     <g transform="translate(388.829903 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_53">
-    <!-- +259 -->
+    <!-- +216 -->
     <g transform="translate(429.107302 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(211.035156 0)"/>
-    </g>
-   </g>
-   <g id="text_54">
-    <!-- +186 -->
-    <g transform="translate(469.3847 143.2248) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(211.035156 0)"/>
     </g>
    </g>
+   <g id="text_54">
+    <!-- +191 -->
+    <g transform="translate(469.3847 143.2248) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
    <g id="text_55">
-    <!-- +210 -->
+    <!-- +205 -->
     <g transform="translate(509.662099 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_56">
-    <!-- +160 -->
+    <!-- +158 -->
     <g transform="translate(549.939498 143.2248) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(211.035156 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(211.035156 0)"/>
     </g>
    </g>
    <g id="text_57">
@@ -1770,11 +1770,11 @@ z
     </g>
    </g>
    <g id="text_65">
-    <!-- -96 -->
+    <!-- -97 -->
     <g transform="translate(432.725974 180.060583) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_66">
@@ -1802,19 +1802,19 @@ z
     </g>
    </g>
    <g id="text_69">
-    <!-- +31 -->
+    <!-- +32 -->
     <g transform="translate(108.955926 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_70">
-    <!-- +30 -->
+    <!-- +31 -->
     <g transform="translate(149.233324 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_71">
@@ -1833,19 +1833,19 @@ z
     </g>
    </g>
    <g id="text_73">
-    <!-- +64 -->
+    <!-- +65 -->
     <g transform="translate(270.06552 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_74">
-    <!-- +78 -->
+    <!-- +79 -->
     <g transform="translate(310.342919 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_75">
@@ -1865,11 +1865,11 @@ z
     </g>
    </g>
    <g id="text_77">
-    <!-- +64 -->
+    <!-- +73 -->
     <g transform="translate(431.175114 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_78">
@@ -1881,130 +1881,129 @@ z
     </g>
    </g>
    <g id="text_79">
-    <!-- +45 -->
+    <!-- +88 -->
     <g transform="translate(511.729912 216.896366) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_80">
-    <!-- +18 -->
-    <g transform="translate(552.00731 216.896366) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_80">
+    <!-- +21 -->
+    <g transform="translate(552.00731 216.896366) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_81">
-    <!-- +35 -->
-    <g transform="translate(108.955926 253.732149) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_82">
-    <!-- +8 -->
-    <g transform="translate(151.301137 253.732149) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_83">
     <!-- +43 -->
-    <g transform="translate(189.510723 253.732149) scale(0.065 -0.065)">
+    <g transform="translate(108.955926 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_82">
+    <!-- +4 -->
+    <g transform="translate(151.301137 253.732149) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_83">
+    <!-- +40 -->
+    <g transform="translate(189.510723 253.732149) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_84">
-    <!-- -39 -->
+    <!-- -37 -->
     <g transform="translate(231.338981 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_85">
-    <!-- +25 -->
+    <!-- +20 -->
     <g transform="translate(270.06552 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_86">
-    <!-- +20 -->
-    <g transform="translate(310.342919 253.732149) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_87">
-    <!-- +24 -->
-    <g transform="translate(350.620317 253.732149) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_88">
-    <!-- -10 -->
-    <g transform="translate(392.448575 253.732149) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_89">
-    <!-- +50 -->
-    <g transform="translate(431.175114 253.732149) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_90">
     <!-- +11 -->
-    <g transform="translate(471.452513 253.732149) scale(0.065 -0.065)">
+    <g transform="translate(310.342919 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
+   <g id="text_87">
+    <!-- +15 -->
+    <g transform="translate(350.620317 253.732149) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_88">
+    <!-- +5 -->
+    <g transform="translate(392.965528 253.732149) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_89">
+    <!-- +30 -->
+    <g transform="translate(431.175114 253.732149) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_90">
+    <!-- +20 -->
+    <g transform="translate(471.452513 253.732149) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
    <g id="text_91">
-    <!-- +18 -->
+    <!-- +13 -->
     <g transform="translate(511.729912 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_92">
-    <!-- -19 -->
+    <!-- -23 -->
     <g transform="translate(553.558169 253.732149) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_93">
-    <!-- +78 -->
+    <!-- +73 -->
     <g transform="translate(108.955926 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_94">
-    <!-- +73 -->
+    <!-- +68 -->
     <g transform="translate(149.233324 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_95">
@@ -2016,52 +2015,51 @@ z
     </g>
    </g>
    <g id="text_96">
-    <!-- +44 -->
-    <g transform="translate(229.788122 290.567931) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_97">
-    <!-- +88 -->
-    <g transform="translate(270.06552 290.567931) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_98">
-    <!-- +87 -->
-    <g transform="translate(310.342919 290.567931) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_99">
-    <!-- +34 -->
-    <g transform="translate(350.620317 290.567931) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
-    </g>
-   </g>
-   <g id="text_100">
     <!-- +41 -->
-    <g transform="translate(390.897716 290.567931) scale(0.065 -0.065)">
+    <g transform="translate(229.788122 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
-   <g id="text_101">
-    <!-- +105 -->
-    <g transform="translate(429.107302 290.567931) scale(0.065 -0.065)">
+   <g id="text_97">
+    <!-- +84 -->
+    <g transform="translate(270.06552 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_98">
+    <!-- +88 -->
+    <g transform="translate(310.342919 290.567931) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_99">
+    <!-- +33 -->
+    <g transform="translate(350.620317 290.567931) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+    </g>
+   </g>
+   <g id="text_100">
+    <!-- +40 -->
+    <g transform="translate(390.897716 290.567931) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(211.035156 0)"/>
+    </g>
+   </g>
+   <g id="text_101">
+    <!-- +77 -->
+    <g transform="translate(431.175114 290.567931) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_102">
@@ -2073,11 +2071,11 @@ z
     </g>
    </g>
    <g id="text_103">
-    <!-- +59 -->
+    <!-- +60 -->
     <g transform="translate(511.729912 290.567931) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_104">
@@ -2089,35 +2087,35 @@ z
     </g>
    </g>
    <g id="text_105">
-    <!-- -35 -->
+    <!-- -34 -->
     <g transform="translate(110.506785 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_106">
-    <!-- -44 -->
+    <!-- -45 -->
     <g transform="translate(150.784184 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_107">
-    <!-- -44 -->
+    <!-- -43 -->
     <g transform="translate(191.061582 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_108">
-    <!-- -48 -->
+    <!-- -49 -->
     <g transform="translate(231.338981 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_109">
@@ -2129,11 +2127,11 @@ z
     </g>
    </g>
    <g id="text_110">
-    <!-- -52 -->
+    <!-- -53 -->
     <g transform="translate(311.893778 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_111">
@@ -2145,43 +2143,43 @@ z
     </g>
    </g>
    <g id="text_112">
-    <!-- -50 -->
+    <!-- -49 -->
     <g transform="translate(392.448575 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_113">
-    <!-- -42 -->
+    <!-- -47 -->
     <g transform="translate(432.725974 327.403714) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_114">
+    <!-- -42 -->
+    <g transform="translate(473.003372 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_114">
-    <!-- -43 -->
-    <g transform="translate(473.003372 327.403714) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
    <g id="text_115">
-    <!-- -56 -->
+    <!-- -55 -->
     <g transform="translate(513.280771 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_116">
-    <!-- -45 -->
+    <!-- -46 -->
     <g transform="translate(553.558169 327.403714) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
   </g>
@@ -2195,23 +2193,23 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image622b0d9787" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imagea45671e477" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mfbfe43c5a8" d="M 0 0 
+       <path id="md5c0b4d70f" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mfbfe43c5a8" x="601.779688" y="321.322999" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c0b4d70f" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
       <!-- −3 -->
-      <g transform="translate(608.779688 325.122218) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 326.306682) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-2212" d="M 678 2272 
 L 4684 2272 
@@ -2229,12 +2227,12 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mfbfe43c5a8" x="601.779688" y="279.776959" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c0b4d70f" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
       <!-- −2 -->
-      <g transform="translate(608.779688 283.576178) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 284.365821) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
       </g>
@@ -2243,12 +2241,12 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mfbfe43c5a8" x="601.779688" y="238.23092" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c0b4d70f" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
       <!-- −1 -->
-      <g transform="translate(608.779688 242.030139) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 242.42496) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-2212"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
       </g>
@@ -2257,7 +2255,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mfbfe43c5a8" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c0b4d70f" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2270,12 +2268,12 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mfbfe43c5a8" x="601.779688" y="155.138841" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c0b4d70f" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
       <!-- 1 -->
-      <g transform="translate(608.779688 158.93806) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 158.543239) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
       </g>
      </g>
@@ -2283,12 +2281,12 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mfbfe43c5a8" x="601.779688" y="113.592802" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c0b4d70f" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
       <!-- 2 -->
-      <g transform="translate(608.779688 117.392021) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 116.602378) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
       </g>
      </g>
@@ -2296,12 +2294,12 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mfbfe43c5a8" x="601.779688" y="72.046763" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md5c0b4d70f" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
       <!-- 3 -->
-      <g transform="translate(608.779688 75.845981) scale(0.1 -0.1)">
+      <g transform="translate(608.779688 74.661517) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
       </g>
      </g>
@@ -2912,8 +2910,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-05T08:48:39Z  ·  Linux chungus x86_64  ·  commit 7e98994a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.762578 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.687734 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3004,14 +3002,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3031,128 +3029,129 @@ z
     <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
     <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
     <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.792969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.580078 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.367188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.941406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3761.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.314453 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.693359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3988.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.917969 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4211.03125 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4334.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.308594 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.6875 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4556.001953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.181641 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.804688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.591797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.214844 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.837891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.625 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.248047 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.332031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.195312 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.947266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.734375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.185547 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.367188 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.746094 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.601562 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.457031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.666016 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5992.029297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.441406 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.964844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.224609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.503906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.769531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.148438 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.427734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6691.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.382812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.564453 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.773438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.464844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.365234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.644531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.853516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.818359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.388672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.488281 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.484375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7520.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.371094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.566406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.945312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.728516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.828125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7867.037109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.820312 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2107.714844 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2139.501953 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2325.927734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2503.173828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.960938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2566.748047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2598.535156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2630.322266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2662.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2717.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2778.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2875.683594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pffbdfc23f1">
+  <clipPath id="p3ffefac427">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m4685768159" d="M 0 0 
+       <path id="me848e37d32" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4685768159" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me848e37d32" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m4685768159" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me848e37d32" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m4685768159" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me848e37d32" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m4685768159" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me848e37d32" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m4685768159" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me848e37d32" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m4685768159" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me848e37d32" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m4685768159" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me848e37d32" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,23 +854,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 368.088255 
-L 637.2 368.088255 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 368.08164 
+L 637.2 368.08164 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mb322ffe7c0" d="M 0 0 
+       <path id="m804cfc89a7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb322ffe7c0" x="49.078125" y="368.088255" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m804cfc89a7" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(24.478125 371.887474) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 371.880859) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -895,18 +895,18 @@ z
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 243.475737 
-L 637.2 243.475737 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 243.439835 
+L 637.2 243.439835 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb322ffe7c0" x="49.078125" y="243.475737" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m804cfc89a7" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(24.478125 247.274956) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 247.239053) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -915,18 +915,18 @@ L 637.2 243.475737
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 118.863219 
-L 637.2 118.863219 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 118.798029 
+L 637.2 118.798029 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb322ffe7c0" x="49.078125" y="118.863219" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m804cfc89a7" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 122.662438) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 122.597248) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -935,282 +935,282 @@ L 637.2 118.863219
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 405.600361 
-L 637.2 405.600361 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 405.602562 
+L 637.2 405.602562 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m662b1ab334" d="M 0 0 
+       <path id="meb2d454d2d" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="405.600361" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 395.733387 
-L 637.2 395.733387 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 395.733268 
+L 637.2 395.733268 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="395.733387" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 387.390979 
-L 637.2 387.390979 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 387.3889 
+L 637.2 387.3889 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="387.390979" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 380.164456 
-L 637.2 380.164456 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 380.160679 
+L 637.2 380.160679 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="380.164456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 373.790211 
-L 637.2 373.790211 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 373.784936 
+L 637.2 373.784936 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="373.790211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 330.57615 
-L 637.2 330.57615 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 330.560718 
+L 637.2 330.560718 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="330.57615" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 308.632974 
-L 637.2 308.632974 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 308.612385 
+L 637.2 308.612385 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="308.632974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 293.064044 
-L 637.2 293.064044 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 293.039796 
+L 637.2 293.039796 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="293.064044" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 280.987843 
-L 637.2 280.987843 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 280.960757 
+L 637.2 280.960757 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="280.987843" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 271.120868 
-L 637.2 271.120868 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.091463 
+L 637.2 271.091463 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="271.120868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 262.77846 
-L 637.2 262.77846 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 262.747094 
+L 637.2 262.747094 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="262.77846" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 255.551938 
-L 637.2 255.551938 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 255.518874 
+L 637.2 255.518874 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="255.551938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 249.177693 
-L 637.2 249.177693 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 249.143131 
+L 637.2 249.143131 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="249.177693" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 205.963631 
-L 637.2 205.963631 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.918912 
+L 637.2 205.918912 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="205.963631" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 184.020456 
-L 637.2 184.020456 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 183.97058 
+L 637.2 183.97058 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="184.020456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 168.451525 
-L 637.2 168.451525 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 168.39799 
+L 637.2 168.39799 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="168.451525" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 156.375325 
-L 637.2 156.375325 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 156.318951 
+L 637.2 156.318951 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="156.375325" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 146.50835 
-L 637.2 146.50835 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 146.449658 
+L 637.2 146.449658 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="146.50835" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 138.165942 
-L 637.2 138.165942 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 138.105289 
+L 637.2 138.105289 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="138.165942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 130.93942 
-L 637.2 130.93942 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 130.877068 
+L 637.2 130.877068 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="130.93942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 124.565175 
-L 637.2 124.565175 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 124.501326 
+L 637.2 124.501326 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="124.565175" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 81.351113 
-L 637.2 81.351113 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 81.277107 
+L 637.2 81.277107 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="81.351113" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 59.407938 
-L 637.2 59.407938 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 59.328775 
+L 637.2 59.328775 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m662b1ab334" x="49.078125" y="59.407938" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#meb2d454d2d" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 123.482083) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 123.058606) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 314.535627) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 314.934389) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,1488 +1686,1488 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="mf22ff869ff" d="M -2.5 2.5 
+     <path id="m832c1ea07f" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p399ecdeb00)">
-     <use xlink:href="#mf22ff869ff" x="377.110281" y="107.572658" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf22ff869ff" x="323.801439" y="112.143178" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf22ff869ff" x="272.665744" y="128.289861" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf22ff869ff" x="235.168828" y="129.778148" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf22ff869ff" x="186.228265" y="150.062022" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf22ff869ff" x="158.303164" y="172.157864" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf22ff869ff" x="149.489547" y="182.173164" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf22ff869ff" x="140.563162" y="202.575355" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf22ff869ff" x="138.984853" y="209.263476" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbc76cd86a)">
+     <use xlink:href="#m832c1ea07f" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m832c1ea07f" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m832c1ea07f" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m832c1ea07f" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m832c1ea07f" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m832c1ea07f" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m832c1ea07f" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m832c1ea07f" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m832c1ea07f" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
-    <path d="M 377.110281 107.572658 
-L 375.99968 107.671923 
-L 374.889079 107.771005 
-L 373.778478 107.869907 
-L 372.667878 107.968628 
-L 371.557277 108.06717 
-L 370.446676 108.165532 
-L 369.336075 108.263716 
-L 368.225474 108.361722 
-L 367.114873 108.459551 
-L 366.004272 108.557204 
-L 364.893671 108.65468 
-L 363.78307 108.751982 
-L 362.67247 108.849108 
-L 361.561869 108.946061 
-L 360.451268 109.04284 
-L 359.340667 109.139447 
-L 358.230066 109.235881 
-L 357.119465 109.332144 
-L 356.008864 109.428236 
-L 354.898263 109.524158 
-L 353.787662 109.61991 
-L 352.677062 109.715493 
-L 351.566461 109.810907 
-L 350.45586 109.906153 
-L 349.345259 110.001232 
-L 348.234658 110.096145 
-L 347.124057 110.190891 
-L 346.013456 110.285471 
-L 344.902855 110.379887 
-L 343.792255 110.474138 
-L 342.681654 110.568225 
-L 341.571053 110.662149 
-L 340.460452 110.75591 
-L 339.349851 110.849509 
-L 338.23925 110.942947 
-L 337.128649 111.036223 
-L 336.018048 111.129339 
-L 334.907447 111.222295 
-L 333.796847 111.315092 
-L 332.686246 111.407729 
-L 331.575645 111.500209 
-L 330.465044 111.592531 
-L 329.354443 111.684695 
-L 328.243842 111.776703 
-L 327.133241 111.868554 
-L 326.02264 111.96025 
-L 324.91204 112.051791 
-L 323.801439 112.143178 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 377.110281 104.685421 
+L 375.99968 104.811068 
+L 374.889079 104.936423 
+L 373.778478 105.06149 
+L 372.667878 105.186268 
+L 371.557277 105.310758 
+L 370.446676 105.434964 
+L 369.336075 105.558885 
+L 368.225474 105.682523 
+L 367.114873 105.805879 
+L 366.004272 105.928954 
+L 364.893671 106.051751 
+L 363.78307 106.174269 
+L 362.67247 106.296511 
+L 361.561869 106.418478 
+L 360.451268 106.54017 
+L 359.340667 106.661589 
+L 358.230066 106.782737 
+L 357.119465 106.903614 
+L 356.008864 107.024221 
+L 354.898263 107.144561 
+L 353.787662 107.264634 
+L 352.677062 107.38444 
+L 351.566461 107.503983 
+L 350.45586 107.623262 
+L 349.345259 107.742278 
+L 348.234658 107.861034 
+L 347.124057 107.979529 
+L 346.013456 108.097766 
+L 344.902855 108.215745 
+L 343.792255 108.333468 
+L 342.681654 108.450935 
+L 341.571053 108.568147 
+L 340.460452 108.685107 
+L 339.349851 108.801814 
+L 338.23925 108.91827 
+L 337.128649 109.034476 
+L 336.018048 109.150433 
+L 334.907447 109.266143 
+L 333.796847 109.381605 
+L 332.686246 109.496822 
+L 331.575645 109.611794 
+L 330.465044 109.726522 
+L 329.354443 109.841008 
+L 328.243842 109.955252 
+L 327.133241 110.069256 
+L 326.02264 110.18302 
+L 324.91204 110.296545 
+L 323.801439 110.409833 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
-    <path d="M 323.801439 112.143178 
-L 322.736112 112.533723 
-L 321.670785 112.92147 
-L 320.605458 113.306458 
-L 319.540131 113.688728 
-L 318.474804 114.068316 
-L 317.409477 114.44526 
-L 316.34415 114.819597 
-L 315.278823 115.191362 
-L 314.213496 115.560591 
-L 313.148169 115.927318 
-L 312.082842 116.291576 
-L 311.017515 116.653399 
-L 309.952188 117.012819 
-L 308.886861 117.369868 
-L 307.821534 117.724577 
-L 306.756207 118.076976 
-L 305.69088 118.427095 
-L 304.625553 118.774963 
-L 303.560226 119.12061 
-L 302.494899 119.464063 
-L 301.429572 119.80535 
-L 300.364245 120.144499 
-L 299.298918 120.481535 
-L 298.233591 120.816485 
-L 297.168264 121.149375 
-L 296.102937 121.48023 
-L 295.03761 121.809074 
-L 293.972283 122.135933 
-L 292.906956 122.460829 
-L 291.84163 122.783786 
-L 290.776303 123.104827 
-L 289.710976 123.423975 
-L 288.645649 123.741252 
-L 287.580322 124.05668 
-L 286.514995 124.37028 
-L 285.449668 124.682073 
-L 284.384341 124.99208 
-L 283.319014 125.300322 
-L 282.253687 125.606818 
-L 281.18836 125.911587 
-L 280.123033 126.21465 
-L 279.057706 126.516026 
-L 277.992379 126.815732 
-L 276.927052 127.113788 
-L 275.861725 127.410211 
-L 274.796398 127.705019 
-L 273.731071 127.99823 
-L 272.665744 128.289861 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 323.801439 110.409833 
+L 322.736112 110.793462 
+L 321.670785 111.174391 
+L 320.605458 111.552658 
+L 319.540131 111.928301 
+L 318.474804 112.301354 
+L 317.409477 112.671854 
+L 316.34415 113.039836 
+L 315.278823 113.405333 
+L 314.213496 113.768378 
+L 313.148169 114.129005 
+L 312.082842 114.487245 
+L 311.017515 114.84313 
+L 309.952188 115.196691 
+L 308.886861 115.547957 
+L 307.821534 115.896959 
+L 306.756207 116.243725 
+L 305.69088 116.588283 
+L 304.625553 116.930662 
+L 303.560226 117.270889 
+L 302.494899 117.608992 
+L 301.429572 117.944995 
+L 300.364245 118.278926 
+L 299.298918 118.610809 
+L 298.233591 118.94067 
+L 297.168264 119.268533 
+L 296.102937 119.594422 
+L 295.03761 119.918361 
+L 293.972283 120.240373 
+L 292.906956 120.560481 
+L 291.84163 120.878707 
+L 290.776303 121.195073 
+L 289.710976 121.509601 
+L 288.645649 121.822311 
+L 287.580322 122.133226 
+L 286.514995 122.442365 
+L 285.449668 122.749749 
+L 284.384341 123.055396 
+L 283.319014 123.359328 
+L 282.253687 123.661563 
+L 281.18836 123.96212 
+L 280.123033 124.261017 
+L 279.057706 124.558273 
+L 277.992379 124.853905 
+L 276.927052 125.147932 
+L 275.861725 125.44037 
+L 274.796398 125.731236 
+L 273.731071 126.020548 
+L 272.665744 126.308323 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
-    <path d="M 272.665744 128.289861 
-L 271.884558 128.321288 
-L 271.103373 128.352697 
-L 270.322187 128.384088 
-L 269.541001 128.41546 
-L 268.759815 128.446815 
-L 267.97863 128.478151 
-L 267.197444 128.509469 
-L 266.416258 128.540769 
-L 265.635072 128.572051 
-L 264.853887 128.603314 
-L 264.072701 128.63456 
-L 263.291515 128.665788 
-L 262.510329 128.696997 
-L 261.729144 128.728189 
-L 260.947958 128.759363 
-L 260.166772 128.790518 
-L 259.385586 128.821656 
-L 258.604401 128.852776 
-L 257.823215 128.883878 
-L 257.042029 128.914962 
-L 256.260843 128.946028 
-L 255.479658 128.977077 
-L 254.698472 129.008108 
-L 253.917286 129.039121 
-L 253.1361 129.070116 
-L 252.354915 129.101093 
-L 251.573729 129.132053 
-L 250.792543 129.162995 
-L 250.011357 129.193919 
-L 249.230172 129.224826 
-L 248.448986 129.255715 
-L 247.6678 129.286586 
-L 246.886614 129.31744 
-L 246.105429 129.348276 
-L 245.324243 129.379095 
-L 244.543057 129.409896 
-L 243.761871 129.440679 
-L 242.980686 129.471445 
-L 242.1995 129.502194 
-L 241.418314 129.532925 
-L 240.637128 129.563639 
-L 239.855943 129.594335 
-L 239.074757 129.625014 
-L 238.293571 129.655676 
-L 237.512385 129.68632 
-L 236.7312 129.716946 
-L 235.950014 129.747556 
-L 235.168828 129.778148 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 272.665744 126.308323 
+L 271.884558 126.344685 
+L 271.103373 126.381023 
+L 270.322187 126.417337 
+L 269.541001 126.453626 
+L 268.759815 126.489891 
+L 267.97863 126.526132 
+L 267.197444 126.562348 
+L 266.416258 126.598541 
+L 265.635072 126.634709 
+L 264.853887 126.670853 
+L 264.072701 126.706973 
+L 263.291515 126.743068 
+L 262.510329 126.77914 
+L 261.729144 126.815188 
+L 260.947958 126.851211 
+L 260.166772 126.887211 
+L 259.385586 126.923187 
+L 258.604401 126.959139 
+L 257.823215 126.995067 
+L 257.042029 127.030971 
+L 256.260843 127.066852 
+L 255.479658 127.102708 
+L 254.698472 127.138541 
+L 253.917286 127.17435 
+L 253.1361 127.210136 
+L 252.354915 127.245898 
+L 251.573729 127.281636 
+L 250.792543 127.317351 
+L 250.011357 127.353042 
+L 249.230172 127.38871 
+L 248.448986 127.424354 
+L 247.6678 127.459974 
+L 246.886614 127.495572 
+L 246.105429 127.531146 
+L 245.324243 127.566696 
+L 244.543057 127.602223 
+L 243.761871 127.637727 
+L 242.980686 127.673208 
+L 242.1995 127.708665 
+L 241.418314 127.744099 
+L 240.637128 127.77951 
+L 239.855943 127.814898 
+L 239.074757 127.850263 
+L 238.293571 127.885605 
+L 237.512385 127.920923 
+L 236.7312 127.956219 
+L 235.950014 127.991491 
+L 235.168828 128.026741 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
-    <path d="M 235.168828 129.778148 
-L 234.149233 130.288403 
-L 233.129638 130.793893 
-L 232.110043 131.294704 
-L 231.090448 131.790924 
-L 230.070853 132.282634 
-L 229.051258 132.769918 
-L 228.031663 133.252853 
-L 227.012068 133.731517 
-L 225.992473 134.205984 
-L 224.972877 134.676327 
-L 223.953282 135.142618 
-L 222.933687 135.604926 
-L 221.914092 136.063317 
-L 220.894497 136.517859 
-L 219.874902 136.968615 
-L 218.855307 137.415647 
-L 217.835712 137.859017 
-L 216.816117 138.298784 
-L 215.796522 138.735007 
-L 214.776927 139.167741 
-L 213.757332 139.597043 
-L 212.737737 140.022966 
-L 211.718142 140.445563 
-L 210.698547 140.864885 
-L 209.678952 141.280984 
-L 208.659356 141.693907 
-L 207.639761 142.103704 
-L 206.620166 142.510422 
-L 205.600571 142.914105 
-L 204.580976 143.314799 
-L 203.561381 143.712549 
-L 202.541786 144.107396 
-L 201.522191 144.499384 
-L 200.502596 144.888553 
-L 199.483001 145.274943 
-L 198.463406 145.658594 
-L 197.443811 146.039544 
-L 196.424216 146.417832 
-L 195.404621 146.793494 
-L 194.385026 147.166566 
-L 193.365431 147.537083 
-L 192.345835 147.905082 
-L 191.32624 148.270595 
-L 190.306645 148.633656 
-L 189.28705 148.994297 
-L 188.267455 149.352551 
-L 187.24786 149.708449 
-L 186.228265 150.062022 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 235.168828 128.026741 
+L 234.149233 128.569311 
+L 233.129638 129.106497 
+L 232.110043 129.638404 
+L 231.090448 130.165135 
+L 230.070853 130.68679 
+L 229.051258 131.203467 
+L 228.031663 131.715258 
+L 227.012068 132.222255 
+L 225.992473 132.724548 
+L 224.972877 133.222223 
+L 223.953282 133.715364 
+L 222.933687 134.204053 
+L 221.914092 134.68837 
+L 220.894497 135.168392 
+L 219.874902 135.644194 
+L 218.855307 136.115851 
+L 217.835712 136.583433 
+L 216.816117 137.047012 
+L 215.796522 137.506653 
+L 214.776927 137.962425 
+L 213.757332 138.414391 
+L 212.737737 138.862615 
+L 211.718142 139.307158 
+L 210.698547 139.74808 
+L 209.678952 140.185439 
+L 208.659356 140.619293 
+L 207.639761 141.049697 
+L 206.620166 141.476706 
+L 205.600571 141.900373 
+L 204.580976 142.32075 
+L 203.561381 142.737887 
+L 202.541786 143.151835 
+L 201.522191 143.562641 
+L 200.502596 143.970353 
+L 199.483001 144.375017 
+L 198.463406 144.776678 
+L 197.443811 145.175381 
+L 196.424216 145.571168 
+L 195.404621 145.964083 
+L 194.385026 146.354166 
+L 193.365431 146.741458 
+L 192.345835 147.126 
+L 191.32624 147.507828 
+L 190.306645 147.886982 
+L 189.28705 148.263499 
+L 188.267455 148.637415 
+L 187.24786 149.008766 
+L 186.228265 149.377587 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
-    <path d="M 186.228265 150.062022 
-L 185.646492 150.627569 
-L 185.064719 151.187267 
-L 184.482946 151.741235 
-L 183.901173 152.289591 
-L 183.3194 152.832446 
-L 182.737627 153.36991 
-L 182.155854 153.902088 
-L 181.574082 154.429084 
-L 180.992309 154.950998 
-L 180.410536 155.467927 
-L 179.828763 155.979965 
-L 179.24699 156.487203 
-L 178.665217 156.989732 
-L 178.083444 157.487637 
-L 177.501671 157.981003 
-L 176.919898 158.469911 
-L 176.338125 158.954443 
-L 175.756352 159.434675 
-L 175.174579 159.910682 
-L 174.592806 160.38254 
-L 174.011033 160.850319 
-L 173.42926 161.314089 
-L 172.847487 161.773919 
-L 172.265714 162.229874 
-L 171.683941 162.682021 
-L 171.102169 163.13042 
-L 170.520396 163.575136 
-L 169.938623 164.016226 
-L 169.35685 164.453751 
-L 168.775077 164.887766 
-L 168.193304 165.318329 
-L 167.611531 165.745493 
-L 167.029758 166.169312 
-L 166.447985 166.589837 
-L 165.866212 167.00712 
-L 165.284439 167.421211 
-L 164.702666 167.832156 
-L 164.120893 168.240005 
-L 163.53912 168.644803 
-L 162.957347 169.046596 
-L 162.375574 169.445428 
-L 161.793801 169.841342 
-L 161.212029 170.234381 
-L 160.630256 170.624585 
-L 160.048483 171.011997 
-L 159.46671 171.396655 
-L 158.884937 171.778598 
-L 158.303164 172.157864 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 186.228265 149.377587 
+L 185.646492 149.942619 
+L 185.064719 150.501814 
+L 184.482946 151.055291 
+L 183.901173 151.603166 
+L 183.3194 152.145552 
+L 182.737627 152.682557 
+L 182.155854 153.214287 
+L 181.574082 153.740845 
+L 180.992309 154.26233 
+L 180.410536 154.778839 
+L 179.828763 155.290466 
+L 179.24699 155.797302 
+L 178.665217 156.299437 
+L 178.083444 156.796957 
+L 177.501671 157.289946 
+L 176.919898 157.778485 
+L 176.338125 158.262655 
+L 175.756352 158.742533 
+L 175.174579 159.218193 
+L 174.592806 159.689711 
+L 174.011033 160.157156 
+L 173.42926 160.6206 
+L 172.847487 161.08011 
+L 172.265714 161.535751 
+L 171.683941 161.987589 
+L 171.102169 162.435687 
+L 170.520396 162.880106 
+L 169.938623 163.320906 
+L 169.35685 163.758146 
+L 168.775077 164.191882 
+L 168.193304 164.62217 
+L 167.611531 165.049065 
+L 167.029758 165.47262 
+L 166.447985 165.892886 
+L 165.866212 166.309914 
+L 165.284439 166.723754 
+L 164.702666 167.134455 
+L 164.120893 167.542062 
+L 163.53912 167.946624 
+L 162.957347 168.348184 
+L 162.375574 168.746787 
+L 161.793801 169.142477 
+L 161.212029 169.535295 
+L 160.630256 169.925283 
+L 160.048483 170.312481 
+L 159.46671 170.696929 
+L 158.884937 171.078667 
+L 158.303164 171.457731 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
-    <path d="M 158.303164 172.157864 
-L 158.119547 172.386587 
-L 157.93593 172.614348 
-L 157.752313 172.841154 
-L 157.568696 173.067013 
-L 157.385079 173.291934 
-L 157.201462 173.515924 
-L 157.017845 173.73899 
-L 156.834228 173.961141 
-L 156.650611 174.182384 
-L 156.466994 174.402726 
-L 156.283377 174.622174 
-L 156.09976 174.840736 
-L 155.916143 175.058419 
-L 155.732525 175.27523 
-L 155.548908 175.491176 
-L 155.365291 175.706264 
-L 155.181674 175.9205 
-L 154.998057 176.133891 
-L 154.81444 176.346445 
-L 154.630823 176.558166 
-L 154.447206 176.769063 
-L 154.263589 176.979141 
-L 154.079972 177.188407 
-L 153.896355 177.396866 
-L 153.712738 177.604526 
-L 153.529121 177.811392 
-L 153.345504 178.01747 
-L 153.161887 178.222766 
-L 152.97827 178.427287 
-L 152.794653 178.631038 
-L 152.611036 178.834024 
-L 152.427419 179.036252 
-L 152.243802 179.237727 
-L 152.060185 179.438455 
-L 151.876568 179.638441 
-L 151.692951 179.83769 
-L 151.509334 180.036209 
-L 151.325717 180.234002 
-L 151.1421 180.431075 
-L 150.958483 180.627433 
-L 150.774866 180.823081 
-L 150.591249 181.018025 
-L 150.407632 181.212268 
-L 150.224015 181.405817 
-L 150.040398 181.598676 
-L 149.856781 181.790851 
-L 149.673164 181.982345 
-L 149.489547 182.173164 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 158.303164 171.457731 
+L 158.119547 171.704528 
+L 157.93593 171.950205 
+L 157.752313 172.194772 
+L 157.568696 172.438239 
+L 157.385079 172.680616 
+L 157.201462 172.921912 
+L 157.017845 173.162138 
+L 156.834228 173.401302 
+L 156.650611 173.639414 
+L 156.466994 173.876484 
+L 156.283377 174.112519 
+L 156.09976 174.34753 
+L 155.916143 174.581525 
+L 155.732525 174.814513 
+L 155.548908 175.046503 
+L 155.365291 175.277502 
+L 155.181674 175.50752 
+L 154.998057 175.736564 
+L 154.81444 175.964644 
+L 154.630823 176.191766 
+L 154.447206 176.41794 
+L 154.263589 176.643172 
+L 154.079972 176.867471 
+L 153.896355 177.090845 
+L 153.712738 177.3133 
+L 153.529121 177.534846 
+L 153.345504 177.755488 
+L 153.161887 177.975234 
+L 152.97827 178.194092 
+L 152.794653 178.412069 
+L 152.611036 178.629171 
+L 152.427419 178.845406 
+L 152.243802 179.060781 
+L 152.060185 179.275302 
+L 151.876568 179.488977 
+L 151.692951 179.701811 
+L 151.509334 179.913812 
+L 151.325717 180.124986 
+L 151.1421 180.335339 
+L 150.958483 180.544878 
+L 150.774866 180.753609 
+L 150.591249 180.961538 
+L 150.407632 181.168672 
+L 150.224015 181.375015 
+L 150.040398 181.580576 
+L 149.856781 181.785359 
+L 149.673164 181.989369 
+L 149.489547 182.192614 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
-    <path d="M 149.489547 182.173164 
-L 149.30358 182.686976 
-L 149.117614 183.195954 
-L 148.931648 183.700191 
-L 148.745681 184.199773 
-L 148.559715 184.694785 
-L 148.373749 185.18531 
-L 148.187782 185.671429 
-L 148.001816 186.153221 
-L 147.81585 186.630761 
-L 147.629883 187.104124 
-L 147.443917 187.573383 
-L 147.257951 188.038607 
-L 147.071984 188.499867 
-L 146.886018 188.957228 
-L 146.700052 189.410757 
-L 146.514085 189.860516 
-L 146.328119 190.306568 
-L 146.142153 190.748974 
-L 145.956186 191.187793 
-L 145.77022 191.623082 
-L 145.584254 192.054898 
-L 145.398287 192.483296 
-L 145.212321 192.908329 
-L 145.026354 193.33005 
-L 144.840388 193.74851 
-L 144.654422 194.163759 
-L 144.468455 194.575847 
-L 144.282489 194.98482 
-L 144.096523 195.390726 
-L 143.910556 195.79361 
-L 143.72459 196.193516 
-L 143.538624 196.59049 
-L 143.352657 196.984573 
-L 143.166691 197.375806 
-L 142.980725 197.764232 
-L 142.794758 198.14989 
-L 142.608792 198.532819 
-L 142.422826 198.913058 
-L 142.236859 199.290643 
-L 142.050893 199.665612 
-L 141.864927 200.038002 
-L 141.67896 200.407846 
-L 141.492994 200.77518 
-L 141.307028 201.140037 
-L 141.121061 201.502451 
-L 140.935095 201.862455 
-L 140.749129 202.220079 
-L 140.563162 202.575355 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 149.489547 182.192614 
+L 149.30358 182.703036 
+L 149.117614 183.208689 
+L 148.931648 183.709663 
+L 148.745681 184.206043 
+L 148.559715 184.697912 
+L 148.373749 185.185353 
+L 148.187782 185.668443 
+L 148.001816 186.147259 
+L 147.81585 186.621878 
+L 147.629883 187.092371 
+L 147.443917 187.55881 
+L 147.257951 188.021265 
+L 147.071984 188.479801 
+L 146.886018 188.934487 
+L 146.700052 189.385385 
+L 146.514085 189.832557 
+L 146.328119 190.276067 
+L 146.142153 190.715972 
+L 145.956186 191.15233 
+L 145.77022 191.5852 
+L 145.584254 192.014635 
+L 145.398287 192.44069 
+L 145.212321 192.863418 
+L 145.026354 193.282871 
+L 144.840388 193.699098 
+L 144.654422 194.112149 
+L 144.468455 194.522072 
+L 144.282489 194.928914 
+L 144.096523 195.332721 
+L 143.910556 195.733538 
+L 143.72459 196.131409 
+L 143.538624 196.526378 
+L 143.352657 196.918485 
+L 143.166691 197.307772 
+L 142.980725 197.694279 
+L 142.794758 198.078047 
+L 142.608792 198.459112 
+L 142.422826 198.837514 
+L 142.236859 199.213289 
+L 142.050893 199.586474 
+L 141.864927 199.957103 
+L 141.67896 200.325212 
+L 141.492994 200.690835 
+L 141.307028 201.054004 
+L 141.121061 201.414753 
+L 140.935095 201.773114 
+L 140.749129 202.129119 
+L 140.563162 202.482797 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
-    <path d="M 140.563162 202.575355 
-L 140.530281 202.723464 
-L 140.497399 202.871169 
-L 140.464518 203.018471 
-L 140.431636 203.165373 
-L 140.398755 203.311878 
-L 140.365874 203.457988 
-L 140.332992 203.603704 
-L 140.300111 203.749028 
-L 140.267229 203.893964 
-L 140.234348 204.038512 
-L 140.201466 204.182675 
-L 140.168585 204.326456 
-L 140.135703 204.469855 
-L 140.102822 204.612875 
-L 140.069941 204.755518 
-L 140.037059 204.897787 
-L 140.004178 205.039682 
-L 139.971296 205.181206 
-L 139.938415 205.322362 
-L 139.905533 205.46315 
-L 139.872652 205.603572 
-L 139.83977 205.743631 
-L 139.806889 205.883329 
-L 139.774008 206.022667 
-L 139.741126 206.161647 
-L 139.708245 206.300271 
-L 139.675363 206.438541 
-L 139.642482 206.576459 
-L 139.6096 206.714026 
-L 139.576719 206.851244 
-L 139.543837 206.988115 
-L 139.510956 207.124641 
-L 139.478075 207.260824 
-L 139.445193 207.396664 
-L 139.412312 207.532165 
-L 139.37943 207.667327 
-L 139.346549 207.802152 
-L 139.313667 207.936642 
-L 139.280786 208.070799 
-L 139.247904 208.204624 
-L 139.215023 208.338119 
-L 139.182142 208.471286 
-L 139.14926 208.604125 
-L 139.116379 208.73664 
-L 139.083497 208.86883 
-L 139.050616 209.000699 
-L 139.017734 209.132247 
-L 138.984853 209.263476 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 140.563162 202.482797 
+L 140.530281 202.634623 
+L 140.497399 202.786024 
+L 140.464518 202.937003 
+L 140.431636 203.087562 
+L 140.398755 203.237704 
+L 140.365874 203.38743 
+L 140.332992 203.536744 
+L 140.300111 203.685646 
+L 140.267229 203.83414 
+L 140.234348 203.982228 
+L 140.201466 204.129912 
+L 140.168585 204.277194 
+L 140.135703 204.424076 
+L 140.102822 204.570561 
+L 140.069941 204.716651 
+L 140.037059 204.862347 
+L 140.004178 205.007652 
+L 139.971296 205.152569 
+L 139.938415 205.297098 
+L 139.905533 205.441242 
+L 139.872652 205.585004 
+L 139.83977 205.728385 
+L 139.806889 205.871387 
+L 139.774008 206.014012 
+L 139.741126 206.156263 
+L 139.708245 206.298141 
+L 139.675363 206.439647 
+L 139.642482 206.580785 
+L 139.6096 206.721556 
+L 139.576719 206.861962 
+L 139.543837 207.002004 
+L 139.510956 207.141685 
+L 139.478075 207.281006 
+L 139.445193 207.41997 
+L 139.412312 207.558578 
+L 139.37943 207.696832 
+L 139.346549 207.834734 
+L 139.313667 207.972286 
+L 139.280786 208.109488 
+L 139.247904 208.246344 
+L 139.215023 208.382855 
+L 139.182142 208.519022 
+L 139.14926 208.654848 
+L 139.116379 208.790334 
+L 139.083497 208.925481 
+L 139.050616 209.060292 
+L 139.017734 209.194768 
+L 138.984853 209.328911 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m22d5fce672" d="M 0 -2.5 
+     <path id="md510416027" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p399ecdeb00)">
-     <use xlink:href="#m22d5fce672" x="610.467187" y="71.829514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m22d5fce672" x="319.880958" y="101.654884" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m22d5fce672" x="210.281253" y="129.793447" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m22d5fce672" x="196.287076" y="133.571842" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m22d5fce672" x="176.054419" y="147.433896" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m22d5fce672" x="152.161413" y="174.830826" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m22d5fce672" x="146.720208" y="186.628416" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m22d5fce672" x="143.994022" y="196.353927" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m22d5fce672" x="142.666037" y="200.270771" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbc76cd86a)">
+     <use xlink:href="#md510416027" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md510416027" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md510416027" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md510416027" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md510416027" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md510416027" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md510416027" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md510416027" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md510416027" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
-    <path d="M 610.467187 71.829514 
-L 604.413308 72.652125 
-L 598.359428 73.462419 
-L 592.305548 74.260759 
-L 586.251668 75.047494 
-L 580.197789 75.822955 
-L 574.143909 76.587462 
-L 568.090029 77.341319 
-L 562.036149 78.084819 
-L 555.98227 78.818243 
-L 549.92839 79.54186 
-L 543.87451 80.25593 
-L 537.82063 80.9607 
-L 531.76675 81.65641 
-L 525.712871 82.343289 
-L 519.658991 83.02156 
-L 513.605111 83.691435 
-L 507.551231 84.35312 
-L 501.497352 85.006812 
-L 495.443472 85.652703 
-L 489.389592 86.290976 
-L 483.335712 86.921809 
-L 477.281832 87.545373 
-L 471.227953 88.161834 
-L 465.174073 88.771352 
-L 459.120193 89.374081 
-L 453.066313 89.970172 
-L 447.012434 90.559768 
-L 440.958554 91.143011 
-L 434.904674 91.720034 
-L 428.850794 92.29097 
-L 422.796914 92.855946 
-L 416.743035 93.415084 
-L 410.689155 93.968505 
-L 404.635275 94.516323 
-L 398.581395 95.058652 
-L 392.527516 95.5956 
-L 386.473636 96.127272 
-L 380.419756 96.653773 
-L 374.365876 97.1752 
-L 368.311997 97.691651 
-L 362.258117 98.203221 
-L 356.204237 98.71 
-L 350.150357 99.212077 
-L 344.096477 99.709539 
-L 338.042598 100.20247 
-L 331.988718 100.690952 
-L 325.934838 101.175064 
-L 319.880958 101.654884 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 610.467187 71.939349 
+L 604.413308 72.766161 
+L 598.359428 73.580532 
+L 592.305548 74.382834 
+L 586.251668 75.173418 
+L 580.197789 75.952621 
+L 574.143909 76.720767 
+L 568.090029 77.478165 
+L 562.036149 78.225112 
+L 555.98227 78.961892 
+L 549.92839 79.688778 
+L 543.87451 80.406032 
+L 537.82063 81.113907 
+L 531.76675 81.812644 
+L 525.712871 82.502477 
+L 519.658991 83.183629 
+L 513.605111 83.856316 
+L 507.551231 84.520747 
+L 501.497352 85.17712 
+L 495.443472 85.82563 
+L 489.389592 86.466463 
+L 483.335712 87.099798 
+L 477.281832 87.725808 
+L 471.227953 88.344661 
+L 465.174073 88.95652 
+L 459.120193 89.561539 
+L 453.066313 90.159871 
+L 447.012434 90.751662 
+L 440.958554 91.337052 
+L 434.904674 91.91618 
+L 428.850794 92.489178 
+L 422.796914 93.056173 
+L 416.743035 93.617292 
+L 410.689155 94.172653 
+L 404.635275 94.722374 
+L 398.581395 95.266569 
+L 392.527516 95.805347 
+L 386.473636 96.338816 
+L 380.419756 96.867078 
+L 374.365876 97.390235 
+L 368.311997 97.908385 
+L 362.258117 98.421621 
+L 356.204237 98.930037 
+L 350.150357 99.433722 
+L 344.096477 99.932764 
+L 338.042598 100.427247 
+L 331.988718 100.917253 
+L 325.934838 101.402864 
+L 319.880958 101.884157 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
-    <path d="M 319.880958 101.654884 
-L 317.597631 102.418331 
-L 315.314304 103.171158 
-L 313.030977 103.913656 
-L 310.74765 104.646105 
-L 308.464322 105.368773 
-L 306.180995 106.081918 
-L 303.897668 106.785788 
-L 301.614341 107.48062 
-L 299.331014 108.166645 
-L 297.047686 108.844082 
-L 294.764359 109.513143 
-L 292.481032 110.174034 
-L 290.197705 110.826952 
-L 287.914378 111.472086 
-L 285.631051 112.10962 
-L 283.347723 112.739732 
-L 281.064396 113.362591 
-L 278.781069 113.978363 
-L 276.497742 114.587207 
-L 274.214415 115.189278 
-L 271.931087 115.784724 
-L 269.64776 116.373691 
-L 267.364433 116.956316 
-L 265.081106 117.532736 
-L 262.797779 118.103081 
-L 260.514451 118.667478 
-L 258.231124 119.226049 
-L 255.947797 119.778915 
-L 253.66447 120.326189 
-L 251.381143 120.867984 
-L 249.097816 121.404409 
-L 246.814488 121.935569 
-L 244.531161 122.461567 
-L 242.247834 122.982501 
-L 239.964507 123.498469 
-L 237.68118 124.009564 
-L 235.397852 124.515877 
-L 233.114525 125.017497 
-L 230.831198 125.51451 
-L 228.547871 126.007001 
-L 226.264544 126.49505 
-L 223.981216 126.978737 
-L 221.697889 127.458139 
-L 219.414562 127.933332 
-L 217.131235 128.404389 
-L 214.847908 128.871381 
-L 212.564581 129.334377 
-L 210.281253 129.793447 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 319.880958 101.884157 
+L 317.597631 102.639125 
+L 315.314304 103.383708 
+L 313.030977 104.118188 
+L 310.74765 104.842836 
+L 308.464322 105.557911 
+L 306.180995 106.263662 
+L 303.897668 106.960331 
+L 301.614341 107.648147 
+L 299.331014 108.327333 
+L 297.047686 108.998103 
+L 294.764359 109.660663 
+L 292.481032 110.31521 
+L 290.197705 110.961938 
+L 287.914378 111.60103 
+L 285.631051 112.232665 
+L 283.347723 112.857014 
+L 281.064396 113.474244 
+L 278.781069 114.084516 
+L 276.497742 114.687984 
+L 274.214415 115.284798 
+L 271.931087 115.875104 
+L 269.64776 116.459042 
+L 267.364433 117.036748 
+L 265.081106 117.608354 
+L 262.797779 118.173987 
+L 260.514451 118.73377 
+L 258.231124 119.287824 
+L 255.947797 119.836264 
+L 253.66447 120.379203 
+L 251.381143 120.91675 
+L 249.097816 121.449012 
+L 246.814488 121.976092 
+L 244.531161 122.498088 
+L 242.247834 123.015099 
+L 239.964507 123.527218 
+L 237.68118 124.034538 
+L 235.397852 124.537147 
+L 233.114525 125.035133 
+L 230.831198 125.528579 
+L 228.547871 126.017567 
+L 226.264544 126.502178 
+L 223.981216 126.982489 
+L 221.697889 127.458575 
+L 219.414562 127.930511 
+L 217.131235 128.398367 
+L 214.847908 128.862215 
+L 212.564581 129.322122 
+L 210.281253 129.778154 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
-    <path d="M 210.281253 129.793447 
-L 209.989708 129.874915 
-L 209.698163 129.95626 
-L 209.406617 130.037484 
-L 209.115072 130.118586 
-L 208.823527 130.199567 
-L 208.531981 130.280426 
-L 208.240436 130.361165 
-L 207.94889 130.441784 
-L 207.657345 130.522282 
-L 207.3658 130.602662 
-L 207.074254 130.682922 
-L 206.782709 130.763063 
-L 206.491164 130.843085 
-L 206.199618 130.92299 
-L 205.908073 131.002776 
-L 205.616527 131.082446 
-L 205.324982 131.161998 
-L 205.033437 131.241433 
-L 204.741891 131.320752 
-L 204.450346 131.399955 
-L 204.158801 131.479042 
-L 203.867255 131.558014 
-L 203.57571 131.63687 
-L 203.284165 131.715612 
-L 202.992619 131.794239 
-L 202.701074 131.872753 
-L 202.409528 131.951152 
-L 202.117983 132.029439 
-L 201.826438 132.107612 
-L 201.534892 132.185672 
-L 201.243347 132.26362 
-L 200.951802 132.341456 
-L 200.660256 132.41918 
-L 200.368711 132.496793 
-L 200.077166 132.574294 
-L 199.78562 132.651685 
-L 199.494075 132.728965 
-L 199.202529 132.806135 
-L 198.910984 132.883195 
-L 198.619439 132.960145 
-L 198.327893 133.036987 
-L 198.036348 133.113719 
-L 197.744803 133.190343 
-L 197.453257 133.266858 
-L 197.161712 133.343265 
-L 196.870166 133.419565 
-L 196.578621 133.495757 
-L 196.287076 133.571842 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 210.281253 129.778154 
+L 209.989708 129.860292 
+L 209.698163 129.942306 
+L 209.406617 130.024196 
+L 209.115072 130.105963 
+L 208.823527 130.187606 
+L 208.531981 130.269126 
+L 208.240436 130.350523 
+L 207.94889 130.431799 
+L 207.657345 130.512952 
+L 207.3658 130.593984 
+L 207.074254 130.674895 
+L 206.782709 130.755685 
+L 206.491164 130.836355 
+L 206.199618 130.916904 
+L 205.908073 130.997334 
+L 205.616527 131.077645 
+L 205.324982 131.157836 
+L 205.033437 131.237909 
+L 204.741891 131.317864 
+L 204.450346 131.397701 
+L 204.158801 131.47742 
+L 203.867255 131.557022 
+L 203.57571 131.636507 
+L 203.284165 131.715876 
+L 202.992619 131.795128 
+L 202.701074 131.874265 
+L 202.409528 131.953286 
+L 202.117983 132.032192 
+L 201.826438 132.110983 
+L 201.534892 132.189659 
+L 201.243347 132.268221 
+L 200.951802 132.34667 
+L 200.660256 132.425005 
+L 200.368711 132.503226 
+L 200.077166 132.581335 
+L 199.78562 132.659331 
+L 199.494075 132.737215 
+L 199.202529 132.814988 
+L 198.910984 132.892648 
+L 198.619439 132.970198 
+L 198.327893 133.047636 
+L 198.036348 133.124964 
+L 197.744803 133.202181 
+L 197.453257 133.279289 
+L 197.161712 133.356286 
+L 196.870166 133.433175 
+L 196.578621 133.509954 
+L 196.287076 133.586625 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
-    <path d="M 196.287076 133.571842 
-L 195.865562 133.899995 
-L 195.444048 134.22617 
-L 195.022535 134.550391 
-L 194.601021 134.872681 
-L 194.179507 135.193063 
-L 193.757994 135.51156 
-L 193.33648 135.828193 
-L 192.914966 136.142984 
-L 192.493453 136.455955 
-L 192.071939 136.767127 
-L 191.650425 137.076519 
-L 191.228912 137.384153 
-L 190.807398 137.690048 
-L 190.385884 137.994224 
-L 189.964371 138.296699 
-L 189.542857 138.597494 
-L 189.121343 138.896626 
-L 188.69983 139.194113 
-L 188.278316 139.489974 
-L 187.856802 139.784227 
-L 187.435289 140.076888 
-L 187.013775 140.367975 
-L 186.592261 140.657505 
-L 186.170748 140.945494 
-L 185.749234 141.231958 
-L 185.32772 141.516915 
-L 184.906207 141.800378 
-L 184.484693 142.082365 
-L 184.063179 142.36289 
-L 183.641666 142.641969 
-L 183.220152 142.919615 
-L 182.798638 143.195845 
-L 182.377125 143.470671 
-L 181.955611 143.74411 
-L 181.534097 144.016173 
-L 181.112583 144.286876 
-L 180.69107 144.556231 
-L 180.269556 144.824252 
-L 179.848042 145.090953 
-L 179.426529 145.356346 
-L 179.005015 145.620443 
-L 178.583501 145.883258 
-L 178.161988 146.144803 
-L 177.740474 146.40509 
-L 177.31896 146.664131 
-L 176.897447 146.921938 
-L 176.475933 147.178523 
-L 176.054419 147.433896 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 196.287076 133.586625 
+L 195.865562 133.913104 
+L 195.444048 134.237626 
+L 195.022535 134.560213 
+L 194.601021 134.88089 
+L 194.179507 135.199679 
+L 193.757994 135.5166 
+L 193.33648 135.831678 
+L 192.914966 136.144931 
+L 192.493453 136.456383 
+L 192.071939 136.766053 
+L 191.650425 137.073961 
+L 191.228912 137.380128 
+L 190.807398 137.684573 
+L 190.385884 137.987315 
+L 189.964371 138.288373 
+L 189.542857 138.587766 
+L 189.121343 138.885513 
+L 188.69983 139.181631 
+L 188.278316 139.476137 
+L 187.856802 139.76905 
+L 187.435289 140.060387 
+L 187.013775 140.350164 
+L 186.592261 140.638398 
+L 186.170748 140.925105 
+L 185.749234 141.210302 
+L 185.32772 141.494004 
+L 184.906207 141.776227 
+L 184.484693 142.056986 
+L 184.063179 142.336296 
+L 183.641666 142.614173 
+L 183.220152 142.89063 
+L 182.798638 143.165683 
+L 182.377125 143.439345 
+L 181.955611 143.711631 
+L 181.534097 143.982553 
+L 181.112583 144.252127 
+L 180.69107 144.520365 
+L 180.269556 144.78728 
+L 179.848042 145.052886 
+L 179.426529 145.317194 
+L 179.005015 145.580218 
+L 178.583501 145.841971 
+L 178.161988 146.102464 
+L 177.740474 146.361709 
+L 177.31896 146.619719 
+L 176.897447 146.876504 
+L 176.475933 147.132078 
+L 176.054419 147.38645 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
-    <path d="M 176.054419 147.433896 
-L 175.556648 148.17189 
-L 175.058877 148.899954 
-L 174.561106 149.618354 
-L 174.063336 150.327342 
-L 173.565565 151.027162 
-L 173.067794 151.718047 
-L 172.570023 152.400224 
-L 172.072252 153.073909 
-L 171.574481 153.73931 
-L 171.07671 154.39663 
-L 170.578939 155.046061 
-L 170.081168 155.687792 
-L 169.583397 156.322002 
-L 169.085626 156.948865 
-L 168.587855 157.568551 
-L 168.090084 158.181221 
-L 167.592313 158.787033 
-L 167.094542 159.386138 
-L 166.596771 159.978684 
-L 166.099 160.564812 
-L 165.601229 161.14466 
-L 165.103458 161.718361 
-L 164.605687 162.286044 
-L 164.107916 162.847834 
-L 163.610145 163.403852 
-L 163.112374 163.954216 
-L 162.614603 164.499039 
-L 162.116832 165.038432 
-L 161.619061 165.572501 
-L 161.12129 166.101352 
-L 160.623519 166.625084 
-L 160.125748 167.143797 
-L 159.627977 167.657585 
-L 159.130206 168.166541 
-L 158.632435 168.670756 
-L 158.134664 169.170316 
-L 157.636893 169.665307 
-L 157.139122 170.155811 
-L 156.641351 170.641909 
-L 156.14358 171.123681 
-L 155.645809 171.601201 
-L 155.148039 172.074544 
-L 154.650268 172.543784 
-L 154.152497 173.00899 
-L 153.654726 173.470231 
-L 153.156955 173.927574 
-L 152.659184 174.381084 
-L 152.161413 174.830826 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 176.054419 147.38645 
+L 175.556648 148.123371 
+L 175.058877 148.850394 
+L 174.561106 149.567782 
+L 174.063336 150.275787 
+L 173.565565 150.974651 
+L 173.067794 151.664607 
+L 172.570023 152.34588 
+L 172.072252 153.018685 
+L 171.574481 153.68323 
+L 171.07671 154.339715 
+L 170.578939 154.988335 
+L 170.081168 155.629274 
+L 169.583397 156.262713 
+L 169.085626 156.888825 
+L 168.587855 157.507778 
+L 168.090084 158.119733 
+L 167.592313 158.724848 
+L 167.094542 159.323273 
+L 166.596771 159.915154 
+L 166.099 160.500634 
+L 165.601229 161.079849 
+L 165.103458 161.652932 
+L 164.605687 162.220011 
+L 164.107916 162.781211 
+L 163.610145 163.336652 
+L 163.112374 163.886452 
+L 162.614603 164.430724 
+L 162.116832 164.969578 
+L 161.619061 165.50312 
+L 161.12129 166.031455 
+L 160.623519 166.554683 
+L 160.125748 167.072902 
+L 159.627977 167.586207 
+L 159.130206 168.09469 
+L 158.632435 168.598441 
+L 158.134664 169.097547 
+L 157.636893 169.592094 
+L 157.139122 170.082163 
+L 156.641351 170.567835 
+L 156.14358 171.049188 
+L 155.645809 171.526299 
+L 155.148039 171.999241 
+L 154.650268 172.468087 
+L 154.152497 172.932907 
+L 153.654726 173.393769 
+L 153.156955 173.850741 
+L 152.659184 174.303887 
+L 152.161413 174.753272 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
-    <path d="M 152.161413 174.830826 
-L 152.048054 175.104762 
-L 151.934696 175.377318 
-L 151.821337 175.648509 
-L 151.707979 175.918347 
-L 151.594621 176.186847 
-L 151.481262 176.454021 
-L 151.367904 176.719883 
-L 151.254545 176.984445 
-L 151.141187 177.247719 
-L 151.027828 177.50972 
-L 150.91447 177.770458 
-L 150.801111 178.029946 
-L 150.687753 178.288195 
-L 150.574395 178.545218 
-L 150.461036 178.801026 
-L 150.347678 179.055631 
-L 150.234319 179.309044 
-L 150.120961 179.561275 
-L 150.007602 179.812336 
-L 149.894244 180.062238 
-L 149.780886 180.310991 
-L 149.667527 180.558607 
-L 149.554169 180.805094 
-L 149.44081 181.050464 
-L 149.327452 181.294726 
-L 149.214093 181.537891 
-L 149.100735 181.779968 
-L 148.987376 182.020967 
-L 148.874018 182.260898 
-L 148.76066 182.499769 
-L 148.647301 182.737591 
-L 148.533943 182.974373 
-L 148.420584 183.210122 
-L 148.307226 183.44485 
-L 148.193867 183.678564 
-L 148.080509 183.911272 
-L 147.967151 184.142985 
-L 147.853792 184.373709 
-L 147.740434 184.603454 
-L 147.627075 184.832228 
-L 147.513717 185.060039 
-L 147.400358 185.286895 
-L 147.287 185.512804 
-L 147.173642 185.737774 
-L 147.060283 185.961812 
-L 146.946925 186.184927 
-L 146.833566 186.407126 
-L 146.720208 186.628416 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 152.161413 174.753272 
+L 152.048054 175.028149 
+L 151.934696 175.301638 
+L 151.821337 175.573752 
+L 151.707979 175.844504 
+L 151.594621 176.11391 
+L 151.481262 176.381981 
+L 151.367904 176.648731 
+L 151.254545 176.914173 
+L 151.141187 177.17832 
+L 151.027828 177.441184 
+L 150.91447 177.702778 
+L 150.801111 177.963113 
+L 150.687753 178.222203 
+L 150.574395 178.480058 
+L 150.461036 178.736691 
+L 150.347678 178.992113 
+L 150.234319 179.246336 
+L 150.120961 179.49937 
+L 150.007602 179.751226 
+L 149.894244 180.001917 
+L 149.780886 180.251452 
+L 149.667527 180.499841 
+L 149.554169 180.747096 
+L 149.44081 180.993227 
+L 149.327452 181.238244 
+L 149.214093 181.482157 
+L 149.100735 181.724976 
+L 148.987376 181.96671 
+L 148.874018 182.207369 
+L 148.76066 182.446964 
+L 148.647301 182.685502 
+L 148.533943 182.922994 
+L 148.420584 183.159449 
+L 148.307226 183.394875 
+L 148.193867 183.629282 
+L 148.080509 183.862678 
+L 147.967151 184.095072 
+L 147.853792 184.326473 
+L 147.740434 184.556888 
+L 147.627075 184.786327 
+L 147.513717 185.014798 
+L 147.400358 185.242308 
+L 147.287 185.468866 
+L 147.173642 185.69448 
+L 147.060283 185.919158 
+L 146.946925 186.142906 
+L 146.833566 186.365734 
+L 146.720208 186.587648 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
-    <path d="M 146.720208 186.628416 
-L 146.663412 186.849924 
-L 146.606617 187.070529 
-L 146.549821 187.290238 
-L 146.493026 187.509059 
-L 146.43623 187.726999 
-L 146.379435 187.944065 
-L 146.322639 188.160263 
-L 146.265843 188.375602 
-L 146.209048 188.590086 
-L 146.152252 188.803725 
-L 146.095457 189.016523 
-L 146.038661 189.228487 
-L 145.981866 189.439625 
-L 145.92507 189.649942 
-L 145.868275 189.859445 
-L 145.811479 190.06814 
-L 145.754684 190.276034 
-L 145.697888 190.483131 
-L 145.641093 190.68944 
-L 145.584297 190.894965 
-L 145.527501 191.099712 
-L 145.470706 191.303687 
-L 145.41391 191.506897 
-L 145.357115 191.709347 
-L 145.300319 191.911042 
-L 145.243524 192.111988 
-L 145.186728 192.31219 
-L 145.129933 192.511655 
-L 145.073137 192.710387 
-L 145.016342 192.908393 
-L 144.959546 193.105676 
-L 144.902751 193.302243 
-L 144.845955 193.498098 
-L 144.789159 193.693248 
-L 144.732364 193.887696 
-L 144.675568 194.081448 
-L 144.618773 194.274508 
-L 144.561977 194.466883 
-L 144.505182 194.658576 
-L 144.448386 194.849592 
-L 144.391591 195.039937 
-L 144.334795 195.229614 
-L 144.278 195.418629 
-L 144.221204 195.606986 
-L 144.164409 195.79469 
-L 144.107613 195.981745 
-L 144.050817 196.168156 
-L 143.994022 196.353927 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 146.720208 186.587648 
+L 146.663412 186.810224 
+L 146.606617 187.031888 
+L 146.549821 187.252648 
+L 146.493026 187.472511 
+L 146.43623 187.691485 
+L 146.379435 187.909577 
+L 146.322639 188.126794 
+L 146.265843 188.343142 
+L 146.209048 188.558629 
+L 146.152252 188.773262 
+L 146.095457 188.987047 
+L 146.038661 189.199992 
+L 145.981866 189.412101 
+L 145.92507 189.623383 
+L 145.868275 189.833844 
+L 145.811479 190.043489 
+L 145.754684 190.252325 
+L 145.697888 190.460359 
+L 145.641093 190.667597 
+L 145.584297 190.874044 
+L 145.527501 191.079707 
+L 145.470706 191.284591 
+L 145.41391 191.488703 
+L 145.357115 191.692048 
+L 145.300319 191.894632 
+L 145.243524 192.09646 
+L 145.186728 192.297539 
+L 145.129933 192.497874 
+L 145.073137 192.69747 
+L 145.016342 192.896333 
+L 144.959546 193.094468 
+L 144.902751 193.29188 
+L 144.845955 193.488575 
+L 144.789159 193.684558 
+L 144.732364 193.879834 
+L 144.675568 194.074408 
+L 144.618773 194.268285 
+L 144.561977 194.46147 
+L 144.505182 194.653968 
+L 144.448386 194.845784 
+L 144.391591 195.036923 
+L 144.334795 195.227389 
+L 144.278 195.417187 
+L 144.221204 195.606323 
+L 144.164409 195.794799 
+L 144.107613 195.982622 
+L 144.050817 196.169795 
+L 143.994022 196.356323 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
-    <path d="M 143.994022 196.353927 
-L 143.966356 196.438487 
-L 143.938689 196.522916 
-L 143.911023 196.607213 
-L 143.883357 196.691378 
-L 143.85569 196.775413 
-L 143.828024 196.859318 
-L 143.800357 196.943093 
-L 143.772691 197.026739 
-L 143.745025 197.110255 
-L 143.717358 197.193643 
-L 143.689692 197.276902 
-L 143.662026 197.360033 
-L 143.634359 197.443037 
-L 143.606693 197.525914 
-L 143.579027 197.608664 
-L 143.55136 197.691288 
-L 143.523694 197.773786 
-L 143.496028 197.856158 
-L 143.468361 197.938405 
-L 143.440695 198.020528 
-L 143.413029 198.102526 
-L 143.385362 198.184399 
-L 143.357696 198.26615 
-L 143.33003 198.347776 
-L 143.302363 198.42928 
-L 143.274697 198.510662 
-L 143.247031 198.591921 
-L 143.219364 198.673058 
-L 143.191698 198.754074 
-L 143.164031 198.834969 
-L 143.136365 198.915743 
-L 143.108699 198.996396 
-L 143.081032 199.07693 
-L 143.053366 199.157344 
-L 143.0257 199.237639 
-L 142.998033 199.317814 
-L 142.970367 199.397871 
-L 142.942701 199.47781 
-L 142.915034 199.557631 
-L 142.887368 199.637335 
-L 142.859702 199.716921 
-L 142.832035 199.79639 
-L 142.804369 199.875743 
-L 142.776703 199.954979 
-L 142.749036 200.0341 
-L 142.72137 200.113105 
-L 142.693704 200.191995 
-L 142.666037 200.270771 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 143.994022 196.356323 
+L 143.966356 196.438823 
+L 143.938689 196.521197 
+L 143.911023 196.603446 
+L 143.883357 196.68557 
+L 143.85569 196.76757 
+L 143.828024 196.849446 
+L 143.800357 196.931198 
+L 143.772691 197.012827 
+L 143.745025 197.094333 
+L 143.717358 197.175716 
+L 143.689692 197.256977 
+L 143.662026 197.338116 
+L 143.634359 197.419134 
+L 143.606693 197.500031 
+L 143.579027 197.580807 
+L 143.55136 197.661463 
+L 143.523694 197.741999 
+L 143.496028 197.822415 
+L 143.468361 197.902712 
+L 143.440695 197.98289 
+L 143.413029 198.062949 
+L 143.385362 198.14289 
+L 143.357696 198.222714 
+L 143.33003 198.302419 
+L 143.302363 198.382008 
+L 143.274697 198.461479 
+L 143.247031 198.540834 
+L 143.219364 198.620073 
+L 143.191698 198.699197 
+L 143.164031 198.778204 
+L 143.136365 198.857097 
+L 143.108699 198.935875 
+L 143.081032 199.014538 
+L 143.053366 199.093087 
+L 143.0257 199.171522 
+L 142.998033 199.249844 
+L 142.970367 199.328053 
+L 142.942701 199.406148 
+L 142.915034 199.484132 
+L 142.887368 199.562003 
+L 142.859702 199.639762 
+L 142.832035 199.71741 
+L 142.804369 199.794946 
+L 142.776703 199.872372 
+L 142.749036 199.949687 
+L 142.72137 200.026891 
+L 142.693704 200.103986 
+L 142.666037 200.180971 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="m157d2a4e1d" d="M -0 3.535534 
+     <path id="me65eec0431" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p399ecdeb00)">
-     <use xlink:href="#m157d2a4e1d" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="242.839153" y="80.520583" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="218.251194" y="86.060539" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="197.814984" y="90.141422" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="166.378359" y="98.767475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="145.830392" y="110.20084" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="134.598477" y="125.76687" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="124.077268" y="149.129162" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="122.462976" y="157.203722" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="81.012077" y="219.378594" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="77.44276" y="238.815213" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m157d2a4e1d" x="76.953425" y="251.874777" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbc76cd86a)">
+     <use xlink:href="#me65eec0431" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me65eec0431" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
     <path d="M 292.033351 64.890426 
-L 291.008471 65.26664 
-L 289.983592 65.640257 
-L 288.958713 66.011312 
-L 287.933834 66.379841 
-L 286.908955 66.745877 
-L 285.884076 67.109453 
-L 284.859197 67.470604 
-L 283.834318 67.82936 
-L 282.809439 68.185754 
-L 281.784559 68.539816 
-L 280.75968 68.891577 
-L 279.734801 69.241066 
-L 278.709922 69.588313 
-L 277.685043 69.933346 
-L 276.660164 70.276193 
-L 275.635285 70.616881 
-L 274.610406 70.955439 
-L 273.585526 71.291891 
-L 272.560647 71.626265 
-L 271.535768 71.958585 
-L 270.510889 72.288878 
-L 269.48601 72.617167 
-L 268.461131 72.943476 
-L 267.436252 73.267829 
-L 266.411373 73.590251 
-L 265.386494 73.910762 
-L 264.361614 74.229387 
-L 263.336735 74.546147 
-L 262.311856 74.861063 
-L 261.286977 75.174158 
-L 260.262098 75.485451 
-L 259.237219 75.794964 
-L 258.21234 76.102718 
-L 257.187461 76.408731 
-L 256.162581 76.713023 
-L 255.137702 77.015614 
-L 254.112823 77.316522 
-L 253.087944 77.615767 
-L 252.063065 77.913366 
-L 251.038186 78.209338 
-L 250.013307 78.503699 
-L 248.988428 78.796468 
-L 247.963549 79.087662 
-L 246.938669 79.377298 
-L 245.91379 79.665392 
-L 244.888911 79.95196 
-L 243.864032 80.237018 
-L 242.839153 80.520583 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+L 291.008471 65.273777 
+L 289.983592 65.654432 
+L 288.958713 66.032429 
+L 287.933834 66.407805 
+L 286.908955 66.780596 
+L 285.884076 67.150837 
+L 284.859197 67.518563 
+L 283.834318 67.883807 
+L 282.809439 68.246604 
+L 281.784559 68.606985 
+L 280.75968 68.964983 
+L 279.734801 69.320629 
+L 278.709922 69.673953 
+L 277.685043 70.024986 
+L 276.660164 70.373758 
+L 275.635285 70.720297 
+L 274.610406 71.064631 
+L 273.585526 71.406789 
+L 272.560647 71.746797 
+L 271.535768 72.084684 
+L 270.510889 72.420474 
+L 269.48601 72.754194 
+L 268.461131 73.085869 
+L 267.436252 73.415525 
+L 266.411373 73.743185 
+L 265.386494 74.068873 
+L 264.361614 74.392614 
+L 263.336735 74.71443 
+L 262.311856 75.034344 
+L 261.286977 75.352379 
+L 260.262098 75.668556 
+L 259.237219 75.982897 
+L 258.21234 76.295423 
+L 257.187461 76.606155 
+L 256.162581 76.915113 
+L 255.137702 77.222318 
+L 254.112823 77.52779 
+L 253.087944 77.831547 
+L 252.063065 78.133609 
+L 251.038186 78.433995 
+L 250.013307 78.732724 
+L 248.988428 79.029813 
+L 247.963549 79.32528 
+L 246.938669 79.619143 
+L 245.91379 79.91142 
+L 244.888911 80.202126 
+L 243.864032 80.49128 
+L 242.839153 80.778898 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
-    <path d="M 242.839153 80.520583 
-L 242.326904 80.641977 
-L 241.814655 80.763099 
-L 241.302406 80.883951 
-L 240.790156 81.004533 
-L 240.277907 81.124847 
-L 239.765658 81.244895 
-L 239.253409 81.364676 
-L 238.74116 81.484193 
-L 238.228911 81.603447 
-L 237.716661 81.722439 
-L 237.204412 81.841169 
-L 236.692163 81.95964 
-L 236.179914 82.077851 
-L 235.667665 82.195806 
-L 235.155416 82.313503 
-L 234.643167 82.430945 
-L 234.130917 82.548133 
-L 233.618668 82.665068 
-L 233.106419 82.78175 
-L 232.59417 82.898182 
-L 232.081921 83.014364 
-L 231.569672 83.130296 
-L 231.057423 83.245981 
-L 230.545173 83.361419 
-L 230.032924 83.476612 
-L 229.520675 83.591559 
-L 229.008426 83.706263 
-L 228.496177 83.820725 
-L 227.983928 83.934945 
-L 227.471678 84.048924 
-L 226.959429 84.162664 
-L 226.44718 84.276165 
-L 225.934931 84.389429 
-L 225.422682 84.502456 
-L 224.910433 84.615248 
-L 224.398184 84.727805 
-L 223.885934 84.840128 
-L 223.373685 84.952219 
-L 222.861436 85.064078 
-L 222.349187 85.175706 
-L 221.836938 85.287105 
-L 221.324689 85.398274 
-L 220.81244 85.509216 
-L 220.30019 85.619931 
-L 219.787941 85.73042 
-L 219.275692 85.840684 
-L 218.763443 85.950723 
-L 218.251194 86.060539 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 242.839153 80.778898 
+L 242.326904 80.901632 
+L 241.814655 81.024089 
+L 241.302406 81.146269 
+L 240.790156 81.268174 
+L 240.277907 81.389805 
+L 239.765658 81.511163 
+L 239.253409 81.63225 
+L 238.74116 81.753066 
+L 238.228911 81.873614 
+L 237.716661 81.993893 
+L 237.204412 82.113906 
+L 236.692163 82.233654 
+L 236.179914 82.353137 
+L 235.667665 82.472357 
+L 235.155416 82.591315 
+L 234.643167 82.710012 
+L 234.130917 82.82845 
+L 233.618668 82.946629 
+L 233.106419 83.06455 
+L 232.59417 83.182215 
+L 232.081921 83.299625 
+L 231.569672 83.416781 
+L 231.057423 83.533684 
+L 230.545173 83.650335 
+L 230.032924 83.766735 
+L 229.520675 83.882885 
+L 229.008426 83.998787 
+L 228.496177 84.114441 
+L 227.983928 84.229848 
+L 227.471678 84.34501 
+L 226.959429 84.459927 
+L 226.44718 84.574601 
+L 225.934931 84.689033 
+L 225.422682 84.803223 
+L 224.910433 84.917173 
+L 224.398184 85.030883 
+L 223.885934 85.144355 
+L 223.373685 85.25759 
+L 222.861436 85.370588 
+L 222.349187 85.483351 
+L 221.836938 85.595879 
+L 221.324689 85.708174 
+L 220.81244 85.820237 
+L 220.30019 85.932068 
+L 219.787941 86.043669 
+L 219.275692 86.155039 
+L 218.763443 86.266182 
+L 218.251194 86.377096 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
-    <path d="M 218.251194 86.060539 
-L 217.825439 86.148773 
-L 217.399685 86.236864 
-L 216.973931 86.324811 
-L 216.548176 86.412616 
-L 216.122422 86.500278 
-L 215.696668 86.587798 
-L 215.270913 86.675178 
-L 214.845159 86.762416 
-L 214.419404 86.849514 
-L 213.99365 86.936472 
-L 213.567896 87.023291 
-L 213.142141 87.10997 
-L 212.716387 87.196511 
-L 212.290632 87.282914 
-L 211.864878 87.369179 
-L 211.439124 87.455306 
-L 211.013369 87.541297 
-L 210.587615 87.627152 
-L 210.161861 87.71287 
-L 209.736106 87.798453 
-L 209.310352 87.883901 
-L 208.884597 87.969214 
-L 208.458843 88.054392 
-L 208.033089 88.139437 
-L 207.607334 88.224349 
-L 207.18158 88.309127 
-L 206.755826 88.393773 
-L 206.330071 88.478287 
-L 205.904317 88.562669 
-L 205.478562 88.646919 
-L 205.052808 88.731039 
-L 204.627054 88.815028 
-L 204.201299 88.898887 
-L 203.775545 88.982616 
-L 203.349791 89.066216 
-L 202.924036 89.149687 
-L 202.498282 89.233029 
-L 202.072527 89.316243 
-L 201.646773 89.39933 
-L 201.221019 89.482289 
-L 200.795264 89.565121 
-L 200.36951 89.647826 
-L 199.943755 89.730405 
-L 199.518001 89.812859 
-L 199.092247 89.895187 
-L 198.666492 89.97739 
-L 198.240738 90.059468 
-L 197.814984 90.141422 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 218.251194 86.377096 
+L 217.825439 86.462006 
+L 217.399685 86.546784 
+L 216.973931 86.631428 
+L 216.548176 86.715941 
+L 216.122422 86.800321 
+L 215.696668 86.884571 
+L 215.270913 86.968689 
+L 214.845159 87.052677 
+L 214.419404 87.136535 
+L 213.99365 87.220264 
+L 213.567896 87.303862 
+L 213.142141 87.387332 
+L 212.716387 87.470674 
+L 212.290632 87.553887 
+L 211.864878 87.636973 
+L 211.439124 87.719931 
+L 211.013369 87.802762 
+L 210.587615 87.885467 
+L 210.161861 87.968046 
+L 209.736106 88.050499 
+L 209.310352 88.132826 
+L 208.884597 88.215029 
+L 208.458843 88.297106 
+L 208.033089 88.37906 
+L 207.607334 88.460889 
+L 207.18158 88.542596 
+L 206.755826 88.624178 
+L 206.330071 88.705639 
+L 205.904317 88.786976 
+L 205.478562 88.868192 
+L 205.052808 88.949286 
+L 204.627054 89.030259 
+L 204.201299 89.111111 
+L 203.775545 89.191842 
+L 203.349791 89.272453 
+L 202.924036 89.352944 
+L 202.498282 89.433316 
+L 202.072527 89.513569 
+L 201.646773 89.593702 
+L 201.221019 89.673717 
+L 200.795264 89.753615 
+L 200.36951 89.833394 
+L 199.943755 89.913056 
+L 199.518001 89.992601 
+L 199.092247 90.072029 
+L 198.666492 90.151341 
+L 198.240738 90.230537 
+L 197.814984 90.309617 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
-    <path d="M 197.814984 90.141422 
-L 197.160054 90.335896 
-L 196.505124 90.529674 
-L 195.850195 90.72276 
-L 195.195265 90.91516 
-L 194.540335 91.106878 
-L 193.885406 91.29792 
-L 193.230476 91.488289 
-L 192.575546 91.677991 
-L 191.920617 91.867031 
-L 191.265687 92.055412 
-L 190.610757 92.24314 
-L 189.955828 92.430219 
-L 189.300898 92.616654 
-L 188.645968 92.802448 
-L 187.991039 92.987607 
-L 187.336109 93.172135 
-L 186.681179 93.356035 
-L 186.02625 93.539313 
-L 185.37132 93.721972 
-L 184.71639 93.904016 
-L 184.06146 94.085451 
-L 183.406531 94.266279 
-L 182.751601 94.446505 
-L 182.096671 94.626132 
-L 181.441742 94.805166 
-L 180.786812 94.983609 
-L 180.131882 95.161466 
-L 179.476953 95.33874 
-L 178.822023 95.515435 
-L 178.167093 95.691555 
-L 177.512164 95.867104 
-L 176.857234 96.042086 
-L 176.202304 96.216503 
-L 175.547375 96.39036 
-L 174.892445 96.563661 
-L 174.237515 96.736408 
-L 173.582586 96.908605 
-L 172.927656 97.080257 
-L 172.272726 97.251365 
-L 171.617797 97.421935 
-L 170.962867 97.591968 
-L 170.307937 97.761469 
-L 169.653008 97.930441 
-L 168.998078 98.098887 
-L 168.343148 98.26681 
-L 167.688219 98.434213 
-L 167.033289 98.601101 
-L 166.378359 98.767475 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 197.814984 90.309617 
+L 197.160054 90.507287 
+L 196.505124 90.704237 
+L 195.850195 90.900474 
+L 195.195265 91.096001 
+L 194.540335 91.290825 
+L 193.885406 91.48495 
+L 193.230476 91.678382 
+L 192.575546 91.871125 
+L 191.920617 92.063184 
+L 191.265687 92.254564 
+L 190.610757 92.44527 
+L 189.955828 92.635306 
+L 189.300898 92.824677 
+L 188.645968 93.013389 
+L 187.991039 93.201444 
+L 187.336109 93.388849 
+L 186.681179 93.575607 
+L 186.02625 93.761723 
+L 185.37132 93.947201 
+L 184.71639 94.132046 
+L 184.06146 94.316261 
+L 183.406531 94.499852 
+L 182.751601 94.682823 
+L 182.096671 94.865177 
+L 181.441742 95.046919 
+L 180.786812 95.228052 
+L 180.131882 95.408582 
+L 179.476953 95.588511 
+L 178.822023 95.767845 
+L 178.167093 95.946586 
+L 177.512164 96.124739 
+L 176.857234 96.302308 
+L 176.202304 96.479296 
+L 175.547375 96.655707 
+L 174.892445 96.831545 
+L 174.237515 97.006814 
+L 173.582586 97.181517 
+L 172.927656 97.355658 
+L 172.272726 97.529241 
+L 171.617797 97.702269 
+L 170.962867 97.874745 
+L 170.307937 98.046674 
+L 169.653008 98.218058 
+L 168.998078 98.388902 
+L 168.343148 98.559208 
+L 167.688219 98.72898 
+L 167.033289 98.898221 
+L 166.378359 99.066934 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
-    <path d="M 166.378359 98.767475 
-L 165.950277 99.032053 
-L 165.522194 99.295344 
-L 165.094111 99.55736 
-L 164.666029 99.818114 
-L 164.237946 100.077617 
-L 163.809864 100.335882 
-L 163.381781 100.59292 
-L 162.953698 100.848744 
-L 162.525616 101.103363 
-L 162.097533 101.35679 
-L 161.66945 101.609037 
-L 161.241368 101.860112 
-L 160.813285 102.110029 
-L 160.385202 102.358796 
-L 159.95712 102.606425 
-L 159.529037 102.852927 
-L 159.100954 103.09831 
-L 158.672872 103.342587 
-L 158.244789 103.585765 
-L 157.816706 103.827856 
-L 157.388624 104.068868 
-L 156.960541 104.308812 
-L 156.532458 104.547697 
-L 156.104376 104.785532 
-L 155.676293 105.022326 
-L 155.24821 105.258089 
-L 154.820128 105.492829 
-L 154.392045 105.726555 
-L 153.963962 105.959276 
-L 153.53588 106.191001 
-L 153.107797 106.421738 
-L 152.679715 106.651495 
-L 152.251632 106.880281 
-L 151.823549 107.108104 
-L 151.395467 107.334971 
-L 150.967384 107.560892 
-L 150.539301 107.785873 
-L 150.111219 108.009923 
-L 149.683136 108.23305 
-L 149.255053 108.45526 
-L 148.826971 108.676561 
-L 148.398888 108.896962 
-L 147.970805 109.116468 
-L 147.542723 109.335087 
-L 147.11464 109.552827 
-L 146.686557 109.769695 
-L 146.258475 109.985696 
-L 145.830392 110.20084 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 166.378359 99.066934 
+L 165.950277 99.329757 
+L 165.522194 99.591309 
+L 165.094111 99.851604 
+L 164.666029 100.110653 
+L 164.237946 100.368468 
+L 163.809864 100.625061 
+L 163.381781 100.880444 
+L 162.953698 101.134628 
+L 162.525616 101.387623 
+L 162.097533 101.639442 
+L 161.66945 101.890094 
+L 161.241368 102.139591 
+L 160.813285 102.387944 
+L 160.385202 102.635162 
+L 159.95712 102.881256 
+L 159.529037 103.126237 
+L 159.100954 103.370114 
+L 158.672872 103.612897 
+L 158.244789 103.854596 
+L 157.816706 104.095221 
+L 157.388624 104.33478 
+L 156.960541 104.573285 
+L 156.532458 104.810743 
+L 156.104376 105.047164 
+L 155.676293 105.282556 
+L 155.24821 105.51693 
+L 154.820128 105.750293 
+L 154.392045 105.982655 
+L 153.963962 106.214023 
+L 153.53588 106.444407 
+L 153.107797 106.673814 
+L 152.679715 106.902253 
+L 152.251632 107.129732 
+L 151.823549 107.356259 
+L 151.395467 107.581842 
+L 150.967384 107.806489 
+L 150.539301 108.030208 
+L 150.111219 108.253006 
+L 149.683136 108.47489 
+L 149.255053 108.695869 
+L 148.826971 108.915949 
+L 148.398888 109.135138 
+L 147.970805 109.353443 
+L 147.542723 109.570872 
+L 147.11464 109.78743 
+L 146.686557 110.003126 
+L 146.258475 110.217965 
+L 145.830392 110.431955 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
-    <path d="M 145.830392 110.20084 
-L 145.596394 110.575284 
-L 145.362396 110.947155 
-L 145.128397 111.316488 
-L 144.894399 111.683318 
-L 144.660401 112.047678 
-L 144.426403 112.409602 
-L 144.192405 112.769121 
-L 143.958406 113.126268 
-L 143.724408 113.481073 
-L 143.49041 113.833567 
-L 143.256412 114.18378 
-L 143.022413 114.531741 
-L 142.788415 114.877479 
-L 142.554417 115.221023 
-L 142.320419 115.562399 
-L 142.086421 115.901636 
-L 141.852422 116.238759 
-L 141.618424 116.573795 
-L 141.384426 116.90677 
-L 141.150428 117.237709 
-L 140.916429 117.566636 
-L 140.682431 117.893576 
-L 140.448433 118.218553 
-L 140.214435 118.54159 
-L 139.980437 118.862711 
-L 139.746438 119.181937 
-L 139.51244 119.499291 
-L 139.278442 119.814795 
-L 139.044444 120.128471 
-L 138.810445 120.440338 
-L 138.576447 120.750419 
-L 138.342449 121.058733 
-L 138.108451 121.365301 
-L 137.874453 121.670142 
-L 137.640454 121.973275 
-L 137.406456 122.27472 
-L 137.172458 122.574495 
-L 136.93846 122.872619 
-L 136.704461 123.16911 
-L 136.470463 123.463985 
-L 136.236465 123.757262 
-L 136.002467 124.048958 
-L 135.768468 124.33909 
-L 135.53447 124.627676 
-L 135.300472 124.91473 
-L 135.066474 125.20027 
-L 134.832476 125.484312 
-L 134.598477 125.76687 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 145.830392 110.431955 
+L 145.596394 110.807167 
+L 145.362396 111.179797 
+L 145.128397 111.549878 
+L 144.894399 111.917447 
+L 144.660401 112.282536 
+L 144.426403 112.64518 
+L 144.192405 113.00541 
+L 143.958406 113.363259 
+L 143.724408 113.718758 
+L 143.49041 114.071938 
+L 143.256412 114.422828 
+L 143.022413 114.771458 
+L 142.788415 115.117857 
+L 142.554417 115.462053 
+L 142.320419 115.804075 
+L 142.086421 116.143949 
+L 141.852422 116.481703 
+L 141.618424 116.817362 
+L 141.384426 117.150953 
+L 141.150428 117.482501 
+L 140.916429 117.81203 
+L 140.682431 118.139565 
+L 140.448433 118.46513 
+L 140.214435 118.788749 
+L 139.980437 119.110445 
+L 139.746438 119.43024 
+L 139.51244 119.748157 
+L 139.278442 120.064218 
+L 139.044444 120.378444 
+L 138.810445 120.690857 
+L 138.576447 121.001476 
+L 138.342449 121.310324 
+L 138.108451 121.617419 
+L 137.874453 121.922782 
+L 137.640454 122.226433 
+L 137.406456 122.528389 
+L 137.172458 122.82867 
+L 136.93846 123.127295 
+L 136.704461 123.424281 
+L 136.470463 123.719647 
+L 136.236465 124.01341 
+L 136.002467 124.305587 
+L 135.768468 124.596196 
+L 135.53447 124.885252 
+L 135.300472 125.172774 
+L 135.066474 125.458776 
+L 134.832476 125.743276 
+L 134.598477 126.026287 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
-    <path d="M 134.598477 125.76687 
-L 134.379286 126.372141 
-L 134.160094 126.970718 
-L 133.940902 127.562746 
-L 133.72171 128.148368 
-L 133.502518 128.727721 
-L 133.283326 129.300937 
-L 133.064134 129.868146 
-L 132.844942 130.429471 
-L 132.625751 130.985033 
-L 132.406559 131.534951 
-L 132.187367 132.079336 
-L 131.968175 132.6183 
-L 131.748983 133.15195 
-L 131.529791 133.680388 
-L 131.310599 134.203717 
-L 131.091408 134.722033 
-L 130.872216 135.235433 
-L 130.653024 135.744007 
-L 130.433832 136.247847 
-L 130.21464 136.747039 
-L 129.995448 137.241669 
-L 129.776256 137.731819 
-L 129.557064 138.217569 
-L 129.337873 138.698999 
-L 129.118681 139.176183 
-L 128.899489 139.649196 
-L 128.680297 140.118111 
-L 128.461105 140.582998 
-L 128.241913 141.043926 
-L 128.022721 141.500961 
-L 127.80353 141.954168 
-L 127.584338 142.403612 
-L 127.365146 142.849354 
-L 127.145954 143.291454 
-L 126.926762 143.729972 
-L 126.70757 144.164966 
-L 126.488378 144.596491 
-L 126.269186 145.024602 
-L 126.049995 145.449353 
-L 125.830803 145.870797 
-L 125.611611 146.288983 
-L 125.392419 146.703964 
-L 125.173227 147.115786 
-L 124.954035 147.524498 
-L 124.734843 147.930147 
-L 124.515652 148.332777 
-L 124.29646 148.732435 
-L 124.077268 149.129162 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 134.598477 126.026287 
+L 134.379286 126.620288 
+L 134.160094 127.207842 
+L 133.940902 127.789086 
+L 133.72171 128.364155 
+L 133.502518 128.93318 
+L 133.283326 129.496285 
+L 133.064134 130.053592 
+L 132.844942 130.60522 
+L 132.625751 131.151283 
+L 132.406559 131.691893 
+L 132.187367 132.227157 
+L 131.968175 132.75718 
+L 131.748983 133.282063 
+L 131.529791 133.801906 
+L 131.310599 134.316804 
+L 131.091408 134.826851 
+L 130.872216 135.332136 
+L 130.653024 135.832749 
+L 130.433832 136.328774 
+L 130.21464 136.820295 
+L 129.995448 137.307393 
+L 129.776256 137.790147 
+L 129.557064 138.268634 
+L 129.337873 138.742928 
+L 129.118681 139.213102 
+L 128.899489 139.679228 
+L 128.680297 140.141375 
+L 128.461105 140.599609 
+L 128.241913 141.053996 
+L 128.022721 141.504601 
+L 127.80353 141.951486 
+L 127.584338 142.394712 
+L 127.365146 142.834339 
+L 127.145954 143.270423 
+L 126.926762 143.703023 
+L 126.70757 144.132193 
+L 126.488378 144.557986 
+L 126.269186 144.980457 
+L 126.049995 145.399656 
+L 125.830803 145.815634 
+L 125.611611 146.228439 
+L 125.392419 146.63812 
+L 125.173227 147.044724 
+L 124.954035 147.448297 
+L 124.734843 147.848882 
+L 124.515652 148.246526 
+L 124.29646 148.641269 
+L 124.077268 149.033155 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
-    <path d="M 124.077268 149.129162 
-L 124.043637 149.310276 
-L 124.010006 149.490786 
-L 123.976375 149.670696 
-L 123.942743 149.85001 
-L 123.909112 150.028731 
-L 123.875481 150.206865 
-L 123.84185 150.384414 
-L 123.808219 150.561382 
-L 123.774588 150.737773 
-L 123.740957 150.913592 
-L 123.707326 151.088841 
-L 123.673695 151.263524 
-L 123.640064 151.437646 
-L 123.606433 151.611209 
-L 123.572802 151.784217 
-L 123.539171 151.956674 
-L 123.50554 152.128583 
-L 123.471909 152.299947 
-L 123.438277 152.470771 
-L 123.404646 152.641058 
-L 123.371015 152.81081 
-L 123.337384 152.980031 
-L 123.303753 153.148725 
-L 123.270122 153.316894 
-L 123.236491 153.484543 
-L 123.20286 153.651674 
-L 123.169229 153.81829 
-L 123.135598 153.984395 
-L 123.101967 154.149992 
-L 123.068336 154.315084 
-L 123.034705 154.479673 
-L 123.001074 154.643764 
-L 122.967442 154.807358 
-L 122.933811 154.970459 
-L 122.90018 155.133071 
-L 122.866549 155.295195 
-L 122.832918 155.456835 
-L 122.799287 155.617993 
-L 122.765656 155.778673 
-L 122.732025 155.938878 
-L 122.698394 156.09861 
-L 122.664763 156.257871 
-L 122.631132 156.416665 
-L 122.597501 156.574995 
-L 122.56387 156.732863 
-L 122.530239 156.890271 
-L 122.496607 157.047223 
-L 122.462976 157.203722 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 124.077268 149.033155 
+L 124.043637 149.223187 
+L 124.010006 149.412554 
+L 123.976375 149.601262 
+L 123.942743 149.789313 
+L 123.909112 149.976714 
+L 123.875481 150.163468 
+L 123.84185 150.34958 
+L 123.808219 150.535054 
+L 123.774588 150.719896 
+L 123.740957 150.904108 
+L 123.707326 151.087695 
+L 123.673695 151.270661 
+L 123.640064 151.453012 
+L 123.606433 151.63475 
+L 123.572802 151.81588 
+L 123.539171 151.996406 
+L 123.50554 152.176332 
+L 123.471909 152.355662 
+L 123.438277 152.534399 
+L 123.404646 152.712549 
+L 123.371015 152.890114 
+L 123.337384 153.067098 
+L 123.303753 153.243506 
+L 123.270122 153.419341 
+L 123.236491 153.594606 
+L 123.20286 153.769306 
+L 123.169229 153.943444 
+L 123.135598 154.117023 
+L 123.101967 154.290048 
+L 123.068336 154.462521 
+L 123.034705 154.634446 
+L 123.001074 154.805828 
+L 122.967442 154.976668 
+L 122.933811 155.146971 
+L 122.90018 155.316739 
+L 122.866549 155.485977 
+L 122.832918 155.654688 
+L 122.799287 155.822874 
+L 122.765656 155.990539 
+L 122.732025 156.157687 
+L 122.698394 156.32432 
+L 122.664763 156.490441 
+L 122.631132 156.656055 
+L 122.597501 156.821163 
+L 122.56387 156.985769 
+L 122.530239 157.149876 
+L 122.496607 157.313488 
+L 122.462976 157.476606 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
-    <path d="M 122.462976 157.203722 
-L 121.599416 159.580035 
-L 120.735856 161.85638 
-L 119.872295 164.040829 
-L 119.008735 166.140514 
-L 118.145174 168.16177 
-L 117.281614 170.110245 
-L 116.418054 171.990998 
-L 115.554493 173.80858 
-L 114.690933 175.567096 
-L 113.827372 177.270266 
-L 112.963812 178.921465 
-L 112.100252 180.523774 
-L 111.236691 182.080003 
-L 110.373131 183.59273 
-L 109.50957 185.06432 
-L 108.64601 186.496951 
-L 107.78245 187.892634 
-L 106.918889 189.253226 
-L 106.055329 190.580448 
-L 105.191768 191.875899 
-L 104.328208 193.141064 
-L 103.464648 194.377327 
-L 102.601087 195.585979 
-L 101.737527 196.768226 
-L 100.873966 197.925197 
-L 100.010406 199.057951 
-L 99.146846 200.16748 
-L 98.283285 201.254718 
-L 97.419725 202.320544 
-L 96.556164 203.365783 
-L 95.692604 204.391217 
-L 94.829044 205.397581 
-L 93.965483 206.385573 
-L 93.101923 207.355851 
-L 92.238362 208.309039 
-L 91.374802 209.245728 
-L 90.511242 210.166481 
-L 89.647681 211.07183 
-L 88.784121 211.962282 
-L 87.92056 212.83832 
-L 87.057 213.700403 
-L 86.193439 214.548968 
-L 85.329879 215.384433 
-L 84.466319 216.207197 
-L 83.602758 217.017639 
-L 82.739198 217.816123 
-L 81.875637 218.602997 
-L 81.012077 219.378594 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 122.462976 157.476606 
+L 121.599416 159.878901 
+L 120.735856 162.179099 
+L 119.872295 164.385527 
+L 119.008735 166.50553 
+L 118.145174 168.545624 
+L 117.281614 170.511616 
+L 116.418054 172.408701 
+L 115.554493 174.241545 
+L 114.690933 176.014358 
+L 113.827372 177.730947 
+L 112.963812 179.394769 
+L 112.100252 181.008972 
+L 111.236691 182.57643 
+L 110.373131 184.099774 
+L 109.50957 185.581419 
+L 108.64601 187.023588 
+L 107.78245 188.428329 
+L 106.918889 189.797537 
+L 106.055329 191.132964 
+L 105.191768 192.436237 
+L 104.328208 193.70887 
+L 103.464648 194.952268 
+L 102.601087 196.167745 
+L 101.737527 197.356529 
+L 100.873966 198.519765 
+L 100.010406 199.658529 
+L 99.146846 200.77383 
+L 98.283285 201.866614 
+L 97.419725 202.937774 
+L 96.556164 203.988148 
+L 95.692604 205.018527 
+L 94.829044 206.029659 
+L 93.965483 207.02225 
+L 93.101923 207.996968 
+L 92.238362 208.954443 
+L 91.374802 209.895277 
+L 90.511242 210.820038 
+L 89.647681 211.729266 
+L 88.784121 212.623473 
+L 87.92056 213.503148 
+L 87.057 214.368757 
+L 86.193439 215.22074 
+L 85.329879 216.059522 
+L 84.466319 216.885505 
+L 83.602758 217.699074 
+L 82.739198 218.500595 
+L 81.875637 219.290422 
+L 81.012077 220.06889 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
-    <path d="M 81.012077 219.378594 
-L 80.937716 219.863605 
-L 80.863356 220.344308 
-L 80.788995 220.820779 
-L 80.714634 221.293091 
-L 80.640273 221.761318 
-L 80.565912 222.225527 
-L 80.491552 222.685789 
-L 80.417191 223.14217 
-L 80.34283 223.594734 
-L 80.268469 224.043544 
-L 80.194109 224.488664 
-L 80.119748 224.930152 
-L 80.045387 225.368067 
-L 79.971026 225.802468 
-L 79.896665 226.233409 
-L 79.822305 226.660946 
-L 79.747944 227.085132 
-L 79.673583 227.506019 
-L 79.599222 227.923658 
-L 79.524862 228.338099 
-L 79.450501 228.749389 
-L 79.37614 229.157578 
-L 79.301779 229.562711 
-L 79.227418 229.964834 
-L 79.153058 230.363991 
-L 79.078697 230.760225 
-L 79.004336 231.153579 
-L 78.929975 231.544095 
-L 78.855615 231.931813 
-L 78.781254 232.316773 
-L 78.706893 232.699014 
-L 78.632532 233.078575 
-L 78.558171 233.455491 
-L 78.483811 233.829801 
-L 78.40945 234.20154 
-L 78.335089 234.570742 
-L 78.260728 234.937443 
-L 78.186368 235.301676 
-L 78.112007 235.663474 
-L 78.037646 236.02287 
-L 77.963285 236.379894 
-L 77.888924 236.734578 
-L 77.814564 237.086953 
-L 77.740203 237.437049 
-L 77.665842 237.784894 
-L 77.591481 238.130517 
-L 77.517121 238.473948 
-L 77.44276 238.815213 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 81.012077 220.06889 
+L 80.937716 220.558236 
+L 80.863356 221.043199 
+L 80.788995 221.523855 
+L 80.714634 222.000281 
+L 80.640273 222.47255 
+L 80.565912 222.940735 
+L 80.491552 223.404904 
+L 80.417191 223.865128 
+L 80.34283 224.321472 
+L 80.268469 224.774 
+L 80.194109 225.222777 
+L 80.119748 225.667864 
+L 80.045387 226.109321 
+L 79.971026 226.547207 
+L 79.896665 226.981579 
+L 79.822305 227.412493 
+L 79.747944 227.840004 
+L 79.673583 228.264166 
+L 79.599222 228.685029 
+L 79.524862 229.102645 
+L 79.450501 229.517064 
+L 79.37614 229.928335 
+L 79.301779 230.336504 
+L 79.227418 230.741619 
+L 79.153058 231.143724 
+L 79.078697 231.542865 
+L 79.004336 231.939084 
+L 78.929975 232.332423 
+L 78.855615 232.722925 
+L 78.781254 233.110631 
+L 78.706893 233.495579 
+L 78.632532 233.877809 
+L 78.558171 234.257359 
+L 78.483811 234.634266 
+L 78.40945 235.008567 
+L 78.335089 235.380297 
+L 78.260728 235.749492 
+L 78.186368 236.116186 
+L 78.112007 236.480413 
+L 78.037646 236.842205 
+L 77.963285 237.201596 
+L 77.888924 237.558616 
+L 77.814564 237.913297 
+L 77.740203 238.265668 
+L 77.665842 238.615761 
+L 77.591481 238.963605 
+L 77.517121 239.309227 
+L 77.44276 239.652656 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
-    <path d="M 77.44276 238.815213 
-L 77.432565 239.122051 
-L 77.422371 239.427159 
-L 77.412176 239.730557 
-L 77.401982 240.032264 
-L 77.391787 240.332298 
-L 77.381593 240.630677 
-L 77.371398 240.927421 
-L 77.361204 241.222546 
-L 77.35101 241.516071 
-L 77.340815 241.808012 
-L 77.330621 242.098387 
-L 77.320426 242.387212 
-L 77.310232 242.674504 
-L 77.300037 242.960279 
-L 77.289843 243.244552 
-L 77.279648 243.52734 
-L 77.269454 243.808659 
-L 77.259259 244.088522 
-L 77.249065 244.366946 
-L 77.23887 244.643944 
-L 77.228676 244.919532 
-L 77.218481 245.193724 
-L 77.208287 245.466534 
-L 77.198092 245.737975 
-L 77.187898 246.008061 
-L 77.177703 246.276807 
-L 77.167509 246.544224 
-L 77.157315 246.810326 
-L 77.14712 247.075127 
-L 77.136926 247.338638 
-L 77.126731 247.600872 
-L 77.116537 247.861842 
-L 77.106342 248.121559 
-L 77.096148 248.380036 
-L 77.085953 248.637284 
-L 77.075759 248.893315 
-L 77.065564 249.148141 
-L 77.05537 249.401772 
-L 77.045175 249.65422 
-L 77.034981 249.905496 
-L 77.024786 250.155611 
-L 77.014592 250.404575 
-L 77.004397 250.652399 
-L 76.994203 250.899093 
-L 76.984008 251.144668 
-L 76.973814 251.389134 
-L 76.96362 251.6325 
-L 76.953425 251.874777 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 77.44276 239.652656 
+L 77.432565 239.959337 
+L 77.422371 240.26429 
+L 77.412176 240.567534 
+L 77.401982 240.869089 
+L 77.391787 241.168973 
+L 77.381593 241.467206 
+L 77.371398 241.763804 
+L 77.361204 242.058786 
+L 77.35101 242.352169 
+L 77.340815 242.64397 
+L 77.330621 242.934207 
+L 77.320426 243.222897 
+L 77.310232 243.510054 
+L 77.300037 243.795697 
+L 77.289843 244.07984 
+L 77.279648 244.362499 
+L 77.269454 244.64369 
+L 77.259259 244.923428 
+L 77.249065 245.201728 
+L 77.23887 245.478604 
+L 77.228676 245.754071 
+L 77.218481 246.028143 
+L 77.208287 246.300835 
+L 77.198092 246.57216 
+L 77.187898 246.842132 
+L 77.177703 247.110764 
+L 77.167509 247.378069 
+L 77.157315 247.644061 
+L 77.14712 247.908753 
+L 77.136926 248.172156 
+L 77.126731 248.434284 
+L 77.116537 248.695148 
+L 77.106342 248.954762 
+L 77.096148 249.213136 
+L 77.085953 249.470283 
+L 77.075759 249.726214 
+L 77.065564 249.980941 
+L 77.05537 250.234475 
+L 77.045175 250.486827 
+L 77.034981 250.738007 
+L 77.024786 250.988028 
+L 77.014592 251.236899 
+L 77.004397 251.484631 
+L 76.994203 251.731235 
+L 76.984008 251.97672 
+L 76.973814 252.221097 
+L 76.96362 252.464376 
+L 76.953425 252.706566 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m8f0817a477" d="M -0 2.5 
+     <path id="mefedd32353" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p399ecdeb00)">
-     <use xlink:href="#m8f0817a477" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbc76cd86a)">
+     <use xlink:href="#mefedd32353" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m07e361c907" d="M -0.833333 2.5 
+     <path id="m2904fc1a84" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,437 +3182,437 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p399ecdeb00)">
-     <use xlink:href="#m07e361c907" x="432.495268" y="103.672741" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07e361c907" x="300.62247" y="118.022676" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07e361c907" x="266.967623" y="125.683" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07e361c907" x="226.040946" y="126.152114" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07e361c907" x="180.985721" y="144.080759" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07e361c907" x="164.441833" y="158.457887" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07e361c907" x="157.761315" y="167.001817" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07e361c907" x="151.269082" y="181.244808" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m07e361c907" x="150.327087" y="186.982195" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbc76cd86a)">
+     <use xlink:href="#m2904fc1a84" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2904fc1a84" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2904fc1a84" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2904fc1a84" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2904fc1a84" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2904fc1a84" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2904fc1a84" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2904fc1a84" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2904fc1a84" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
-    <path d="M 432.495268 103.672741 
-L 429.747918 104.014004 
-L 427.000568 104.353127 
-L 424.253218 104.69014 
-L 421.505868 105.025066 
-L 418.758518 105.357932 
-L 416.011168 105.688764 
-L 413.263818 106.017585 
-L 410.516468 106.344421 
-L 407.769118 106.669294 
-L 405.021768 106.992229 
-L 402.274418 107.313249 
-L 399.527068 107.632375 
-L 396.779718 107.949631 
-L 394.032368 108.265037 
-L 391.285019 108.578616 
-L 388.537669 108.890389 
-L 385.790319 109.200376 
-L 383.042969 109.508597 
-L 380.295619 109.815073 
-L 377.548269 110.119823 
-L 374.800919 110.422866 
-L 372.053569 110.724222 
-L 369.306219 111.023909 
-L 366.558869 111.321946 
-L 363.811519 111.618351 
-L 361.064169 111.91314 
-L 358.316819 112.206333 
-L 355.569469 112.497946 
-L 352.822119 112.787996 
-L 350.074769 113.0765 
-L 347.327419 113.363474 
-L 344.580069 113.648934 
-L 341.832719 113.932897 
-L 339.085369 114.215377 
-L 336.338019 114.49639 
-L 333.590669 114.775952 
-L 330.843319 115.054077 
-L 328.09597 115.33078 
-L 325.34862 115.606076 
-L 322.60127 115.879978 
-L 319.85392 116.152501 
-L 317.10657 116.423658 
-L 314.35922 116.693464 
-L 311.61187 116.961931 
-L 308.86452 117.229073 
-L 306.11717 117.494902 
-L 303.36982 117.759433 
-L 300.62247 118.022676 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 432.495268 96.067622 
+L 429.747918 96.465952 
+L 427.000568 96.861373 
+L 424.253218 97.253925 
+L 421.505868 97.643652 
+L 418.758518 98.030593 
+L 416.011168 98.414787 
+L 413.263818 98.796274 
+L 410.516468 99.175091 
+L 407.769118 99.551275 
+L 405.021768 99.924863 
+L 402.274418 100.295891 
+L 399.527068 100.664392 
+L 396.779718 101.030402 
+L 394.032368 101.393954 
+L 391.285019 101.755081 
+L 388.537669 102.113814 
+L 385.790319 102.470186 
+L 383.042969 102.824226 
+L 380.295619 103.175967 
+L 377.548269 103.525436 
+L 374.800919 103.872664 
+L 372.053569 104.217678 
+L 369.306219 104.560508 
+L 366.558869 104.90118 
+L 363.811519 105.239721 
+L 361.064169 105.576158 
+L 358.316819 105.910517 
+L 355.569469 106.242823 
+L 352.822119 106.573102 
+L 350.074769 106.901378 
+L 347.327419 107.227675 
+L 344.580069 107.552017 
+L 341.832719 107.874428 
+L 339.085369 108.194929 
+L 336.338019 108.513544 
+L 333.590669 108.830294 
+L 330.843319 109.145202 
+L 328.09597 109.458288 
+L 325.34862 109.769574 
+L 322.60127 110.07908 
+L 319.85392 110.386826 
+L 317.10657 110.692833 
+L 314.35922 110.99712 
+L 311.61187 111.299705 
+L 308.86452 111.600609 
+L 306.11717 111.899849 
+L 303.36982 112.197444 
+L 300.62247 112.493412 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
-    <path d="M 300.62247 118.022676 
-L 299.921327 118.193843 
-L 299.220185 118.364469 
-L 298.519042 118.534559 
-L 297.817899 118.704117 
-L 297.116757 118.873145 
-L 296.415614 119.041646 
-L 295.714471 119.209625 
-L 295.013329 119.377083 
-L 294.312186 119.544025 
-L 293.611044 119.710454 
-L 292.909901 119.876373 
-L 292.208758 120.041784 
-L 291.507616 120.206691 
-L 290.806473 120.371098 
-L 290.10533 120.535006 
-L 289.404188 120.69842 
-L 288.703045 120.861341 
-L 288.001902 121.023774 
-L 287.30076 121.18572 
-L 286.599617 121.347184 
-L 285.898474 121.508167 
-L 285.197332 121.668672 
-L 284.496189 121.828703 
-L 283.795047 121.988262 
-L 283.093904 122.147352 
-L 282.392761 122.305976 
-L 281.691619 122.464136 
-L 280.990476 122.621836 
-L 280.289333 122.779077 
-L 279.588191 122.935863 
-L 278.887048 123.092195 
-L 278.185905 123.248078 
-L 277.484763 123.403512 
-L 276.78362 123.558502 
-L 276.082478 123.713049 
-L 275.381335 123.867156 
-L 274.680192 124.020825 
-L 273.97905 124.174059 
-L 273.277907 124.326861 
-L 272.576764 124.479232 
-L 271.875622 124.631175 
-L 271.174479 124.782693 
-L 270.473336 124.933788 
-L 269.772194 125.084463 
-L 269.071051 125.234719 
-L 268.369908 125.384559 
-L 267.668766 125.533985 
-L 266.967623 125.683 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 300.62247 112.493412 
+L 299.921327 112.680457 
+L 299.220185 112.866857 
+L 298.519042 113.052618 
+L 297.817899 113.237744 
+L 297.116757 113.422238 
+L 296.415614 113.606106 
+L 295.714471 113.789352 
+L 295.013329 113.971979 
+L 294.312186 114.153992 
+L 293.611044 114.335395 
+L 292.909901 114.516193 
+L 292.208758 114.696388 
+L 291.507616 114.875986 
+L 290.806473 115.05499 
+L 290.10533 115.233403 
+L 289.404188 115.411231 
+L 288.703045 115.588476 
+L 288.001902 115.765143 
+L 287.30076 115.941236 
+L 286.599617 116.116757 
+L 285.898474 116.291711 
+L 285.197332 116.466101 
+L 284.496189 116.639931 
+L 283.795047 116.813205 
+L 283.093904 116.985926 
+L 282.392761 117.158098 
+L 281.691619 117.329723 
+L 280.990476 117.500807 
+L 280.289333 117.671351 
+L 279.588191 117.841359 
+L 278.887048 118.010836 
+L 278.185905 118.179783 
+L 277.484763 118.348205 
+L 276.78362 118.516104 
+L 276.082478 118.683485 
+L 275.381335 118.850349 
+L 274.680192 119.0167 
+L 273.97905 119.182542 
+L 273.277907 119.347877 
+L 272.576764 119.512709 
+L 271.875622 119.677041 
+L 271.174479 119.840875 
+L 270.473336 120.004214 
+L 269.772194 120.167063 
+L 269.071051 120.329422 
+L 268.369908 120.491297 
+L 267.668766 120.652688 
+L 266.967623 120.8136 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
-    <path d="M 266.967623 125.683 
-L 266.114984 125.692815 
-L 265.262345 125.702628 
-L 264.409706 125.712439 
-L 263.557067 125.722249 
-L 262.704428 125.732056 
-L 261.851789 125.741862 
-L 260.999149 125.751666 
-L 260.14651 125.761469 
-L 259.293871 125.771269 
-L 258.441232 125.781068 
-L 257.588593 125.790865 
-L 256.735954 125.80066 
-L 255.883315 125.810454 
-L 255.030676 125.820245 
-L 254.178037 125.830035 
-L 253.325397 125.839823 
-L 252.472758 125.84961 
-L 251.620119 125.859394 
-L 250.76748 125.869177 
-L 249.914841 125.878958 
-L 249.062202 125.888738 
-L 248.209563 125.898515 
-L 247.356924 125.908291 
-L 246.504285 125.918065 
-L 245.651645 125.927837 
-L 244.799006 125.937608 
-L 243.946367 125.947377 
-L 243.093728 125.957144 
-L 242.241089 125.966909 
-L 241.38845 125.976672 
-L 240.535811 125.986434 
-L 239.683172 125.996194 
-L 238.830533 126.005952 
-L 237.977893 126.015708 
-L 237.125254 126.025463 
-L 236.272615 126.035216 
-L 235.419976 126.044967 
-L 234.567337 126.054716 
-L 233.714698 126.064464 
-L 232.862059 126.07421 
-L 232.00942 126.083954 
-L 231.156781 126.093696 
-L 230.304141 126.103437 
-L 229.451502 126.113176 
-L 228.598863 126.122913 
-L 227.746224 126.132648 
-L 226.893585 126.142382 
-L 226.040946 126.152114 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 266.967623 120.8136 
+L 266.114984 120.840706 
+L 265.262345 120.867798 
+L 264.409706 120.894876 
+L 263.557067 120.921941 
+L 262.704428 120.948992 
+L 261.851789 120.97603 
+L 260.999149 121.003055 
+L 260.14651 121.030065 
+L 259.293871 121.057063 
+L 258.441232 121.084047 
+L 257.588593 121.111017 
+L 256.735954 121.137974 
+L 255.883315 121.164918 
+L 255.030676 121.191848 
+L 254.178037 121.218765 
+L 253.325397 121.245668 
+L 252.472758 121.272558 
+L 251.620119 121.299435 
+L 250.76748 121.326298 
+L 249.914841 121.353149 
+L 249.062202 121.379985 
+L 248.209563 121.406809 
+L 247.356924 121.433619 
+L 246.504285 121.460416 
+L 245.651645 121.487199 
+L 244.799006 121.51397 
+L 243.946367 121.540727 
+L 243.093728 121.567471 
+L 242.241089 121.594202 
+L 241.38845 121.620919 
+L 240.535811 121.647624 
+L 239.683172 121.674315 
+L 238.830533 121.700993 
+L 237.977893 121.727658 
+L 237.125254 121.754309 
+L 236.272615 121.780948 
+L 235.419976 121.807574 
+L 234.567337 121.834186 
+L 233.714698 121.860785 
+L 232.862059 121.887372 
+L 232.00942 121.913945 
+L 231.156781 121.940505 
+L 230.304141 121.967052 
+L 229.451502 121.993587 
+L 228.598863 122.020108 
+L 227.746224 122.046616 
+L 226.893585 122.073111 
+L 226.040946 122.099593 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
-    <path d="M 226.040946 126.152114 
-L 225.102295 126.593132 
-L 224.163645 127.030587 
-L 223.224994 127.464533 
-L 222.286344 127.895027 
-L 221.347693 128.322124 
-L 220.409043 128.745877 
-L 219.470392 129.166337 
-L 218.531742 129.583556 
-L 217.593091 129.997584 
-L 216.654441 130.408467 
-L 215.71579 130.816255 
-L 214.77714 131.220993 
-L 213.838489 131.622726 
-L 212.899839 132.021499 
-L 211.961188 132.417356 
-L 211.022538 132.810337 
-L 210.083887 133.200486 
-L 209.145237 133.587842 
-L 208.206586 133.972446 
-L 207.267936 134.354335 
-L 206.329285 134.733549 
-L 205.390635 135.110123 
-L 204.451984 135.484096 
-L 203.513334 135.855502 
-L 202.574683 136.224376 
-L 201.636033 136.590753 
-L 200.697382 136.954667 
-L 199.758732 137.31615 
-L 198.820081 137.675234 
-L 197.881431 138.031951 
-L 196.94278 138.386333 
-L 196.00413 138.738409 
-L 195.065479 139.088209 
-L 194.126829 139.435763 
-L 193.188178 139.781099 
-L 192.249528 140.124246 
-L 191.310877 140.46523 
-L 190.372227 140.804079 
-L 189.433576 141.14082 
-L 188.494926 141.475479 
-L 187.556275 141.808081 
-L 186.617625 142.138651 
-L 185.678974 142.467214 
-L 184.740324 142.793795 
-L 183.801673 143.118416 
-L 182.863022 143.441102 
-L 181.924372 143.761876 
-L 180.985721 144.080759 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 226.040946 122.099593 
+L 225.102295 122.594147 
+L 224.163645 123.084223 
+L 223.224994 123.569901 
+L 222.286344 124.051261 
+L 221.347693 124.528378 
+L 220.409043 125.001327 
+L 219.470392 125.470179 
+L 218.531742 125.935005 
+L 217.593091 126.395873 
+L 216.654441 126.852851 
+L 215.71579 127.306003 
+L 214.77714 127.755394 
+L 213.838489 128.201084 
+L 212.899839 128.643134 
+L 211.961188 129.081604 
+L 211.022538 129.516551 
+L 210.083887 129.94803 
+L 209.145237 130.376098 
+L 208.206586 130.800807 
+L 207.267936 131.22221 
+L 206.329285 131.640357 
+L 205.390635 132.055299 
+L 204.451984 132.467085 
+L 203.513334 132.875761 
+L 202.574683 133.281376 
+L 201.636033 133.683973 
+L 200.697382 134.083599 
+L 199.758732 134.480295 
+L 198.820081 134.874106 
+L 197.881431 135.265073 
+L 196.94278 135.653235 
+L 196.00413 136.038635 
+L 195.065479 136.421309 
+L 194.126829 136.801298 
+L 193.188178 137.178637 
+L 192.249528 137.553365 
+L 191.310877 137.925516 
+L 190.372227 138.295126 
+L 189.433576 138.662229 
+L 188.494926 139.02686 
+L 187.556275 139.389051 
+L 186.617625 139.748835 
+L 185.678974 140.106243 
+L 184.740324 140.461306 
+L 183.801673 140.814056 
+L 182.863022 141.164522 
+L 181.924372 141.512734 
+L 180.985721 141.85872 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
-    <path d="M 180.985721 144.080759 
-L 180.641057 144.422756 
-L 180.296393 144.762604 
-L 179.951728 145.100332 
-L 179.607064 145.435966 
-L 179.2624 145.769531 
-L 178.917735 146.101052 
-L 178.573071 146.430555 
-L 178.228407 146.758064 
-L 177.883742 147.083602 
-L 177.539078 147.407195 
-L 177.194414 147.728863 
-L 176.849749 148.048632 
-L 176.505085 148.366522 
-L 176.160421 148.682555 
-L 175.815756 148.996754 
-L 175.471092 149.309139 
-L 175.126428 149.619731 
-L 174.781763 149.928551 
-L 174.437099 150.235619 
-L 174.092434 150.540954 
-L 173.74777 150.844576 
-L 173.403106 151.146505 
-L 173.058441 151.446758 
-L 172.713777 151.745354 
-L 172.369113 152.042312 
-L 172.024448 152.33765 
-L 171.679784 152.631384 
-L 171.33512 152.923533 
-L 170.990455 153.214113 
-L 170.645791 153.503142 
-L 170.301127 153.790634 
-L 169.956462 154.076608 
-L 169.611798 154.361079 
-L 169.267134 154.644062 
-L 168.922469 154.925573 
-L 168.577805 155.205627 
-L 168.23314 155.484239 
-L 167.888476 155.761425 
-L 167.543812 156.037198 
-L 167.199147 156.311573 
-L 166.854483 156.584563 
-L 166.509819 156.856184 
-L 166.165154 157.126448 
-L 165.82049 157.395369 
-L 165.475826 157.662961 
-L 165.131161 157.929236 
-L 164.786497 158.194207 
-L 164.441833 158.457887 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 180.985721 141.85872 
+L 180.641057 142.197208 
+L 180.296393 142.533594 
+L 179.951728 142.867901 
+L 179.607064 143.200157 
+L 179.2624 143.530386 
+L 178.917735 143.858612 
+L 178.573071 144.184861 
+L 178.228407 144.509154 
+L 177.883742 144.831517 
+L 177.539078 145.151971 
+L 177.194414 145.470539 
+L 176.849749 145.787243 
+L 176.505085 146.102105 
+L 176.160421 146.415147 
+L 175.815756 146.726388 
+L 175.471092 147.03585 
+L 175.126428 147.343553 
+L 174.781763 147.649517 
+L 174.437099 147.953761 
+L 174.092434 148.256305 
+L 173.74777 148.557167 
+L 173.403106 148.856366 
+L 173.058441 149.15392 
+L 172.713777 149.449848 
+L 172.369113 149.744167 
+L 172.024448 150.036894 
+L 171.679784 150.328047 
+L 171.33512 150.617642 
+L 170.990455 150.905696 
+L 170.645791 151.192225 
+L 170.301127 151.477245 
+L 169.956462 151.760773 
+L 169.611798 152.042823 
+L 169.267134 152.323412 
+L 168.922469 152.602553 
+L 168.577805 152.880262 
+L 168.23314 153.156554 
+L 167.888476 153.431443 
+L 167.543812 153.704943 
+L 167.199147 153.977068 
+L 166.854483 154.247832 
+L 166.509819 154.517248 
+L 166.165154 154.78533 
+L 165.82049 155.052091 
+L 165.475826 155.317544 
+L 165.131161 155.581701 
+L 164.786497 155.844575 
+L 164.441833 156.106179 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
-    <path d="M 164.441833 158.457887 
-L 164.302655 158.650363 
-L 164.163478 158.842157 
-L 164.0243 159.033274 
-L 163.885123 159.223718 
-L 163.745945 159.413494 
-L 163.606768 159.602608 
-L 163.467591 159.791062 
-L 163.328413 159.978863 
-L 163.189236 160.166014 
-L 163.050058 160.35252 
-L 162.910881 160.538386 
-L 162.771703 160.723615 
-L 162.632526 160.908213 
-L 162.493348 161.092183 
-L 162.354171 161.27553 
-L 162.214994 161.458258 
-L 162.075816 161.640371 
-L 161.936639 161.821873 
-L 161.797461 162.002769 
-L 161.658284 162.183061 
-L 161.519106 162.362756 
-L 161.379929 162.541855 
-L 161.240751 162.720364 
-L 161.101574 162.898286 
-L 160.962397 163.075625 
-L 160.823219 163.252384 
-L 160.684042 163.428569 
-L 160.544864 163.604181 
-L 160.405687 163.779226 
-L 160.266509 163.953706 
-L 160.127332 164.127625 
-L 159.988155 164.300987 
-L 159.848977 164.473796 
-L 159.7098 164.646055 
-L 159.570622 164.817767 
-L 159.431445 164.988936 
-L 159.292267 165.159565 
-L 159.15309 165.329658 
-L 159.013912 165.499218 
-L 158.874735 165.668249 
-L 158.735558 165.836753 
-L 158.59638 166.004734 
-L 158.457203 166.172196 
-L 158.318025 166.339141 
-L 158.178848 166.505572 
-L 158.03967 166.671493 
-L 157.900493 166.836907 
-L 157.761315 167.001817 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 164.441833 156.106179 
+L 164.302655 156.313016 
+L 164.163478 156.519064 
+L 164.0243 156.724332 
+L 163.885123 156.928824 
+L 163.745945 157.132547 
+L 163.606768 157.335505 
+L 163.467591 157.537706 
+L 163.328413 157.739154 
+L 163.189236 157.939855 
+L 163.050058 158.139815 
+L 162.910881 158.339039 
+L 162.771703 158.537532 
+L 162.632526 158.7353 
+L 162.493348 158.932348 
+L 162.354171 159.128682 
+L 162.214994 159.324306 
+L 162.075816 159.519225 
+L 161.936639 159.713445 
+L 161.797461 159.906971 
+L 161.658284 160.099808 
+L 161.519106 160.291959 
+L 161.379929 160.483432 
+L 161.240751 160.674229 
+L 161.101574 160.864356 
+L 160.962397 161.053818 
+L 160.823219 161.242619 
+L 160.684042 161.430764 
+L 160.544864 161.618257 
+L 160.405687 161.805102 
+L 160.266509 161.991306 
+L 160.127332 162.17687 
+L 159.988155 162.361801 
+L 159.848977 162.546102 
+L 159.7098 162.729778 
+L 159.570622 162.912833 
+L 159.431445 163.095271 
+L 159.292267 163.277096 
+L 159.15309 163.458312 
+L 159.013912 163.638924 
+L 158.874735 163.818935 
+L 158.735558 163.998349 
+L 158.59638 164.177171 
+L 158.457203 164.355404 
+L 158.318025 164.533052 
+L 158.178848 164.710119 
+L 158.03967 164.886608 
+L 157.900493 165.062524 
+L 157.761315 165.23787 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
-    <path d="M 157.761315 167.001817 
-L 157.626061 167.340196 
-L 157.490806 167.676472 
-L 157.355551 168.010672 
-L 157.220296 168.342821 
-L 157.085041 168.672943 
-L 156.949786 169.001064 
-L 156.814531 169.327208 
-L 156.679277 169.651397 
-L 156.544022 169.973657 
-L 156.408767 170.294009 
-L 156.273512 170.612475 
-L 156.138257 170.929079 
-L 156.003002 171.243841 
-L 155.867747 171.556783 
-L 155.732493 171.867925 
-L 155.597238 172.177289 
-L 155.461983 172.484895 
-L 155.326728 172.790762 
-L 155.191473 173.094911 
-L 155.056218 173.397359 
-L 154.920963 173.698126 
-L 154.785709 173.997232 
-L 154.650454 174.294693 
-L 154.515199 174.590528 
-L 154.379944 174.884755 
-L 154.244689 175.177391 
-L 154.109434 175.468453 
-L 153.974179 175.757957 
-L 153.838924 176.045922 
-L 153.70367 176.332362 
-L 153.568415 176.617294 
-L 153.43316 176.900734 
-L 153.297905 177.182697 
-L 153.16265 177.463199 
-L 153.027395 177.742254 
-L 152.89214 178.019878 
-L 152.756886 178.296085 
-L 152.621631 178.570889 
-L 152.486376 178.844305 
-L 152.351121 179.116347 
-L 152.215866 179.387028 
-L 152.080611 179.656361 
-L 151.945356 179.924361 
-L 151.810102 180.191041 
-L 151.674847 180.456413 
-L 151.539592 180.720489 
-L 151.404337 180.983284 
-L 151.269082 181.244808 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 157.761315 165.23787 
+L 157.626061 165.555379 
+L 157.490806 165.871037 
+L 157.355551 166.184864 
+L 157.220296 166.496882 
+L 157.085041 166.807113 
+L 156.949786 167.115575 
+L 156.814531 167.42229 
+L 156.679277 167.727276 
+L 156.544022 168.030554 
+L 156.408767 168.332142 
+L 156.273512 168.632059 
+L 156.138257 168.930324 
+L 156.003002 169.226954 
+L 155.867747 169.521967 
+L 155.732493 169.815382 
+L 155.597238 170.107214 
+L 155.461983 170.397482 
+L 155.326728 170.686201 
+L 155.191473 170.973389 
+L 155.056218 171.259061 
+L 154.920963 171.543233 
+L 154.785709 171.825922 
+L 154.650454 172.107141 
+L 154.515199 172.386908 
+L 154.379944 172.665235 
+L 154.244689 172.94214 
+L 154.109434 173.217634 
+L 153.974179 173.491734 
+L 153.838924 173.764453 
+L 153.70367 174.035805 
+L 153.568415 174.305803 
+L 153.43316 174.574461 
+L 153.297905 174.841792 
+L 153.16265 175.10781 
+L 153.027395 175.372527 
+L 152.89214 175.635955 
+L 152.756886 175.898108 
+L 152.621631 176.158997 
+L 152.486376 176.418635 
+L 152.351121 176.677034 
+L 152.215866 176.934205 
+L 152.080611 177.19016 
+L 151.945356 177.44491 
+L 151.810102 177.698467 
+L 151.674847 177.950842 
+L 151.539592 178.202046 
+L 151.404337 178.452089 
+L 151.269082 178.700983 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
-    <path d="M 151.269082 181.244808 
-L 151.249457 181.370756 
-L 151.229832 181.496412 
-L 151.210207 181.621777 
-L 151.190583 181.746852 
-L 151.170958 181.871638 
-L 151.151333 181.996138 
-L 151.131708 182.120351 
-L 151.112083 182.24428 
-L 151.092458 182.367926 
-L 151.072833 182.491291 
-L 151.053208 182.614374 
-L 151.033583 182.737179 
-L 151.013958 182.859705 
-L 150.994334 182.981954 
-L 150.974709 183.103928 
-L 150.955084 183.225628 
-L 150.935459 183.347055 
-L 150.915834 183.46821 
-L 150.896209 183.589094 
-L 150.876584 183.709709 
-L 150.856959 183.830055 
-L 150.837334 183.950135 
-L 150.817709 184.069948 
-L 150.798085 184.189497 
-L 150.77846 184.308783 
-L 150.758835 184.427806 
-L 150.73921 184.546568 
-L 150.719585 184.66507 
-L 150.69996 184.783313 
-L 150.680335 184.901298 
-L 150.66071 185.019027 
-L 150.641085 185.1365 
-L 150.62146 185.253718 
-L 150.601836 185.370683 
-L 150.582211 185.487396 
-L 150.562586 185.603858 
-L 150.542961 185.72007 
-L 150.523336 185.836033 
-L 150.503711 185.951747 
-L 150.484086 186.067215 
-L 150.464461 186.182437 
-L 150.444836 186.297415 
-L 150.425212 186.412148 
-L 150.405587 186.526639 
-L 150.385962 186.640888 
-L 150.366337 186.754896 
-L 150.346712 186.868665 
-L 150.327087 186.982195 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 151.269082 178.700983 
+L 151.249457 178.845517 
+L 151.229832 178.989667 
+L 151.210207 179.133434 
+L 151.190583 179.27682 
+L 151.170958 179.419827 
+L 151.151333 179.562457 
+L 151.131708 179.704713 
+L 151.112083 179.846595 
+L 151.092458 179.988107 
+L 151.072833 180.12925 
+L 151.053208 180.270025 
+L 151.033583 180.410436 
+L 151.013958 180.550483 
+L 150.994334 180.690169 
+L 150.974709 180.829495 
+L 150.955084 180.968464 
+L 150.935459 181.107077 
+L 150.915834 181.245335 
+L 150.896209 181.383242 
+L 150.876584 181.520798 
+L 150.856959 181.658005 
+L 150.837334 181.794866 
+L 150.817709 181.931381 
+L 150.798085 182.067553 
+L 150.77846 182.203383 
+L 150.758835 182.338873 
+L 150.73921 182.474025 
+L 150.719585 182.608841 
+L 150.69996 182.743321 
+L 150.680335 182.877468 
+L 150.66071 183.011284 
+L 150.641085 183.144769 
+L 150.62146 183.277927 
+L 150.601836 183.410757 
+L 150.582211 183.543262 
+L 150.562586 183.675444 
+L 150.542961 183.807304 
+L 150.523336 183.938843 
+L 150.503711 184.070064 
+L 150.484086 184.200967 
+L 150.464461 184.331554 
+L 150.444836 184.461827 
+L 150.425212 184.591787 
+L 150.405587 184.721437 
+L 150.385962 184.850776 
+L 150.366337 184.979807 
+L 150.346712 185.108531 
+L 150.327087 185.23695 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m26440347c3" d="M -1.25 2.5 
+     <path id="mfa0971461d" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,437 +3627,437 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p399ecdeb00)">
-     <use xlink:href="#m26440347c3" x="345.030867" y="135.087035" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m26440347c3" x="273.364924" y="141.893443" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m26440347c3" x="240.719951" y="147.934009" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m26440347c3" x="221.353978" y="153.24805" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m26440347c3" x="207.129625" y="155.190071" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m26440347c3" x="181.064802" y="166.690306" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m26440347c3" x="179.282169" y="170.285179" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m26440347c3" x="177.719335" y="175.659634" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m26440347c3" x="177.643939" y="181.03308" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbc76cd86a)">
+     <use xlink:href="#mfa0971461d" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfa0971461d" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfa0971461d" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfa0971461d" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfa0971461d" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfa0971461d" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfa0971461d" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfa0971461d" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfa0971461d" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
-    <path d="M 345.030867 135.087035 
-L 343.537827 135.237927 
-L 342.044786 135.3884 
-L 340.551746 135.538456 
-L 339.058705 135.688097 
-L 337.565665 135.837325 
-L 336.072624 135.986143 
-L 334.579584 136.134552 
-L 333.086543 136.282556 
-L 331.593503 136.430156 
-L 330.100462 136.577355 
-L 328.607422 136.724155 
-L 327.114381 136.870557 
-L 325.621341 137.016564 
-L 324.1283 137.162179 
-L 322.63526 137.307403 
-L 321.142219 137.452238 
-L 319.649179 137.596686 
-L 318.156138 137.74075 
-L 316.663098 137.884432 
-L 315.170057 138.027733 
-L 313.677017 138.170655 
-L 312.183977 138.313201 
-L 310.690936 138.455373 
-L 309.197896 138.597172 
-L 307.704855 138.738601 
-L 306.211815 138.879661 
-L 304.718774 139.020354 
-L 303.225734 139.160682 
-L 301.732693 139.300648 
-L 300.239653 139.440252 
-L 298.746612 139.579498 
-L 297.253572 139.718385 
-L 295.760531 139.856918 
-L 294.267491 139.995096 
-L 292.77445 140.132923 
-L 291.28141 140.2704 
-L 289.788369 140.407528 
-L 288.295329 140.54431 
-L 286.802288 140.680747 
-L 285.309248 140.81684 
-L 283.816207 140.952593 
-L 282.323167 141.088005 
-L 280.830126 141.22308 
-L 279.337086 141.357819 
-L 277.844045 141.492222 
-L 276.351005 141.626293 
-L 274.857964 141.760033 
-L 273.364924 141.893443 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 345.030867 136.859359 
+L 343.537827 137.008025 
+L 342.044786 137.156283 
+L 340.551746 137.304137 
+L 339.058705 137.451587 
+L 337.565665 137.598638 
+L 336.072624 137.745289 
+L 334.579584 137.891545 
+L 333.086543 138.037406 
+L 331.593503 138.182876 
+L 330.100462 138.327955 
+L 328.607422 138.472647 
+L 327.114381 138.616953 
+L 325.621341 138.760876 
+L 324.1283 138.904416 
+L 322.63526 139.047578 
+L 321.142219 139.190361 
+L 319.649179 139.332769 
+L 318.156138 139.474803 
+L 316.663098 139.616466 
+L 315.170057 139.757758 
+L 313.677017 139.898683 
+L 312.183977 140.039242 
+L 310.690936 140.179437 
+L 309.197896 140.31927 
+L 307.704855 140.458743 
+L 306.211815 140.597857 
+L 304.718774 140.736614 
+L 303.225734 140.875017 
+L 301.732693 141.013066 
+L 300.239653 141.150765 
+L 298.746612 141.288114 
+L 297.253572 141.425116 
+L 295.760531 141.561771 
+L 294.267491 141.698083 
+L 292.77445 141.834052 
+L 291.28141 141.969681 
+L 289.788369 142.10497 
+L 288.295329 142.239922 
+L 286.802288 142.374539 
+L 285.309248 142.508822 
+L 283.816207 142.642772 
+L 282.323167 142.776392 
+L 280.830126 142.909683 
+L 279.337086 143.042646 
+L 277.844045 143.175283 
+L 276.351005 143.307597 
+L 274.857964 143.439587 
+L 273.364924 143.571257 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
-    <path d="M 273.364924 141.893443 
-L 272.68482 142.026416 
-L 272.004717 142.159064 
-L 271.324613 142.291387 
-L 270.644509 142.423388 
-L 269.964406 142.555067 
-L 269.284302 142.686427 
-L 268.604199 142.817469 
-L 267.924095 142.948194 
-L 267.243991 143.078604 
-L 266.563888 143.208701 
-L 265.883784 143.338486 
-L 265.203681 143.46796 
-L 264.523577 143.597125 
-L 263.843473 143.725983 
-L 263.16337 143.854535 
-L 262.483266 143.982782 
-L 261.803163 144.110725 
-L 261.123059 144.238367 
-L 260.442955 144.365709 
-L 259.762852 144.492752 
-L 259.082748 144.619497 
-L 258.402645 144.745946 
-L 257.722541 144.8721 
-L 257.042437 144.997961 
-L 256.362334 145.12353 
-L 255.68223 145.248808 
-L 255.002127 145.373797 
-L 254.322023 145.498498 
-L 253.641919 145.622912 
-L 252.961816 145.747041 
-L 252.281712 145.870885 
-L 251.601609 145.994447 
-L 250.921505 146.117728 
-L 250.241401 146.240728 
-L 249.561298 146.36345 
-L 248.881194 146.485893 
-L 248.201091 146.608061 
-L 247.520987 146.729953 
-L 246.840883 146.851571 
-L 246.16078 146.972917 
-L 245.480676 147.093991 
-L 244.800573 147.214795 
-L 244.120469 147.335329 
-L 243.440365 147.455596 
-L 242.760262 147.575596 
-L 242.080158 147.695331 
-L 241.400055 147.814802 
-L 240.719951 147.934009 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 273.364924 143.571257 
+L 272.68482 143.697254 
+L 272.004717 143.822959 
+L 271.324613 143.948373 
+L 270.644509 144.073497 
+L 269.964406 144.198332 
+L 269.284302 144.32288 
+L 268.604199 144.447142 
+L 267.924095 144.571119 
+L 267.243991 144.694813 
+L 266.563888 144.818225 
+L 265.883784 144.941357 
+L 265.203681 145.064209 
+L 264.523577 145.186783 
+L 263.843473 145.309079 
+L 263.16337 145.431101 
+L 262.483266 145.552847 
+L 261.803163 145.674321 
+L 261.123059 145.795522 
+L 260.442955 145.916453 
+L 259.762852 146.037114 
+L 259.082748 146.157507 
+L 258.402645 146.277633 
+L 257.722541 146.397493 
+L 257.042437 146.517088 
+L 256.362334 146.636419 
+L 255.68223 146.755488 
+L 255.002127 146.874295 
+L 254.322023 146.992842 
+L 253.641919 147.11113 
+L 252.961816 147.229161 
+L 252.281712 147.346934 
+L 251.601609 147.464452 
+L 250.921505 147.581715 
+L 250.241401 147.698725 
+L 249.561298 147.815482 
+L 248.881194 147.931988 
+L 248.201091 148.048244 
+L 247.520987 148.164251 
+L 246.840883 148.280009 
+L 246.16078 148.395521 
+L 245.480676 148.510787 
+L 244.800573 148.625807 
+L 244.120469 148.740584 
+L 243.440365 148.855118 
+L 242.760262 148.96941 
+L 242.080158 149.083462 
+L 241.400055 149.197273 
+L 240.719951 149.310846 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
-    <path d="M 240.719951 147.934009 
-L 240.316493 148.050211 
-L 239.913035 148.166164 
-L 239.509578 148.281869 
-L 239.10612 148.397328 
-L 238.702662 148.51254 
-L 238.299204 148.627508 
-L 237.895746 148.742232 
-L 237.492289 148.856714 
-L 237.088831 148.970953 
-L 236.685373 149.084953 
-L 236.281915 149.198712 
-L 235.878458 149.312233 
-L 235.475 149.425516 
-L 235.071542 149.538563 
-L 234.668084 149.651374 
-L 234.264626 149.76395 
-L 233.861169 149.876293 
-L 233.457711 149.988402 
-L 233.054253 150.100281 
-L 232.650795 150.211928 
-L 232.247338 150.323345 
-L 231.84388 150.434534 
-L 231.440422 150.545494 
-L 231.036964 150.656228 
-L 230.633506 150.766735 
-L 230.230049 150.877018 
-L 229.826591 150.987076 
-L 229.423133 151.09691 
-L 229.019675 151.206522 
-L 228.616218 151.315913 
-L 228.21276 151.425083 
-L 227.809302 151.534033 
-L 227.405844 151.642764 
-L 227.002386 151.751277 
-L 226.598929 151.859573 
-L 226.195471 151.967653 
-L 225.792013 152.075517 
-L 225.388555 152.183167 
-L 224.985098 152.290603 
-L 224.58164 152.397827 
-L 224.178182 152.504838 
-L 223.774724 152.611638 
-L 223.371266 152.718228 
-L 222.967809 152.824608 
-L 222.564351 152.930779 
-L 222.160893 153.036743 
-L 221.757435 153.142499 
-L 221.353978 153.24805 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 240.719951 149.310846 
+L 240.316493 149.416442 
+L 239.913035 149.521833 
+L 239.509578 149.627019 
+L 239.10612 149.732001 
+L 238.702662 149.83678 
+L 238.299204 149.941356 
+L 237.895746 150.045731 
+L 237.492289 150.149905 
+L 237.088831 150.253879 
+L 236.685373 150.357653 
+L 236.281915 150.461229 
+L 235.878458 150.564607 
+L 235.475 150.667788 
+L 235.071542 150.770773 
+L 234.668084 150.873562 
+L 234.264626 150.976156 
+L 233.861169 151.078556 
+L 233.457711 151.180763 
+L 233.054253 151.282778 
+L 232.650795 151.3846 
+L 232.247338 151.486231 
+L 231.84388 151.587672 
+L 231.440422 151.688923 
+L 231.036964 151.789985 
+L 230.633506 151.890859 
+L 230.230049 151.991545 
+L 229.826591 152.092044 
+L 229.423133 152.192357 
+L 229.019675 152.292484 
+L 228.616218 152.392427 
+L 228.21276 152.492185 
+L 227.809302 152.59176 
+L 227.405844 152.691152 
+L 227.002386 152.790362 
+L 226.598929 152.88939 
+L 226.195471 152.988237 
+L 225.792013 153.086905 
+L 225.388555 153.185392 
+L 224.985098 153.283701 
+L 224.58164 153.381832 
+L 224.178182 153.479785 
+L 223.774724 153.577561 
+L 223.371266 153.675161 
+L 222.967809 153.772585 
+L 222.564351 153.869835 
+L 222.160893 153.966909 
+L 221.757435 154.06381 
+L 221.353978 154.160538 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
-    <path d="M 221.353978 153.24805 
-L 221.057637 153.289227 
-L 220.761296 153.330374 
-L 220.464956 153.371489 
-L 220.168615 153.412573 
-L 219.872274 153.453626 
-L 219.575933 153.494648 
-L 219.279593 153.535638 
-L 218.983252 153.576598 
-L 218.686911 153.617527 
-L 218.390571 153.658424 
-L 218.09423 153.699291 
-L 217.797889 153.740127 
-L 217.501549 153.780932 
-L 217.205208 153.821707 
-L 216.908867 153.862451 
-L 216.612527 153.903164 
-L 216.316186 153.943846 
-L 216.019845 153.984498 
-L 215.723505 154.02512 
-L 215.427164 154.065711 
-L 215.130823 154.106271 
-L 214.834483 154.146801 
-L 214.538142 154.187301 
-L 214.241801 154.227771 
-L 213.945461 154.26821 
-L 213.64912 154.308619 
-L 213.352779 154.348998 
-L 213.056438 154.389347 
-L 212.760098 154.429666 
-L 212.463757 154.469955 
-L 212.167416 154.510213 
-L 211.871076 154.550442 
-L 211.574735 154.590641 
-L 211.278394 154.630811 
-L 210.982054 154.67095 
-L 210.685713 154.71106 
-L 210.389372 154.75114 
-L 210.093032 154.79119 
-L 209.796691 154.83121 
-L 209.50035 154.871202 
-L 209.20401 154.911163 
-L 208.907669 154.951095 
-L 208.611328 154.990998 
-L 208.314988 155.030871 
-L 208.018647 155.070715 
-L 207.722306 155.110529 
-L 207.425965 155.150315 
-L 207.129625 155.190071 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 221.353978 154.160538 
+L 221.057637 154.201493 
+L 220.761296 154.242416 
+L 220.464956 154.283309 
+L 220.168615 154.32417 
+L 219.872274 154.365001 
+L 219.575933 154.405801 
+L 219.279593 154.446571 
+L 218.983252 154.487309 
+L 218.686911 154.528017 
+L 218.390571 154.568695 
+L 218.09423 154.609342 
+L 217.797889 154.649958 
+L 217.501549 154.690544 
+L 217.205208 154.7311 
+L 216.908867 154.771625 
+L 216.612527 154.81212 
+L 216.316186 154.852584 
+L 216.019845 154.893019 
+L 215.723505 154.933423 
+L 215.427164 154.973797 
+L 215.130823 155.014141 
+L 214.834483 155.054455 
+L 214.538142 155.094738 
+L 214.241801 155.134992 
+L 213.945461 155.175216 
+L 213.64912 155.215411 
+L 213.352779 155.255575 
+L 213.056438 155.29571 
+L 212.760098 155.335814 
+L 212.463757 155.37589 
+L 212.167416 155.415935 
+L 211.871076 155.455951 
+L 211.574735 155.495937 
+L 211.278394 155.535894 
+L 210.982054 155.575821 
+L 210.685713 155.615719 
+L 210.389372 155.655588 
+L 210.093032 155.695427 
+L 209.796691 155.735237 
+L 209.50035 155.775018 
+L 209.20401 155.814769 
+L 208.907669 155.854491 
+L 208.611328 155.894184 
+L 208.314988 155.933848 
+L 208.018647 155.973483 
+L 207.722306 156.013089 
+L 207.425965 156.052666 
+L 207.129625 156.092215 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
-    <path d="M 207.129625 155.190071 
-L 206.586608 155.456362 
-L 206.043591 155.72135 
-L 205.500573 155.985046 
-L 204.957556 156.247464 
-L 204.414539 156.508616 
-L 203.871522 156.768513 
-L 203.328505 157.027168 
-L 202.785488 157.284593 
-L 202.242471 157.5408 
-L 201.699453 157.795798 
-L 201.156436 158.049602 
-L 200.613419 158.30222 
-L 200.070402 158.553665 
-L 199.527385 158.803946 
-L 198.984368 159.053076 
-L 198.441351 159.301064 
-L 197.898333 159.547921 
-L 197.355316 159.793657 
-L 196.812299 160.038282 
-L 196.269282 160.281807 
-L 195.726265 160.52424 
-L 195.183248 160.765592 
-L 194.640231 161.005873 
-L 194.097213 161.245092 
-L 193.554196 161.483258 
-L 193.011179 161.72038 
-L 192.468162 161.956468 
-L 191.925145 162.19153 
-L 191.382128 162.425576 
-L 190.839111 162.658614 
-L 190.296093 162.890653 
-L 189.753076 163.121702 
-L 189.210059 163.351768 
-L 188.667042 163.58086 
-L 188.124025 163.808986 
-L 187.581008 164.036155 
-L 187.037991 164.262374 
-L 186.494973 164.487652 
-L 185.951956 164.711995 
-L 185.408939 164.935413 
-L 184.865922 165.157912 
-L 184.322905 165.3795 
-L 183.779888 165.600184 
-L 183.236871 165.819973 
-L 182.693853 166.038872 
-L 182.150836 166.256889 
-L 181.607819 166.474032 
-L 181.064802 166.690306 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 207.129625 156.092215 
+L 206.586608 156.337277 
+L 206.043591 156.581236 
+L 205.500573 156.8241 
+L 204.957556 157.065879 
+L 204.414539 157.306583 
+L 203.871522 157.546221 
+L 203.328505 157.784803 
+L 202.785488 158.022338 
+L 202.242471 158.258836 
+L 201.699453 158.494304 
+L 201.156436 158.728753 
+L 200.613419 158.962191 
+L 200.070402 159.194626 
+L 199.527385 159.426068 
+L 198.984368 159.656524 
+L 198.441351 159.886004 
+L 197.898333 160.114514 
+L 197.355316 160.342064 
+L 196.812299 160.568662 
+L 196.269282 160.794315 
+L 195.726265 161.019031 
+L 195.183248 161.242818 
+L 194.640231 161.465684 
+L 194.097213 161.687635 
+L 193.554196 161.908681 
+L 193.011179 162.128828 
+L 192.468162 162.348083 
+L 191.925145 162.566453 
+L 191.382128 162.783946 
+L 190.839111 163.000569 
+L 190.296093 163.216328 
+L 189.753076 163.431231 
+L 189.210059 163.645283 
+L 188.667042 163.858493 
+L 188.124025 164.070866 
+L 187.581008 164.28241 
+L 187.037991 164.49313 
+L 186.494973 164.703032 
+L 185.951956 164.912124 
+L 185.408939 165.120412 
+L 184.865922 165.327901 
+L 184.322905 165.534597 
+L 183.779888 165.740508 
+L 183.236871 165.945638 
+L 182.693853 166.149994 
+L 182.150836 166.353581 
+L 181.607819 166.556405 
+L 181.064802 166.758473 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
-    <path d="M 181.064802 166.690306 
-L 181.027664 166.767688 
-L 180.990526 166.844958 
-L 180.953387 166.922119 
-L 180.916249 166.99917 
-L 180.879111 167.076111 
-L 180.841973 167.152943 
-L 180.804835 167.229666 
-L 180.767696 167.30628 
-L 180.730558 167.382786 
-L 180.69342 167.459185 
-L 180.656282 167.535475 
-L 180.619144 167.611658 
-L 180.582006 167.687734 
-L 180.544867 167.763703 
-L 180.507729 167.839566 
-L 180.470591 167.915322 
-L 180.433453 167.990973 
-L 180.396315 168.066518 
-L 180.359176 168.141957 
-L 180.322038 168.217292 
-L 180.2849 168.292522 
-L 180.247762 168.367647 
-L 180.210624 168.442669 
-L 180.173485 168.517586 
-L 180.136347 168.5924 
-L 180.099209 168.667111 
-L 180.062071 168.741718 
-L 180.024933 168.816223 
-L 179.987795 168.890626 
-L 179.950656 168.964926 
-L 179.913518 169.039125 
-L 179.87638 169.113221 
-L 179.839242 169.187217 
-L 179.802104 169.261112 
-L 179.764965 169.334905 
-L 179.727827 169.408599 
-L 179.690689 169.482192 
-L 179.653551 169.555685 
-L 179.616413 169.629078 
-L 179.579275 169.702372 
-L 179.542136 169.775567 
-L 179.504998 169.848664 
-L 179.46786 169.921661 
-L 179.430722 169.99456 
-L 179.393584 170.067361 
-L 179.356445 170.140065 
-L 179.319307 170.21267 
-L 179.282169 170.285179 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 181.064802 166.758473 
+L 181.027664 166.834431 
+L 180.990526 166.910283 
+L 180.953387 166.986029 
+L 180.916249 167.06167 
+L 180.879111 167.137204 
+L 180.841973 167.212634 
+L 180.804835 167.287958 
+L 180.767696 167.363178 
+L 180.730558 167.438293 
+L 180.69342 167.513304 
+L 180.656282 167.588212 
+L 180.619144 167.663016 
+L 180.582006 167.737716 
+L 180.544867 167.812314 
+L 180.507729 167.886809 
+L 180.470591 167.961202 
+L 180.433453 168.035493 
+L 180.396315 168.109681 
+L 180.359176 168.183769 
+L 180.322038 168.257755 
+L 180.2849 168.33164 
+L 180.247762 168.405424 
+L 180.210624 168.479108 
+L 180.173485 168.552692 
+L 180.136347 168.626175 
+L 180.099209 168.69956 
+L 180.062071 168.772844 
+L 180.024933 168.84603 
+L 179.987795 168.919117 
+L 179.950656 168.992106 
+L 179.913518 169.064996 
+L 179.87638 169.137788 
+L 179.839242 169.210482 
+L 179.802104 169.283079 
+L 179.764965 169.355579 
+L 179.727827 169.427981 
+L 179.690689 169.500287 
+L 179.653551 169.572497 
+L 179.616413 169.64461 
+L 179.579275 169.716627 
+L 179.542136 169.788549 
+L 179.504998 169.860375 
+L 179.46786 169.932106 
+L 179.430722 170.003743 
+L 179.393584 170.075284 
+L 179.356445 170.146731 
+L 179.319307 170.218084 
+L 179.282169 170.289343 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
-    <path d="M 179.282169 170.285179 
-L 179.24961 170.402767 
-L 179.217051 170.520101 
-L 179.184492 170.63718 
-L 179.151933 170.754007 
-L 179.119374 170.870582 
-L 179.086815 170.986907 
-L 179.054256 171.102982 
-L 179.021697 171.218809 
-L 178.989138 171.334388 
-L 178.956579 171.449721 
-L 178.924019 171.564809 
-L 178.89146 171.679652 
-L 178.858901 171.794253 
-L 178.826342 171.908611 
-L 178.793783 172.022728 
-L 178.761224 172.136605 
-L 178.728665 172.250243 
-L 178.696106 172.363642 
-L 178.663547 172.476805 
-L 178.630988 172.589731 
-L 178.598429 172.702423 
-L 178.56587 172.81488 
-L 178.533311 172.927104 
-L 178.500752 173.039095 
-L 178.468193 173.150856 
-L 178.435634 173.262386 
-L 178.403075 173.373686 
-L 178.370516 173.484759 
-L 178.337957 173.595604 
-L 178.305398 173.706222 
-L 178.272838 173.816614 
-L 178.240279 173.926782 
-L 178.20772 174.036726 
-L 178.175161 174.146447 
-L 178.142602 174.255946 
-L 178.110043 174.365224 
-L 178.077484 174.474282 
-L 178.044925 174.583121 
-L 178.012366 174.691741 
-L 177.979807 174.800143 
-L 177.947248 174.908329 
-L 177.914689 175.016299 
-L 177.88213 175.124054 
-L 177.849571 175.231595 
-L 177.817012 175.338922 
-L 177.784453 175.446037 
-L 177.751894 175.552941 
-L 177.719335 175.659634 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 179.282169 170.289343 
+L 179.24961 170.402945 
+L 179.217051 170.516309 
+L 179.184492 170.629436 
+L 179.151933 170.742327 
+L 179.119374 170.854984 
+L 179.086815 170.967406 
+L 179.054256 171.079595 
+L 179.021697 171.191553 
+L 178.989138 171.303279 
+L 178.956579 171.414775 
+L 178.924019 171.526042 
+L 178.89146 171.637081 
+L 178.858901 171.747892 
+L 178.826342 171.858477 
+L 178.793783 171.968837 
+L 178.761224 172.078972 
+L 178.728665 172.188883 
+L 178.696106 172.298572 
+L 178.663547 172.408039 
+L 178.630988 172.517285 
+L 178.598429 172.626311 
+L 178.56587 172.735117 
+L 178.533311 172.843706 
+L 178.500752 172.952077 
+L 178.468193 173.060232 
+L 178.435634 173.16817 
+L 178.403075 173.275895 
+L 178.370516 173.383405 
+L 178.337957 173.490702 
+L 178.305398 173.597787 
+L 178.272838 173.70466 
+L 178.240279 173.811323 
+L 178.20772 173.917776 
+L 178.175161 174.02402 
+L 178.142602 174.130056 
+L 178.110043 174.235884 
+L 178.077484 174.341507 
+L 178.044925 174.446923 
+L 178.012366 174.552135 
+L 177.979807 174.657142 
+L 177.947248 174.761946 
+L 177.914689 174.866548 
+L 177.88213 174.970948 
+L 177.849571 175.075147 
+L 177.817012 175.179146 
+L 177.784453 175.282945 
+L 177.751894 175.386546 
+L 177.719335 175.489948 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
-    <path d="M 177.719335 175.659634 
-L 177.717764 175.777199 
-L 177.716193 175.894509 
-L 177.714622 176.011566 
-L 177.713052 176.12837 
-L 177.711481 176.244922 
-L 177.70991 176.361224 
-L 177.708339 176.477277 
-L 177.706769 176.593081 
-L 177.705198 176.708638 
-L 177.703627 176.823949 
-L 177.702056 176.939015 
-L 177.700486 177.053836 
-L 177.698915 177.168414 
-L 177.697344 177.282751 
-L 177.695773 177.396846 
-L 177.694203 177.510701 
-L 177.692632 177.624317 
-L 177.691061 177.737695 
-L 177.68949 177.850836 
-L 177.68792 177.963742 
-L 177.686349 178.076412 
-L 177.684778 178.188848 
-L 177.683207 178.30105 
-L 177.681637 178.413021 
-L 177.680066 178.524761 
-L 177.678495 178.63627 
-L 177.676924 178.74755 
-L 177.675354 178.858601 
-L 177.673783 178.969426 
-L 177.672212 179.080023 
-L 177.670641 179.190395 
-L 177.669071 179.300543 
-L 177.6675 179.410467 
-L 177.665929 179.520168 
-L 177.664358 179.629647 
-L 177.662788 179.738905 
-L 177.661217 179.847943 
-L 177.659646 179.956761 
-L 177.658075 180.065362 
-L 177.656505 180.173745 
-L 177.654934 180.281911 
-L 177.653363 180.389861 
-L 177.651792 180.497597 
-L 177.650222 180.605118 
-L 177.648651 180.712426 
-L 177.64708 180.819522 
-L 177.645509 180.926407 
-L 177.643939 181.03308 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 177.719335 175.489948 
+L 177.717764 175.623422 
+L 177.716193 175.756567 
+L 177.714622 175.889385 
+L 177.713052 176.021878 
+L 177.711481 176.154048 
+L 177.70991 176.285896 
+L 177.708339 176.417423 
+L 177.706769 176.548632 
+L 177.705198 176.679523 
+L 177.703627 176.810099 
+L 177.702056 176.94036 
+L 177.700486 177.070309 
+L 177.698915 177.199946 
+L 177.697344 177.329274 
+L 177.695773 177.458293 
+L 177.694203 177.587006 
+L 177.692632 177.715413 
+L 177.691061 177.843517 
+L 177.68949 177.971318 
+L 177.68792 178.098818 
+L 177.686349 178.226018 
+L 177.684778 178.352921 
+L 177.683207 178.479526 
+L 177.681637 178.605836 
+L 177.680066 178.731852 
+L 177.678495 178.857575 
+L 177.676924 178.983007 
+L 177.675354 179.108149 
+L 177.673783 179.233003 
+L 177.672212 179.357569 
+L 177.670641 179.481849 
+L 177.669071 179.605844 
+L 177.6675 179.729556 
+L 177.665929 179.852986 
+L 177.664358 179.976135 
+L 177.662788 180.099005 
+L 177.661217 180.221596 
+L 177.659646 180.34391 
+L 177.658075 180.465949 
+L 177.656505 180.587713 
+L 177.654934 180.709203 
+L 177.653363 180.830422 
+L 177.651792 180.95137 
+L 177.650222 181.072048 
+L 177.648651 181.192458 
+L 177.64708 181.3126 
+L 177.645509 181.432477 
+L 177.643939 181.552088 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m2a75398bb3" d="M 0 -2.5 
+     <path id="mbc23ff7fc2" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,437 +4070,437 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p399ecdeb00)">
-     <use xlink:href="#m2a75398bb3" x="226.871027" y="113.078527" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2a75398bb3" x="226.871027" y="113.102618" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2a75398bb3" x="226.871027" y="113.251157" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2a75398bb3" x="226.871027" y="113.159816" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2a75398bb3" x="177.768423" y="132.098656" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2a75398bb3" x="160.37503" y="145.292152" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2a75398bb3" x="153.995779" y="152.427338" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2a75398bb3" x="147.106887" y="167.637027" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m2a75398bb3" x="145.871703" y="174.910889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pbbc76cd86a)">
+     <use xlink:href="#mbc23ff7fc2" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc23ff7fc2" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc23ff7fc2" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc23ff7fc2" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc23ff7fc2" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc23ff7fc2" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc23ff7fc2" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc23ff7fc2" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mbc23ff7fc2" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
-    <path d="M 226.871027 113.078527 
-L 226.871027 113.079029 
-L 226.871027 113.079531 
-L 226.871027 113.080033 
-L 226.871027 113.080535 
-L 226.871027 113.081037 
-L 226.871027 113.081539 
-L 226.871027 113.082041 
-L 226.871027 113.082543 
-L 226.871027 113.083045 
-L 226.871027 113.083547 
-L 226.871027 113.084049 
-L 226.871027 113.084551 
-L 226.871027 113.085053 
-L 226.871027 113.085555 
-L 226.871027 113.086057 
-L 226.871027 113.086559 
-L 226.871027 113.087061 
-L 226.871027 113.087563 
-L 226.871027 113.088065 
-L 226.871027 113.088566 
-L 226.871027 113.089068 
-L 226.871027 113.08957 
-L 226.871027 113.090072 
-L 226.871027 113.090574 
-L 226.871027 113.091076 
-L 226.871027 113.091578 
-L 226.871027 113.09208 
-L 226.871027 113.092581 
-L 226.871027 113.093083 
-L 226.871027 113.093585 
-L 226.871027 113.094087 
-L 226.871027 113.094589 
-L 226.871027 113.095091 
-L 226.871027 113.095593 
-L 226.871027 113.096094 
-L 226.871027 113.096596 
-L 226.871027 113.097098 
-L 226.871027 113.0976 
-L 226.871027 113.098102 
-L 226.871027 113.098604 
-L 226.871027 113.099105 
-L 226.871027 113.099607 
-L 226.871027 113.100109 
-L 226.871027 113.100611 
-L 226.871027 113.101113 
-L 226.871027 113.101614 
-L 226.871027 113.102116 
-L 226.871027 113.102618 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 226.871027 113.224491 
+L 226.871027 113.2212 
+L 226.871027 113.21791 
+L 226.871027 113.214619 
+L 226.871027 113.211328 
+L 226.871027 113.208036 
+L 226.871027 113.204745 
+L 226.871027 113.201453 
+L 226.871027 113.198162 
+L 226.871027 113.19487 
+L 226.871027 113.191577 
+L 226.871027 113.188285 
+L 226.871027 113.184992 
+L 226.871027 113.181699 
+L 226.871027 113.178406 
+L 226.871027 113.175113 
+L 226.871027 113.17182 
+L 226.871027 113.168526 
+L 226.871027 113.165232 
+L 226.871027 113.161938 
+L 226.871027 113.158644 
+L 226.871027 113.15535 
+L 226.871027 113.152055 
+L 226.871027 113.14876 
+L 226.871027 113.145465 
+L 226.871027 113.14217 
+L 226.871027 113.138874 
+L 226.871027 113.135579 
+L 226.871027 113.132283 
+L 226.871027 113.128987 
+L 226.871027 113.125691 
+L 226.871027 113.122394 
+L 226.871027 113.119098 
+L 226.871027 113.115801 
+L 226.871027 113.112504 
+L 226.871027 113.109206 
+L 226.871027 113.105909 
+L 226.871027 113.102611 
+L 226.871027 113.099314 
+L 226.871027 113.096015 
+L 226.871027 113.092717 
+L 226.871027 113.089419 
+L 226.871027 113.08612 
+L 226.871027 113.082821 
+L 226.871027 113.079522 
+L 226.871027 113.076223 
+L 226.871027 113.072924 
+L 226.871027 113.069624 
+L 226.871027 113.066324 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
-    <path d="M 226.871027 113.102618 
-L 226.871027 113.105717 
-L 226.871027 113.108815 
-L 226.871027 113.111914 
-L 226.871027 113.115012 
-L 226.871027 113.11811 
-L 226.871027 113.121208 
-L 226.871027 113.124305 
-L 226.871027 113.127403 
-L 226.871027 113.1305 
-L 226.871027 113.133597 
-L 226.871027 113.136694 
-L 226.871027 113.139791 
-L 226.871027 113.142888 
-L 226.871027 113.145984 
-L 226.871027 113.14908 
-L 226.871027 113.152176 
-L 226.871027 113.155272 
-L 226.871027 113.158368 
-L 226.871027 113.161464 
-L 226.871027 113.164559 
-L 226.871027 113.167654 
-L 226.871027 113.170749 
-L 226.871027 113.173844 
-L 226.871027 113.176939 
-L 226.871027 113.180033 
-L 226.871027 113.183127 
-L 226.871027 113.186222 
-L 226.871027 113.189316 
-L 226.871027 113.192409 
-L 226.871027 113.195503 
-L 226.871027 113.198596 
-L 226.871027 113.20169 
-L 226.871027 113.204783 
-L 226.871027 113.207876 
-L 226.871027 113.210968 
-L 226.871027 113.214061 
-L 226.871027 113.217153 
-L 226.871027 113.220245 
-L 226.871027 113.223337 
-L 226.871027 113.226429 
-L 226.871027 113.229521 
-L 226.871027 113.232612 
-L 226.871027 113.235704 
-L 226.871027 113.238795 
-L 226.871027 113.241886 
-L 226.871027 113.244976 
-L 226.871027 113.248067 
-L 226.871027 113.251157 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 226.871027 113.066324 
+L 226.871027 113.068658 
+L 226.871027 113.070991 
+L 226.871027 113.073324 
+L 226.871027 113.075658 
+L 226.871027 113.077991 
+L 226.871027 113.080324 
+L 226.871027 113.082657 
+L 226.871027 113.08499 
+L 226.871027 113.087322 
+L 226.871027 113.089655 
+L 226.871027 113.091988 
+L 226.871027 113.09432 
+L 226.871027 113.096652 
+L 226.871027 113.098985 
+L 226.871027 113.101317 
+L 226.871027 113.103649 
+L 226.871027 113.105981 
+L 226.871027 113.108312 
+L 226.871027 113.110644 
+L 226.871027 113.112976 
+L 226.871027 113.115307 
+L 226.871027 113.117639 
+L 226.871027 113.11997 
+L 226.871027 113.122301 
+L 226.871027 113.124633 
+L 226.871027 113.126964 
+L 226.871027 113.129295 
+L 226.871027 113.131625 
+L 226.871027 113.133956 
+L 226.871027 113.136287 
+L 226.871027 113.138617 
+L 226.871027 113.140948 
+L 226.871027 113.143278 
+L 226.871027 113.145608 
+L 226.871027 113.147938 
+L 226.871027 113.150268 
+L 226.871027 113.152598 
+L 226.871027 113.154928 
+L 226.871027 113.157258 
+L 226.871027 113.159588 
+L 226.871027 113.161917 
+L 226.871027 113.164247 
+L 226.871027 113.166576 
+L 226.871027 113.168905 
+L 226.871027 113.171234 
+L 226.871027 113.173563 
+L 226.871027 113.175892 
+L 226.871027 113.178221 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
-    <path d="M 226.871027 113.251157 
-L 226.871027 113.249256 
-L 226.871027 113.247355 
-L 226.871027 113.245453 
-L 226.871027 113.243552 
-L 226.871027 113.24165 
-L 226.871027 113.239748 
-L 226.871027 113.237846 
-L 226.871027 113.235945 
-L 226.871027 113.234043 
-L 226.871027 113.232141 
-L 226.871027 113.230239 
-L 226.871027 113.228336 
-L 226.871027 113.226434 
-L 226.871027 113.224532 
-L 226.871027 113.22263 
-L 226.871027 113.220727 
-L 226.871027 113.218825 
-L 226.871027 113.216922 
-L 226.871027 113.21502 
-L 226.871027 113.213117 
-L 226.871027 113.211214 
-L 226.871027 113.209312 
-L 226.871027 113.207409 
-L 226.871027 113.205506 
-L 226.871027 113.203603 
-L 226.871027 113.2017 
-L 226.871027 113.199797 
-L 226.871027 113.197894 
-L 226.871027 113.19599 
-L 226.871027 113.194087 
-L 226.871027 113.192184 
-L 226.871027 113.19028 
-L 226.871027 113.188377 
-L 226.871027 113.186473 
-L 226.871027 113.184569 
-L 226.871027 113.182666 
-L 226.871027 113.180762 
-L 226.871027 113.178858 
-L 226.871027 113.176954 
-L 226.871027 113.17505 
-L 226.871027 113.173146 
-L 226.871027 113.171242 
-L 226.871027 113.169338 
-L 226.871027 113.167434 
-L 226.871027 113.165529 
-L 226.871027 113.163625 
-L 226.871027 113.16172 
-L 226.871027 113.159816 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 226.871027 113.178221 
+L 226.871027 113.176382 
+L 226.871027 113.174543 
+L 226.871027 113.172704 
+L 226.871027 113.170865 
+L 226.871027 113.169026 
+L 226.871027 113.167187 
+L 226.871027 113.165348 
+L 226.871027 113.163508 
+L 226.871027 113.161669 
+L 226.871027 113.159829 
+L 226.871027 113.15799 
+L 226.871027 113.15615 
+L 226.871027 113.154311 
+L 226.871027 113.152471 
+L 226.871027 113.150631 
+L 226.871027 113.148791 
+L 226.871027 113.146952 
+L 226.871027 113.145112 
+L 226.871027 113.143272 
+L 226.871027 113.141432 
+L 226.871027 113.139591 
+L 226.871027 113.137751 
+L 226.871027 113.135911 
+L 226.871027 113.134071 
+L 226.871027 113.13223 
+L 226.871027 113.13039 
+L 226.871027 113.128549 
+L 226.871027 113.126709 
+L 226.871027 113.124868 
+L 226.871027 113.123027 
+L 226.871027 113.121187 
+L 226.871027 113.119346 
+L 226.871027 113.117505 
+L 226.871027 113.115664 
+L 226.871027 113.113823 
+L 226.871027 113.111982 
+L 226.871027 113.110141 
+L 226.871027 113.1083 
+L 226.871027 113.106458 
+L 226.871027 113.104617 
+L 226.871027 113.102776 
+L 226.871027 113.100934 
+L 226.871027 113.099093 
+L 226.871027 113.097251 
+L 226.871027 113.09541 
+L 226.871027 113.093568 
+L 226.871027 113.091726 
+L 226.871027 113.089884 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
-    <path d="M 226.871027 113.159816 
-L 225.848056 113.630174 
-L 224.825086 114.096478 
-L 223.802115 114.5588 
-L 222.779144 115.017205 
-L 221.756173 115.47176 
-L 220.733202 115.922529 
-L 219.710231 116.369574 
-L 218.68726 116.812957 
-L 217.664289 117.252736 
-L 216.641318 117.688971 
-L 215.618347 118.121717 
-L 214.595376 118.551031 
-L 213.572405 118.976966 
-L 212.549434 119.399574 
-L 211.526464 119.818908 
-L 210.503493 120.235018 
-L 209.480522 120.647952 
-L 208.457551 121.05776 
-L 207.43458 121.464488 
-L 206.411609 121.868182 
-L 205.388638 122.268886 
-L 204.365667 122.666646 
-L 203.342696 123.061504 
-L 202.319725 123.453501 
-L 201.296754 123.84268 
-L 200.273783 124.229079 
-L 199.250812 124.61274 
-L 198.227842 124.9937 
-L 197.204871 125.371997 
-L 196.1819 125.747667 
-L 195.158929 126.120748 
-L 194.135958 126.491275 
-L 193.112987 126.859282 
-L 192.090016 127.224804 
-L 191.067045 127.587873 
-L 190.044074 127.948523 
-L 189.021103 128.306785 
-L 187.998132 128.662691 
-L 186.975161 129.016272 
-L 185.952191 129.367558 
-L 184.92922 129.716578 
-L 183.906249 130.063362 
-L 182.883278 130.407937 
-L 181.860307 130.750333 
-L 180.837336 131.090576 
-L 179.814365 131.428693 
-L 178.791394 131.764711 
-L 177.768423 132.098656 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 226.871027 113.089884 
+L 225.848056 113.569013 
+L 224.825086 114.043937 
+L 223.802115 114.514732 
+L 222.779144 114.981467 
+L 221.756173 115.444211 
+L 220.733202 115.903034 
+L 219.710231 116.358 
+L 218.68726 116.809174 
+L 217.664289 117.256619 
+L 216.641318 117.700396 
+L 215.618347 118.140564 
+L 214.595376 118.577181 
+L 213.572405 119.010305 
+L 212.549434 119.439991 
+L 211.526464 119.866293 
+L 210.503493 120.289264 
+L 209.480522 120.708955 
+L 208.457551 121.125418 
+L 207.43458 121.538701 
+L 206.411609 121.948852 
+L 205.388638 122.35592 
+L 204.365667 122.759948 
+L 203.342696 123.160984 
+L 202.319725 123.55907 
+L 201.296754 123.95425 
+L 200.273783 124.346566 
+L 199.250812 124.736059 
+L 198.227842 125.12277 
+L 197.204871 125.506737 
+L 196.1819 125.888 
+L 195.158929 126.266597 
+L 194.135958 126.642564 
+L 193.112987 127.015938 
+L 192.090016 127.386754 
+L 191.067045 127.755047 
+L 190.044074 128.120851 
+L 189.021103 128.4842 
+L 187.998132 128.845126 
+L 186.975161 129.203661 
+L 185.952191 129.559838 
+L 184.92922 129.913686 
+L 183.906249 130.265236 
+L 182.883278 130.614518 
+L 181.860307 130.96156 
+L 180.837336 131.306392 
+L 179.814365 131.649041 
+L 178.791394 131.989534 
+L 177.768423 132.327899 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
-    <path d="M 177.768423 132.098656 
-L 177.406061 132.40903 
-L 177.043698 132.717635 
-L 176.681336 133.024489 
-L 176.318974 133.329614 
-L 175.956611 133.633028 
-L 175.594249 133.93475 
-L 175.231887 134.234799 
-L 174.869524 134.533194 
-L 174.507162 134.829953 
-L 174.1448 135.125093 
-L 173.782437 135.418633 
-L 173.420075 135.710589 
-L 173.057713 136.000978 
-L 172.69535 136.289818 
-L 172.332988 136.577124 
-L 171.970626 136.862913 
-L 171.608263 137.1472 
-L 171.245901 137.430002 
-L 170.883538 137.711334 
-L 170.521176 137.991211 
-L 170.158814 138.269648 
-L 169.796451 138.54666 
-L 169.434089 138.822261 
-L 169.071727 139.096466 
-L 168.709364 139.369288 
-L 168.347002 139.640742 
-L 167.98464 139.910841 
-L 167.622277 140.179599 
-L 167.259915 140.447029 
-L 166.897553 140.713144 
-L 166.53519 140.977956 
-L 166.172828 141.241479 
-L 165.810466 141.503725 
-L 165.448103 141.764707 
-L 165.085741 142.024435 
-L 164.723378 142.282924 
-L 164.361016 142.540183 
-L 163.998654 142.796226 
-L 163.636291 143.051063 
-L 163.273929 143.304705 
-L 162.911567 143.557164 
-L 162.549204 143.808451 
-L 162.186842 144.058577 
-L 161.82448 144.307552 
-L 161.462117 144.555386 
-L 161.099755 144.802091 
-L 160.737393 145.047676 
-L 160.37503 145.292152 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 177.768423 132.327899 
+L 177.406061 132.64173 
+L 177.043698 132.953752 
+L 176.681336 133.263986 
+L 176.318974 133.572451 
+L 175.956611 133.879169 
+L 175.594249 134.184159 
+L 175.231887 134.48744 
+L 174.869524 134.789031 
+L 174.507162 135.088952 
+L 174.1448 135.387219 
+L 173.782437 135.683852 
+L 173.420075 135.978869 
+L 173.057713 136.272286 
+L 172.69535 136.564122 
+L 172.332988 136.854392 
+L 171.970626 137.143115 
+L 171.608263 137.430305 
+L 171.245901 137.71598 
+L 170.883538 138.000155 
+L 170.521176 138.282847 
+L 170.158814 138.564069 
+L 169.796451 138.843838 
+L 169.434089 139.122169 
+L 169.071727 139.399075 
+L 168.709364 139.674573 
+L 168.347002 139.948675 
+L 167.98464 140.221397 
+L 167.622277 140.492751 
+L 167.259915 140.762752 
+L 166.897553 141.031412 
+L 166.53519 141.298746 
+L 166.172828 141.564767 
+L 165.810466 141.829486 
+L 165.448103 142.092917 
+L 165.085741 142.355072 
+L 164.723378 142.615964 
+L 164.361016 142.875604 
+L 163.998654 143.134005 
+L 163.636291 143.391178 
+L 163.273929 143.647135 
+L 162.911567 143.901888 
+L 162.549204 144.155447 
+L 162.186842 144.407824 
+L 161.82448 144.65903 
+L 161.462117 144.909076 
+L 161.099755 145.157972 
+L 160.737393 145.405728 
+L 160.37503 145.652356 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
-    <path d="M 160.37503 145.292152 
-L 160.242129 145.450814 
-L 160.109228 145.609011 
-L 159.976327 145.766748 
-L 159.843426 145.924026 
-L 159.710525 146.080848 
-L 159.577624 146.237217 
-L 159.444723 146.393136 
-L 159.311822 146.548607 
-L 159.178921 146.703632 
-L 159.04602 146.858215 
-L 158.913119 147.012357 
-L 158.780218 147.166062 
-L 158.647316 147.319331 
-L 158.514415 147.472168 
-L 158.381514 147.624574 
-L 158.248613 147.776552 
-L 158.115712 147.928104 
-L 157.982811 148.079233 
-L 157.84991 148.229941 
-L 157.717009 148.380231 
-L 157.584108 148.530105 
-L 157.451207 148.679564 
-L 157.318306 148.828612 
-L 157.185405 148.977251 
-L 157.052504 149.125483 
-L 156.919603 149.273309 
-L 156.786702 149.420733 
-L 156.653801 149.567757 
-L 156.5209 149.714382 
-L 156.387998 149.860611 
-L 156.255097 150.006446 
-L 156.122196 150.151889 
-L 155.989295 150.296942 
-L 155.856394 150.441607 
-L 155.723493 150.585887 
-L 155.590592 150.729783 
-L 155.457691 150.873297 
-L 155.32479 151.016432 
-L 155.191889 151.15919 
-L 155.058988 151.301571 
-L 154.926087 151.44358 
-L 154.793186 151.585216 
-L 154.660285 151.726483 
-L 154.527384 151.867382 
-L 154.394483 152.007915 
-L 154.261581 152.148084 
-L 154.12868 152.287891 
-L 153.995779 152.427338 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 160.37503 145.652356 
+L 160.242129 145.808437 
+L 160.109228 145.964068 
+L 159.976327 146.119254 
+L 159.843426 146.273995 
+L 159.710525 146.428296 
+L 159.577624 146.582158 
+L 159.444723 146.735584 
+L 159.311822 146.888577 
+L 159.178921 147.041138 
+L 159.04602 147.19327 
+L 158.913119 147.344976 
+L 158.780218 147.496258 
+L 158.647316 147.647119 
+L 158.514415 147.79756 
+L 158.381514 147.947584 
+L 158.248613 148.097194 
+L 158.115712 148.246391 
+L 157.982811 148.395179 
+L 157.84991 148.543558 
+L 157.717009 148.691532 
+L 157.584108 148.839102 
+L 157.451207 148.986271 
+L 157.318306 149.133041 
+L 157.185405 149.279414 
+L 157.052504 149.425393 
+L 156.919603 149.570979 
+L 156.786702 149.716174 
+L 156.653801 149.860981 
+L 156.5209 150.005402 
+L 156.387998 150.149438 
+L 156.255097 150.293092 
+L 156.122196 150.436366 
+L 155.989295 150.579262 
+L 155.856394 150.721781 
+L 155.723493 150.863926 
+L 155.590592 151.005699 
+L 155.457691 151.147102 
+L 155.32479 151.288136 
+L 155.191889 151.428803 
+L 155.058988 151.569107 
+L 154.926087 151.709047 
+L 154.793186 151.848626 
+L 154.660285 151.987847 
+L 154.527384 152.12671 
+L 154.394483 152.265218 
+L 154.261581 152.403373 
+L 154.12868 152.541176 
+L 153.995779 152.678629 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
-    <path d="M 153.995779 152.427338 
-L 153.852261 152.791984 
-L 153.708742 153.154189 
-L 153.565224 153.513987 
-L 153.421705 153.871408 
-L 153.278186 154.226484 
-L 153.134668 154.579245 
-L 152.991149 154.929722 
-L 152.847631 155.277944 
-L 152.704112 155.62394 
-L 152.560593 155.967738 
-L 152.417075 156.309365 
-L 152.273556 156.648849 
-L 152.130038 156.986217 
-L 151.986519 157.321495 
-L 151.843 157.654709 
-L 151.699482 157.985883 
-L 151.555963 158.315044 
-L 151.412445 158.642214 
-L 151.268926 158.967418 
-L 151.125407 159.29068 
-L 150.981889 159.612022 
-L 150.83837 159.931468 
-L 150.694852 160.249039 
-L 150.551333 160.564757 
-L 150.407814 160.878644 
-L 150.264296 161.190721 
-L 150.120777 161.501009 
-L 149.977259 161.809528 
-L 149.83374 162.116298 
-L 149.690221 162.421339 
-L 149.546703 162.72467 
-L 149.403184 163.026311 
-L 149.259666 163.326279 
-L 149.116147 163.624594 
-L 148.972628 163.921274 
-L 148.82911 164.216336 
-L 148.685591 164.509798 
-L 148.542073 164.801678 
-L 148.398554 165.091992 
-L 148.255035 165.380756 
-L 148.111517 165.667988 
-L 147.967998 165.953704 
-L 147.82448 166.237919 
-L 147.680961 166.520649 
-L 147.537442 166.80191 
-L 147.393924 167.081716 
-L 147.250405 167.360084 
-L 147.106887 167.637027 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 153.995779 152.678629 
+L 153.852261 153.05028 
+L 153.708742 153.419398 
+L 153.565224 153.786016 
+L 153.421705 154.150167 
+L 153.278186 154.511885 
+L 153.134668 154.871202 
+L 152.991149 155.228149 
+L 152.847631 155.582758 
+L 152.704112 155.935059 
+L 152.560593 156.285083 
+L 152.417075 156.632857 
+L 152.273556 156.978411 
+L 152.130038 157.321774 
+L 151.986519 157.662972 
+L 151.843 158.002033 
+L 151.699482 158.338983 
+L 151.555963 158.673849 
+L 151.412445 159.006656 
+L 151.268926 159.33743 
+L 151.125407 159.666195 
+L 150.981889 159.992974 
+L 150.83837 160.317793 
+L 150.694852 160.640675 
+L 150.551333 160.961642 
+L 150.407814 161.280717 
+L 150.264296 161.597922 
+L 150.120777 161.91328 
+L 149.977259 162.22681 
+L 149.83374 162.538536 
+L 149.690221 162.848476 
+L 149.546703 163.156652 
+L 149.403184 163.463083 
+L 149.259666 163.767789 
+L 149.116147 164.07079 
+L 148.972628 164.372104 
+L 148.82911 164.671751 
+L 148.685591 164.969747 
+L 148.542073 165.266112 
+L 148.398554 165.560864 
+L 148.255035 165.854019 
+L 148.111517 166.145595 
+L 147.967998 166.435609 
+L 147.82448 166.724077 
+L 147.680961 167.011016 
+L 147.537442 167.296442 
+L 147.393924 167.580372 
+L 147.250405 167.862819 
+L 147.106887 168.143801 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
-    <path d="M 147.106887 167.637027 
-L 147.081154 167.798979 
-L 147.055421 167.960448 
-L 147.029688 168.121436 
-L 147.003955 168.281947 
-L 146.978222 168.441984 
-L 146.952489 168.601549 
-L 146.926756 168.760644 
-L 146.901023 168.919273 
-L 146.87529 169.077439 
-L 146.849557 169.235143 
-L 146.823824 169.39239 
-L 146.798091 169.549181 
-L 146.772358 169.705519 
-L 146.746625 169.861406 
-L 146.720892 170.016846 
-L 146.695159 170.171841 
-L 146.669426 170.326393 
-L 146.643693 170.480505 
-L 146.61796 170.634179 
-L 146.592227 170.787418 
-L 146.566494 170.940225 
-L 146.540761 171.092601 
-L 146.515028 171.244549 
-L 146.489295 171.396072 
-L 146.463562 171.547172 
-L 146.437829 171.697852 
-L 146.412096 171.848112 
-L 146.386363 171.997957 
-L 146.36063 172.147388 
-L 146.334897 172.296408 
-L 146.309164 172.445018 
-L 146.283431 172.593222 
-L 146.257698 172.74102 
-L 146.231965 172.888417 
-L 146.206232 173.035412 
-L 146.180499 173.18201 
-L 146.154766 173.328212 
-L 146.129033 173.474019 
-L 146.1033 173.619435 
-L 146.077567 173.764461 
-L 146.051834 173.9091 
-L 146.026101 174.053353 
-L 146.000368 174.197223 
-L 145.974635 174.340711 
-L 145.948902 174.483819 
-L 145.923169 174.626551 
-L 145.897436 174.768906 
-L 145.871703 174.910889 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 147.106887 168.143801 
+L 147.081154 168.298658 
+L 147.055421 168.453074 
+L 147.029688 168.607051 
+L 147.003955 168.760591 
+L 146.978222 168.913697 
+L 146.952489 169.066371 
+L 146.926756 169.218615 
+L 146.901023 169.370433 
+L 146.87529 169.521825 
+L 146.849557 169.672796 
+L 146.823824 169.823347 
+L 146.798091 169.97348 
+L 146.772358 170.123198 
+L 146.746625 170.272503 
+L 146.720892 170.421397 
+L 146.695159 170.569883 
+L 146.669426 170.717963 
+L 146.643693 170.865639 
+L 146.61796 171.012913 
+L 146.592227 171.159787 
+L 146.566494 171.306264 
+L 146.540761 171.452346 
+L 146.515028 171.598034 
+L 146.489295 171.743332 
+L 146.463562 171.88824 
+L 146.437829 172.032762 
+L 146.412096 172.176899 
+L 146.386363 172.320653 
+L 146.36063 172.464026 
+L 146.334897 172.60702 
+L 146.309164 172.749638 
+L 146.283431 172.891881 
+L 146.257698 173.033751 
+L 146.231965 173.175251 
+L 146.206232 173.316381 
+L 146.180499 173.457144 
+L 146.154766 173.597543 
+L 146.129033 173.737578 
+L 146.1033 173.877252 
+L 146.077567 174.016566 
+L 146.051834 174.155523 
+L 146.026101 174.294124 
+L 146.000368 174.432371 
+L 145.974635 174.570265 
+L 145.948902 174.70781 
+L 145.923169 174.845005 
+L 145.897436 174.981854 
+L 145.871703 175.118358 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m47ccd355f3" d="M 0 -2.5 
+     <path id="m40ed5004f9" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,433 +4509,433 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p399ecdeb00)">
-     <use xlink:href="#m47ccd355f3" x="585.66883" y="174.374171" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47ccd355f3" x="527.144592" y="176.439455" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47ccd355f3" x="457.339427" y="184.525165" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47ccd355f3" x="292.124837" y="179.218412" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47ccd355f3" x="243.129344" y="190.901895" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47ccd355f3" x="213.541392" y="204.840226" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47ccd355f3" x="204.551957" y="212.456838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47ccd355f3" x="195.860087" y="228.889995" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m47ccd355f3" x="194.019853" y="234.405357" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pbbc76cd86a)">
+     <use xlink:href="#m40ed5004f9" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40ed5004f9" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40ed5004f9" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40ed5004f9" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40ed5004f9" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40ed5004f9" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40ed5004f9" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40ed5004f9" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m40ed5004f9" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
-    <path d="M 585.66883 174.374171 
-L 584.449575 174.418012 
-L 583.23032 174.461817 
-L 582.011065 174.505586 
-L 580.79181 174.549321 
-L 579.572555 174.59302 
-L 578.3533 174.636683 
-L 577.134045 174.680312 
-L 575.91479 174.723905 
-L 574.695535 174.767463 
-L 573.47628 174.810986 
-L 572.257025 174.854475 
-L 571.037771 174.897928 
-L 569.818516 174.941346 
-L 568.599261 174.98473 
-L 567.380006 175.028079 
-L 566.160751 175.071393 
-L 564.941496 175.114673 
-L 563.722241 175.157918 
-L 562.502986 175.201128 
-L 561.283731 175.244304 
-L 560.064476 175.287446 
-L 558.845221 175.330553 
-L 557.625966 175.373626 
-L 556.406711 175.416664 
-L 555.187456 175.459669 
-L 553.968201 175.502639 
-L 552.748946 175.545575 
-L 551.529691 175.588477 
-L 550.310436 175.631346 
-L 549.091181 175.67418 
-L 547.871926 175.71698 
-L 546.652672 175.759747 
-L 545.433417 175.80248 
-L 544.214162 175.845179 
-L 542.994907 175.887844 
-L 541.775652 175.930476 
-L 540.556397 175.973074 
-L 539.337142 176.015639 
-L 538.117887 176.05817 
-L 536.898632 176.100668 
-L 535.679377 176.143132 
-L 534.460122 176.185564 
-L 533.240867 176.227962 
-L 532.021612 176.270326 
-L 530.802357 176.312658 
-L 529.583102 176.354957 
-L 528.363847 176.397222 
-L 527.144592 176.439455 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 585.66883 173.051371 
+L 584.449575 173.099758 
+L 583.23032 173.148101 
+L 582.011065 173.196401 
+L 580.79181 173.244658 
+L 579.572555 173.292872 
+L 578.3533 173.341043 
+L 577.134045 173.389171 
+L 575.91479 173.437256 
+L 574.695535 173.485299 
+L 573.47628 173.533299 
+L 572.257025 173.581257 
+L 571.037771 173.629172 
+L 569.818516 173.677045 
+L 568.599261 173.724875 
+L 567.380006 173.772663 
+L 566.160751 173.82041 
+L 564.941496 173.868114 
+L 563.722241 173.915776 
+L 562.502986 173.963396 
+L 561.283731 174.010974 
+L 560.064476 174.058511 
+L 558.845221 174.106005 
+L 557.625966 174.153458 
+L 556.406711 174.20087 
+L 555.187456 174.24824 
+L 553.968201 174.295569 
+L 552.748946 174.342856 
+L 551.529691 174.390102 
+L 550.310436 174.437307 
+L 549.091181 174.484471 
+L 547.871926 174.531593 
+L 546.652672 174.578675 
+L 545.433417 174.625716 
+L 544.214162 174.672716 
+L 542.994907 174.719675 
+L 541.775652 174.766593 
+L 540.556397 174.813471 
+L 539.337142 174.860308 
+L 538.117887 174.907105 
+L 536.898632 174.953861 
+L 535.679377 175.000577 
+L 534.460122 175.047253 
+L 533.240867 175.093889 
+L 532.021612 175.140484 
+L 530.802357 175.187039 
+L 529.583102 175.233554 
+L 528.363847 175.28003 
+L 527.144592 175.326465 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
-    <path d="M 527.144592 176.439455 
-L 525.690318 176.620838 
-L 524.236044 176.801615 
-L 522.781769 176.98179 
-L 521.327495 177.161367 
-L 519.873221 177.34035 
-L 518.418947 177.518744 
-L 516.964672 177.696551 
-L 515.510398 177.873776 
-L 514.056124 178.050422 
-L 512.60185 178.226494 
-L 511.147575 178.401995 
-L 509.693301 178.576928 
-L 508.239027 178.751298 
-L 506.784752 178.925108 
-L 505.330478 179.098361 
-L 503.876204 179.271062 
-L 502.42193 179.443213 
-L 500.967655 179.614818 
-L 499.513381 179.785881 
-L 498.059107 179.956405 
-L 496.604833 180.126393 
-L 495.150558 180.295849 
-L 493.696284 180.464776 
-L 492.24201 180.633178 
-L 490.787735 180.801057 
-L 489.333461 180.968416 
-L 487.879187 181.13526 
-L 486.424913 181.301591 
-L 484.970638 181.467413 
-L 483.516364 181.632728 
-L 482.06209 181.797539 
-L 480.607816 181.96185 
-L 479.153541 182.125664 
-L 477.699267 182.288983 
-L 476.244993 182.451811 
-L 474.790718 182.614151 
-L 473.336444 182.776005 
-L 471.88217 182.937376 
-L 470.427896 183.098268 
-L 468.973621 183.258682 
-L 467.519347 183.418623 
-L 466.065073 183.578092 
-L 464.610799 183.737093 
-L 463.156524 183.895628 
-L 461.70225 184.0537 
-L 460.247976 184.211312 
-L 458.793701 184.368466 
-L 457.339427 184.525165 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 527.144592 175.326465 
+L 525.690318 175.514532 
+L 524.236044 175.701947 
+L 522.781769 175.888716 
+L 521.327495 176.074843 
+L 519.873221 176.260332 
+L 518.418947 176.445187 
+L 516.964672 176.629413 
+L 515.510398 176.813015 
+L 514.056124 176.995995 
+L 512.60185 177.17836 
+L 511.147575 177.360112 
+L 509.693301 177.541256 
+L 508.239027 177.721795 
+L 506.784752 177.901735 
+L 505.330478 178.081078 
+L 503.876204 178.259829 
+L 502.42193 178.437992 
+L 500.967655 178.61557 
+L 499.513381 178.792568 
+L 498.059107 178.968989 
+L 496.604833 179.144837 
+L 495.150558 179.320115 
+L 493.696284 179.494828 
+L 492.24201 179.668978 
+L 490.787735 179.84257 
+L 489.333461 180.015607 
+L 487.879187 180.188093 
+L 486.424913 180.360031 
+L 484.970638 180.531425 
+L 483.516364 180.702277 
+L 482.06209 180.872592 
+L 480.607816 181.042373 
+L 479.153541 181.211623 
+L 477.699267 181.380345 
+L 476.244993 181.548543 
+L 474.790718 181.71622 
+L 473.336444 181.88338 
+L 471.88217 182.050024 
+L 470.427896 182.216158 
+L 468.973621 182.381783 
+L 467.519347 182.546902 
+L 466.065073 182.71152 
+L 464.610799 182.875639 
+L 463.156524 183.039261 
+L 461.70225 183.20239 
+L 460.247976 183.36503 
+L 458.793701 183.527182 
+L 457.339427 183.688849 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
-    <path d="M 457.339427 184.525165 
-L 453.897457 184.419752 
-L 450.455486 184.314134 
-L 447.013515 184.20831 
-L 443.571545 184.102278 
-L 440.129574 183.996038 
-L 436.687603 183.889589 
-L 433.245633 183.78293 
-L 429.803662 183.67606 
-L 426.361692 183.568979 
-L 422.919721 183.461686 
-L 419.47775 183.35418 
-L 416.03578 183.246459 
-L 412.593809 183.138524 
-L 409.151838 183.030373 
-L 405.709868 182.922006 
-L 402.267897 182.813421 
-L 398.825927 182.704618 
-L 395.383956 182.595595 
-L 391.941985 182.486353 
-L 388.500015 182.37689 
-L 385.058044 182.267204 
-L 381.616074 182.157296 
-L 378.174103 182.047165 
-L 374.732132 181.936808 
-L 371.290162 181.826227 
-L 367.848191 181.715418 
-L 364.40622 181.604383 
-L 360.96425 181.493119 
-L 357.522279 181.381626 
-L 354.080309 181.269903 
-L 350.638338 181.157949 
-L 347.196367 181.045762 
-L 343.754397 180.933343 
-L 340.312426 180.820689 
-L 336.870455 180.707801 
-L 333.428485 180.594677 
-L 329.986514 180.481315 
-L 326.544544 180.367716 
-L 323.102573 180.253878 
-L 319.660602 180.139799 
-L 316.218632 180.02548 
-L 312.776661 179.910919 
-L 309.33469 179.796115 
-L 305.89272 179.681066 
-L 302.450749 179.565773 
-L 299.008779 179.450234 
-L 295.566808 179.334447 
-L 292.124837 179.218412 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 457.339427 183.688849 
+L 453.897457 183.585416 
+L 450.455486 183.481785 
+L 447.013515 183.377954 
+L 443.571545 183.273925 
+L 440.129574 183.169695 
+L 436.687603 183.065264 
+L 433.245633 182.960631 
+L 429.803662 182.855795 
+L 426.361692 182.750756 
+L 422.919721 182.645513 
+L 419.47775 182.540064 
+L 416.03578 182.43441 
+L 412.593809 182.32855 
+L 409.151838 182.222482 
+L 405.709868 182.116205 
+L 402.267897 182.00972 
+L 398.825927 181.903024 
+L 395.383956 181.796118 
+L 391.941985 181.689001 
+L 388.500015 181.581671 
+L 385.058044 181.474128 
+L 381.616074 181.36637 
+L 378.174103 181.258398 
+L 374.732132 181.15021 
+L 371.290162 181.041805 
+L 367.848191 180.933183 
+L 364.40622 180.824343 
+L 360.96425 180.715283 
+L 357.522279 180.606003 
+L 354.080309 180.496501 
+L 350.638338 180.386778 
+L 347.196367 180.276832 
+L 343.754397 180.166663 
+L 340.312426 180.056268 
+L 336.870455 179.945648 
+L 333.428485 179.834802 
+L 329.986514 179.723728 
+L 326.544544 179.612425 
+L 323.102573 179.500894 
+L 319.660602 179.389132 
+L 316.218632 179.277139 
+L 312.776661 179.164913 
+L 309.33469 179.052455 
+L 305.89272 178.939762 
+L 302.450749 178.826834 
+L 299.008779 178.713671 
+L 295.566808 178.60027 
+L 292.124837 178.486631 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
-    <path d="M 292.124837 179.218412 
-L 291.104098 179.48941 
-L 290.083359 179.759057 
-L 289.062619 180.027368 
-L 288.04188 180.294354 
-L 287.02114 180.560031 
-L 286.000401 180.824409 
-L 284.979661 181.087502 
-L 283.958922 181.349322 
-L 282.938182 181.609882 
-L 281.917443 181.869193 
-L 280.896704 182.127268 
-L 279.875964 182.384118 
-L 278.855225 182.639754 
-L 277.834485 182.894189 
-L 276.813746 183.147433 
-L 275.793006 183.399497 
-L 274.772267 183.650393 
-L 273.751528 183.900132 
-L 272.730788 184.148723 
-L 271.710049 184.396177 
-L 270.689309 184.642505 
-L 269.66857 184.887717 
-L 268.64783 185.131823 
-L 267.627091 185.374832 
-L 266.606351 185.616756 
-L 265.585612 185.857602 
-L 264.564873 186.097382 
-L 263.544133 186.336104 
-L 262.523394 186.573777 
-L 261.502654 186.810412 
-L 260.481915 187.046016 
-L 259.461175 187.280599 
-L 258.440436 187.514169 
-L 257.419697 187.746736 
-L 256.398957 187.978307 
-L 255.378218 188.208892 
-L 254.357478 188.438499 
-L 253.336739 188.667135 
-L 252.315999 188.89481 
-L 251.29526 189.121531 
-L 250.274521 189.347306 
-L 249.253781 189.572143 
-L 248.233042 189.79605 
-L 247.212302 190.019034 
-L 246.191563 190.241103 
-L 245.170823 190.462265 
-L 244.150084 190.682527 
-L 243.129344 190.901895 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 292.124837 178.486631 
+L 291.104098 178.762747 
+L 290.083359 179.037463 
+L 289.062619 179.310791 
+L 288.04188 179.582746 
+L 287.02114 179.853342 
+L 286.000401 180.122591 
+L 284.979661 180.390508 
+L 283.958922 180.657106 
+L 282.938182 180.922397 
+L 281.917443 181.186394 
+L 280.896704 181.44911 
+L 279.875964 181.710557 
+L 278.855225 181.970747 
+L 277.834485 182.229693 
+L 276.813746 182.487405 
+L 275.793006 182.743897 
+L 274.772267 182.999179 
+L 273.751528 183.253263 
+L 272.730788 183.50616 
+L 271.710049 183.75788 
+L 270.689309 184.008436 
+L 269.66857 184.257837 
+L 268.64783 184.506094 
+L 267.627091 184.753219 
+L 266.606351 184.999219 
+L 265.585612 185.244107 
+L 264.564873 185.487893 
+L 263.544133 185.730585 
+L 262.523394 185.972194 
+L 261.502654 186.212729 
+L 260.481915 186.4522 
+L 259.461175 186.690617 
+L 258.440436 186.927988 
+L 257.419697 187.164323 
+L 256.398957 187.39963 
+L 255.378218 187.633919 
+L 254.357478 187.867198 
+L 253.336739 188.099476 
+L 252.315999 188.330762 
+L 251.29526 188.561064 
+L 250.274521 188.79039 
+L 249.253781 189.018748 
+L 248.233042 189.246148 
+L 247.212302 189.472596 
+L 246.191563 189.6981 
+L 245.170823 189.922669 
+L 244.150084 190.146311 
+L 243.129344 190.369032 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
-    <path d="M 243.129344 190.901895 
-L 242.512929 191.23209 
-L 241.896513 191.560283 
-L 241.280097 191.886497 
-L 240.663682 192.210757 
-L 240.047266 192.533085 
-L 239.43085 192.853505 
-L 238.814435 193.172039 
-L 238.198019 193.488709 
-L 237.581603 193.803537 
-L 236.965188 194.116544 
-L 236.348772 194.427751 
-L 235.732356 194.737178 
-L 235.115941 195.044847 
-L 234.499525 195.350776 
-L 233.883109 195.654986 
-L 233.266694 195.957495 
-L 232.650278 196.258323 
-L 232.033862 196.557487 
-L 231.417447 196.855007 
-L 230.801031 197.1509 
-L 230.184615 197.445185 
-L 229.5682 197.737877 
-L 228.951784 198.028996 
-L 228.335368 198.318556 
-L 227.718953 198.606576 
-L 227.102537 198.89307 
-L 226.486121 199.178057 
-L 225.869706 199.46155 
-L 225.25329 199.743566 
-L 224.636874 200.02412 
-L 224.020459 200.303227 
-L 223.404043 200.580902 
-L 222.787627 200.857159 
-L 222.171212 201.132014 
-L 221.554796 201.405479 
-L 220.93838 201.67757 
-L 220.321965 201.948299 
-L 219.705549 202.217681 
-L 219.089133 202.485729 
-L 218.472718 202.752456 
-L 217.856302 203.017874 
-L 217.239886 203.281997 
-L 216.623471 203.544838 
-L 216.007055 203.806408 
-L 215.390639 204.06672 
-L 214.774224 204.325785 
-L 214.157808 204.583617 
-L 213.541392 204.840226 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 243.129344 190.369032 
+L 242.512929 190.702612 
+L 241.896513 191.034148 
+L 241.280097 191.363666 
+L 240.663682 191.691191 
+L 240.047266 192.016746 
+L 239.43085 192.340354 
+L 238.814435 192.66204 
+L 238.198019 192.981825 
+L 237.581603 193.299732 
+L 236.965188 193.615782 
+L 236.348772 193.929999 
+L 235.732356 194.242401 
+L 235.115941 194.553011 
+L 234.499525 194.86185 
+L 233.883109 195.168936 
+L 233.266694 195.474289 
+L 232.650278 195.77793 
+L 232.033862 196.079877 
+L 231.417447 196.38015 
+L 230.801031 196.678765 
+L 230.184615 196.975743 
+L 229.5682 197.2711 
+L 228.951784 197.564854 
+L 228.335368 197.857023 
+L 227.718953 198.147623 
+L 227.102537 198.436672 
+L 226.486121 198.724185 
+L 225.869706 199.010179 
+L 225.25329 199.29467 
+L 224.636874 199.577674 
+L 224.020459 199.859206 
+L 223.404043 200.139281 
+L 222.787627 200.417915 
+L 222.171212 200.695121 
+L 221.554796 200.970916 
+L 220.93838 201.245312 
+L 220.321965 201.518324 
+L 219.705549 201.789967 
+L 219.089133 202.060253 
+L 218.472718 202.329196 
+L 217.856302 202.59681 
+L 217.239886 202.863107 
+L 216.623471 203.1281 
+L 216.007055 203.391802 
+L 215.390639 203.654226 
+L 214.774224 203.915384 
+L 214.157808 204.175288 
+L 213.541392 204.43395 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
-    <path d="M 213.541392 204.840226 
-L 213.354112 205.010346 
-L 213.166833 205.179934 
-L 212.979553 205.348992 
-L 212.792273 205.517523 
-L 212.604993 205.685532 
-L 212.417713 205.85302 
-L 212.230433 206.019992 
-L 212.043153 206.18645 
-L 211.855873 206.352397 
-L 211.668593 206.517837 
-L 211.481314 206.682773 
-L 211.294034 206.847208 
-L 211.106754 207.011145 
-L 210.919474 207.174587 
-L 210.732194 207.337536 
-L 210.544914 207.499997 
-L 210.357634 207.661971 
-L 210.170354 207.823462 
-L 209.983074 207.984472 
-L 209.795794 208.145005 
-L 209.608515 208.305063 
-L 209.421235 208.464649 
-L 209.233955 208.623766 
-L 209.046675 208.782416 
-L 208.859395 208.940603 
-L 208.672115 209.098328 
-L 208.484835 209.255596 
-L 208.297555 209.412407 
-L 208.110275 209.568766 
-L 207.922996 209.724674 
-L 207.735716 209.880134 
-L 207.548436 210.035149 
-L 207.361156 210.189721 
-L 207.173876 210.343853 
-L 206.986596 210.497547 
-L 206.799316 210.650806 
-L 206.612036 210.803632 
-L 206.424756 210.956028 
-L 206.237476 211.107996 
-L 206.050197 211.259538 
-L 205.862917 211.410657 
-L 205.675637 211.561356 
-L 205.488357 211.711635 
-L 205.301077 211.861499 
-L 205.113797 212.010949 
-L 204.926517 212.159987 
-L 204.739237 212.308616 
-L 204.551957 212.456838 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 213.541392 204.43395 
+L 213.354112 204.606227 
+L 213.166833 204.777957 
+L 212.979553 204.949144 
+L 212.792273 205.119791 
+L 212.604993 205.289902 
+L 212.417713 205.45948 
+L 212.230433 205.628529 
+L 212.043153 205.797051 
+L 211.855873 205.96505 
+L 211.668593 206.13253 
+L 211.481314 206.299492 
+L 211.294034 206.465942 
+L 211.106754 206.631881 
+L 210.919474 206.797313 
+L 210.732194 206.962241 
+L 210.544914 207.126668 
+L 210.357634 207.290597 
+L 210.170354 207.454031 
+L 209.983074 207.616974 
+L 209.795794 207.779427 
+L 209.608515 207.941394 
+L 209.421235 208.102878 
+L 209.233955 208.263881 
+L 209.046675 208.424408 
+L 208.859395 208.584459 
+L 208.672115 208.744039 
+L 208.484835 208.903149 
+L 208.297555 209.061794 
+L 208.110275 209.219974 
+L 207.922996 209.377694 
+L 207.735716 209.534956 
+L 207.548436 209.691762 
+L 207.361156 209.848115 
+L 207.173876 210.004018 
+L 206.986596 210.159473 
+L 206.799316 210.314483 
+L 206.612036 210.469051 
+L 206.424756 210.623178 
+L 206.237476 210.776867 
+L 206.050197 210.930122 
+L 205.862917 211.082944 
+L 205.675637 211.235336 
+L 205.488357 211.387299 
+L 205.301077 211.538838 
+L 205.113797 211.689953 
+L 204.926517 211.840648 
+L 204.739237 211.990924 
+L 204.551957 212.140784 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
-    <path d="M 204.551957 212.456838 
-L 204.370877 212.855389 
-L 204.189796 213.251026 
-L 204.008716 213.643792 
-L 203.827635 214.033728 
-L 203.646554 214.420875 
-L 203.465474 214.805271 
-L 203.284393 215.186957 
-L 203.103312 215.565969 
-L 202.922232 215.942346 
-L 202.741151 216.316123 
-L 202.56007 216.687336 
-L 202.37899 217.056021 
-L 202.197909 217.42221 
-L 202.016829 217.785939 
-L 201.835748 218.147239 
-L 201.654667 218.506143 
-L 201.473587 218.862682 
-L 201.292506 219.216888 
-L 201.111425 219.568791 
-L 200.930345 219.91842 
-L 200.749264 220.265805 
-L 200.568183 220.610975 
-L 200.387103 220.953957 
-L 200.206022 221.294778 
-L 200.024942 221.633467 
-L 199.843861 221.97005 
-L 199.66278 222.304552 
-L 199.4817 222.636999 
-L 199.300619 222.967417 
-L 199.119538 223.295829 
-L 198.938458 223.62226 
-L 198.757377 223.946735 
-L 198.576296 224.269275 
-L 198.395216 224.589905 
-L 198.214135 224.908646 
-L 198.033055 225.225521 
-L 197.851974 225.540551 
-L 197.670893 225.853758 
-L 197.489813 226.165163 
-L 197.308732 226.474786 
-L 197.127651 226.782648 
-L 196.946571 227.088768 
-L 196.76549 227.393167 
-L 196.58441 227.695863 
-L 196.403329 227.996875 
-L 196.222248 228.296222 
-L 196.041168 228.593923 
-L 195.860087 228.889995 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 204.551957 212.140784 
+L 204.370877 212.539554 
+L 204.189796 212.935407 
+L 204.008716 213.328386 
+L 203.827635 213.718533 
+L 203.646554 214.105889 
+L 203.465474 214.490492 
+L 203.284393 214.872381 
+L 203.103312 215.251596 
+L 202.922232 215.628172 
+L 202.741151 216.002146 
+L 202.56007 216.373555 
+L 202.37899 216.742433 
+L 202.197909 217.108814 
+L 202.016829 217.472732 
+L 201.835748 217.834219 
+L 201.654667 218.193309 
+L 201.473587 218.550032 
+L 201.292506 218.90442 
+L 201.111425 219.256502 
+L 200.930345 219.60631 
+L 200.749264 219.953871 
+L 200.568183 220.299215 
+L 200.387103 220.64237 
+L 200.206022 220.983363 
+L 200.024942 221.322222 
+L 199.843861 221.658972 
+L 199.66278 221.993641 
+L 199.4817 222.326253 
+L 199.300619 222.656834 
+L 199.119538 222.985408 
+L 198.938458 223.312 
+L 198.757377 223.636633 
+L 198.576296 223.959331 
+L 198.395216 224.280117 
+L 198.214135 224.599013 
+L 198.033055 224.916041 
+L 197.851974 225.231223 
+L 197.670893 225.544581 
+L 197.489813 225.856135 
+L 197.308732 226.165906 
+L 197.127651 226.473915 
+L 196.946571 226.780181 
+L 196.76549 227.084723 
+L 196.58441 227.387562 
+L 196.403329 227.688717 
+L 196.222248 227.988205 
+L 196.041168 228.286045 
+L 195.860087 228.582256 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
-    <path d="M 195.860087 228.889995 
-L 195.821749 229.010823 
-L 195.783411 229.131381 
-L 195.745072 229.251671 
-L 195.706734 229.371695 
-L 195.668396 229.491453 
-L 195.630058 229.610947 
-L 195.59172 229.730177 
-L 195.553381 229.849145 
-L 195.515043 229.967852 
-L 195.476705 230.0863 
-L 195.438367 230.204489 
-L 195.400028 230.32242 
-L 195.36169 230.440095 
-L 195.323352 230.557514 
-L 195.285014 230.674679 
-L 195.246676 230.791592 
-L 195.208337 230.908252 
-L 195.169999 231.024661 
-L 195.131661 231.14082 
-L 195.093323 231.256731 
-L 195.054985 231.372394 
-L 195.016646 231.48781 
-L 194.978308 231.60298 
-L 194.93997 231.717906 
-L 194.901632 231.832589 
-L 194.863293 231.947029 
-L 194.824955 232.061227 
-L 194.786617 232.175185 
-L 194.748279 232.288904 
-L 194.709941 232.402384 
-L 194.671602 232.515626 
-L 194.633264 232.628632 
-L 194.594926 232.741403 
-L 194.556588 232.853939 
-L 194.51825 232.966242 
-L 194.479911 233.078312 
-L 194.441573 233.19015 
-L 194.403235 233.301758 
-L 194.364897 233.413136 
-L 194.326559 233.524286 
-L 194.28822 233.635207 
-L 194.249882 233.745902 
-L 194.211544 233.856371 
-L 194.173206 233.966614 
-L 194.134867 234.076634 
-L 194.096529 234.18643 
-L 194.058191 234.296004 
-L 194.019853 234.405357 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+    <path d="M 195.860087 228.582256 
+L 195.821749 228.70763 
+L 195.783411 228.832714 
+L 195.745072 228.95751 
+L 195.706734 229.082019 
+L 195.668396 229.206242 
+L 195.630058 229.330181 
+L 195.59172 229.453836 
+L 195.553381 229.57721 
+L 195.515043 229.700304 
+L 195.476705 229.823118 
+L 195.438367 229.945654 
+L 195.400028 230.067913 
+L 195.36169 230.189897 
+L 195.323352 230.311606 
+L 195.285014 230.433042 
+L 195.246676 230.554207 
+L 195.208337 230.675101 
+L 195.169999 230.795726 
+L 195.131661 230.916082 
+L 195.093323 231.036171 
+L 195.054985 231.155995 
+L 195.016646 231.275554 
+L 194.978308 231.394849 
+L 194.93997 231.513882 
+L 194.901632 231.632654 
+L 194.863293 231.751166 
+L 194.824955 231.869419 
+L 194.786617 231.987414 
+L 194.748279 232.105153 
+L 194.709941 232.222636 
+L 194.671602 232.339864 
+L 194.633264 232.45684 
+L 194.594926 232.573563 
+L 194.556588 232.690035 
+L 194.51825 232.806257 
+L 194.479911 232.922229 
+L 194.441573 233.037954 
+L 194.403235 233.153432 
+L 194.364897 233.268665 
+L 194.326559 233.383652 
+L 194.28822 233.498396 
+L 194.249882 233.612897 
+L 194.211544 233.727156 
+L 194.173206 233.841175 
+L 194.134867 233.954953 
+L 194.096529 234.068494 
+L 194.058191 234.181796 
+L 194.019853 234.294862 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m8842d87690" d="M 0 3.5 
+      <path id="m63d95b7ef4" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m8842d87690" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m63d95b7ef4" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#mf22ff869ff" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m832c1ea07f" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m22d5fce672" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md510416027" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#m157d2a4e1d" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me65eec0431" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m8f0817a477" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mefedd32353" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m07e361c907" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2904fc1a84" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m26440347c3" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfa0971461d" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m2a75398bb3" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mbc23ff7fc2" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m47ccd355f3" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m40ed5004f9" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p399ecdeb00)">
-     <use xlink:href="#m8842d87690" x="319.643112" y="128.482083" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8842d87690" x="269.129958" y="143.974903" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8842d87690" x="247.452898" y="148.851677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8842d87690" x="199.905291" y="164.339631" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8842d87690" x="190.316224" y="176.898679" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8842d87690" x="165.455859" y="194.290364" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8842d87690" x="159.141659" y="202.569831" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8842d87690" x="158.180344" y="206.633979" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8842d87690" x="120.106777" y="293.254174" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8842d87690" x="97.799363" y="319.535627" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pbbc76cd86a)">
+     <use xlink:href="#m63d95b7ef4" x="319.643112" y="128.058606" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m63d95b7ef4" x="269.129958" y="143.619588" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m63d95b7ef4" x="247.452898" y="148.796216" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m63d95b7ef4" x="199.905291" y="164.613561" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m63d95b7ef4" x="190.316224" y="176.51234" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m63d95b7ef4" x="165.455859" y="194.390137" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m63d95b7ef4" x="159.141659" y="202.712405" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m63d95b7ef4" x="158.180344" y="207.202304" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m63d95b7ef4" x="120.106777" y="293.917646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m63d95b7ef4" x="97.799363" y="319.934389" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 128.482083 
-L 318.590755 128.854509 
-L 317.538397 129.22439 
-L 316.48604 129.59176 
-L 315.433682 129.956652 
-L 314.381325 130.319101 
-L 313.328968 130.679139 
-L 312.27661 131.036797 
-L 311.224253 131.392107 
-L 310.171896 131.7451 
-L 309.119538 132.095805 
-L 308.067181 132.444252 
-L 307.014823 132.790469 
-L 305.962466 133.134486 
-L 304.910109 133.47633 
-L 303.857751 133.816029 
-L 302.805394 134.153608 
-L 301.753037 134.489094 
-L 300.700679 134.822514 
-L 299.648322 135.153892 
-L 298.595965 135.483253 
-L 297.543607 135.810622 
-L 296.49125 136.136023 
-L 295.438892 136.459479 
-L 294.386535 136.781012 
-L 293.334178 137.100647 
-L 292.28182 137.418406 
-L 291.229463 137.734309 
-L 290.177106 138.048379 
-L 289.124748 138.360637 
-L 288.072391 138.671103 
-L 287.020033 138.979799 
-L 285.967676 139.286743 
-L 284.915319 139.591957 
-L 283.862961 139.895459 
-L 282.810604 140.197268 
-L 281.758247 140.497404 
-L 280.705889 140.795884 
-L 279.653532 141.092727 
-L 278.601175 141.387951 
-L 277.548817 141.681573 
-L 276.49646 141.97361 
-L 275.444102 142.26408 
-L 274.391745 142.553 
-L 273.339388 142.840385 
-L 272.28703 143.126252 
-L 271.234673 143.410617 
-L 270.182316 143.693495 
-L 269.129958 143.974903 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 128.058606 
+L 318.590755 128.432898 
+L 317.538397 128.80462 
+L 316.48604 129.173806 
+L 315.433682 129.540492 
+L 314.381325 129.90471 
+L 313.328968 130.266494 
+L 312.27661 130.625876 
+L 311.224253 130.982888 
+L 310.171896 131.337561 
+L 309.119538 131.689925 
+L 308.067181 132.04001 
+L 307.014823 132.387846 
+L 305.962466 132.733461 
+L 304.910109 133.076883 
+L 303.857751 133.41814 
+L 302.805394 133.757259 
+L 301.753037 134.094267 
+L 300.700679 134.42919 
+L 299.648322 134.762053 
+L 298.595965 135.092882 
+L 297.543607 135.421701 
+L 296.49125 135.748535 
+L 295.438892 136.073407 
+L 294.386535 136.396342 
+L 293.334178 136.717361 
+L 292.28182 137.036487 
+L 291.229463 137.353744 
+L 290.177106 137.669151 
+L 289.124748 137.982732 
+L 288.072391 138.294506 
+L 287.020033 138.604495 
+L 285.967676 138.912719 
+L 284.915319 139.219198 
+L 283.862961 139.523951 
+L 282.810604 139.826999 
+L 281.758247 140.128359 
+L 280.705889 140.42805 
+L 279.653532 140.726092 
+L 278.601175 141.022501 
+L 277.548817 141.317297 
+L 276.49646 141.610495 
+L 275.444102 141.902114 
+L 274.391745 142.192171 
+L 273.339388 142.480681 
+L 272.28703 142.767662 
+L 271.234673 143.05313 
+L 270.182316 143.3371 
+L 269.129958 143.619588 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 143.974903 
-L 268.678353 144.081117 
-L 268.226747 144.187122 
-L 267.775142 144.29292 
-L 267.323537 144.398512 
-L 266.871931 144.503898 
-L 266.420326 144.60908 
-L 265.96872 144.714057 
-L 265.517115 144.818831 
-L 265.065509 144.923403 
-L 264.613904 145.027773 
-L 264.162299 145.131942 
-L 263.710693 145.235911 
-L 263.259088 145.33968 
-L 262.807482 145.443252 
-L 262.355877 145.546625 
-L 261.904271 145.649801 
-L 261.452666 145.752781 
-L 261.001061 145.855565 
-L 260.549455 145.958154 
-L 260.09785 146.060549 
-L 259.646244 146.162751 
-L 259.194639 146.264761 
-L 258.743034 146.366578 
-L 258.291428 146.468204 
-L 257.839823 146.56964 
-L 257.388217 146.670885 
-L 256.936612 146.771942 
-L 256.485006 146.872811 
-L 256.033401 146.973492 
-L 255.581796 147.073985 
-L 255.13019 147.174293 
-L 254.678585 147.274415 
-L 254.226979 147.374352 
-L 253.775374 147.474105 
-L 253.323769 147.573674 
-L 252.872163 147.673061 
-L 252.420558 147.772265 
-L 251.968952 147.871288 
-L 251.517347 147.97013 
-L 251.065741 148.068792 
-L 250.614136 148.167274 
-L 250.162531 148.265577 
-L 249.710925 148.363703 
-L 249.25932 148.46165 
-L 248.807714 148.559421 
-L 248.356109 148.657015 
-L 247.904503 148.754433 
-L 247.452898 148.851677 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 143.619588 
+L 268.678353 143.732641 
+L 268.226747 143.845459 
+L 267.775142 143.958042 
+L 267.323537 144.070391 
+L 266.871931 144.182508 
+L 266.420326 144.294393 
+L 265.96872 144.406047 
+L 265.517115 144.517472 
+L 265.065509 144.628667 
+L 264.613904 144.739635 
+L 264.162299 144.850376 
+L 263.710693 144.96089 
+L 263.259088 145.071179 
+L 262.807482 145.181244 
+L 262.355877 145.291086 
+L 261.904271 145.400705 
+L 261.452666 145.510103 
+L 261.001061 145.61928 
+L 260.549455 145.728238 
+L 260.09785 145.836976 
+L 259.646244 145.945497 
+L 259.194639 146.0538 
+L 258.743034 146.161887 
+L 258.291428 146.269759 
+L 257.839823 146.377416 
+L 257.388217 146.48486 
+L 256.936612 146.59209 
+L 256.485006 146.699109 
+L 256.033401 146.805916 
+L 255.581796 146.912513 
+L 255.13019 147.018901 
+L 254.678585 147.12508 
+L 254.226979 147.231051 
+L 253.775374 147.336815 
+L 253.323769 147.442373 
+L 252.872163 147.547726 
+L 252.420558 147.652873 
+L 251.968952 147.757817 
+L 251.517347 147.862558 
+L 251.065741 147.967097 
+L 250.614136 148.071434 
+L 250.162531 148.17557 
+L 249.710925 148.279506 
+L 249.25932 148.383244 
+L 248.807714 148.486782 
+L 248.356109 148.590123 
+L 247.904503 148.693268 
+L 247.452898 148.796216 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 148.851677 
-L 246.462323 149.223969 
-L 245.471748 149.593717 
-L 244.481173 149.960957 
-L 243.490597 150.325721 
-L 242.500022 150.688043 
-L 241.509447 151.047955 
-L 240.518872 151.40549 
-L 239.528297 151.760678 
-L 238.537722 152.11355 
-L 237.547147 152.464136 
-L 236.556571 152.812466 
-L 235.565996 153.158568 
-L 234.575421 153.50247 
-L 233.584846 153.844201 
-L 232.594271 154.183788 
-L 231.603696 154.521257 
-L 230.613121 154.856635 
-L 229.622545 155.189947 
-L 228.63197 155.521219 
-L 227.641395 155.850475 
-L 226.65082 156.177741 
-L 225.660245 156.503039 
-L 224.66967 156.826393 
-L 223.679095 157.147827 
-L 222.688519 157.467364 
-L 221.697944 157.785024 
-L 220.707369 158.100831 
-L 219.716794 158.414806 
-L 218.726219 158.726969 
-L 217.735644 159.037343 
-L 216.745069 159.345946 
-L 215.754493 159.6528 
-L 214.763918 159.957923 
-L 213.773343 160.261336 
-L 212.782768 160.563057 
-L 211.792193 160.863106 
-L 210.801618 161.1615 
-L 209.811043 161.458258 
-L 208.820467 161.753397 
-L 207.829892 162.046936 
-L 206.839317 162.338891 
-L 205.848742 162.62928 
-L 204.858167 162.918118 
-L 203.867592 163.205424 
-L 202.877017 163.491212 
-L 201.886441 163.775498 
-L 200.895866 164.0583 
-L 199.905291 164.339631 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 148.796216 
+L 246.462323 149.177595 
+L 245.471748 149.556305 
+L 244.481173 149.932385 
+L 243.490597 150.30587 
+L 242.500022 150.676795 
+L 241.509447 151.045197 
+L 240.518872 151.411107 
+L 239.528297 151.774561 
+L 238.537722 152.135591 
+L 237.547147 152.494229 
+L 236.556571 152.850507 
+L 235.565996 153.204455 
+L 234.575421 153.556103 
+L 233.584846 153.905482 
+L 232.594271 154.252621 
+L 231.603696 154.597547 
+L 230.613121 154.940289 
+L 229.622545 155.280875 
+L 228.63197 155.619332 
+L 227.641395 155.955685 
+L 226.65082 156.289961 
+L 225.660245 156.622186 
+L 224.66967 156.952384 
+L 223.679095 157.28058 
+L 222.688519 157.606798 
+L 221.697944 157.931063 
+L 220.707369 158.253396 
+L 219.716794 158.573821 
+L 218.726219 158.892361 
+L 217.735644 159.209037 
+L 216.745069 159.523871 
+L 215.754493 159.836885 
+L 214.763918 160.148099 
+L 213.773343 160.457534 
+L 212.782768 160.76521 
+L 211.792193 161.071148 
+L 210.801618 161.375366 
+L 209.811043 161.677883 
+L 208.820467 161.97872 
+L 207.829892 162.277894 
+L 206.839317 162.575424 
+L 205.848742 162.871327 
+L 204.858167 163.165621 
+L 203.867592 163.458324 
+L 202.877017 163.749453 
+L 201.886441 164.039024 
+L 200.895866 164.327055 
+L 199.905291 164.613561 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 199.905291 164.339631 
-L 199.705519 164.63333 
-L 199.505747 164.925444 
-L 199.305974 165.21599 
-L 199.106202 165.504984 
-L 198.90643 165.792443 
-L 198.706658 166.078384 
-L 198.506885 166.362821 
-L 198.307113 166.645772 
-L 198.107341 166.92725 
-L 197.907569 167.207273 
-L 197.707797 167.485854 
-L 197.508024 167.763008 
-L 197.308252 168.03875 
-L 197.10848 168.313094 
-L 196.908708 168.586054 
-L 196.708935 168.857645 
-L 196.509163 169.127879 
-L 196.309391 169.396771 
-L 196.109619 169.664334 
-L 195.909846 169.93058 
-L 195.710074 170.195522 
-L 195.510302 170.459174 
-L 195.31053 170.721548 
-L 195.110758 170.982656 
-L 194.910985 171.24251 
-L 194.711213 171.501122 
-L 194.511441 171.758504 
-L 194.311669 172.014668 
-L 194.111896 172.269625 
-L 193.912124 172.523387 
-L 193.712352 172.775965 
-L 193.51258 173.027369 
-L 193.312807 173.27761 
-L 193.113035 173.5267 
-L 192.913263 173.774649 
-L 192.713491 174.021466 
-L 192.513719 174.267164 
-L 192.313946 174.51175 
-L 192.114174 174.755237 
-L 191.914402 174.997633 
-L 191.71463 175.238948 
-L 191.514857 175.479191 
-L 191.315085 175.718373 
-L 191.115313 175.956503 
-L 190.915541 176.193589 
-L 190.715768 176.429641 
-L 190.515996 176.664668 
-L 190.316224 176.898679 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.905291 164.613561 
+L 199.705519 164.890101 
+L 199.505747 165.165235 
+L 199.305974 165.438977 
+L 199.106202 165.711342 
+L 198.90643 165.982344 
+L 198.706658 166.251996 
+L 198.506885 166.520311 
+L 198.307113 166.787303 
+L 198.107341 167.052984 
+L 197.907569 167.317367 
+L 197.707797 167.580466 
+L 197.508024 167.842292 
+L 197.308252 168.102858 
+L 197.10848 168.362175 
+L 196.908708 168.620257 
+L 196.708935 168.877113 
+L 196.509163 169.132757 
+L 196.309391 169.387198 
+L 196.109619 169.64045 
+L 195.909846 169.892522 
+L 195.710074 170.143426 
+L 195.510302 170.393172 
+L 195.31053 170.641771 
+L 195.110758 170.889234 
+L 194.910985 171.13557 
+L 194.711213 171.380791 
+L 194.511441 171.624905 
+L 194.311669 171.867924 
+L 194.111896 172.109857 
+L 193.912124 172.350713 
+L 193.712352 172.590502 
+L 193.51258 172.829234 
+L 193.312807 173.066918 
+L 193.113035 173.303562 
+L 192.913263 173.539176 
+L 192.713491 173.77377 
+L 192.513719 174.00735 
+L 192.313946 174.239928 
+L 192.114174 174.47151 
+L 191.914402 174.702106 
+L 191.71463 174.931724 
+L 191.514857 175.160372 
+L 191.315085 175.388058 
+L 191.115313 175.61479 
+L 190.915541 175.840577 
+L 190.715768 176.065425 
+L 190.515996 176.289344 
+L 190.316224 176.51234 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 190.316224 176.898679 
-L 189.7983 177.324318 
-L 189.280375 177.746636 
-L 188.762451 178.165683 
-L 188.244527 178.581511 
-L 187.726603 178.994168 
-L 187.208678 179.403703 
-L 186.690754 179.810161 
-L 186.17283 180.21359 
-L 185.654906 180.614033 
-L 185.136981 181.011536 
-L 184.619057 181.406139 
-L 184.101133 181.797887 
-L 183.583208 182.186819 
-L 183.065284 182.572975 
-L 182.54736 182.956396 
-L 182.029436 183.33712 
-L 181.511511 183.715184 
-L 180.993587 184.090625 
-L 180.475663 184.463479 
-L 179.957739 184.833782 
-L 179.439814 185.201569 
-L 178.92189 185.566873 
-L 178.403966 185.929728 
-L 177.886041 186.290166 
-L 177.368117 186.648219 
-L 176.850193 187.003919 
-L 176.332269 187.357296 
-L 175.814344 187.708381 
-L 175.29642 188.057203 
-L 174.778496 188.403791 
-L 174.260572 188.748173 
-L 173.742647 189.090378 
-L 173.224723 189.430433 
-L 172.706799 189.768364 
-L 172.188874 190.104198 
-L 171.67095 190.437961 
-L 171.153026 190.769678 
-L 170.635102 191.099375 
-L 170.117177 191.427075 
-L 169.599253 191.752802 
-L 169.081329 192.076581 
-L 168.563404 192.398434 
-L 168.04548 192.718384 
-L 167.527556 193.036454 
-L 167.009632 193.352666 
-L 166.491707 193.667041 
-L 165.973783 193.979599 
-L 165.455859 194.290364 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 190.316224 176.51234 
+L 189.7983 176.951879 
+L 189.280375 177.387877 
+L 188.762451 177.820392 
+L 188.244527 178.249478 
+L 187.726603 178.67519 
+L 187.208678 179.09758 
+L 186.690754 179.516699 
+L 186.17283 179.932598 
+L 185.654906 180.345326 
+L 185.136981 180.754932 
+L 184.619057 181.16146 
+L 184.101133 181.564959 
+L 183.583208 181.965472 
+L 183.065284 182.363044 
+L 182.54736 182.757716 
+L 182.029436 183.149532 
+L 181.511511 183.538533 
+L 180.993587 183.924757 
+L 180.475663 184.308246 
+L 179.957739 184.689037 
+L 179.439814 185.067168 
+L 178.92189 185.442676 
+L 178.403966 185.815596 
+L 177.886041 186.185966 
+L 177.368117 186.553818 
+L 176.850193 186.919188 
+L 176.332269 187.282108 
+L 175.814344 187.642611 
+L 175.29642 188.000728 
+L 174.778496 188.356493 
+L 174.260572 188.709934 
+L 173.742647 189.061083 
+L 173.224723 189.409968 
+L 172.706799 189.756619 
+L 172.188874 190.101064 
+L 171.67095 190.443332 
+L 171.153026 190.783449 
+L 170.635102 191.121442 
+L 170.117177 191.457338 
+L 169.599253 191.791162 
+L 169.081329 192.122941 
+L 168.563404 192.452698 
+L 168.04548 192.780458 
+L 167.527556 193.106246 
+L 167.009632 193.430085 
+L 166.491707 193.751998 
+L 165.973783 194.072008 
+L 165.455859 194.390137 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 165.455859 194.290364 
-L 165.324313 194.476426 
-L 165.192767 194.661851 
-L 165.061221 194.846643 
-L 164.929675 195.030806 
-L 164.79813 195.214344 
-L 164.666584 195.397262 
-L 164.535038 195.579564 
-L 164.403492 195.761254 
-L 164.271946 195.942336 
-L 164.1404 196.122813 
-L 164.008855 196.302692 
-L 163.877309 196.481974 
-L 163.745763 196.660664 
-L 163.614217 196.838766 
-L 163.482671 197.016284 
-L 163.351125 197.193222 
-L 163.21958 197.369583 
-L 163.088034 197.545371 
-L 162.956488 197.72059 
-L 162.824942 197.895243 
-L 162.693396 198.069335 
-L 162.56185 198.242869 
-L 162.430305 198.415847 
-L 162.298759 198.588275 
-L 162.167213 198.760155 
-L 162.035667 198.931491 
-L 161.904121 199.102286 
-L 161.772575 199.272544 
-L 161.64103 199.442268 
-L 161.509484 199.611461 
-L 161.377938 199.780127 
-L 161.246392 199.948269 
-L 161.114846 200.11589 
-L 160.9833 200.282993 
-L 160.851754 200.449583 
-L 160.720209 200.61566 
-L 160.588663 200.78123 
-L 160.457117 200.946295 
-L 160.325571 201.110858 
-L 160.194025 201.274922 
-L 160.062479 201.43849 
-L 159.930934 201.601566 
-L 159.799388 201.764151 
-L 159.667842 201.926249 
-L 159.536296 202.087864 
-L 159.40475 202.248997 
-L 159.273204 202.409651 
-L 159.141659 202.569831 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.455859 194.390137 
+L 165.324313 194.577232 
+L 165.192767 194.763683 
+L 165.061221 194.949493 
+L 164.929675 195.134668 
+L 164.79813 195.319212 
+L 164.666584 195.503128 
+L 164.535038 195.686422 
+L 164.403492 195.869097 
+L 164.271946 196.051158 
+L 164.1404 196.232609 
+L 164.008855 196.413453 
+L 163.877309 196.593695 
+L 163.745763 196.77334 
+L 163.614217 196.952389 
+L 163.482671 197.130849 
+L 163.351125 197.308722 
+L 163.21958 197.486013 
+L 163.088034 197.662724 
+L 162.956488 197.838861 
+L 162.824942 198.014427 
+L 162.693396 198.189425 
+L 162.56185 198.363859 
+L 162.430305 198.537732 
+L 162.298759 198.711049 
+L 162.167213 198.883813 
+L 162.035667 199.056028 
+L 161.904121 199.227696 
+L 161.772575 199.398821 
+L 161.64103 199.569407 
+L 161.509484 199.739457 
+L 161.377938 199.908975 
+L 161.246392 200.077964 
+L 161.114846 200.246426 
+L 160.9833 200.414366 
+L 160.851754 200.581787 
+L 160.720209 200.748691 
+L 160.588663 200.915082 
+L 160.457117 201.080964 
+L 160.325571 201.246338 
+L 160.194025 201.411209 
+L 160.062479 201.575579 
+L 159.930934 201.739452 
+L 159.799388 201.90283 
+L 159.667842 202.065717 
+L 159.536296 202.228114 
+L 159.40475 202.390026 
+L 159.273204 202.551456 
+L 159.141659 202.712405 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 159.141659 202.569831 
-L 159.121631 202.657689 
-L 159.101604 202.745406 
-L 159.081576 202.83298 
-L 159.061549 202.920413 
-L 159.041522 203.007705 
-L 159.021494 203.094856 
-L 159.001467 203.181867 
-L 158.98144 203.268739 
-L 158.961412 203.355471 
-L 158.941385 203.442065 
-L 158.921357 203.52852 
-L 158.90133 203.614837 
-L 158.881303 203.701017 
-L 158.861275 203.78706 
-L 158.841248 203.872966 
-L 158.82122 203.958736 
-L 158.801193 204.04437 
-L 158.781166 204.129869 
-L 158.761138 204.215234 
-L 158.741111 204.300463 
-L 158.721084 204.385559 
-L 158.701056 204.470521 
-L 158.681029 204.55535 
-L 158.661001 204.640046 
-L 158.640974 204.72461 
-L 158.620947 204.809042 
-L 158.600919 204.893343 
-L 158.580892 204.977512 
-L 158.560865 205.061551 
-L 158.540837 205.145459 
-L 158.52081 205.229237 
-L 158.500782 205.312886 
-L 158.480755 205.396406 
-L 158.460728 205.479797 
-L 158.4407 205.56306 
-L 158.420673 205.646195 
-L 158.400645 205.729202 
-L 158.380618 205.812083 
-L 158.360591 205.894836 
-L 158.340563 205.977464 
-L 158.320536 206.059965 
-L 158.300509 206.142341 
-L 158.280481 206.224591 
-L 158.260454 206.306717 
-L 158.240426 206.388718 
-L 158.220399 206.470595 
-L 158.200372 206.552349 
-L 158.180344 206.633979 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.141659 202.712405 
+L 159.121631 202.809845 
+L 159.101604 202.907111 
+L 159.081576 203.004202 
+L 159.061549 203.101119 
+L 159.041522 203.197863 
+L 159.021494 203.294435 
+L 159.001467 203.390834 
+L 158.98144 203.487062 
+L 158.961412 203.58312 
+L 158.941385 203.679007 
+L 158.921357 203.774725 
+L 158.90133 203.870273 
+L 158.881303 203.965654 
+L 158.861275 204.060866 
+L 158.841248 204.155912 
+L 158.82122 204.25079 
+L 158.801193 204.345503 
+L 158.781166 204.44005 
+L 158.761138 204.534433 
+L 158.741111 204.628651 
+L 158.721084 204.722706 
+L 158.701056 204.816597 
+L 158.681029 204.910326 
+L 158.661001 205.003893 
+L 158.640974 205.097298 
+L 158.620947 205.190542 
+L 158.600919 205.283627 
+L 158.580892 205.376551 
+L 158.560865 205.469316 
+L 158.540837 205.561922 
+L 158.52081 205.65437 
+L 158.500782 205.746661 
+L 158.480755 205.838795 
+L 158.460728 205.930771 
+L 158.4407 206.022592 
+L 158.420673 206.114258 
+L 158.400645 206.205768 
+L 158.380618 206.297124 
+L 158.360591 206.388327 
+L 158.340563 206.479375 
+L 158.320536 206.570271 
+L 158.300509 206.661015 
+L 158.280481 206.751606 
+L 158.260454 206.842046 
+L 158.240426 206.932336 
+L 158.220399 207.022475 
+L 158.200372 207.112464 
+L 158.180344 207.202304 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 158.180344 206.633979 
-L 157.387145 210.919782 
-L 156.593946 214.890946 
-L 155.800746 218.590524 
-L 155.007547 222.053299 
-L 154.214348 225.307769 
-L 153.421148 228.377581 
-L 152.627949 231.282569 
-L 151.83475 234.039534 
-L 151.04155 236.662833 
-L 150.248351 239.164829 
-L 149.455152 241.556247 
-L 148.661952 243.846448 
-L 147.868753 246.043655 
-L 147.075554 248.155124 
-L 146.282354 250.187297 
-L 145.489155 252.145916 
-L 144.695956 254.036118 
-L 143.902756 255.862522 
-L 143.109557 257.629296 
-L 142.316358 259.34021 
-L 141.523159 260.998688 
-L 140.729959 262.607849 
-L 139.93676 264.170542 
-L 139.143561 265.689375 
-L 138.350361 267.166743 
-L 137.557162 268.60485 
-L 136.763963 270.005729 
-L 135.970763 271.371259 
-L 135.177564 272.70318 
-L 134.384365 274.003107 
-L 133.591165 275.27254 
-L 132.797966 276.512878 
-L 132.004767 277.725424 
-L 131.211567 278.911398 
-L 130.418368 280.071937 
-L 129.625169 281.208112 
-L 128.831969 282.320923 
-L 128.03877 283.411312 
-L 127.245571 284.480164 
-L 126.452371 285.528315 
-L 125.659172 286.556551 
-L 124.865973 287.565615 
-L 124.072774 288.556207 
-L 123.279574 289.528994 
-L 122.486375 290.484602 
-L 121.693176 291.42363 
-L 120.899976 292.346641 
-L 120.106777 293.254174 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.180344 207.202304 
+L 157.387145 211.496253 
+L 156.593946 215.474477 
+L 155.800746 219.180242 
+L 155.007547 222.648488 
+L 154.214348 225.907837 
+L 153.421148 228.98203 
+L 152.627949 231.890978 
+L 151.83475 234.651542 
+L 151.04155 237.278129 
+L 150.248351 239.783144 
+L 149.455152 242.177344 
+L 148.661952 244.470119 
+L 147.868753 246.669716 
+L 147.075554 248.783412 
+L 146.282354 250.817666 
+L 145.489155 252.778233 
+L 144.695956 254.670266 
+L 143.902756 256.498395 
+L 143.109557 258.266795 
+L 142.316358 259.979247 
+L 141.523159 261.639182 
+L 140.729959 263.249727 
+L 139.93676 264.813734 
+L 139.143561 266.333819 
+L 138.350361 267.812381 
+L 137.557162 269.251629 
+L 136.763963 270.653599 
+L 135.970763 272.020173 
+L 135.177564 273.353095 
+L 134.384365 274.653983 
+L 133.591165 275.92434 
+L 132.797966 277.165566 
+L 132.004767 278.378968 
+L 131.211567 279.565766 
+L 130.418368 280.727101 
+L 129.625169 281.864043 
+L 128.831969 282.977596 
+L 128.03877 284.068702 
+L 127.245571 285.13825 
+L 126.452371 286.187073 
+L 125.659172 287.215961 
+L 124.865973 288.225656 
+L 124.072774 289.216863 
+L 123.279574 290.190245 
+L 122.486375 291.146432 
+L 121.693176 292.086022 
+L 120.899976 293.009581 
+L 120.106777 293.917646 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 120.106777 293.254174 
-L 119.642039 293.954511 
-L 119.177301 294.6459 
-L 118.712564 295.328568 
-L 118.247826 296.002732 
-L 117.783088 296.668601 
-L 117.31835 297.326376 
-L 116.853612 297.976253 
-L 116.388875 298.618418 
-L 115.924137 299.253053 
-L 115.459399 299.880331 
-L 114.994661 300.500422 
-L 114.529924 301.113489 
-L 114.065186 301.719688 
-L 113.600448 302.319172 
-L 113.13571 302.912088 
-L 112.670972 303.498579 
-L 112.206235 304.078782 
-L 111.741497 304.65283 
-L 111.276759 305.220854 
-L 110.812021 305.782977 
-L 110.347283 306.339321 
-L 109.882546 306.890004 
-L 109.417808 307.435141 
-L 108.95307 307.97484 
-L 108.488332 308.509211 
-L 108.023595 309.038357 
-L 107.558857 309.562379 
-L 107.094119 310.081376 
-L 106.629381 310.595443 
-L 106.164643 311.104672 
-L 105.699906 311.609155 
-L 105.235168 312.108978 
-L 104.77043 312.604227 
-L 104.305692 313.094986 
-L 103.840955 313.581334 
-L 103.376217 314.06335 
-L 102.911479 314.541111 
-L 102.446741 315.014691 
-L 101.982003 315.484163 
-L 101.517266 315.949597 
-L 101.052528 316.411062 
-L 100.58779 316.868626 
-L 100.123052 317.322354 
-L 99.658315 317.772309 
-L 99.193577 318.218554 
-L 98.728839 318.661149 
-L 98.264101 319.100154 
-L 97.799363 319.535627 
-" clip-path="url(#p399ecdeb00)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 120.106777 293.917646 
+L 119.642039 294.609116 
+L 119.177301 295.291864 
+L 118.712564 295.966108 
+L 118.247826 296.632056 
+L 117.783088 297.289912 
+L 117.31835 297.939868 
+L 116.853612 298.582113 
+L 116.388875 299.216827 
+L 115.924137 299.844185 
+L 115.459399 300.464355 
+L 114.994661 301.077501 
+L 114.529924 301.683779 
+L 114.065186 302.283342 
+L 113.600448 302.876337 
+L 113.13571 303.462906 
+L 112.670972 304.043187 
+L 112.206235 304.617313 
+L 111.741497 305.185414 
+L 111.276759 305.747615 
+L 110.812021 306.304037 
+L 110.347283 306.854797 
+L 109.882546 307.40001 
+L 109.417808 307.939786 
+L 108.95307 308.474233 
+L 108.488332 309.003455 
+L 108.023595 309.527553 
+L 107.558857 310.046625 
+L 107.094119 310.560767 
+L 106.629381 311.070071 
+L 106.164643 311.574629 
+L 105.699906 312.074526 
+L 105.235168 312.56985 
+L 104.77043 313.060682 
+L 104.305692 313.547103 
+L 103.840955 314.029192 
+L 103.376217 314.507026 
+L 102.911479 314.980679 
+L 102.446741 315.450223 
+L 101.982003 315.915729 
+L 101.517266 316.377266 
+L 101.052528 316.834901 
+L 100.58779 317.2887 
+L 100.123052 317.738726 
+L 99.658315 318.185041 
+L 99.193577 318.627707 
+L 98.728839 319.066781 
+L 98.264101 319.502324 
+L 97.799363 319.934389 
+" clip-path="url(#pbbc76cd86a)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-05T08:48:39Z  ·  Linux chungus x86_64  ·  commit 7e98994a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.762578 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.687734 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6228,36 +6228,6 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
 L 1344 2619 
 L 1344 1825 
@@ -6315,6 +6285,36 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6355,14 +6355,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6382,128 +6382,129 @@ z
     <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
     <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
     <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.792969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.580078 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.367188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.941406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3761.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.314453 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.693359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3988.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.917969 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4211.03125 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4334.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.308594 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.6875 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4556.001953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.181641 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.804688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.591797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.214844 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.837891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.625 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.248047 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.332031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.195312 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.947266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.734375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.185547 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.367188 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.746094 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.601562 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.457031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.666016 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5992.029297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.441406 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.964844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.224609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.503906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.769531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.148438 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.427734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6691.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.382812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.564453 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.773438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.464844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.365234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.644531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.853516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.818359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.388672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.488281 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.484375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7520.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.371094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.566406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.945312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.728516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.828125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7867.037109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.820312 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2107.714844 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2139.501953 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2325.927734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2503.173828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.960938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2566.748047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2598.535156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2630.322266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2662.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2717.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2778.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2875.683594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p399ecdeb00">
+  <clipPath id="pbbc76cd86a">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m12bfd1e5d7" d="M 0 0 
+       <path id="m13c9913171" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m12bfd1e5d7" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13c9913171" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m12bfd1e5d7" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13c9913171" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m12bfd1e5d7" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13c9913171" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m12bfd1e5d7" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13c9913171" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m12bfd1e5d7" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13c9913171" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m12bfd1e5d7" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13c9913171" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m12bfd1e5d7" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m13c9913171" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -895,23 +895,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_15">
-      <path d="M 49.078125 388.333941 
-L 637.2 388.333941 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 391.82245 
+L 637.2 391.82245 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m85e6c56838" d="M 0 0 
+       <path id="mdec1e703fd" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m85e6c56838" x="49.078125" y="388.333941" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdec1e703fd" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(24.478125 392.13316) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 395.621669) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -920,18 +920,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
-      <path d="M 49.078125 264.064771 
-L 637.2 264.064771 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 265.911133 
+L 637.2 265.911133 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m85e6c56838" x="49.078125" y="264.064771" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdec1e703fd" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(24.478125 267.863989) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 269.710352) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
        <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
@@ -940,18 +940,18 @@ L 637.2 264.064771
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
-      <path d="M 49.078125 139.7956 
-L 637.2 139.7956 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 139.999816 
+L 637.2 139.999816 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m85e6c56838" x="49.078125" y="139.7956" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdec1e703fd" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(24.478125 143.594819) scale(0.1 -0.1)">
+      <g transform="translate(24.478125 143.799035) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
        <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
@@ -960,282 +960,282 @@ L 637.2 139.7956
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
-      <path d="M 49.078125 407.583479 
-L 637.2 407.583479 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 411.32636 
+L 637.2 411.32636 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mcf8085d2fc" d="M 0 0 
+       <path id="m38eeaadfec" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="407.583479" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
-      <path d="M 49.078125 400.376868 
-L 637.2 400.376868 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 404.024518 
+L 637.2 404.024518 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="400.376868" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
-      <path d="M 49.078125 394.020186 
-L 637.2 394.020186 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 397.583836 
+L 637.2 397.583836 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="394.020186" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
-      <path d="M 49.078125 350.925193 
-L 637.2 350.925193 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 353.919367 
+L 637.2 353.919367 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="350.925193" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_29">
-      <path d="M 49.078125 329.042478 
-L 637.2 329.042478 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 331.747485 
+L 637.2 331.747485 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="329.042478" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_31">
-      <path d="M 49.078125 313.516445 
-L 637.2 313.516445 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 316.016284 
+L 637.2 316.016284 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="313.516445" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_33">
-      <path d="M 49.078125 301.473518 
-L 637.2 301.473518 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 303.814216 
+L 637.2 303.814216 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="301.473518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_35">
-      <path d="M 49.078125 291.633731 
-L 637.2 291.633731 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 293.844402 
+L 637.2 293.844402 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="291.633731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_37">
-      <path d="M 49.078125 283.314309 
-L 637.2 283.314309 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 285.415043 
+L 637.2 285.415043 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="283.314309" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_39">
-      <path d="M 49.078125 276.107697 
-L 637.2 276.107697 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 278.113201 
+L 637.2 278.113201 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="276.107697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_41">
-      <path d="M 49.078125 269.751016 
-L 637.2 269.751016 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 271.672519 
+L 637.2 271.672519 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="269.751016" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_43">
-      <path d="M 49.078125 226.656023 
-L 637.2 226.656023 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 228.00805 
+L 637.2 228.00805 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="226.656023" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_45">
-      <path d="M 49.078125 204.773308 
-L 637.2 204.773308 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 205.836168 
+L 637.2 205.836168 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="204.773308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_47">
-      <path d="M 49.078125 189.247275 
-L 637.2 189.247275 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 190.104967 
+L 637.2 190.104967 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="189.247275" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_49">
-      <path d="M 49.078125 177.204348 
-L 637.2 177.204348 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 177.9029 
+L 637.2 177.9029 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="177.204348" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_51">
-      <path d="M 49.078125 167.36456 
-L 637.2 167.36456 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 167.933085 
+L 637.2 167.933085 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="167.36456" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_53">
-      <path d="M 49.078125 159.045138 
-L 637.2 159.045138 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 159.503726 
+L 637.2 159.503726 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="159.045138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_55">
-      <path d="M 49.078125 151.838527 
-L 637.2 151.838527 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 152.201884 
+L 637.2 152.201884 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="151.838527" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_57">
-      <path d="M 49.078125 145.481845 
-L 637.2 145.481845 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 145.761202 
+L 637.2 145.761202 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="145.481845" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_59">
-      <path d="M 49.078125 102.386852 
-L 637.2 102.386852 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 102.096733 
+L 637.2 102.096733 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="102.386852" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_61">
-      <path d="M 49.078125 80.504138 
-L 637.2 80.504138 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 79.924851 
+L 637.2 79.924851 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="80.504138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_63">
-      <path d="M 49.078125 64.978104 
-L 637.2 64.978104 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 64.19365 
+L 637.2 64.19365 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="64.978104" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_65">
-      <path d="M 49.078125 52.935177 
-L 637.2 52.935177 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 49.078125 51.991583 
+L 637.2 51.991583 
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mcf8085d2fc" x="49.078125" y="52.935177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m38eeaadfec" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pc841ea4d8a)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p7bba25b3b1)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1421,7 +1421,7 @@ L 637.2 47.3475
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_13">
-    <!--  memcpy ceiling ≈ 41 GB/s -->
+    <!--  memcpy ceiling ≈ 40 GB/s -->
     <g style="fill: #777777" transform="translate(525.255641 62.295398) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325 
@@ -1527,7 +1527,7 @@ z
      <use xlink:href="#DejaVuSans-2248" transform="translate(856.054688 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(939.84375 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(971.630859 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(1035.253906 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(1035.253906 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(1098.876953 0)"/>
      <use xlink:href="#DejaVuSans-47" transform="translate(1130.664062 0)"/>
      <use xlink:href="#DejaVuSans-42" transform="translate(1208.154297 0)"/>
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m5f72f096ee" d="M -2.5 2.5 
+     <path id="m426bc01dfd" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc841ea4d8a)">
-     <use xlink:href="#m5f72f096ee" x="75.810937" y="261.840221" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="105.634056" y="267.384633" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="204.490635" y="299.649233" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="234.479899" y="305.099581" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="242.537956" y="313.975785" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="300.771958" y="296.298292" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="303.26414" y="307.767632" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="304.261013" y="317.626344" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="313.897453" y="316.761174" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="414.166268" y="332.190815" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="587.289889" y="325.542509" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5f72f096ee" x="610.467187" y="316.957831" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7bba25b3b1)">
+     <use xlink:href="#m426bc01dfd" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426bc01dfd" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="mcb16408f96" d="M 0 -2.5 
+     <path id="mabee48d180" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc841ea4d8a)">
-     <use xlink:href="#mcb16408f96" x="75.810937" y="260.621481" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="105.634056" y="254.891557" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="204.490635" y="299.605423" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="234.479899" y="296.942514" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="242.537956" y="305.594775" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="300.771958" y="285.704093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="303.26414" y="298.175236" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="304.261013" y="313.221769" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="313.897453" y="305.449341" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="414.166268" y="323.426439" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="587.289889" y="326.825525" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mcb16408f96" x="610.467187" y="316.038155" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7bba25b3b1)">
+     <use xlink:href="#mabee48d180" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mabee48d180" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m2188bf1e6a" d="M -0 3.535534 
+     <path id="m147cecbcd9" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc841ea4d8a)">
-     <use xlink:href="#m2188bf1e6a" x="75.810937" y="229.170099" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="105.634056" y="231.076357" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="204.490635" y="258.407245" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="234.479899" y="258.497713" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="242.537956" y="270.565473" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="300.771958" y="258.825348" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="303.26414" y="268.756406" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="304.261013" y="280.059851" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="313.897453" y="273.915137" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="414.166268" y="293.202536" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="587.289889" y="298.872219" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2188bf1e6a" x="610.467187" y="294.650642" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7bba25b3b1)">
+     <use xlink:href="#m147cecbcd9" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m147cecbcd9" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m0e25d0275f" d="M -0.833333 2.5 
+     <path id="mcd5d1e1b38" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc841ea4d8a)">
-     <use xlink:href="#m0e25d0275f" x="75.810937" y="319.852724" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="105.634056" y="344.972995" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="204.490635" y="347.60001" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="234.479899" y="370.036131" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="242.537956" y="349.165122" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="300.771958" y="363.248815" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="303.26414" y="382.974659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="304.261013" y="342.017637" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="313.897453" y="377.890387" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="414.166268" y="396.192102" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="587.289889" y="375.485358" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0e25d0275f" x="610.467187" y="376.079868" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7bba25b3b1)">
+     <use xlink:href="#mcd5d1e1b38" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcd5d1e1b38" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m21e0424a38" d="M -1.25 2.5 
+     <path id="mc0492ac41b" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc841ea4d8a)">
-     <use xlink:href="#m21e0424a38" x="75.810937" y="320.038154" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="105.634056" y="318.60189" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="204.490635" y="333.716848" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="234.479899" y="344.919854" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="242.537956" y="348.969585" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="300.771958" y="330.515988" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="303.26414" y="343.267467" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="304.261013" y="348.888969" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="313.897453" y="350.572846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="414.166268" y="356.217107" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="587.289889" y="367.442518" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m21e0424a38" x="610.467187" y="360.392799" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7bba25b3b1)">
+     <use xlink:href="#mc0492ac41b" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mc0492ac41b" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m72b9efb76f" d="M 0 -2.5 
+     <path id="m034cfad974" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pc841ea4d8a)">
-     <use xlink:href="#m72b9efb76f" x="75.810937" y="272.872661" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="105.634056" y="286.668454" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="204.490635" y="318.646385" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="234.479899" y="319.138266" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="242.537956" y="325.259999" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="300.771958" y="331.239996" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="303.26414" y="334.630868" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="304.261013" y="343.799259" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="313.897453" y="333.826817" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="414.166268" y="354.894045" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="587.289889" y="363.838613" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m72b9efb76f" x="610.467187" y="358.397679" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p7bba25b3b1)">
+     <use xlink:href="#m034cfad974" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m034cfad974" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m3075b9660e" d="M 0 -2.5 
+     <path id="m2fe04c379a" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pc841ea4d8a)">
-     <use xlink:href="#m3075b9660e" x="75.810937" y="344.243278" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="105.634056" y="349.682132" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="204.490635" y="362.870389" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="234.479899" y="370.151606" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="242.537956" y="377.306498" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="300.771958" y="366.096198" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="303.26414" y="371.918043" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="304.261013" y="379.819042" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="313.897453" y="382.082903" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="414.166268" y="388.990954" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="587.289889" y="391.736513" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3075b9660e" x="610.467187" y="381.494896" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p7bba25b3b1)">
+     <use xlink:href="#m2fe04c379a" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2fe04c379a" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m0627026e06" d="M 0 3.5 
+      <path id="mc0c3f25cb2" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m0627026e06" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mc0c3f25cb2" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m5f72f096ee" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m426bc01dfd" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#mcb16408f96" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mabee48d180" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m2188bf1e6a" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m147cecbcd9" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m0e25d0275f" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcd5d1e1b38" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m21e0424a38" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mc0492ac41b" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m72b9efb76f" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m034cfad974" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m3075b9660e" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2fe04c379a" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pc841ea4d8a)">
-     <use xlink:href="#m0627026e06" x="75.810937" y="275.288883" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="105.634056" y="291.180497" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="204.490635" y="326.637655" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="234.479899" y="326.337391" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="242.537956" y="324.707677" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="300.771958" y="316.120217" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="303.26414" y="335.825171" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="304.261013" y="356.217107" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="313.897453" y="337.414997" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="414.166268" y="357.220519" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="587.289889" y="362.147977" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m0627026e06" x="610.467187" y="343.279176" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p7bba25b3b1)">
+     <use xlink:href="#mc0c3f25cb2" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc0c3f25cb2" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -2892,8 +2892,8 @@ z
    </g>
   </g>
   <g id="text_24">
-   <!-- 2026-06-23T12:17:53Z  ·  Linux chungus x86_64  ·  commit ef1bb7eb  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(46.763359 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-05T23:02:37Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.687734 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2965,6 +2965,36 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -3000,19 +3030,19 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3032,128 +3062,129 @@ z
     <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
     <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
     <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3104.980469 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3168.603516 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3232.080078 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3295.556641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3359.179688 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3420.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3484.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3515.966797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3547.753906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.541016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3611.328125 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3643.115234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3670.898438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3732.421875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3793.701172 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3857.080078 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3920.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3959.419922 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4020.601562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4079.78125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4141.304688 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4182.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4216.109375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4243.892578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4305.416016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4366.695312 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4430.074219 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4493.697266 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4527.388672 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4586.568359 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4650.191406 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4681.978516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4745.601562 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4809.224609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4841.011719 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4904.634766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4940.71875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4979.582031 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5034.5625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5098.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5129.972656 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5161.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.546875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5225.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5257.121094 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5296.330078 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5359.708984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5398.572266 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5459.753906 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5523.132812 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5586.609375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5649.988281 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5713.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5776.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5816.052734 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5847.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5931.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5963.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6060.828125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6122.351562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6185.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6213.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6274.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6338.269531 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6370.056641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6422.15625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6485.535156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6546.814453 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6610.291016 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6662.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6725.769531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6786.951172 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6826.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6859.851562 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6891.638672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6932.751953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6994.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7033.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7061.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7122.205078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7153.992188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7181.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7233.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7265.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7329.138672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7390.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7429.871094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7491.394531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7530.757812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7628.169922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7655.953125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7719.332031 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7747.115234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7799.214844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7838.423828 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7866.207031 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2107.714844 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2139.501953 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2325.927734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2503.173828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.960938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2566.748047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2598.535156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2630.322266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2662.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2717.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2778.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2875.683594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc841ea4d8a">
+  <clipPath id="p7bba25b3b1">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -40,23 +40,23 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 290.571865 308.04375 
-L 290.571865 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 290.788615 308.04375 
+L 290.788615 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mb418e177b2" d="M 0 0 
+       <path id="mdea3005a9a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb418e177b2" x="290.571865" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdea3005a9a" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(281.771865 322.642188) scale(0.1 -0.1)">
+      <g transform="translate(281.988615 322.642188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -134,18 +134,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 446.931505 308.04375 
-L 446.931505 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 447.590599 308.04375 
+L 447.590599 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb418e177b2" x="446.931505" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdea3005a9a" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(438.131505 322.642188) scale(0.1 -0.1)">
+      <g transform="translate(438.790599 322.642188) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -175,246 +175,246 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 181.281168 308.04375 
-L 181.281168 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 181.188732 308.04375 
+L 181.188732 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m6ef4d3dad5" d="M 0 0 
+       <path id="m66a99e04d8" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="181.281168" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 208.814733 308.04375 
-L 208.814733 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 208.800191 308.04375 
+L 208.800191 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="208.814733" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 228.350109 308.04375 
-L 228.350109 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 228.390833 308.04375 
+L 228.390833 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="228.350109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 243.502924 308.04375 
-L 243.502924 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 243.586515 308.04375 
+L 243.586515 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="243.502924" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 255.883675 308.04375 
-L 255.883675 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 256.002291 308.04375 
+L 256.002291 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="255.883675" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 266.351451 308.04375 
-L 266.351451 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 266.499681 308.04375 
+L 266.499681 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="266.351451" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_17">
-      <path d="M 275.419051 308.04375 
-L 275.419051 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 275.592933 308.04375 
+L 275.592933 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="275.419051" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_19">
-      <path d="M 283.417241 308.04375 
-L 283.417241 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 283.61375 308.04375 
+L 283.61375 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="283.417241" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_21">
-      <path d="M 337.640807 308.04375 
-L 337.640807 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 337.990716 308.04375 
+L 337.990716 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="337.640807" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_23">
-      <path d="M 365.174373 308.04375 
-L 365.174373 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 365.602174 308.04375 
+L 365.602174 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="365.174373" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_25">
-      <path d="M 384.709748 308.04375 
-L 384.709748 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 385.192816 308.04375 
+L 385.192816 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="384.709748" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_27">
-      <path d="M 399.862563 308.04375 
-L 399.862563 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 400.388498 308.04375 
+L 400.388498 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="399.862563" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_15">
      <g id="line2d_29">
-      <path d="M 412.243314 308.04375 
-L 412.243314 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 412.804275 308.04375 
+L 412.804275 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="412.243314" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_16">
      <g id="line2d_31">
-      <path d="M 422.71109 308.04375 
-L 422.71109 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 423.301664 308.04375 
+L 423.301664 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="422.71109" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_17">
      <g id="line2d_33">
-      <path d="M 431.77869 308.04375 
-L 431.77869 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 432.394917 308.04375 
+L 432.394917 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="431.77869" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_18">
      <g id="line2d_35">
-      <path d="M 439.77688 308.04375 
-L 439.77688 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 440.415734 308.04375 
+L 440.415734 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="439.77688" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_19">
      <g id="line2d_37">
-      <path d="M 494.000446 308.04375 
-L 494.000446 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 494.792699 308.04375 
+L 494.792699 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="494.000446" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_20">
      <g id="line2d_39">
-      <path d="M 521.534012 308.04375 
-L 521.534012 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 522.404158 308.04375 
+L 522.404158 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="521.534012" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_21">
      <g id="line2d_41">
-      <path d="M 541.069388 308.04375 
-L 541.069388 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 541.9948 308.04375 
+L 541.9948 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="541.069388" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_22">
      <g id="line2d_43">
-      <path d="M 556.222202 308.04375 
-L 556.222202 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+      <path d="M 557.190482 308.04375 
+L 557.190482 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m6ef4d3dad5" x="556.222202" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m66a99e04d8" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m0268a8d3d8" d="M 0 0 
+       <path id="mf6026e9257" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0268a8d3d8" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6026e9257" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,68 +1062,12 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m0268a8d3d8" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6026e9257" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
-      <!-- Go compress/flate -->
-      <g transform="translate(50.390156 267.3976) scale(0.09 -0.09)">
-       <defs>
-        <path id="DejaVuSans-47" d="M 3809 666 
-L 3809 1919 
-L 2778 1919 
-L 2778 2438 
-L 4434 2438 
-L 4434 434 
-Q 4069 175 3628 42 
-Q 3188 -91 2688 -91 
-Q 1594 -91 976 548 
-Q 359 1188 359 2328 
-Q 359 3472 976 4111 
-Q 1594 4750 2688 4750 
-Q 3144 4750 3555 4637 
-Q 3966 4525 4313 4306 
-L 4313 3634 
-Q 3963 3931 3569 4081 
-Q 3175 4231 2741 4231 
-Q 1884 4231 1454 3753 
-Q 1025 3275 1025 2328 
-Q 1025 1384 1454 906 
-Q 1884 428 2741 428 
-Q 3075 428 3337 486 
-Q 3600 544 3809 666 
-z
-" transform="scale(0.015625)"/>
-       </defs>
-       <use xlink:href="#DejaVuSans-47"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(77.490234 0)"/>
-       <use xlink:href="#DejaVuSans-20" transform="translate(138.671875 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(170.458984 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(225.439453 0)"/>
-       <use xlink:href="#DejaVuSans-6d" transform="translate(286.621094 0)"/>
-       <use xlink:href="#DejaVuSans-70" transform="translate(384.033203 0)"/>
-       <use xlink:href="#DejaVuSans-72" transform="translate(447.509766 0)"/>
-       <use xlink:href="#DejaVuSans-65" transform="translate(486.373047 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(547.896484 0)"/>
-       <use xlink:href="#DejaVuSans-73" transform="translate(599.996094 0)"/>
-       <use xlink:href="#DejaVuSans-2f" transform="translate(652.095703 0)"/>
-       <use xlink:href="#DejaVuSans-66" transform="translate(685.787109 0)"/>
-       <use xlink:href="#DejaVuSans-6c" transform="translate(720.992188 0)"/>
-       <use xlink:href="#DejaVuSans-61" transform="translate(748.775391 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(810.054688 0)"/>
-       <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_3">
-     <g id="line2d_47">
-      <g>
-       <use xlink:href="#m0268a8d3d8" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_6">
       <!-- JS fflate -->
-      <g transform="translate(97.713281 234.756529) scale(0.09 -0.09)">
+      <g transform="translate(97.713281 267.3976) scale(0.09 -0.09)">
        <defs>
         <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1182,15 +1126,15 @@ z
       </g>
      </g>
     </g>
-    <g id="ytick_4">
-     <g id="line2d_48">
+    <g id="ytick_3">
+     <g id="line2d_47">
       <g>
-       <use xlink:href="#m0268a8d3d8" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6026e9257" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_7">
+     <g id="text_6">
       <!-- lean-zip (native)  ◄ subject -->
-      <g transform="translate(10.8 202.115458) scale(0.09 -0.09)">
+      <g transform="translate(10.8 234.756529) scale(0.09 -0.09)">
        <defs>
         <path id="DejaVuSans-2d" d="M 313 2009 
 L 1997 2009 
@@ -1295,10 +1239,66 @@ z
       </g>
      </g>
     </g>
+    <g id="ytick_4">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#mf6026e9257" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- Go compress/flate -->
+      <g transform="translate(50.390156 202.115458) scale(0.09 -0.09)">
+       <defs>
+        <path id="DejaVuSans-47" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-47"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(77.490234 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(138.671875 0)"/>
+       <use xlink:href="#DejaVuSans-63" transform="translate(170.458984 0)"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(225.439453 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(286.621094 0)"/>
+       <use xlink:href="#DejaVuSans-70" transform="translate(384.033203 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(447.509766 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(486.373047 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(547.896484 0)"/>
+       <use xlink:href="#DejaVuSans-73" transform="translate(599.996094 0)"/>
+       <use xlink:href="#DejaVuSans-2f" transform="translate(652.095703 0)"/>
+       <use xlink:href="#DejaVuSans-66" transform="translate(685.787109 0)"/>
+       <use xlink:href="#DejaVuSans-6c" transform="translate(720.992188 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(748.775391 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(810.054688 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(849.263672 0)"/>
+      </g>
+     </g>
+    </g>
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m0268a8d3d8" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6026e9257" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0268a8d3d8" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6026e9257" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m0268a8d3d8" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6026e9257" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m0268a8d3d8" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf6026e9257" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1430,48 +1430,48 @@ z
    </g>
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
-L 154.513283 296.619375 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 154.556151 296.619375 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
-L 167.187538 263.978304 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 162.32653 263.978304 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
-L 190.461899 231.337232 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 178.681331 231.337232 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
-L 208.409213 198.696161 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+L 201.044126 198.696161 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
-L 209.370107 166.055089 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 209.976983 166.055089 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
-L 238.951072 133.414018 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 239.121093 133.414018 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
-L 246.772854 100.772946 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 247.282543 100.772946 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
-L 285.62053 68.131875 
-" clip-path="url(#pf305676189)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+L 285.279501 68.131875 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
-    <path d="M 542.351473 308.04375 
-L 542.351473 56.7075 
-" clip-path="url(#pf305676189)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+    <path d="M 542.286834 308.04375 
+L 542.286834 56.7075 
+" clip-path="url(#p7f7272cb28)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1495,7 +1495,7 @@ L 565.2 56.7075
    </g>
    <g id="text_12">
     <!-- 135 -->
-    <g style="fill: #17becf" transform="translate(157.826435 298.964844) scale(0.085 -0.085)">
+    <g style="fill: #17becf" transform="translate(157.878675 298.964844) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666 
 L 3169 4666 
@@ -1529,48 +1529,8 @@ z
     </g>
    </g>
    <g id="text_13">
-    <!-- 163 -->
-    <g style="fill: #8c564b" transform="translate(170.500689 266.323772) scale(0.085 -0.085)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_14">
-    <!-- 229 -->
-    <g style="fill: #e377c2" transform="translate(193.775051 233.682701) scale(0.085 -0.085)">
+    <!-- 152 -->
+    <g style="fill: #e377c2" transform="translate(165.649054 266.323772) scale(0.085 -0.085)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
 L 3431 531 
@@ -1596,66 +1556,28 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
-   <g id="text_15">
-    <!-- 298 -->
-    <g style="fill: #d62728" transform="translate(211.722364 201.041629) scale(0.085 -0.085)">
+   <g id="text_14">
+    <!-- 193 -->
+    <g style="fill: #d62728" transform="translate(182.003855 233.682701) scale(0.085 -0.085)">
      <defs>
-      <path id="DejaVuSans-Bold-32" d="M 1844 884 
-L 3897 884 
-L 3897 0 
-L 506 0 
-L 506 884 
-L 2209 2388 
-Q 2438 2594 2547 2791 
-Q 2656 2988 2656 3200 
-Q 2656 3528 2436 3728 
-Q 2216 3928 1850 3928 
-Q 1569 3928 1234 3808 
-Q 900 3688 519 3450 
-L 519 4475 
-Q 925 4609 1322 4679 
-Q 1719 4750 2100 4750 
-Q 2938 4750 3402 4381 
-Q 3866 4013 3866 3353 
-Q 3866 2972 3669 2642 
-Q 3472 2313 2841 1759 
-L 1844 884 
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
@@ -1688,63 +1610,78 @@ Q 1491 2759 1650 2554
 Q 1809 2350 2125 2350 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
-z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(139.160156 0)"/>
     </g>
    </g>
-   <g id="text_16">
-    <!-- 302 -->
-    <g style="fill: #bcbd22" transform="translate(212.683258 168.400558) scale(0.085 -0.085)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
-    </g>
-   </g>
-   <g id="text_17">
-    <!-- 468 -->
-    <g style="fill: #1f77b4" transform="translate(242.264223 135.759487) scale(0.085 -0.085)">
+   <g id="text_15">
+    <!-- 268 -->
+    <g style="fill: #8c564b" transform="translate(204.36665 201.041629) scale(0.085 -0.085)">
      <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1785,30 +1722,78 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 305 -->
+    <g style="fill: #bcbd22" transform="translate(213.299507 168.400558) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 468 -->
+    <g style="fill: #1f77b4" transform="translate(242.443617 135.759487) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_18">
-    <!-- 525 -->
-    <g style="fill: #2ca02c" transform="translate(250.086005 103.118415) scale(0.085 -0.085)">
+    <!-- 528 -->
+    <g style="fill: #2ca02c" transform="translate(250.605067 103.118415) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_19">
-    <!-- 930 -->
-    <g style="fill: #9467bd" transform="translate(288.933681 70.477344) scale(0.085 -0.085)">
+    <!-- 922 -->
+    <g style="fill: #9467bd" transform="translate(288.602025 70.477344) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-39"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- memcpy ≈ 41 GB/s  -->
-    <g style="fill: #777777" transform="translate(540.687723 128.870982) rotate(-90) scale(0.08 -0.08)">
+    <!-- memcpy ≈ 40 GB/s  -->
+    <g style="fill: #777777" transform="translate(540.623084 128.870982) rotate(-90) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-79" d="M 2059 -325 
 Q 1816 -950 1584 -1140 
@@ -1879,7 +1864,7 @@ z
      <use xlink:href="#DejaVuSans-2248" transform="translate(465.771484 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(549.560547 0)"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(581.347656 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(644.970703 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(644.970703 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(708.59375 0)"/>
      <use xlink:href="#DejaVuSans-47" transform="translate(740.380859 0)"/>
      <use xlink:href="#DejaVuSans-42" transform="translate(817.871094 0)"/>
@@ -1890,7 +1875,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m113d0e3ab0" d="M 0 3 
+     <path id="ma42923418a" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1902,31 +1887,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#pf305676189)">
-     <use xlink:href="#m113d0e3ab0" x="154.513283" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p7f7272cb28)">
+     <use xlink:href="#ma42923418a" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m08e1977f97" d="M 0 3 
-C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
-C 2.683901 1.55874 3 0.795609 3 0 
-C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
-C 1.55874 -2.683901 0.795609 -3 0 -3 
-C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
-C -2.683901 -1.55874 -3 -0.795609 -3 0 
-C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
-C -1.55874 2.683901 -0.795609 3 0 3 
-z
-" style="stroke: #8c564b"/>
-    </defs>
-    <g clip-path="url(#pf305676189)">
-     <use xlink:href="#m08e1977f97" x="167.187538" y="263.978304" style="fill: #8c564b; stroke: #8c564b"/>
-    </g>
-   </g>
-   <g id="line2d_56">
-    <defs>
-     <path id="m6fb3c7aea6" d="M 0 3 
+     <path id="m38bd4fbc25" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1938,13 +1905,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#pf305676189)">
-     <use xlink:href="#m6fb3c7aea6" x="190.461899" y="231.337232" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p7f7272cb28)">
+     <use xlink:href="#m38bd4fbc25" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
-   <g id="line2d_57">
+   <g id="line2d_56">
     <defs>
-     <path id="maa97c94352" d="M 0 5 
+     <path id="m332b2c8996" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1956,13 +1923,31 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#pf305676189)">
-     <use xlink:href="#maa97c94352" x="208.409213" y="198.696161" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p7f7272cb28)">
+     <use xlink:href="#m332b2c8996" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
+    </g>
+   </g>
+   <g id="line2d_57">
+    <defs>
+     <path id="m3122648009" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #8c564b"/>
+    </defs>
+    <g clip-path="url(#p7f7272cb28)">
+     <use xlink:href="#m3122648009" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="mc509fcda8a" d="M 0 3 
+     <path id="m066882d5d8" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1974,13 +1959,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#pf305676189)">
-     <use xlink:href="#mc509fcda8a" x="209.370107" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p7f7272cb28)">
+     <use xlink:href="#m066882d5d8" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m541c20cb0c" d="M 0 3 
+     <path id="m44a3cc8dc9" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1992,13 +1977,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#pf305676189)">
-     <use xlink:href="#m541c20cb0c" x="238.951072" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p7f7272cb28)">
+     <use xlink:href="#m44a3cc8dc9" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m061a60f416" d="M 0 3 
+     <path id="m935ac39f9f" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2010,13 +1995,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#pf305676189)">
-     <use xlink:href="#m061a60f416" x="246.772854" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p7f7272cb28)">
+     <use xlink:href="#m935ac39f9f" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m10c10d014b" d="M 0 3 
+     <path id="m47aa7b27c6" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2028,8 +2013,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#pf305676189)">
-     <use xlink:href="#m10c10d014b" x="285.62053" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p7f7272cb28)">
+     <use xlink:href="#m47aa7b27c6" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2642,9 +2627,19 @@ z
    </g>
   </g>
   <g id="text_22">
-   <!-- 2026-06-23T12:17:53Z  ·  Linux chungus x86_64  ·  commit ef1bb7eb  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(10.763359 358.2) scale(0.07 -0.07)">
+   <!-- 2026-07-05T23:02:37Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(7.687734 358.2) scale(0.07 -0.07)">
     <defs>
+     <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
 L 3928 4134 
@@ -2667,16 +2662,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -2730,19 +2715,19 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(190.869141 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(254.492188 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(290.576172 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(354.199219 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(354.199219 0)"/>
     <use xlink:href="#DejaVuSans-2d" transform="translate(417.822266 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(453.90625 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(517.529297 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2762,128 +2747,129 @@ z
     <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
     <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
     <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-66" transform="translate(3069.775391 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3104.980469 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3168.603516 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3232.080078 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3295.556641 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3359.179688 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3420.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3484.179688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3515.966797 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3547.753906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3579.541016 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3611.328125 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3643.115234 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3670.898438 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3732.421875 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3793.701172 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3857.080078 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3920.556641 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3959.419922 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4020.601562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4079.78125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4141.304688 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4182.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4216.109375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4243.892578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4305.416016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4366.695312 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4430.074219 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4493.697266 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4527.388672 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4586.568359 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4650.191406 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4681.978516 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4745.601562 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4809.224609 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4841.011719 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4904.634766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4940.71875 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4979.582031 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5034.5625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5098.185547 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5129.972656 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5161.759766 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5193.546875 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5225.333984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5257.121094 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5296.330078 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5359.708984 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5398.572266 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5459.753906 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5523.132812 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5586.609375 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5649.988281 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5713.464844 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5776.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5816.052734 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5847.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5931.628906 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5963.416016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6060.828125 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6122.351562 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6185.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6213.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6274.890625 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6338.269531 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6370.056641 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6422.15625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6485.535156 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6546.814453 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6610.291016 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6662.390625 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6725.769531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6786.951172 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6826.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6859.851562 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6891.638672 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6932.751953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6994.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7033.240234 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7061.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7122.205078 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7153.992188 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7181.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7233.875 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7265.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7329.138672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7390.662109 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7429.871094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7491.394531 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7530.757812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7628.169922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7655.953125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7719.332031 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7747.115234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7799.214844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7838.423828 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7866.207031 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2107.714844 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2139.501953 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2325.927734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2503.173828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.960938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2566.748047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2598.535156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2630.322266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2662.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2717.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2778.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2875.683594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pf305676189">
+  <clipPath id="p7f7272cb28">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pe76aa6970d)">
+   <g clip-path="url(#p616e7aafef)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image16dcd41a37" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image5cdcf1868f" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m1bb7fa9a59" d="M 0 0 
+       <path id="m6c5602186a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m1bb7fa9a59" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6c5602186a" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m5648f6697d" d="M 0 0 
+       <path id="md4558f574d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5648f6697d" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4558f574d" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m5648f6697d" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4558f574d" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m5648f6697d" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4558f574d" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m5648f6697d" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4558f574d" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m5648f6697d" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4558f574d" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m5648f6697d" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4558f574d" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m5648f6697d" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4558f574d" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m5648f6697d" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md4558f574d" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image830fce5ab3" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imagee64091f619" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="me9160304c5" d="M 0 0 
+       <path id="m3efb680d58" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me9160304c5" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efb680d58" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#me9160304c5" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efb680d58" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#me9160304c5" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efb680d58" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me9160304c5" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efb680d58" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#me9160304c5" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3efb680d58" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-05T08:48:39Z  ·  Linux chungus x86_64  ·  commit 7e98994a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(45.762578 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.687734 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2751,45 +2751,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -2843,6 +2804,45 @@ M 1991 3584
 L 1991 3584 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3b" d="M 750 3309 
 L 1409 3309 
 L 1409 2516 
@@ -2870,14 +2870,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2897,128 +2897,129 @@ z
     <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
     <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
     <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.792969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.580078 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.367188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.941406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3761.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.314453 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.693359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3988.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.917969 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4211.03125 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4334.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.308594 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.6875 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4556.001953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.181641 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.804688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.591797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.214844 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.837891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.625 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.248047 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.332031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.195312 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.947266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.734375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.185547 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.367188 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.746094 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.601562 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.457031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.666016 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5992.029297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.441406 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.964844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.224609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.503906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.769531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.148438 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.427734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6691.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.382812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.564453 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.773438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.464844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.365234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.644531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.853516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.818359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.388672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.488281 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.484375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7520.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.371094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.566406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.945312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.728516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.828125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7867.037109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.820312 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2107.714844 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2139.501953 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2325.927734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2503.173828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.960938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2566.748047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2598.535156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2630.322266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2662.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2717.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2778.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2875.683594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pe76aa6970d">
+  <clipPath id="p616e7aafef">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="570.874844pt" height="386.202469pt" viewBox="0 0 570.874844 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.024531pt" height="386.202469pt" viewBox="0 0 575.024531 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 570.874844 386.202469 
-L 570.874844 0 
+L 575.024531 386.202469 
+L 575.024531 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 187.562422 104.1264 
-L 292.187422 104.1264 
-L 292.187422 74.7432 
-L 187.562422 74.7432 
+    <path d="M 189.637266 104.1264 
+L 294.262266 104.1264 
+L 294.262266 74.7432 
+L 189.637266 74.7432 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 292.187422 104.1264 
-L 396.812422 104.1264 
-L 396.812422 74.7432 
-L 292.187422 74.7432 
+    <path d="M 294.262266 104.1264 
+L 398.887266 104.1264 
+L 398.887266 74.7432 
+L 294.262266 74.7432 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 396.812422 104.1264 
-L 501.437422 104.1264 
-L 501.437422 74.7432 
-L 396.812422 74.7432 
+    <path d="M 398.887266 104.1264 
+L 503.512266 104.1264 
+L 503.512266 74.7432 
+L 398.887266 74.7432 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 187.562422 133.5096 
-L 292.187422 133.5096 
-L 292.187422 104.1264 
-L 187.562422 104.1264 
+    <path d="M 189.637266 133.5096 
+L 294.262266 133.5096 
+L 294.262266 104.1264 
+L 189.637266 104.1264 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 292.187422 133.5096 
-L 396.812422 133.5096 
-L 396.812422 104.1264 
-L 292.187422 104.1264 
+    <path d="M 294.262266 133.5096 
+L 398.887266 133.5096 
+L 398.887266 104.1264 
+L 294.262266 104.1264 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 396.812422 133.5096 
-L 501.437422 133.5096 
-L 501.437422 104.1264 
-L 396.812422 104.1264 
+    <path d="M 398.887266 133.5096 
+L 503.512266 133.5096 
+L 503.512266 104.1264 
+L 398.887266 104.1264 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 187.562422 162.8928 
-L 292.187422 162.8928 
-L 292.187422 133.5096 
-L 187.562422 133.5096 
+    <path d="M 189.637266 162.8928 
+L 294.262266 162.8928 
+L 294.262266 133.5096 
+L 189.637266 133.5096 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 292.187422 162.8928 
-L 396.812422 162.8928 
-L 396.812422 133.5096 
-L 292.187422 133.5096 
+    <path d="M 294.262266 162.8928 
+L 398.887266 162.8928 
+L 398.887266 133.5096 
+L 294.262266 133.5096 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #feeb9d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 396.812422 162.8928 
-L 501.437422 162.8928 
-L 501.437422 133.5096 
-L 396.812422 133.5096 
+    <path d="M 398.887266 162.8928 
+L 503.512266 162.8928 
+L 503.512266 133.5096 
+L 398.887266 133.5096 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 187.562422 192.276 
-L 292.187422 192.276 
-L 292.187422 162.8928 
-L 187.562422 162.8928 
+    <path d="M 189.637266 192.276 
+L 294.262266 192.276 
+L 294.262266 162.8928 
+L 189.637266 162.8928 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 292.187422 192.276 
-L 396.812422 192.276 
-L 396.812422 162.8928 
-L 292.187422 162.8928 
+    <path d="M 294.262266 192.276 
+L 398.887266 192.276 
+L 398.887266 162.8928 
+L 294.262266 162.8928 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 396.812422 192.276 
-L 501.437422 192.276 
-L 501.437422 162.8928 
-L 396.812422 162.8928 
+    <path d="M 398.887266 192.276 
+L 503.512266 192.276 
+L 503.512266 162.8928 
+L 398.887266 162.8928 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 187.562422 221.6592 
-L 292.187422 221.6592 
-L 292.187422 192.276 
-L 187.562422 192.276 
+    <path d="M 189.637266 221.6592 
+L 294.262266 221.6592 
+L 294.262266 192.276 
+L 189.637266 192.276 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 292.187422 221.6592 
-L 396.812422 221.6592 
-L 396.812422 192.276 
-L 292.187422 192.276 
+    <path d="M 294.262266 221.6592 
+L 398.887266 221.6592 
+L 398.887266 192.276 
+L 294.262266 192.276 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fed07e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 396.812422 221.6592 
-L 501.437422 221.6592 
-L 501.437422 192.276 
-L 396.812422 192.276 
+    <path d="M 398.887266 221.6592 
+L 503.512266 221.6592 
+L 503.512266 192.276 
+L 398.887266 192.276 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fffab6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 187.562422 251.0424 
-L 292.187422 251.0424 
-L 292.187422 221.6592 
-L 187.562422 221.6592 
+    <path d="M 189.637266 251.0424 
+L 294.262266 251.0424 
+L 294.262266 221.6592 
+L 189.637266 221.6592 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 292.187422 251.0424 
-L 396.812422 251.0424 
-L 396.812422 221.6592 
-L 292.187422 221.6592 
+    <path d="M 294.262266 251.0424 
+L 398.887266 251.0424 
+L 398.887266 221.6592 
+L 294.262266 221.6592 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 396.812422 251.0424 
-L 501.437422 251.0424 
-L 501.437422 221.6592 
-L 396.812422 221.6592 
+    <path d="M 398.887266 251.0424 
+L 503.512266 251.0424 
+L 503.512266 221.6592 
+L 398.887266 221.6592 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #ebf7a3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 187.562422 280.4256 
-L 292.187422 280.4256 
-L 292.187422 251.0424 
-L 187.562422 251.0424 
+    <path d="M 189.637266 280.4256 
+L 294.262266 280.4256 
+L 294.262266 251.0424 
+L 189.637266 251.0424 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 292.187422 280.4256 
-L 396.812422 280.4256 
-L 396.812422 251.0424 
-L 292.187422 251.0424 
+    <path d="M 294.262266 280.4256 
+L 398.887266 280.4256 
+L 398.887266 251.0424 
+L 294.262266 251.0424 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fcaa5f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fcaa5f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 396.812422 280.4256 
-L 501.437422 280.4256 
-L 501.437422 251.0424 
-L 396.812422 251.0424 
+    <path d="M 398.887266 280.4256 
+L 503.512266 280.4256 
+L 503.512266 251.0424 
+L 398.887266 251.0424 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 187.562422 309.8088 
-L 292.187422 309.8088 
-L 292.187422 280.4256 
-L 187.562422 280.4256 
+    <path d="M 189.637266 309.8088 
+L 294.262266 309.8088 
+L 294.262266 280.4256 
+L 189.637266 280.4256 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 292.187422 309.8088 
-L 396.812422 309.8088 
-L 396.812422 280.4256 
-L 292.187422 280.4256 
+    <path d="M 294.262266 309.8088 
+L 398.887266 309.8088 
+L 398.887266 280.4256 
+L 294.262266 280.4256 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 396.812422 309.8088 
-L 501.437422 309.8088 
-L 501.437422 280.4256 
-L 396.812422 280.4256 
+    <path d="M 398.887266 309.8088 
+L 503.512266 309.8088 
+L 503.512266 280.4256 
+L 398.887266 280.4256 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 187.562422 339.192 
-L 292.187422 339.192 
-L 292.187422 309.8088 
-L 187.562422 309.8088 
+    <path d="M 189.637266 339.192 
+L 294.262266 339.192 
+L 294.262266 309.8088 
+L 189.637266 309.8088 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 292.187422 339.192 
-L 396.812422 339.192 
-L 396.812422 309.8088 
-L 292.187422 309.8088 
+    <path d="M 294.262266 339.192 
+L 398.887266 339.192 
+L 398.887266 309.8088 
+L 294.262266 309.8088 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 396.812422 339.192 
-L 501.437422 339.192 
-L 501.437422 309.8088 
-L 396.812422 309.8088 
+    <path d="M 398.887266 339.192 
+L 503.512266 339.192 
+L 503.512266 309.8088 
+L 398.887266 309.8088 
 z
-" clip-path="url(#pb59757bbeb)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p17ec4c83de)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(120.549688 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.624531 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(227.833906 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.90875 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(306.406016 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.480859 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(404.757734 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.832578 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(116.487422 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.562266 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(228.423672 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(336.864922 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.939766 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -951,8 +951,8 @@ z
     </g>
    </g>
    <g id="text_8">
-    <!-- 878 -->
-    <g transform="translate(441.489922 91.6423) scale(0.08 -0.08)">
+    <!-- 852 -->
+    <g transform="translate(443.564766 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -993,15 +993,40 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-38"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(111.125547 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.200391 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1100,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(228.423672 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1131,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(339.409922 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.484766 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1169,16 +1194,16 @@ z
     </g>
    </g>
    <g id="text_12">
-    <!-- 311 -->
-    <g transform="translate(441.489922 121.0255) scale(0.08 -0.08)">
+    <!-- 312 -->
+    <g transform="translate(443.564766 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(98.818672 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(100.893516 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1349,34 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(228.423672 150.4087) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(230.498516 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1385,23 +1383,23 @@ z
     </g>
    </g>
    <g id="text_15">
-    <!-- 48 -->
-    <g transform="translate(339.409922 150.4087) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+    <!-- 50 -->
+    <g transform="translate(341.484766 150.4087) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
-    <!-- 180 -->
-    <g transform="translate(441.489922 150.4087) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-31"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+    <!-- 275 -->
+    <g transform="translate(443.564766 150.4087) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(119.851172 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(121.926016 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1461,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(228.423672 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1503,22 +1501,22 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(339.409922 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.484766 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
-    <!-- 205 -->
-    <g transform="translate(441.489922 179.7919) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+    <!-- 160 -->
+    <g transform="translate(443.564766 179.7919) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(128.388672 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(130.463516 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1542,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(228.423672 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1551,23 +1549,23 @@ z
     </g>
    </g>
    <g id="text_23">
-    <!-- 37 -->
-    <g transform="translate(339.409922 209.1751) scale(0.08 -0.08)">
+    <!-- 38 -->
+    <g transform="translate(341.484766 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
-    <!-- 451 -->
-    <g transform="translate(441.489922 209.1751) scale(0.08 -0.08)">
+    <!-- 448 -->
+    <g transform="translate(443.564766 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(111.694922 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(113.769766 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1626,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(228.423672 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1636,22 +1634,22 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(339.409922 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.484766 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- 532 -->
-    <g transform="translate(441.489922 238.5583) scale(0.08 -0.08)">
+    <!-- 527 -->
+    <g transform="translate(443.564766 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(98.196797 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.271641 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1760,7 +1758,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.325 -->
-    <g transform="translate(227.223047 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.297891 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1879,14 +1877,14 @@ z
    </g>
    <g id="text_31">
     <!-- 25 -->
-    <g transform="translate(338.933672 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(341.008516 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-35" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 179 -->
-    <g transform="translate(440.775547 267.9415) scale(0.08 -0.08)">
+    <!-- 178 -->
+    <g transform="translate(442.850391 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1912,45 +1910,54 @@ L 428 3781
 L 428 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
 z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(96.311797 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.386641 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2015,7 +2022,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(228.423672 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2024,22 +2031,22 @@ z
     </g>
    </g>
    <g id="text_35">
-    <!-- 20 -->
-    <g transform="translate(339.409922 297.3247) scale(0.08 -0.08)">
+    <!-- 21 -->
+    <g transform="translate(341.484766 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
-    <!-- 68 -->
-    <g transform="translate(444.034922 297.3247) scale(0.08 -0.08)">
+    <!-- 69 -->
+    <g transform="translate(446.109766 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(124.533047 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.607891 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2050,7 +2057,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(228.423672 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.498516 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2060,13 +2067,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(341.954922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.029766 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(445.124922 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.199766 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2082,7 +2089,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(152.039141 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(154.113984 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2226,7 +2233,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-05T08:48:39Z  ·  Linux chungus x86_64  ·  commit 7e98994a  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-05T22:33:53Z  ·  Linux chungus2 x86_64  ·  commit 9c93b270  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2367,14 +2374,14 @@ z
     <use xlink:href="#DejaVuSans-30" transform="translate(453.90625 0)"/>
     <use xlink:href="#DejaVuSans-35" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(642.236328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2394,129 +2401,130 @@ z
     <use xlink:href="#DejaVuSans-67" transform="translate(1865.136719 0)"/>
     <use xlink:href="#DejaVuSans-75" transform="translate(1928.613281 0)"/>
     <use xlink:href="#DejaVuSans-73" transform="translate(1991.992188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2044.091797 0)"/>
-    <use xlink:href="#DejaVuSans-78" transform="translate(2075.878906 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(2135.058594 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2198.681641 0)"/>
-    <use xlink:href="#DejaVuSans-5f" transform="translate(2262.304688 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(2312.304688 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(2375.927734 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2439.550781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2471.337891 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(2503.125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2534.912109 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2566.699219 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2598.486328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2653.466797 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2714.648438 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2812.060547 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2909.472656 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2937.255859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2976.464844 0)"/>
-    <use xlink:href="#DejaVuSans-37" transform="translate(3008.251953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3133.398438 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3197.021484 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3260.644531 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3324.267578 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3387.890625 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3451.513672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3512.792969 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3544.580078 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3576.367188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.154297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3639.941406 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3671.728516 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3699.511719 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3761.035156 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3822.314453 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3885.693359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3988.033203 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4049.214844 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4108.394531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4169.917969 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4211.03125 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4244.722656 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4272.505859 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4334.029297 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4395.308594 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4458.6875 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4522.310547 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4556.001953 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4615.181641 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4678.804688 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4710.591797 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4774.214844 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4837.837891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4869.625 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4933.248047 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4969.332031 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5008.195312 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5063.175781 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5126.798828 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5158.585938 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5190.373047 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.160156 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5253.947266 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5285.734375 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5324.943359 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5388.322266 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5427.185547 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5488.367188 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5551.746094 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5678.601562 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5805.457031 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5844.666016 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5876.453125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5960.242188 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(5992.029297 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6089.441406 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6150.964844 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6242.224609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6303.503906 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6366.882812 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6398.669922 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6450.769531 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6514.148438 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6575.427734 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6691.003906 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6754.382812 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6815.564453 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6854.773438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6888.464844 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6920.251953 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6961.365234 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7022.644531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7061.853516 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7089.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7150.818359 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7182.605469 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7210.388672 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7262.488281 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7294.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7419.275391 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7458.484375 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7520.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7559.371094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7656.783203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7684.566406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7747.945312 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7775.728516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7827.828125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7867.037109 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7894.820312 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2044.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2107.714844 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(2139.501953 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(2198.681641 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2262.304688 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(2325.927734 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(2375.927734 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(2439.550781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2503.173828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2534.960938 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(2566.748047 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2598.535156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2630.322266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2662.109375 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2717.089844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2778.271484 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(2875.683594 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3190.478516 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3254.101562 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3317.724609 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3381.201172 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3444.824219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3508.447266 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3572.070312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3603.857422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3635.644531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3667.431641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3699.21875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3731.005859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3758.789062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3820.3125 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3881.591797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3944.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4008.447266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4047.310547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4108.492188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4167.671875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4229.195312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4270.308594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4304 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4331.783203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4393.306641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4454.585938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4517.964844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4581.587891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4615.279297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4674.458984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4738.082031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4769.869141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4833.492188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4897.115234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4928.902344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4992.525391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5028.609375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5067.472656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5122.453125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5186.076172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5217.863281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5249.650391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5281.4375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5313.224609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5345.011719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5384.220703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5447.599609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5486.462891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5547.644531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5611.023438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5674.5 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5737.878906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5801.355469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5864.734375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5903.943359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5935.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6019.519531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6051.306641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6148.71875 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6210.242188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6273.71875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6301.501953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6362.78125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6426.160156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6457.947266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6510.046875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6573.425781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6634.705078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6698.181641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6750.28125 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6813.660156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6874.841797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6914.050781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6947.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6979.529297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7020.642578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7081.921875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7121.130859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7148.914062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7210.095703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7241.882812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7269.666016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7321.765625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7353.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7417.029297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7478.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7517.761719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7579.285156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7618.648438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7716.060547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7743.84375 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7807.222656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7835.005859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7887.105469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7926.314453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7954.097656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb59757bbeb">
-   <rect x="82.937422" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p17ec4c83de">
+   <rect x="85.012266" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/archive/decode_density.chungus.ef1bb7eb.json
+++ b/bench/results/archive/decode_density.chungus.ef1bb7eb.json
@@ -1,8 +1,8 @@
 {
 "meta": {
-"date": "2026-07-05T23:02:37Z",
-"machine": "Linux chungus2 x86_64",
-"git_commit": "9c93b270",
+"date": "2026-06-23T12:17:53Z",
+"machine": "Linux chungus x86_64",
+"git_commit": "ef1bb7eb",
 "toolchain": "leanprover/lean4:v4.30.0-rc2",
 "experiment": "decode-density: fixed libdeflate input, ratio = libdeflate compression ratio, decompress_mbps = each decoder on identical streams; compressor field holds the decoder name"
 },
@@ -15,7 +15,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 118.97
+"decompress_mbps": 204.24
 },
 {
 "compressor": "zlib",
@@ -25,7 +25,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 384.45
+"decompress_mbps": 382.54
 },
 {
 "compressor": "miniz_oxide",
@@ -35,7 +35,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 452.1
+"decompress_mbps": 449.95
 },
 {
 "compressor": "libdeflate",
@@ -45,7 +45,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 775.35
+"decompress_mbps": 767.74
 },
 {
 "compressor": "memcpy",
@@ -55,7 +55,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 33944.96
+"decompress_mbps": 42235.98
 },
 {
 "compressor": "native",
@@ -65,7 +65,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 141.59
+"decompress_mbps": 259.32
 },
 {
 "compressor": "zlib",
@@ -75,7 +75,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 387.94
+"decompress_mbps": 387.31
 },
 {
 "compressor": "miniz_oxide",
@@ -85,7 +85,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 487.03
+"decompress_mbps": 487.66
 },
 {
 "compressor": "libdeflate",
@@ -95,7 +95,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 864.76
+"decompress_mbps": 858.04
 },
 {
 "compressor": "memcpy",
@@ -105,7 +105,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 35667.72
+"decompress_mbps": 38921.26
 },
 {
 "compressor": "native",
@@ -115,7 +115,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 150.21
+"decompress_mbps": 256.89
 },
 {
 "compressor": "zlib",
@@ -125,7 +125,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 378.06
+"decompress_mbps": 376.66
 },
 {
 "compressor": "miniz_oxide",
@@ -135,7 +135,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 467.61
+"decompress_mbps": 464.49
 },
 {
 "compressor": "libdeflate",
@@ -145,7 +145,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 811.85
+"decompress_mbps": 833.17
 },
 {
 "compressor": "memcpy",
@@ -155,7 +155,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 43688.59
+"decompress_mbps": 55659.24
 },
 {
 "compressor": "native",
@@ -165,7 +165,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 153.31
+"decompress_mbps": 248.6
 },
 {
 "compressor": "zlib",
@@ -175,7 +175,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 373.29
+"decompress_mbps": 374.64
 },
 {
 "compressor": "miniz_oxide",
@@ -185,7 +185,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 442.12
+"decompress_mbps": 443.04
 },
 {
 "compressor": "libdeflate",
@@ -195,7 +195,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 747.7
+"decompress_mbps": 745.64
 },
 {
 "compressor": "memcpy",
@@ -205,7 +205,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 47953.99
+"decompress_mbps": 56190.78
 },
 {
 "compressor": "native",
@@ -215,7 +215,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 152.48
+"decompress_mbps": 268.09
 },
 {
 "compressor": "zlib",
@@ -225,7 +225,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 422.62
+"decompress_mbps": 423.54
 },
 {
 "compressor": "miniz_oxide",
@@ -235,7 +235,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 499.35
+"decompress_mbps": 497.6
 },
 {
 "compressor": "libdeflate",
@@ -245,7 +245,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 906.76
+"decompress_mbps": 931.67
 },
 {
 "compressor": "memcpy",
@@ -255,7 +255,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 43066.47
+"decompress_mbps": 53661.66
 },
 {
 "compressor": "native",
@@ -265,7 +265,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 161.14
+"decompress_mbps": 231.16
 },
 {
 "compressor": "zlib",
@@ -275,7 +275,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 376.08
+"decompress_mbps": 376.68
 },
 {
 "compressor": "miniz_oxide",
@@ -285,7 +285,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 425.11
+"decompress_mbps": 415.57
 },
 {
 "compressor": "libdeflate",
@@ -295,7 +295,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 736.05
+"decompress_mbps": 739.87
 },
 {
 "compressor": "memcpy",
@@ -305,7 +305,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 20164.15
+"decompress_mbps": 20265.09
 },
 {
 "compressor": "native",
@@ -315,7 +315,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 126.49
+"decompress_mbps": 172.24
 },
 {
 "compressor": "zlib",
@@ -325,7 +325,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 372.0
+"decompress_mbps": 371.78
 },
 {
 "compressor": "miniz_oxide",
@@ -335,7 +335,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 390.61
+"decompress_mbps": 381.77
 },
 {
 "compressor": "libdeflate",
@@ -345,7 +345,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 721.99
+"decompress_mbps": 721.45
 },
 {
 "compressor": "memcpy",
@@ -355,7 +355,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 19245.67
+"decompress_mbps": 20027.02
 },
 {
 "compressor": "native",
@@ -365,7 +365,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 135.79
+"decompress_mbps": 181.32
 },
 {
 "compressor": "zlib",
@@ -375,7 +375,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 376.49
+"decompress_mbps": 370.67
 },
 {
 "compressor": "miniz_oxide",
@@ -385,7 +385,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 405.75
+"decompress_mbps": 402.19
 },
 {
 "compressor": "libdeflate",
@@ -395,7 +395,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 750.64
+"decompress_mbps": 743.51
 },
 {
 "compressor": "memcpy",
@@ -405,7 +405,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 19744.6
+"decompress_mbps": 19761.22
 },
 {
 "compressor": "native",
@@ -415,7 +415,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 139.42
+"decompress_mbps": 184.02
 },
 {
 "compressor": "zlib",
@@ -425,7 +425,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 381.58
+"decompress_mbps": 381.69
 },
 {
 "compressor": "miniz_oxide",
@@ -435,7 +435,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 409.84
+"decompress_mbps": 405.76
 },
 {
 "compressor": "libdeflate",
@@ -445,7 +445,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 760.07
+"decompress_mbps": 761.61
 },
 {
 "compressor": "memcpy",
@@ -455,7 +455,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 19731.02
+"decompress_mbps": 19680.37
 },
 {
 "compressor": "native",
@@ -465,7 +465,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 125.9
+"decompress_mbps": 165.14
 },
 {
 "compressor": "zlib",
@@ -474,1568 +474,1568 @@
 "level": 12,
 "out_size": 18241312,
 "ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 380.98
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 397.0
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 742.04
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 19790.26
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 137.25
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 445.75
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 537.11
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 846.26
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 41043.32
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 145.95
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 453.49
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 535.77
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 889.89
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 55821.06
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 159.91
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 445.91
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 533.61
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 912.36
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 57953.9
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 163.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 452.28
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 521.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 904.02
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 36113.45
-},
-{
-"compressor": "native",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 154.79
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 484.53
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 521.27
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 902.55
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 36437.83
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 379.2
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 874.36
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 857.94
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 1783.26
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 19092.03
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 441.16
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 950.96
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 923.7
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 1832.92
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 20578.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 550.93
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 1050.51
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 1064.27
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 1891.98
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 19343.07
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 628.5
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 1112.33
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 1123.8
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 1961.55
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 20130.69
-},
-{
-"compressor": "native",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 582.9
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 1126.1
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 1119.9
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 1939.26
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 19807.23
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 126.85
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 284.13
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 361.41
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 581.81
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 49702.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 112.07
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 277.11
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 321.72
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 552.65
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 63123.33
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 119.23
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 280.48
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 331.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 572.84
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 63056.17
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 123.03
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 282.99
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 339.66
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 583.56
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 60259.72
-},
-{
-"compressor": "native",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 112.06
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 275.89
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 315.31
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 562.11
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 62337.97
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 189.81
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 516.11
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 622.32
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 1047.11
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 53913.91
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 225.46
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 541.29
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 624.18
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 1101.24
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 55576.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 248.35
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 548.67
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 671.03
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 1126.28
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 53055.94
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 251.11
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 547.87
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 670.97
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 1117.62
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 44988.74
-},
-{
-"compressor": "native",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 243.51
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 551.4
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 668.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 1111.85
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 56859.78
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 141.14
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 430.56
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 534.47
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 1010.71
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 62527.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 178.69
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 464.35
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 580.89
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 1172.57
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 62743.89
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 195.42
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 466.06
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 548.78
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 1073.69
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 60651.53
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 208.83
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 454.78
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 522.68
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 987.45
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 62563.77
-},
-{
-"compressor": "native",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 201.14
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 533.82
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 586.07
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 1176.93
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 62150.95
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 218.77
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 558.92
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 587.4
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 1086.9
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 18952.59
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 206.89
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 570.72
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 595.75
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 1143.07
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 18575.65
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 224.52
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 524.34
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 531.67
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 1119.76
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 19690.08
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 234.48
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 526.09
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 534.08
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 1069.59
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 25135.82
-},
-{
-"compressor": "native",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 199.74
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 544.7
-},
-{
-"compressor": "miniz_oxide",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 524.15
-},
-{
-"compressor": "libdeflate",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 1079.34
-},
-{
-"compressor": "memcpy",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 18171.25
-},
-{
-"compressor": "native",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 129.24
-},
-{
-"compressor": "zlib",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
 "compress_mbps": null,
 "decompress_mbps": 376.41
 },
 {
 "compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 393.85
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 735.17
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 20273.0
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 222.32
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 445.13
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 537.27
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 851.42
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 40981.23
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 247.37
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 454.69
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 536.67
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 889.43
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 42545.91
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 264.57
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 444.96
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 531.51
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 916.74
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 51670.82
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 261.55
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 450.3
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 522.24
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 917.08
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 34641.48
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 251.12
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 488.01
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 520.82
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 928.8
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 58014.01
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 564.73
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 891.82
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 827.9
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 1717.89
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 19642.75
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 658.84
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 938.2
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 919.4
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 1852.77
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 17659.0
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 812.23
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 1042.08
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 1065.88
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 1908.97
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 20564.38
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 930.67
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 1113.67
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 1123.44
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 1959.08
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 19744.11
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 822.63
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 1118.37
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 1112.17
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 1954.68
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 19335.13
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 182.67
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 285.08
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 362.1
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 585.32
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 61746.22
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 166.44
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 278.6
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 321.58
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 561.1
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 62370.44
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 177.98
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 283.0
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 332.9
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 582.81
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 62132.01
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 182.84
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 281.67
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 335.8
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 575.55
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 61101.9
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 165.82
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 274.07
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 313.7
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 560.73
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 62697.69
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 274.36
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 510.55
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 615.8
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 995.67
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 56484.8
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 372.81
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 533.58
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 609.65
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 1092.22
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 44212.02
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 381.16
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 550.32
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 669.68
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 1101.95
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 57396.22
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 397.3
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 541.17
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 673.33
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 1118.96
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 54022.62
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 386.93
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 551.68
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 666.7
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 1115.79
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 57852.6
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 241.16
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 420.09
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 531.09
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 1027.28
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 62694.1
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 313.92
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 463.97
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 580.0
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 1197.68
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 64049.3
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 315.42
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 467.51
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 543.79
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 1108.66
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 62988.39
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 332.16
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 450.59
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 519.86
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 1011.98
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 62793.76
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 318.92
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 532.71
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 582.44
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 1170.41
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 62526.64
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 330.34
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 554.95
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 581.55
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 1078.64
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 19383.9
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 288.8
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 569.1
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 592.6
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 1116.99
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 19571.21
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 313.67
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 517.19
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 517.61
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 1110.52
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 18501.21
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 328.0
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 525.98
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 530.32
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 1069.97
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 19155.78
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 269.38
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 534.98
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 510.05
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 1104.29
+},
+{
+"compressor": "memcpy",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 18137.52
+},
+{
+"compressor": "native",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 1,
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 392.2
+"decompress_mbps": 193.03
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 372.28
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 392.4
 },
 {
 "compressor": "libdeflate",
@@ -2045,7 +2045,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 581.05
+"decompress_mbps": 570.81
 },
 {
 "compressor": "memcpy",
@@ -2055,7 +2055,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 54864.45
+"decompress_mbps": 58562.46
 },
 {
 "compressor": "native",
@@ -2065,7 +2065,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 137.46
+"decompress_mbps": 225.66
 },
 {
 "compressor": "zlib",
@@ -2075,7 +2075,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 377.0
+"decompress_mbps": 377.49
 },
 {
 "compressor": "miniz_oxide",
@@ -2085,7 +2085,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 389.27
+"decompress_mbps": 387.68
 },
 {
 "compressor": "libdeflate",
@@ -2095,7 +2095,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 578.18
+"decompress_mbps": 573.32
 },
 {
 "compressor": "memcpy",
@@ -2105,7 +2105,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 61774.2
+"decompress_mbps": 61675.04
 },
 {
 "compressor": "native",
@@ -2115,7 +2115,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 145.82
+"decompress_mbps": 230.44
 },
 {
 "compressor": "zlib",
@@ -2125,7 +2125,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 374.09
+"decompress_mbps": 375.29
 },
 {
 "compressor": "miniz_oxide",
@@ -2135,7 +2135,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 383.08
+"decompress_mbps": 381.74
 },
 {
 "compressor": "libdeflate",
@@ -2145,7 +2145,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 565.94
+"decompress_mbps": 567.38
 },
 {
 "compressor": "memcpy",
@@ -2155,7 +2155,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 61647.56
+"decompress_mbps": 61713.57
 },
 {
 "compressor": "native",
@@ -2165,7 +2165,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 146.7
+"decompress_mbps": 225.57
 },
 {
 "compressor": "zlib",
@@ -2175,7 +2175,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 377.02
+"decompress_mbps": 378.2
 },
 {
 "compressor": "miniz_oxide",
@@ -2185,7 +2185,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 382.94
+"decompress_mbps": 381.43
 },
 {
 "compressor": "libdeflate",
@@ -2195,7 +2195,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 567.86
+"decompress_mbps": 566.08
 },
 {
 "compressor": "memcpy",
@@ -2205,7 +2205,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 62040.75
+"decompress_mbps": 62219.36
 },
 {
 "compressor": "native",
@@ -2215,7 +2215,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 143.69
+"decompress_mbps": 232.07
 },
 {
 "compressor": "zlib",
@@ -2225,7 +2225,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 378.32
+"decompress_mbps": 379.39
 },
 {
 "compressor": "miniz_oxide",
@@ -2235,7 +2235,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 390.8
+"decompress_mbps": 387.8
 },
 {
 "compressor": "libdeflate",
@@ -2245,7 +2245,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 585.62
+"decompress_mbps": 585.49
 },
 {
 "compressor": "memcpy",
@@ -2255,7 +2255,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 61979.04
+"decompress_mbps": 62062.46
 },
 {
 "compressor": "native",
@@ -2265,7 +2265,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 157.72
+"decompress_mbps": 255.23
 },
 {
 "compressor": "zlib",
@@ -2275,7 +2275,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 387.87
+"decompress_mbps": 380.34
 },
 {
 "compressor": "miniz_oxide",
@@ -2285,7 +2285,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 436.93
+"decompress_mbps": 425.1
 },
 {
 "compressor": "libdeflate",
@@ -2295,7 +2295,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 841.6
+"decompress_mbps": 846.46
 },
 {
 "compressor": "memcpy",
@@ -2305,7 +2305,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 19682.67
+"decompress_mbps": 19846.03
 },
 {
 "compressor": "native",
@@ -2315,7 +2315,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 185.53
+"decompress_mbps": 315.39
 },
 {
 "compressor": "zlib",
@@ -2325,7 +2325,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 398.22
+"decompress_mbps": 394.0
 },
 {
 "compressor": "miniz_oxide",
@@ -2335,7 +2335,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 465.01
+"decompress_mbps": 454.36
 },
 {
 "compressor": "libdeflate",
@@ -2345,7 +2345,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 910.81
+"decompress_mbps": 908.27
 },
 {
 "compressor": "memcpy",
@@ -2355,7 +2355,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 19359.91
+"decompress_mbps": 20374.74
 },
 {
 "compressor": "native",
@@ -2365,7 +2365,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 198.18
+"decompress_mbps": 325.09
 },
 {
 "compressor": "zlib",
@@ -2375,7 +2375,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 400.72
+"decompress_mbps": 396.61
 },
 {
 "compressor": "miniz_oxide",
@@ -2385,7 +2385,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 471.3
+"decompress_mbps": 463.24
 },
 {
 "compressor": "libdeflate",
@@ -2395,7 +2395,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 872.52
+"decompress_mbps": 886.52
 },
 {
 "compressor": "memcpy",
@@ -2405,7 +2405,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 19408.74
+"decompress_mbps": 19707.64
 },
 {
 "compressor": "native",
@@ -2415,7 +2415,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 204.78
+"decompress_mbps": 324.83
 },
 {
 "compressor": "zlib",
@@ -2425,7 +2425,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 401.49
+"decompress_mbps": 401.42
 },
 {
 "compressor": "miniz_oxide",
@@ -2435,7 +2435,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 465.21
+"decompress_mbps": 463.97
 },
 {
 "compressor": "libdeflate",
@@ -2445,7 +2445,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 841.53
+"decompress_mbps": 848.54
 },
 {
 "compressor": "memcpy",
@@ -2455,7 +2455,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 19613.54
+"decompress_mbps": 20102.62
 },
 {
 "compressor": "native",
@@ -2465,7 +2465,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 201.58
+"decompress_mbps": 327.98
 },
 {
 "compressor": "zlib",
@@ -2475,7 +2475,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 420.5
+"decompress_mbps": 419.17
 },
 {
 "compressor": "miniz_oxide",
@@ -2485,7 +2485,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 485.62
+"decompress_mbps": 475.86
 },
 {
 "compressor": "libdeflate",
@@ -2495,7 +2495,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 886.23
+"decompress_mbps": 902.81
 },
 {
 "compressor": "memcpy",
@@ -2505,7 +2505,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 19508.19
+"decompress_mbps": 19760.71
 },
 {
 "compressor": "native",
@@ -2515,7 +2515,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 139.21
+"decompress_mbps": 188.47
 },
 {
 "compressor": "zlib",
@@ -2525,7 +2525,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 328.26
+"decompress_mbps": 329.18
 },
 {
 "compressor": "miniz_oxide",
@@ -2535,7 +2535,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 351.89
+"decompress_mbps": 352.79
 },
 {
 "compressor": "libdeflate",
@@ -2545,7 +2545,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 507.33
+"decompress_mbps": 504.56
 },
 {
 "compressor": "memcpy",
@@ -2555,7 +2555,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 42407.41
+"decompress_mbps": 59304.96
 },
 {
 "compressor": "native",
@@ -2565,7 +2565,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 93.93
+"decompress_mbps": 154.41
 },
 {
 "compressor": "zlib",
@@ -2575,7 +2575,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 274.68
+"decompress_mbps": 277.99
 },
 {
 "compressor": "miniz_oxide",
@@ -2585,7 +2585,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 293.49
+"decompress_mbps": 292.78
 },
 {
 "compressor": "libdeflate",
@@ -2595,7 +2595,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 467.2
+"decompress_mbps": 470.59
 },
 {
 "compressor": "memcpy",
@@ -2605,7 +2605,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 60064.85
+"decompress_mbps": 58017.51
 },
 {
 "compressor": "native",
@@ -2615,7 +2615,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 96.96
+"decompress_mbps": 162.45
 },
 {
 "compressor": "zlib",
@@ -2625,7 +2625,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 316.46
+"decompress_mbps": 320.1
 },
 {
 "compressor": "miniz_oxide",
@@ -2635,7 +2635,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 311.96
+"decompress_mbps": 312.58
 },
 {
 "compressor": "libdeflate",
@@ -2645,7 +2645,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 519.37
+"decompress_mbps": 524.69
 },
 {
 "compressor": "memcpy",
@@ -2655,7 +2655,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 58898.68
+"decompress_mbps": 55799.12
 },
 {
 "compressor": "native",
@@ -2665,7 +2665,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 98.57
+"decompress_mbps": 162.19
 },
 {
 "compressor": "zlib",
@@ -2675,7 +2675,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 311.05
+"decompress_mbps": 309.65
 },
 {
 "compressor": "miniz_oxide",
@@ -2685,7 +2685,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 303.89
+"decompress_mbps": 304.42
 },
 {
 "compressor": "libdeflate",
@@ -2695,7 +2695,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 507.18
+"decompress_mbps": 510.9
 },
 {
 "compressor": "memcpy",
@@ -2705,7 +2705,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 37749.44
+"decompress_mbps": 59304.96
 },
 {
 "compressor": "native",
@@ -2715,7 +2715,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 90.01
+"decompress_mbps": 162.53
 },
 {
 "compressor": "zlib",
@@ -2725,7 +2725,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 297.0
+"decompress_mbps": 299.43
 },
 {
 "compressor": "miniz_oxide",
@@ -2735,7 +2735,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 323.41
+"decompress_mbps": 320.21
 },
 {
 "compressor": "libdeflate",
@@ -2745,7 +2745,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 563.85
+"decompress_mbps": 566.77
 },
 {
 "compressor": "memcpy",
@@ -2755,7 +2755,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 47628.58
+"decompress_mbps": 52533.27
 },
 {
 "compressor": "native",
@@ -2765,7 +2765,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 272.32
+"decompress_mbps": 411.45
 },
 {
 "compressor": "zlib",
@@ -2775,7 +2775,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 757.67
+"decompress_mbps": 758.55
 },
 {
 "compressor": "miniz_oxide",
@@ -2785,7 +2785,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 903.86
+"decompress_mbps": 910.65
 },
 {
 "compressor": "libdeflate",
@@ -2795,7 +2795,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 1656.23
+"decompress_mbps": 1683.73
 },
 {
 "compressor": "memcpy",
@@ -2805,7 +2805,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 64455.5
+"decompress_mbps": 63011.82
 },
 {
 "compressor": "native",
@@ -2815,7 +2815,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 345.08
+"decompress_mbps": 542.35
 },
 {
 "compressor": "zlib",
@@ -2825,7 +2825,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 848.53
+"decompress_mbps": 851.93
 },
 {
 "compressor": "miniz_oxide",
@@ -2835,7 +2835,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 1067.3
+"decompress_mbps": 1070.63
 },
 {
 "compressor": "libdeflate",
@@ -2845,7 +2845,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 1811.22
+"decompress_mbps": 1828.79
 },
 {
 "compressor": "memcpy",
@@ -2855,7 +2855,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 64949.88
+"decompress_mbps": 61727.67
 },
 {
 "compressor": "native",
@@ -2865,7 +2865,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 402.52
+"decompress_mbps": 605.06
 },
 {
 "compressor": "zlib",
@@ -2875,7 +2875,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 934.41
+"decompress_mbps": 940.34
 },
 {
 "compressor": "miniz_oxide",
@@ -2885,7 +2885,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 1187.45
+"decompress_mbps": 1185.27
 },
 {
 "compressor": "libdeflate",
@@ -2895,7 +2895,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 1810.06
+"decompress_mbps": 1842.72
 },
 {
 "compressor": "memcpy",
@@ -2905,7 +2905,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 64874.66
+"decompress_mbps": 63841.2
 },
 {
 "compressor": "native",
@@ -2915,7 +2915,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 430.31
+"decompress_mbps": 634.45
 },
 {
 "compressor": "zlib",
@@ -2925,7 +2925,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 978.15
+"decompress_mbps": 983.03
 },
 {
 "compressor": "miniz_oxide",
@@ -2935,7 +2935,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 1208.02
+"decompress_mbps": 1211.91
 },
 {
 "compressor": "libdeflate",
@@ -2945,7 +2945,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 1808.3
+"decompress_mbps": 1820.26
 },
 {
 "compressor": "memcpy",
@@ -2955,7 +2955,7 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 64529.74
+"decompress_mbps": 64018.39
 },
 {
 "compressor": "native",
@@ -2965,7 +2965,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 403.04
+"decompress_mbps": 588.69
 },
 {
 "compressor": "zlib",
@@ -2975,7 +2975,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 1002.47
+"decompress_mbps": 1014.66
 },
 {
 "compressor": "miniz_oxide",
@@ -2985,7 +2985,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 1206.09
+"decompress_mbps": 1213.71
 },
 {
 "compressor": "libdeflate",
@@ -2995,7 +2995,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 1861.15
+"decompress_mbps": 1902.22
 },
 {
 "compressor": "memcpy",
@@ -3005,7 +3005,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 52967.06
+"decompress_mbps": 63697.61
 },
 {
 "compressor": "go",
@@ -3015,7 +3015,7 @@
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 193.18
+"decompress_mbps": 116.76
 },
 {
 "compressor": "go",
@@ -3025,7 +3025,7 @@
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 222.38
+"decompress_mbps": 130.32
 },
 {
 "compressor": "go",
@@ -3035,7 +3035,7 @@
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 211.53
+"decompress_mbps": 120.09
 },
 {
 "compressor": "go",
@@ -3045,7 +3045,7 @@
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 207.41
+"decompress_mbps": 121.35
 },
 {
 "compressor": "go",
@@ -3055,7 +3055,7 @@
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 206.33
+"decompress_mbps": 123.81
 },
 {
 "compressor": "go",
@@ -3065,7 +3065,7 @@
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 238.5
+"decompress_mbps": 210.86
 },
 {
 "compressor": "go",
@@ -3075,7 +3075,7 @@
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 231.85
+"decompress_mbps": 199.51
 },
 {
 "compressor": "go",
@@ -3085,7 +3085,7 @@
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 227.07
+"decompress_mbps": 229.6
 },
 {
 "compressor": "go",
@@ -3095,7 +3095,7 @@
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 232.67
+"decompress_mbps": 235.89
 },
 {
 "compressor": "go",
@@ -3105,7 +3105,7 @@
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 237.74
+"decompress_mbps": 207
 },
 {
 "compressor": "go",
@@ -3115,7 +3115,7 @@
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 234.99
+"decompress_mbps": 162.39
 },
 {
 "compressor": "go",
@@ -3125,7 +3125,7 @@
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 239
+"decompress_mbps": 125.38
 },
 {
 "compressor": "go",
@@ -3135,7 +3135,7 @@
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 228.73
+"decompress_mbps": 158.12
 },
 {
 "compressor": "go",
@@ -3145,7 +3145,7 @@
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 233.28
+"decompress_mbps": 110.44
 },
 {
 "compressor": "go",
@@ -3155,7 +3155,7 @@
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 232.5
+"decompress_mbps": 125.5
 },
 {
 "compressor": "go",
@@ -3165,7 +3165,7 @@
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 558.1
+"decompress_mbps": 311.19
 },
 {
 "compressor": "go",
@@ -3175,7 +3175,7 @@
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 806.01
+"decompress_mbps": 362.99
 },
 {
 "compressor": "go",
@@ -3185,7 +3185,7 @@
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 589.23
+"decompress_mbps": 297.04
 },
 {
 "compressor": "go",
@@ -3195,7 +3195,7 @@
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 681.12
+"decompress_mbps": 355.69
 },
 {
 "compressor": "go",
@@ -3205,7 +3205,7 @@
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 806.12
+"decompress_mbps": 372.41
 },
 {
 "compressor": "go",
@@ -3215,7 +3215,7 @@
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 169.98
+"decompress_mbps": 88.34
 },
 {
 "compressor": "go",
@@ -3225,7 +3225,7 @@
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 162.31
+"decompress_mbps": 81.88
 },
 {
 "compressor": "go",
@@ -3235,7 +3235,7 @@
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 160.56
+"decompress_mbps": 100.91
 },
 {
 "compressor": "go",
@@ -3245,7 +3245,7 @@
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 167.99
+"decompress_mbps": 86.45
 },
 {
 "compressor": "go",
@@ -3255,7 +3255,7 @@
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 170.43
+"decompress_mbps": 114.31
 },
 {
 "compressor": "go",
@@ -3265,7 +3265,7 @@
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 256.05
+"decompress_mbps": 174.29
 },
 {
 "compressor": "go",
@@ -3275,7 +3275,7 @@
 "out_size": 3608138,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 274.68
+"decompress_mbps": 128.11
 },
 {
 "compressor": "go",
@@ -3285,7 +3285,7 @@
 "out_size": 3818964,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 272.57
+"decompress_mbps": 248.74
 },
 {
 "compressor": "go",
@@ -3295,7 +3295,7 @@
 "out_size": 3660266,
 "ratio": 0.3629,
 "compress_mbps": null,
-"decompress_mbps": 269.24
+"decompress_mbps": 159.17
 },
 {
 "compressor": "go",
@@ -3305,7 +3305,7 @@
 "out_size": 3654860,
 "ratio": 0.3624,
 "compress_mbps": null,
-"decompress_mbps": 271.4
+"decompress_mbps": 185.33
 },
 {
 "compressor": "go",
@@ -3315,7 +3315,7 @@
 "out_size": 2197055,
 "ratio": 0.3315,
 "compress_mbps": null,
-"decompress_mbps": 228.21
+"decompress_mbps": 188.4
 },
 {
 "compressor": "go",
@@ -3325,7 +3325,7 @@
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 284.67
+"decompress_mbps": 119.7
 },
 {
 "compressor": "go",
@@ -3335,7 +3335,7 @@
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 259.33
+"decompress_mbps": 166.27
 },
 {
 "compressor": "go",
@@ -3345,7 +3345,7 @@
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 278.68
+"decompress_mbps": 140.36
 },
 {
 "compressor": "go",
@@ -3355,7 +3355,7 @@
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 260.47
+"decompress_mbps": 183.48
 },
 {
 "compressor": "go",
@@ -3365,7 +3365,7 @@
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 306.44
+"decompress_mbps": 174.16
 },
 {
 "compressor": "go",
@@ -3375,7 +3375,7 @@
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 329.17
+"decompress_mbps": 198.63
 },
 {
 "compressor": "go",
@@ -3385,7 +3385,7 @@
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 321.14
+"decompress_mbps": 204.14
 },
 {
 "compressor": "go",
@@ -3395,7 +3395,7 @@
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 326.57
+"decompress_mbps": 212.71
 },
 {
 "compressor": "go",
@@ -3405,7 +3405,7 @@
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 333.52
+"decompress_mbps": 218.21
 },
 {
 "compressor": "go",
@@ -3415,7 +3415,7 @@
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 184.18
+"decompress_mbps": 96.63
 },
 {
 "compressor": "go",
@@ -3425,7 +3425,7 @@
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 187.33
+"decompress_mbps": 95.22
 },
 {
 "compressor": "go",
@@ -3435,7 +3435,7 @@
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 187.33
+"decompress_mbps": 128.54
 },
 {
 "compressor": "go",
@@ -3445,7 +3445,7 @@
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 189.57
+"decompress_mbps": 125.49
 },
 {
 "compressor": "go",
@@ -3455,7 +3455,7 @@
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 190.6
+"decompress_mbps": 138
 },
 {
 "compressor": "go",
@@ -3465,7 +3465,7 @@
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 230.55
+"decompress_mbps": 211.39
 },
 {
 "compressor": "go",
@@ -3475,7 +3475,7 @@
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 261.07
+"decompress_mbps": 239.53
 },
 {
 "compressor": "go",
@@ -3485,7 +3485,7 @@
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 239.46
+"decompress_mbps": 202.77
 },
 {
 "compressor": "go",
@@ -3495,7 +3495,7 @@
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 250.32
+"decompress_mbps": 206.63
 },
 {
 "compressor": "go",
@@ -3505,7 +3505,7 @@
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 253.35
+"decompress_mbps": 232.88
 },
 {
 "compressor": "go",
@@ -3515,7 +3515,7 @@
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 173.81
+"decompress_mbps": 120.88
 },
 {
 "compressor": "go",
@@ -3525,7 +3525,7 @@
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 143.3
+"decompress_mbps": 87.42
 },
 {
 "compressor": "go",
@@ -3535,7 +3535,7 @@
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 142.12
+"decompress_mbps": 113.24
 },
 {
 "compressor": "go",
@@ -3545,7 +3545,7 @@
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 153.91
+"decompress_mbps": 126.88
 },
 {
 "compressor": "go",
@@ -3555,7 +3555,7 @@
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 151.08
+"decompress_mbps": 91.54
 },
 {
 "compressor": "go",
@@ -3565,7 +3565,7 @@
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 447.02
+"decompress_mbps": 214.69
 },
 {
 "compressor": "go",
@@ -3575,7 +3575,7 @@
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 614.33
+"decompress_mbps": 486.33
 },
 {
 "compressor": "go",
@@ -3585,7 +3585,7 @@
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 514.94
+"decompress_mbps": 185.31
 },
 {
 "compressor": "go",
@@ -3595,7 +3595,7 @@
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 587.73
+"decompress_mbps": 223.32
 },
 {
 "compressor": "go",
@@ -3605,1807 +3605,1807 @@
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 616.6
+"decompress_mbps": 512.78
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 1,
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 234.26
+"decompress_mbps": 173.01
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 12,
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 294.85
+"decompress_mbps": 196.78
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 3,
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 276.87
+"decompress_mbps": 190.31
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 6,
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 276.67
+"decompress_mbps": 201.31
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 9,
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 266.23
+"decompress_mbps": 181.75
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 1,
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 237.96
+"decompress_mbps": 193.6
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 12,
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 218.61
+"decompress_mbps": 200.82
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 3,
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 220.09
+"decompress_mbps": 202.09
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 6,
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 229.54
+"decompress_mbps": 207.69
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 9,
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 232.43
+"decompress_mbps": 212.88
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 1,
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 236.21
+"decompress_mbps": 243.78
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 12,
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 271.12
+"decompress_mbps": 228.87
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 3,
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 261.49
+"decompress_mbps": 231.68
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 6,
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 272.52
+"decompress_mbps": 230.49
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 9,
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 271.77
+"decompress_mbps": 185.47
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 1,
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 687.46
+"decompress_mbps": 349.6
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 12,
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 858.5
+"decompress_mbps": 432.34
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 3,
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 754.55
+"decompress_mbps": 349.44
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 6,
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 855.42
+"decompress_mbps": 354.47
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 9,
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 915.03
+"decompress_mbps": 375.37
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 1,
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 177.18
+"decompress_mbps": 163.93
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 12,
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 182.73
+"decompress_mbps": 158.74
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 3,
 "out_size": 3137061,
 "ratio": 0.5099,
 "compress_mbps": null,
-"decompress_mbps": 178.19
+"decompress_mbps": 170.14
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 6,
 "out_size": 3072378,
 "ratio": 0.4994,
 "compress_mbps": null,
-"decompress_mbps": 186.41
+"decompress_mbps": 181.32
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 9,
 "out_size": 3066968,
 "ratio": 0.4985,
 "compress_mbps": null,
-"decompress_mbps": 189.24
+"decompress_mbps": 163.84
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 1,
 "out_size": 3868663,
 "ratio": 0.3836,
 "compress_mbps": null,
-"decompress_mbps": 255.54
+"decompress_mbps": 249.15
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 12,
 "out_size": 3608138,
 "ratio": 0.3577,
 "compress_mbps": null,
-"decompress_mbps": 293.57
+"decompress_mbps": 284.75
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 3,
 "out_size": 3818964,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 287.69
+"decompress_mbps": 291.91
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 6,
 "out_size": 3660266,
 "ratio": 0.3629,
 "compress_mbps": null,
-"decompress_mbps": 290.93
+"decompress_mbps": 291.92
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/osdb",
 "size": 10085684,
 "level": 9,
 "out_size": 3654860,
 "ratio": 0.3624,
 "compress_mbps": null,
-"decompress_mbps": 291.06
+"decompress_mbps": 257.61
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 1,
 "out_size": 2197055,
 "ratio": 0.3315,
 "compress_mbps": null,
-"decompress_mbps": 290.11
+"decompress_mbps": 196.69
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 12,
 "out_size": 1696488,
 "ratio": 0.256,
 "compress_mbps": null,
-"decompress_mbps": 379.91
+"decompress_mbps": 239.57
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 3,
 "out_size": 2021047,
 "ratio": 0.305,
 "compress_mbps": null,
-"decompress_mbps": 356.83
+"decompress_mbps": 238.99
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 6,
 "out_size": 1876257,
 "ratio": 0.2831,
 "compress_mbps": null,
-"decompress_mbps": 361.58
+"decompress_mbps": 223.54
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/reymont",
 "size": 6627202,
 "level": 9,
 "out_size": 1806374,
 "ratio": 0.2726,
 "compress_mbps": null,
-"decompress_mbps": 352.8
+"decompress_mbps": 219.06
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 1,
 "out_size": 5866517,
 "ratio": 0.2715,
 "compress_mbps": null,
-"decompress_mbps": 354.81
+"decompress_mbps": 280.88
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 12,
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 336.21
+"decompress_mbps": 277.95
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 3,
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 345.18
+"decompress_mbps": 268.23
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 6,
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 366.7
+"decompress_mbps": 275.11
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 9,
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 371.81
+"decompress_mbps": 279.11
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 1,
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 159.73
+"decompress_mbps": 158.99
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 12,
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 177.11
+"decompress_mbps": 167.41
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 3,
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 173.27
+"decompress_mbps": 192.88
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 6,
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 174.67
+"decompress_mbps": 167.82
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 9,
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 175.68
+"decompress_mbps": 154.85
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 1,
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 276.68
+"decompress_mbps": 198.22
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 12,
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 335.81
+"decompress_mbps": 231.22
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 3,
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 323.61
+"decompress_mbps": 219.01
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 6,
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 329.08
+"decompress_mbps": 207.38
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 9,
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 327.84
+"decompress_mbps": 228.08
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 1,
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 151.36
+"decompress_mbps": 153.44
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 12,
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 150.35
+"decompress_mbps": 180.45
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 3,
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 144.89
+"decompress_mbps": 164.5
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 6,
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 158.82
+"decompress_mbps": 147.27
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 9,
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 156.89
+"decompress_mbps": 174.41
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 1,
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 516.23
+"decompress_mbps": 294.25
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 12,
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 678.15
+"decompress_mbps": 275.84
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 3,
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 614.14
+"decompress_mbps": 298.7
 },
 {
-"compressor": "zig",
+"compressor": "js",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 6,
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 672.85
+"decompress_mbps": 364.03
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 363.7
 },
 {
 "compressor": "zig",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 690.32
-},
-{
-"compressor": "ocaml",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 1,
 "out_size": 4217525,
 "ratio": 0.4138,
 "compress_mbps": null,
-"decompress_mbps": 106.82
+"decompress_mbps": 235.05
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 12,
 "out_size": 3679105,
 "ratio": 0.361,
 "compress_mbps": null,
-"decompress_mbps": 120.03
+"decompress_mbps": 291.29
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 3,
 "out_size": 3989875,
 "ratio": 0.3915,
 "compress_mbps": null,
-"decompress_mbps": 114.3
+"decompress_mbps": 278.91
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 6,
 "out_size": 3859436,
 "ratio": 0.3787,
 "compress_mbps": null,
-"decompress_mbps": 112.83
+"decompress_mbps": 274.55
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/dickens",
 "size": 10192446,
 "level": 9,
 "out_size": 3810354,
 "ratio": 0.3738,
 "compress_mbps": null,
-"decompress_mbps": 112.94
+"decompress_mbps": 265.71
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 1,
 "out_size": 20192961,
 "ratio": 0.3942,
 "compress_mbps": null,
-"decompress_mbps": 124.08
+"decompress_mbps": 235.63
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 12,
 "out_size": 18241312,
 "ratio": 0.3561,
 "compress_mbps": null,
-"decompress_mbps": 115.12
+"decompress_mbps": 219.12
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 3,
 "out_size": 19234937,
 "ratio": 0.3755,
 "compress_mbps": null,
-"decompress_mbps": 114.37
+"decompress_mbps": 218.46
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 6,
 "out_size": 18805391,
 "ratio": 0.3671,
 "compress_mbps": null,
-"decompress_mbps": 121.38
+"decompress_mbps": 228.23
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/mozilla",
 "size": 51220480,
 "level": 9,
 "out_size": 18713659,
 "ratio": 0.3654,
 "compress_mbps": null,
-"decompress_mbps": 122.55
+"decompress_mbps": 230.37
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 1,
 "out_size": 3740775,
 "ratio": 0.3752,
 "compress_mbps": null,
-"decompress_mbps": 138.35
+"decompress_mbps": 235.42
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 12,
 "out_size": 3447985,
 "ratio": 0.3458,
 "compress_mbps": null,
-"decompress_mbps": 130.3
+"decompress_mbps": 269.72
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 3,
 "out_size": 3672389,
 "ratio": 0.3683,
 "compress_mbps": null,
-"decompress_mbps": 134.64
+"decompress_mbps": 259.96
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 6,
 "out_size": 3648644,
 "ratio": 0.3659,
 "compress_mbps": null,
-"decompress_mbps": 134.95
+"decompress_mbps": 270.49
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/mr",
 "size": 9970564,
 "level": 9,
 "out_size": 3625176,
 "ratio": 0.3636,
 "compress_mbps": null,
-"decompress_mbps": 133.84
+"decompress_mbps": 267.14
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 1,
 "out_size": 3837577,
 "ratio": 0.1144,
 "compress_mbps": null,
-"decompress_mbps": 206.85
+"decompress_mbps": 688.3
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 12,
 "out_size": 2748273,
 "ratio": 0.0819,
 "compress_mbps": null,
-"decompress_mbps": 234.61
+"decompress_mbps": 858.89
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 3,
 "out_size": 3599455,
 "ratio": 0.1073,
 "compress_mbps": null,
-"decompress_mbps": 222.8
+"decompress_mbps": 755.66
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 6,
 "out_size": 3091741,
 "ratio": 0.0921,
 "compress_mbps": null,
-"decompress_mbps": 234.12
+"decompress_mbps": 849.42
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/nci",
 "size": 33553445,
 "level": 9,
 "out_size": 2925243,
 "ratio": 0.0872,
 "compress_mbps": null,
-"decompress_mbps": 229.17
+"decompress_mbps": 910.91
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 1,
 "out_size": 3275124,
 "ratio": 0.5324,
 "compress_mbps": null,
-"decompress_mbps": 107.3
+"decompress_mbps": 176.61
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 12,
 "out_size": 2994086,
 "ratio": 0.4867,
 "compress_mbps": null,
-"decompress_mbps": 97.22
+"decompress_mbps": 182.47
 },
 {
-"compressor": "ocaml",
+"compressor": "zig",
 "pattern": "silesia/ooffice",
 "size": 6152192,
 "level": 3,
 "out_size": 3137061,
 "ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 97.87
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 101.7
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 103.58
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 148.86
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 151.28
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 149.38
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 151.82
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 152.33
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 126.98
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 149.99
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 135.97
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 136.74
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 139.34
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
-"compress_mbps": null,
-"decompress_mbps": 156.49
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 12,
-"out_size": 5118130,
-"ratio": 0.2369,
-"compress_mbps": null,
-"decompress_mbps": 154.0
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 3,
-"out_size": 5605878,
-"ratio": 0.2595,
-"compress_mbps": null,
-"decompress_mbps": 153.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 6,
-"out_size": 5337149,
-"ratio": 0.247,
-"compress_mbps": null,
-"decompress_mbps": 156.34
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 9,
-"out_size": 5270405,
-"ratio": 0.2439,
-"compress_mbps": null,
-"decompress_mbps": 157.59
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 1,
-"out_size": 5575128,
-"ratio": 0.7688,
-"compress_mbps": null,
-"decompress_mbps": 108.51
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 12,
-"out_size": 5250745,
-"ratio": 0.724,
-"compress_mbps": null,
-"decompress_mbps": 111.52
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 3,
-"out_size": 5397999,
-"ratio": 0.7444,
-"compress_mbps": null,
-"decompress_mbps": 112.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 6,
-"out_size": 5335405,
-"ratio": 0.7357,
-"compress_mbps": null,
-"decompress_mbps": 111.12
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/sao",
-"size": 7251944,
-"level": 9,
-"out_size": 5323197,
-"ratio": 0.734,
-"compress_mbps": null,
-"decompress_mbps": 115.55
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 1,
-"out_size": 13550569,
-"ratio": 0.3268,
-"compress_mbps": null,
-"decompress_mbps": 116.36
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 12,
-"out_size": 11520871,
-"ratio": 0.2779,
-"compress_mbps": null,
-"decompress_mbps": 127.08
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 3,
-"out_size": 12839361,
-"ratio": 0.3097,
-"compress_mbps": null,
-"decompress_mbps": 124.53
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 6,
-"out_size": 12140474,
-"ratio": 0.2928,
-"compress_mbps": null,
-"decompress_mbps": 123.71
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/webster",
-"size": 41458703,
-"level": 9,
-"out_size": 11882496,
-"ratio": 0.2866,
-"compress_mbps": null,
-"decompress_mbps": 129.14
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 1,
-"out_size": 6293390,
-"ratio": 0.7426,
-"compress_mbps": null,
-"decompress_mbps": 107.47
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 12,
-"out_size": 5747146,
-"ratio": 0.6782,
-"compress_mbps": null,
-"decompress_mbps": 92.71
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 3,
-"out_size": 6058381,
-"ratio": 0.7149,
-"compress_mbps": null,
-"decompress_mbps": 90.59
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 6,
-"out_size": 5998438,
-"ratio": 0.7078,
-"compress_mbps": null,
-"decompress_mbps": 92.32
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/x-ray",
-"size": 8474240,
-"level": 9,
-"out_size": 5986859,
-"ratio": 0.7065,
-"compress_mbps": null,
-"decompress_mbps": 94.47
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 1,
-"out_size": 887708,
-"ratio": 0.1661,
-"compress_mbps": null,
-"decompress_mbps": 190.84
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 12,
-"out_size": 629349,
-"ratio": 0.1177,
-"compress_mbps": null,
-"decompress_mbps": 217.91
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 3,
-"out_size": 793388,
-"ratio": 0.1484,
-"compress_mbps": null,
-"decompress_mbps": 205.95
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 6,
-"out_size": 684405,
-"ratio": 0.128,
-"compress_mbps": null,
-"decompress_mbps": 206.96
-},
-{
-"compressor": "ocaml",
-"pattern": "silesia/xml",
-"size": 5345280,
-"level": 9,
-"out_size": 649494,
-"ratio": 0.1215,
-"compress_mbps": null,
-"decompress_mbps": 209.58
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 1,
-"out_size": 4217525,
-"ratio": 0.4138,
-"compress_mbps": null,
-"decompress_mbps": 111.17
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 12,
-"out_size": 3679105,
-"ratio": 0.361,
-"compress_mbps": null,
-"decompress_mbps": 129.5
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 3,
-"out_size": 3989875,
-"ratio": 0.3915,
-"compress_mbps": null,
-"decompress_mbps": 136.08
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 6,
-"out_size": 3859436,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 127.38
-},
-{
-"compressor": "js",
-"pattern": "silesia/dickens",
-"size": 10192446,
-"level": 9,
-"out_size": 3810354,
-"ratio": 0.3738,
-"compress_mbps": null,
-"decompress_mbps": 119.02
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 1,
-"out_size": 20192961,
-"ratio": 0.3942,
-"compress_mbps": null,
-"decompress_mbps": 160.99
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 12,
-"out_size": 18241312,
-"ratio": 0.3561,
-"compress_mbps": null,
-"decompress_mbps": 171.52
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 3,
-"out_size": 19234937,
-"ratio": 0.3755,
-"compress_mbps": null,
-"decompress_mbps": 166.26
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 6,
-"out_size": 18805391,
-"ratio": 0.3671,
-"compress_mbps": null,
-"decompress_mbps": 159.97
-},
-{
-"compressor": "js",
-"pattern": "silesia/mozilla",
-"size": 51220480,
-"level": 9,
-"out_size": 18713659,
-"ratio": 0.3654,
-"compress_mbps": null,
-"decompress_mbps": 162.96
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 1,
-"out_size": 3740775,
-"ratio": 0.3752,
-"compress_mbps": null,
-"decompress_mbps": 144.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 12,
-"out_size": 3447985,
-"ratio": 0.3458,
-"compress_mbps": null,
-"decompress_mbps": 144.41
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 3,
-"out_size": 3672389,
-"ratio": 0.3683,
-"compress_mbps": null,
-"decompress_mbps": 145.09
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 6,
-"out_size": 3648644,
-"ratio": 0.3659,
-"compress_mbps": null,
-"decompress_mbps": 137
-},
-{
-"compressor": "js",
-"pattern": "silesia/mr",
-"size": 9970564,
-"level": 9,
-"out_size": 3625176,
-"ratio": 0.3636,
-"compress_mbps": null,
-"decompress_mbps": 137.5
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 1,
-"out_size": 3837577,
-"ratio": 0.1144,
-"compress_mbps": null,
-"decompress_mbps": 269.98
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 12,
-"out_size": 2748273,
-"ratio": 0.0819,
-"compress_mbps": null,
-"decompress_mbps": 295.47
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 3,
-"out_size": 3599455,
-"ratio": 0.1073,
-"compress_mbps": null,
-"decompress_mbps": 290.76
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 6,
-"out_size": 3091741,
-"ratio": 0.0921,
-"compress_mbps": null,
-"decompress_mbps": 315.99
-},
-{
-"compressor": "js",
-"pattern": "silesia/nci",
-"size": 33553445,
-"level": 9,
-"out_size": 2925243,
-"ratio": 0.0872,
-"compress_mbps": null,
-"decompress_mbps": 265.51
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 1,
-"out_size": 3275124,
-"ratio": 0.5324,
-"compress_mbps": null,
-"decompress_mbps": 103.42
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 12,
-"out_size": 2994086,
-"ratio": 0.4867,
-"compress_mbps": null,
-"decompress_mbps": 99.06
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 3,
-"out_size": 3137061,
-"ratio": 0.5099,
-"compress_mbps": null,
-"decompress_mbps": 110.36
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 6,
-"out_size": 3072378,
-"ratio": 0.4994,
-"compress_mbps": null,
-"decompress_mbps": 110.93
-},
-{
-"compressor": "js",
-"pattern": "silesia/ooffice",
-"size": 6152192,
-"level": 9,
-"out_size": 3066968,
-"ratio": 0.4985,
-"compress_mbps": null,
-"decompress_mbps": 102.94
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 1,
-"out_size": 3868663,
-"ratio": 0.3836,
-"compress_mbps": null,
-"decompress_mbps": 150.39
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 12,
-"out_size": 3608138,
-"ratio": 0.3577,
-"compress_mbps": null,
-"decompress_mbps": 173
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 3,
-"out_size": 3818964,
-"ratio": 0.3787,
-"compress_mbps": null,
-"decompress_mbps": 160.76
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 6,
-"out_size": 3660266,
-"ratio": 0.3629,
-"compress_mbps": null,
-"decompress_mbps": 163.1
-},
-{
-"compressor": "js",
-"pattern": "silesia/osdb",
-"size": 10085684,
-"level": 9,
-"out_size": 3654860,
-"ratio": 0.3624,
-"compress_mbps": null,
-"decompress_mbps": 152.96
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 1,
-"out_size": 2197055,
-"ratio": 0.3315,
-"compress_mbps": null,
-"decompress_mbps": 157.19
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 12,
-"out_size": 1696488,
-"ratio": 0.256,
-"compress_mbps": null,
-"decompress_mbps": 144
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 3,
-"out_size": 2021047,
-"ratio": 0.305,
-"compress_mbps": null,
-"decompress_mbps": 150.15
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 6,
-"out_size": 1876257,
-"ratio": 0.2831,
-"compress_mbps": null,
-"decompress_mbps": 145.39
-},
-{
-"compressor": "js",
-"pattern": "silesia/reymont",
-"size": 6627202,
-"level": 9,
-"out_size": 1806374,
-"ratio": 0.2726,
-"compress_mbps": null,
-"decompress_mbps": 147.68
-},
-{
-"compressor": "js",
-"pattern": "silesia/samba",
-"size": 21606400,
-"level": 1,
-"out_size": 5866517,
-"ratio": 0.2715,
 "compress_mbps": null,
 "decompress_mbps": 178.06
 },
 {
-"compressor": "js",
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 185.82
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 188.17
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 254.87
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 291.68
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 286.58
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 288.03
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 287.08
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 286.87
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 380.57
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 356.68
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 360.43
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 349.13
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 353.59
+},
+{
+"compressor": "zig",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 12,
 "out_size": 5118130,
 "ratio": 0.2369,
 "compress_mbps": null,
-"decompress_mbps": 171.2
+"decompress_mbps": 335.01
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 3,
 "out_size": 5605878,
 "ratio": 0.2595,
 "compress_mbps": null,
-"decompress_mbps": 198.78
+"decompress_mbps": 344.31
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 6,
 "out_size": 5337149,
 "ratio": 0.247,
 "compress_mbps": null,
-"decompress_mbps": 165.37
+"decompress_mbps": 363.73
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/samba",
 "size": 21606400,
 "level": 9,
 "out_size": 5270405,
 "ratio": 0.2439,
 "compress_mbps": null,
-"decompress_mbps": 175.33
+"decompress_mbps": 371.44
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 1,
 "out_size": 5575128,
 "ratio": 0.7688,
 "compress_mbps": null,
-"decompress_mbps": 100.52
+"decompress_mbps": 161.03
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 12,
 "out_size": 5250745,
 "ratio": 0.724,
 "compress_mbps": null,
-"decompress_mbps": 104.46
+"decompress_mbps": 176.46
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 3,
 "out_size": 5397999,
 "ratio": 0.7444,
 "compress_mbps": null,
-"decompress_mbps": 110.52
+"decompress_mbps": 172.43
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 6,
 "out_size": 5335405,
 "ratio": 0.7357,
 "compress_mbps": null,
-"decompress_mbps": 101.31
+"decompress_mbps": 174.14
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/sao",
 "size": 7251944,
 "level": 9,
 "out_size": 5323197,
 "ratio": 0.734,
 "compress_mbps": null,
-"decompress_mbps": 110.4
+"decompress_mbps": 176.47
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 1,
 "out_size": 13550569,
 "ratio": 0.3268,
 "compress_mbps": null,
-"decompress_mbps": 141.85
+"decompress_mbps": 278.56
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 12,
 "out_size": 11520871,
 "ratio": 0.2779,
 "compress_mbps": null,
-"decompress_mbps": 160.25
+"decompress_mbps": 332.71
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 3,
 "out_size": 12839361,
 "ratio": 0.3097,
 "compress_mbps": null,
-"decompress_mbps": 151.06
+"decompress_mbps": 315.34
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 6,
 "out_size": 12140474,
 "ratio": 0.2928,
 "compress_mbps": null,
-"decompress_mbps": 154.25
+"decompress_mbps": 321.78
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/webster",
 "size": 41458703,
 "level": 9,
 "out_size": 11882496,
 "ratio": 0.2866,
 "compress_mbps": null,
-"decompress_mbps": 155.8
+"decompress_mbps": 316.15
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 1,
 "out_size": 6293390,
 "ratio": 0.7426,
 "compress_mbps": null,
-"decompress_mbps": 108.07
+"decompress_mbps": 152.42
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 12,
 "out_size": 5747146,
 "ratio": 0.6782,
 "compress_mbps": null,
-"decompress_mbps": 108.74
+"decompress_mbps": 148.7
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 3,
 "out_size": 6058381,
 "ratio": 0.7149,
 "compress_mbps": null,
-"decompress_mbps": 105.2
+"decompress_mbps": 143.29
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 6,
 "out_size": 5998438,
 "ratio": 0.7078,
 "compress_mbps": null,
-"decompress_mbps": 99.13
+"decompress_mbps": 157.44
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/x-ray",
 "size": 8474240,
 "level": 9,
 "out_size": 5986859,
 "ratio": 0.7065,
 "compress_mbps": null,
-"decompress_mbps": 107.79
+"decompress_mbps": 155.86
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 1,
 "out_size": 887708,
 "ratio": 0.1661,
 "compress_mbps": null,
-"decompress_mbps": 175.86
+"decompress_mbps": 509.98
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 12,
 "out_size": 629349,
 "ratio": 0.1177,
 "compress_mbps": null,
-"decompress_mbps": 264.72
+"decompress_mbps": 677.44
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 3,
 "out_size": 793388,
 "ratio": 0.1484,
 "compress_mbps": null,
-"decompress_mbps": 233.44
+"decompress_mbps": 593.38
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 6,
 "out_size": 684405,
 "ratio": 0.128,
 "compress_mbps": null,
-"decompress_mbps": 248.16
+"decompress_mbps": 657.82
 },
 {
-"compressor": "js",
+"compressor": "zig",
 "pattern": "silesia/xml",
 "size": 5345280,
 "level": 9,
 "out_size": 649494,
 "ratio": 0.1215,
 "compress_mbps": null,
-"decompress_mbps": 254.37
+"decompress_mbps": 683.0
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": null,
+"decompress_mbps": 105.12
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": null,
+"decompress_mbps": 119.28
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": null,
+"decompress_mbps": 111.08
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 112.28
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": null,
+"decompress_mbps": 114.32
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": null,
+"decompress_mbps": 122.88
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": null,
+"decompress_mbps": 117.89
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": null,
+"decompress_mbps": 114.02
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": null,
+"decompress_mbps": 117.09
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": null,
+"decompress_mbps": 121.92
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": null,
+"decompress_mbps": 136.42
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": null,
+"decompress_mbps": 129.55
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": null,
+"decompress_mbps": 132.33
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": null,
+"decompress_mbps": 135.55
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": null,
+"decompress_mbps": 137.76
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": null,
+"decompress_mbps": 202.7
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": null,
+"decompress_mbps": 224.79
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": null,
+"decompress_mbps": 211.34
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": null,
+"decompress_mbps": 226.36
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": null,
+"decompress_mbps": 228.14
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": null,
+"decompress_mbps": 103.62
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": null,
+"decompress_mbps": 94.63
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": null,
+"decompress_mbps": 98.59
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": null,
+"decompress_mbps": 98.79
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": null,
+"decompress_mbps": 102.16
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": null,
+"decompress_mbps": 147.9
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": null,
+"decompress_mbps": 151.13
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": null,
+"decompress_mbps": 148.92
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": null,
+"decompress_mbps": 150.99
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": null,
+"decompress_mbps": 147.67
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": null,
+"decompress_mbps": 124.79
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": null,
+"decompress_mbps": 147.07
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": null,
+"decompress_mbps": 134.55
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": null,
+"decompress_mbps": 140.06
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": null,
+"decompress_mbps": 139.24
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": null,
+"decompress_mbps": 155.41
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": null,
+"decompress_mbps": 152.93
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": null,
+"decompress_mbps": 155.78
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": null,
+"decompress_mbps": 160.29
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": null,
+"decompress_mbps": 161.02
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": null,
+"decompress_mbps": 105.63
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": null,
+"decompress_mbps": 110.68
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": null,
+"decompress_mbps": 111.19
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": null,
+"decompress_mbps": 113.51
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": null,
+"decompress_mbps": 114.76
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": null,
+"decompress_mbps": 115.95
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": null,
+"decompress_mbps": 130.72
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": null,
+"decompress_mbps": 123.32
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": null,
+"decompress_mbps": 122.67
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": null,
+"decompress_mbps": 128.68
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": null,
+"decompress_mbps": 105.0
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": null,
+"decompress_mbps": 90.66
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": null,
+"decompress_mbps": 92.26
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": null,
+"decompress_mbps": 93.89
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": null,
+"decompress_mbps": 95.04
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": null,
+"decompress_mbps": 190.33
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": null,
+"decompress_mbps": 226.25
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": null,
+"decompress_mbps": 204.82
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": null,
+"decompress_mbps": 204.66
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": null,
+"decompress_mbps": 219.59
 }
 ]
 }

--- a/bench/results/archive/latest.chungus.7e98994a.json
+++ b/bench/results/archive/latest.chungus.7e98994a.json
@@ -1,0 +1,17491 @@
+{
+ "meta": {
+  "date": "2026-07-05T08:48:39Z",
+  "machine": "Linux chungus x86_64",
+  "git_commit": "7e98994a",
+  "toolchain": "leanprover/lean4:v4.30.0-rc2",
+  "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
+ },
+ "results": [
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 60455,
+   "ratio": 0.3975,
+   "compress_mbps": 63.04,
+   "decompress_mbps": 111.7
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 56316,
+   "ratio": 0.3703,
+   "compress_mbps": 46.82,
+   "decompress_mbps": 124.01
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 55646,
+   "ratio": 0.3659,
+   "compress_mbps": 42.01,
+   "decompress_mbps": 134.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 54681,
+   "ratio": 0.3595,
+   "compress_mbps": 31.16,
+   "decompress_mbps": 138.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54437,
+   "ratio": 0.3579,
+   "compress_mbps": 24.45,
+   "decompress_mbps": 146.02
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54348,
+   "ratio": 0.3573,
+   "compress_mbps": 21.77,
+   "decompress_mbps": 150.37
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54140,
+   "ratio": 0.356,
+   "compress_mbps": 19.02,
+   "decompress_mbps": 151.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54127,
+   "ratio": 0.3559,
+   "compress_mbps": 18.45,
+   "decompress_mbps": 150.6
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 52732,
+   "ratio": 0.3467,
+   "compress_mbps": 4.0,
+   "decompress_mbps": 151.63
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 53135,
+   "ratio": 0.4245,
+   "compress_mbps": 57.53,
+   "decompress_mbps": 105.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50187,
+   "ratio": 0.4009,
+   "compress_mbps": 43.62,
+   "decompress_mbps": 113.11
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 49810,
+   "ratio": 0.3979,
+   "compress_mbps": 39.7,
+   "decompress_mbps": 122.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 48992,
+   "ratio": 0.3914,
+   "compress_mbps": 29.19,
+   "decompress_mbps": 127.06
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48891,
+   "ratio": 0.3906,
+   "compress_mbps": 25.21,
+   "decompress_mbps": 132.93
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48715,
+   "ratio": 0.3892,
+   "compress_mbps": 20.59,
+   "decompress_mbps": 135.72
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48634,
+   "ratio": 0.3885,
+   "compress_mbps": 19.4,
+   "decompress_mbps": 136.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48634,
+   "ratio": 0.3885,
+   "compress_mbps": 19.36,
+   "decompress_mbps": 136.31
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 47430,
+   "ratio": 0.3789,
+   "compress_mbps": 4.32,
+   "decompress_mbps": 136.31
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8476,
+   "ratio": 0.3445,
+   "compress_mbps": 43.15,
+   "decompress_mbps": 125.02
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8271,
+   "ratio": 0.3362,
+   "compress_mbps": 37.84,
+   "decompress_mbps": 128.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8158,
+   "ratio": 0.3316,
+   "compress_mbps": 36.94,
+   "decompress_mbps": 131.86
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 7961,
+   "ratio": 0.3236,
+   "compress_mbps": 33.05,
+   "decompress_mbps": 137.31
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7932,
+   "ratio": 0.3224,
+   "compress_mbps": 28.32,
+   "decompress_mbps": 141.52
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7938,
+   "ratio": 0.3226,
+   "compress_mbps": 24.25,
+   "decompress_mbps": 143.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7929,
+   "ratio": 0.3223,
+   "compress_mbps": 23.21,
+   "decompress_mbps": 144.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7929,
+   "ratio": 0.3223,
+   "compress_mbps": 23.29,
+   "decompress_mbps": 144.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7803,
+   "ratio": 0.3172,
+   "compress_mbps": 4.38,
+   "decompress_mbps": 143.8
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3509,
+   "ratio": 0.3147,
+   "compress_mbps": 27.91,
+   "decompress_mbps": 99.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3269,
+   "ratio": 0.2932,
+   "compress_mbps": 25.47,
+   "decompress_mbps": 101.95
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3208,
+   "ratio": 0.2877,
+   "compress_mbps": 24.44,
+   "decompress_mbps": 105.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3141,
+   "ratio": 0.2817,
+   "compress_mbps": 23.49,
+   "decompress_mbps": 107.25
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 21.23,
+   "decompress_mbps": 109.39
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3135,
+   "ratio": 0.2812,
+   "compress_mbps": 19.37,
+   "decompress_mbps": 110.02
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 18.53,
+   "decompress_mbps": 110.02
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3128,
+   "ratio": 0.2805,
+   "compress_mbps": 18.78,
+   "decompress_mbps": 110.22
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3056,
+   "ratio": 0.2741,
+   "compress_mbps": 4.5,
+   "decompress_mbps": 110.9
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1282,
+   "ratio": 0.3445,
+   "compress_mbps": 12.49,
+   "decompress_mbps": 55.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1225,
+   "ratio": 0.3292,
+   "compress_mbps": 12.51,
+   "decompress_mbps": 56.17
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1220,
+   "ratio": 0.3279,
+   "compress_mbps": 12.47,
+   "decompress_mbps": 56.18
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1213,
+   "ratio": 0.326,
+   "compress_mbps": 11.69,
+   "decompress_mbps": 57.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 11.51,
+   "decompress_mbps": 57.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 10.41,
+   "decompress_mbps": 57.6
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 10.44,
+   "decompress_mbps": 57.53
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1209,
+   "ratio": 0.3249,
+   "compress_mbps": 10.42,
+   "decompress_mbps": 57.47
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1205,
+   "ratio": 0.3238,
+   "compress_mbps": 3.47,
+   "decompress_mbps": 57.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 251793,
+   "ratio": 0.2445,
+   "compress_mbps": 122.48,
+   "decompress_mbps": 207.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 242565,
+   "ratio": 0.2356,
+   "compress_mbps": 85.61,
+   "decompress_mbps": 222.66
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 242532,
+   "ratio": 0.2355,
+   "compress_mbps": 73.13,
+   "decompress_mbps": 231.51
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 239804,
+   "ratio": 0.2329,
+   "compress_mbps": 68.75,
+   "decompress_mbps": 238.61
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 215530,
+   "ratio": 0.2093,
+   "compress_mbps": 39.0,
+   "decompress_mbps": 234.82
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 201414,
+   "ratio": 0.1956,
+   "compress_mbps": 22.49,
+   "decompress_mbps": 242.38
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 200711,
+   "ratio": 0.1949,
+   "compress_mbps": 16.39,
+   "decompress_mbps": 245.06
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 200719,
+   "ratio": 0.1949,
+   "compress_mbps": 12.26,
+   "decompress_mbps": 247.86
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 182508,
+   "ratio": 0.1772,
+   "compress_mbps": 2.89,
+   "decompress_mbps": 248.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 160674,
+   "ratio": 0.3765,
+   "compress_mbps": 71.1,
+   "decompress_mbps": 119.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 149787,
+   "ratio": 0.351,
+   "compress_mbps": 51.25,
+   "decompress_mbps": 128.69
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 148055,
+   "ratio": 0.3469,
+   "compress_mbps": 45.71,
+   "decompress_mbps": 141.58
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 145631,
+   "ratio": 0.3413,
+   "compress_mbps": 33.73,
+   "decompress_mbps": 146.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145321,
+   "ratio": 0.3405,
+   "compress_mbps": 27.29,
+   "decompress_mbps": 153.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 145046,
+   "ratio": 0.3399,
+   "compress_mbps": 23.64,
+   "decompress_mbps": 157.37
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144554,
+   "ratio": 0.3387,
+   "compress_mbps": 21.18,
+   "decompress_mbps": 158.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144540,
+   "ratio": 0.3387,
+   "compress_mbps": 20.77,
+   "decompress_mbps": 158.7
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 140322,
+   "ratio": 0.3288,
+   "compress_mbps": 3.94,
+   "decompress_mbps": 158.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 212588,
+   "ratio": 0.4412,
+   "compress_mbps": 60.56,
+   "decompress_mbps": 99.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 199981,
+   "ratio": 0.415,
+   "compress_mbps": 43.79,
+   "decompress_mbps": 107.94
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 198551,
+   "ratio": 0.4121,
+   "compress_mbps": 39.2,
+   "decompress_mbps": 118.12
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 195460,
+   "ratio": 0.4056,
+   "compress_mbps": 26.42,
+   "decompress_mbps": 122.03
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 194902,
+   "ratio": 0.4045,
+   "compress_mbps": 22.11,
+   "decompress_mbps": 128.83
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195177,
+   "ratio": 0.405,
+   "compress_mbps": 20.45,
+   "decompress_mbps": 131.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194385,
+   "ratio": 0.4034,
+   "compress_mbps": 18.08,
+   "decompress_mbps": 132.71
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194380,
+   "ratio": 0.4034,
+   "compress_mbps": 17.87,
+   "decompress_mbps": 132.77
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 189365,
+   "ratio": 0.393,
+   "compress_mbps": 3.8,
+   "decompress_mbps": 132.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60161,
+   "ratio": 0.1172,
+   "compress_mbps": 181.49,
+   "decompress_mbps": 338.36
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 58873,
+   "ratio": 0.1147,
+   "compress_mbps": 139.69,
+   "decompress_mbps": 359.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 58327,
+   "ratio": 0.1137,
+   "compress_mbps": 122.73,
+   "decompress_mbps": 382.33
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 55673,
+   "ratio": 0.1085,
+   "compress_mbps": 83.52,
+   "decompress_mbps": 351.06
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 54950,
+   "ratio": 0.1071,
+   "compress_mbps": 58.12,
+   "decompress_mbps": 374.88
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55259,
+   "ratio": 0.1077,
+   "compress_mbps": 39.26,
+   "decompress_mbps": 403.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 53713,
+   "ratio": 0.1047,
+   "compress_mbps": 30.0,
+   "decompress_mbps": 425.68
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52897,
+   "ratio": 0.1031,
+   "compress_mbps": 25.77,
+   "decompress_mbps": 456.29
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52729,
+   "ratio": 0.1027,
+   "compress_mbps": 4.94,
+   "decompress_mbps": 470.01
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14249,
+   "ratio": 0.3726,
+   "compress_mbps": 31.28,
+   "decompress_mbps": 113.25
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13825,
+   "ratio": 0.3615,
+   "compress_mbps": 28.98,
+   "decompress_mbps": 115.97
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13751,
+   "ratio": 0.3596,
+   "compress_mbps": 28.18,
+   "decompress_mbps": 117.26
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13366,
+   "ratio": 0.3495,
+   "compress_mbps": 25.39,
+   "decompress_mbps": 123.39
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13346,
+   "ratio": 0.349,
+   "compress_mbps": 22.57,
+   "decompress_mbps": 130.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13040,
+   "ratio": 0.341,
+   "compress_mbps": 9.91,
+   "decompress_mbps": 132.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13035,
+   "ratio": 0.3409,
+   "compress_mbps": 9.38,
+   "decompress_mbps": 133.77
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13028,
+   "ratio": 0.3407,
+   "compress_mbps": 8.71,
+   "decompress_mbps": 134.94
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12427,
+   "ratio": 0.325,
+   "compress_mbps": 4.21,
+   "decompress_mbps": 136.8
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1800,
+   "ratio": 0.4258,
+   "compress_mbps": 14.63,
+   "decompress_mbps": 57.2
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1750,
+   "ratio": 0.414,
+   "compress_mbps": 14.0,
+   "decompress_mbps": 57.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 13.37,
+   "decompress_mbps": 57.48
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1732,
+   "ratio": 0.4097,
+   "compress_mbps": 13.11,
+   "decompress_mbps": 58.8
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 13.09,
+   "decompress_mbps": 59.26
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 11.39,
+   "decompress_mbps": 59.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 11.41,
+   "decompress_mbps": 59.29
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1729,
+   "ratio": 0.409,
+   "compress_mbps": 11.4,
+   "decompress_mbps": 59.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1708,
+   "ratio": 0.4041,
+   "compress_mbps": 3.95,
+   "decompress_mbps": 59.18
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 65130,
+   "ratio": 0.4282,
+   "compress_mbps": 118.84,
+   "decompress_mbps": 399.29
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 62270,
+   "ratio": 0.4094,
+   "compress_mbps": 101.78,
+   "decompress_mbps": 418.8
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 59488,
+   "ratio": 0.3911,
+   "compress_mbps": 67.0,
+   "decompress_mbps": 435.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 57679,
+   "ratio": 0.3792,
+   "compress_mbps": 71.67,
+   "decompress_mbps": 414.35
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 55616,
+   "ratio": 0.3657,
+   "compress_mbps": 41.81,
+   "decompress_mbps": 408.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54398,
+   "ratio": 0.3577,
+   "compress_mbps": 25.53,
+   "decompress_mbps": 421.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54253,
+   "ratio": 0.3567,
+   "compress_mbps": 21.45,
+   "decompress_mbps": 423.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54164,
+   "ratio": 0.3561,
+   "compress_mbps": 16.99,
+   "decompress_mbps": 425.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54164,
+   "ratio": 0.3561,
+   "compress_mbps": 16.98,
+   "decompress_mbps": 423.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 56791,
+   "ratio": 0.4537,
+   "compress_mbps": 115.6,
+   "decompress_mbps": 394.7
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 54652,
+   "ratio": 0.4366,
+   "compress_mbps": 97.78,
+   "decompress_mbps": 407.38
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 52663,
+   "ratio": 0.4207,
+   "compress_mbps": 62.36,
+   "decompress_mbps": 428.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 51266,
+   "ratio": 0.4095,
+   "compress_mbps": 67.4,
+   "decompress_mbps": 398.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 49622,
+   "ratio": 0.3964,
+   "compress_mbps": 37.32,
+   "decompress_mbps": 386.08
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48891,
+   "ratio": 0.3906,
+   "compress_mbps": 22.81,
+   "decompress_mbps": 395.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48801,
+   "ratio": 0.3898,
+   "compress_mbps": 20.02,
+   "decompress_mbps": 397.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48772,
+   "ratio": 0.3896,
+   "compress_mbps": 18.15,
+   "decompress_mbps": 395.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48772,
+   "ratio": 0.3896,
+   "compress_mbps": 18.14,
+   "decompress_mbps": 399.23
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 9028,
+   "ratio": 0.3669,
+   "compress_mbps": 414.75,
+   "decompress_mbps": 1058.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8811,
+   "ratio": 0.3581,
+   "compress_mbps": 218.08,
+   "decompress_mbps": 1085.71
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8616,
+   "ratio": 0.3502,
+   "compress_mbps": 163.26,
+   "decompress_mbps": 1104.41
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8219,
+   "ratio": 0.3341,
+   "compress_mbps": 116.35,
+   "decompress_mbps": 1113.96
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8001,
+   "ratio": 0.3252,
+   "compress_mbps": 84.93,
+   "decompress_mbps": 1146.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7955,
+   "ratio": 0.3233,
+   "compress_mbps": 68.91,
+   "decompress_mbps": 1156.51
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7933,
+   "ratio": 0.3224,
+   "compress_mbps": 62.88,
+   "decompress_mbps": 1159.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7934,
+   "ratio": 0.3225,
+   "compress_mbps": 58.08,
+   "decompress_mbps": 1161.26
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7934,
+   "ratio": 0.3225,
+   "compress_mbps": 58.09,
+   "decompress_mbps": 1160.11
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3647,
+   "ratio": 0.3271,
+   "compress_mbps": 426.79,
+   "decompress_mbps": 1073.55
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3501,
+   "ratio": 0.314,
+   "compress_mbps": 408.84,
+   "decompress_mbps": 1117.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3393,
+   "ratio": 0.3043,
+   "compress_mbps": 338.35,
+   "decompress_mbps": 1147.08
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3215,
+   "ratio": 0.2883,
+   "compress_mbps": 271.93,
+   "decompress_mbps": 1175.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3140,
+   "ratio": 0.2816,
+   "compress_mbps": 205.2,
+   "decompress_mbps": 1205.2
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 154.1,
+   "decompress_mbps": 1215.53
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 131.87,
+   "decompress_mbps": 1216.78
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3109,
+   "ratio": 0.2788,
+   "compress_mbps": 111.18,
+   "decompress_mbps": 1216.5
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3109,
+   "ratio": 0.2788,
+   "compress_mbps": 110.92,
+   "decompress_mbps": 1220.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1326,
+   "ratio": 0.3564,
+   "compress_mbps": 317.29,
+   "decompress_mbps": 787.88
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1306,
+   "ratio": 0.351,
+   "compress_mbps": 310.71,
+   "decompress_mbps": 796.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1301,
+   "ratio": 0.3496,
+   "compress_mbps": 291.04,
+   "decompress_mbps": 799.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1228,
+   "ratio": 0.33,
+   "compress_mbps": 233.69,
+   "decompress_mbps": 825.26
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 198.9,
+   "decompress_mbps": 831.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 177.77,
+   "decompress_mbps": 832.23
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 170.71,
+   "decompress_mbps": 821.82
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 167.8,
+   "decompress_mbps": 826.61
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 168.26,
+   "decompress_mbps": 828.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 242293,
+   "ratio": 0.2353,
+   "compress_mbps": 261.91,
+   "decompress_mbps": 834.71
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 233553,
+   "ratio": 0.2268,
+   "compress_mbps": 248.46,
+   "decompress_mbps": 990.64
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 228222,
+   "ratio": 0.2216,
+   "compress_mbps": 195.71,
+   "decompress_mbps": 1047.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 223668,
+   "ratio": 0.2172,
+   "compress_mbps": 177.25,
+   "decompress_mbps": 1079.08
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 205994,
+   "ratio": 0.2,
+   "compress_mbps": 110.7,
+   "decompress_mbps": 1038.46
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 203986,
+   "ratio": 0.1981,
+   "compress_mbps": 50.06,
+   "decompress_mbps": 1033.64
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 207681,
+   "ratio": 0.2017,
+   "compress_mbps": 37.08,
+   "decompress_mbps": 1027.99
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 206827,
+   "ratio": 0.2009,
+   "compress_mbps": 7.29,
+   "decompress_mbps": 1001.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 207023,
+   "ratio": 0.201,
+   "compress_mbps": 3.43,
+   "decompress_mbps": 1007.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 174124,
+   "ratio": 0.408,
+   "compress_mbps": 124.52,
+   "decompress_mbps": 403.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 166150,
+   "ratio": 0.3893,
+   "compress_mbps": 105.75,
+   "decompress_mbps": 410.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 158784,
+   "ratio": 0.3721,
+   "compress_mbps": 70.62,
+   "decompress_mbps": 431.19
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 152782,
+   "ratio": 0.358,
+   "compress_mbps": 74.37,
+   "decompress_mbps": 417.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 147196,
+   "ratio": 0.3449,
+   "compress_mbps": 43.69,
+   "decompress_mbps": 412.43
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144898,
+   "ratio": 0.3395,
+   "compress_mbps": 26.54,
+   "decompress_mbps": 422.22
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144589,
+   "ratio": 0.3388,
+   "compress_mbps": 23.0,
+   "decompress_mbps": 422.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144436,
+   "ratio": 0.3385,
+   "compress_mbps": 19.77,
+   "decompress_mbps": 426.62
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144433,
+   "ratio": 0.3384,
+   "compress_mbps": 19.7,
+   "decompress_mbps": 427.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 228883,
+   "ratio": 0.475,
+   "compress_mbps": 108.85,
+   "decompress_mbps": 379.18
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 219047,
+   "ratio": 0.4546,
+   "compress_mbps": 91.35,
+   "decompress_mbps": 396.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 209408,
+   "ratio": 0.4346,
+   "compress_mbps": 55.73,
+   "decompress_mbps": 408.77
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 205916,
+   "ratio": 0.4273,
+   "compress_mbps": 62.79,
+   "decompress_mbps": 384.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 199188,
+   "ratio": 0.4134,
+   "compress_mbps": 33.23,
+   "decompress_mbps": 365.25
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195255,
+   "ratio": 0.4052,
+   "compress_mbps": 19.51,
+   "decompress_mbps": 371.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194657,
+   "ratio": 0.404,
+   "compress_mbps": 16.52,
+   "decompress_mbps": 368.04
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194326,
+   "ratio": 0.4033,
+   "compress_mbps": 13.04,
+   "decompress_mbps": 372.62
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 194326,
+   "ratio": 0.4033,
+   "compress_mbps": 13.03,
+   "decompress_mbps": 376.86
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 65553,
+   "ratio": 0.1277,
+   "compress_mbps": 277.05,
+   "decompress_mbps": 898.35
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 63891,
+   "ratio": 0.1245,
+   "compress_mbps": 249.81,
+   "decompress_mbps": 925.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 62515,
+   "ratio": 0.1218,
+   "compress_mbps": 196.22,
+   "decompress_mbps": 996.47
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 58451,
+   "ratio": 0.1139,
+   "compress_mbps": 170.56,
+   "decompress_mbps": 705.74
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 57410,
+   "ratio": 0.1119,
+   "compress_mbps": 131.27,
+   "decompress_mbps": 733.83
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 56459,
+   "ratio": 0.11,
+   "compress_mbps": 77.73,
+   "decompress_mbps": 785.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 55358,
+   "ratio": 0.1079,
+   "compress_mbps": 60.89,
+   "decompress_mbps": 824.41
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52991,
+   "ratio": 0.1033,
+   "compress_mbps": 27.8,
+   "decompress_mbps": 878.92
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52215,
+   "ratio": 0.1017,
+   "compress_mbps": 9.91,
+   "decompress_mbps": 892.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14112,
+   "ratio": 0.369,
+   "compress_mbps": 130.36,
+   "decompress_mbps": 944.12
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13815,
+   "ratio": 0.3613,
+   "compress_mbps": 110.11,
+   "decompress_mbps": 978.68
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13795,
+   "ratio": 0.3607,
+   "compress_mbps": 79.64,
+   "decompress_mbps": 1014.48
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13375,
+   "ratio": 0.3498,
+   "compress_mbps": 81.09,
+   "decompress_mbps": 997.82
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13062,
+   "ratio": 0.3416,
+   "compress_mbps": 56.15,
+   "decompress_mbps": 1040.2
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12984,
+   "ratio": 0.3395,
+   "compress_mbps": 33.24,
+   "decompress_mbps": 1062.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12949,
+   "ratio": 0.3386,
+   "compress_mbps": 25.62,
+   "decompress_mbps": 1070.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12894,
+   "ratio": 0.3372,
+   "compress_mbps": 11.1,
+   "decompress_mbps": 1080.36
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12832,
+   "ratio": 0.3356,
+   "compress_mbps": 5.1,
+   "decompress_mbps": 1081.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1846,
+   "ratio": 0.4367,
+   "compress_mbps": 290.31,
+   "decompress_mbps": 710.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1820,
+   "ratio": 0.4306,
+   "compress_mbps": 284.39,
+   "decompress_mbps": 723.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1808,
+   "ratio": 0.4277,
+   "compress_mbps": 272.54,
+   "decompress_mbps": 726.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1749,
+   "ratio": 0.4138,
+   "compress_mbps": 226.28,
+   "decompress_mbps": 749.43
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 202.59,
+   "decompress_mbps": 753.91
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 199.81,
+   "decompress_mbps": 754.2
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 196.62,
+   "decompress_mbps": 753.91
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 197.1,
+   "decompress_mbps": 754.2
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 197.89,
+   "decompress_mbps": 752.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 76470,
+   "ratio": 0.5028,
+   "compress_mbps": 156.81,
+   "decompress_mbps": 442.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 62765,
+   "ratio": 0.4127,
+   "compress_mbps": 133.14,
+   "decompress_mbps": 491.57
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 57162,
+   "ratio": 0.3758,
+   "compress_mbps": 72.46,
+   "decompress_mbps": 549.38
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56826,
+   "ratio": 0.3736,
+   "compress_mbps": 64.54,
+   "decompress_mbps": 540.99
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 55696,
+   "ratio": 0.3662,
+   "compress_mbps": 46.93,
+   "decompress_mbps": 528.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54440,
+   "ratio": 0.3579,
+   "compress_mbps": 26.59,
+   "decompress_mbps": 545.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54283,
+   "ratio": 0.3569,
+   "compress_mbps": 22.46,
+   "decompress_mbps": 546.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54221,
+   "ratio": 0.3565,
+   "compress_mbps": 19.77,
+   "decompress_mbps": 546.31
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54217,
+   "ratio": 0.3565,
+   "compress_mbps": 19.52,
+   "decompress_mbps": 546.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 64926,
+   "ratio": 0.5187,
+   "compress_mbps": 150.76,
+   "decompress_mbps": 420.61
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 54985,
+   "ratio": 0.4393,
+   "compress_mbps": 124.87,
+   "decompress_mbps": 468.91
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51148,
+   "ratio": 0.4086,
+   "compress_mbps": 67.28,
+   "decompress_mbps": 536.64
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50599,
+   "ratio": 0.4042,
+   "compress_mbps": 59.25,
+   "decompress_mbps": 526.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 49775,
+   "ratio": 0.3976,
+   "compress_mbps": 42.72,
+   "decompress_mbps": 513.76
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48967,
+   "ratio": 0.3912,
+   "compress_mbps": 25.03,
+   "decompress_mbps": 524.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48870,
+   "ratio": 0.3904,
+   "compress_mbps": 22.21,
+   "decompress_mbps": 523.8
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48845,
+   "ratio": 0.3902,
+   "compress_mbps": 20.95,
+   "decompress_mbps": 522.13
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48845,
+   "ratio": 0.3902,
+   "compress_mbps": 20.95,
+   "decompress_mbps": 524.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 10024,
+   "ratio": 0.4074,
+   "compress_mbps": 568.72,
+   "decompress_mbps": 906.86
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8577,
+   "ratio": 0.3486,
+   "compress_mbps": 269.07,
+   "decompress_mbps": 929.83
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8168,
+   "ratio": 0.332,
+   "compress_mbps": 155.49,
+   "decompress_mbps": 951.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8069,
+   "ratio": 0.328,
+   "compress_mbps": 116.17,
+   "decompress_mbps": 969.68
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7997,
+   "ratio": 0.325,
+   "compress_mbps": 100.13,
+   "decompress_mbps": 1001.46
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7952,
+   "ratio": 0.3232,
+   "compress_mbps": 74.99,
+   "decompress_mbps": 1003.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 72.24,
+   "decompress_mbps": 1009.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 71.2,
+   "decompress_mbps": 1009.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7947,
+   "ratio": 0.323,
+   "compress_mbps": 70.94,
+   "decompress_mbps": 1010.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 4061,
+   "ratio": 0.3642,
+   "compress_mbps": 505.27,
+   "decompress_mbps": 857.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3446,
+   "ratio": 0.3091,
+   "compress_mbps": 303.09,
+   "decompress_mbps": 902.14
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3201,
+   "ratio": 0.2871,
+   "compress_mbps": 235.32,
+   "decompress_mbps": 933.5
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 196.56,
+   "decompress_mbps": 955.13
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3139,
+   "ratio": 0.2815,
+   "compress_mbps": 162.35,
+   "decompress_mbps": 979.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3115,
+   "ratio": 0.2794,
+   "compress_mbps": 116.87,
+   "decompress_mbps": 990.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 106.87,
+   "decompress_mbps": 991.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 103.44,
+   "decompress_mbps": 992.11
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 103.35,
+   "decompress_mbps": 992.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1410,
+   "ratio": 0.3789,
+   "compress_mbps": 365.35,
+   "decompress_mbps": 595.71
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1262,
+   "ratio": 0.3392,
+   "compress_mbps": 234.59,
+   "decompress_mbps": 602.38
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1238,
+   "ratio": 0.3327,
+   "compress_mbps": 206.3,
+   "decompress_mbps": 606.19
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 178.27,
+   "decompress_mbps": 624.32
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 163.31,
+   "decompress_mbps": 633.68
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 147.91,
+   "decompress_mbps": 631.88
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 147.05,
+   "decompress_mbps": 632.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 147.52,
+   "decompress_mbps": 634.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1216,
+   "ratio": 0.3268,
+   "compress_mbps": 147.39,
+   "decompress_mbps": 634.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 274412,
+   "ratio": 0.2665,
+   "compress_mbps": 452.12,
+   "decompress_mbps": 796.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 213239,
+   "ratio": 0.2071,
+   "compress_mbps": 274.72,
+   "decompress_mbps": 895.56
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 232107,
+   "ratio": 0.2254,
+   "compress_mbps": 137.22,
+   "decompress_mbps": 936.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 202733,
+   "ratio": 0.1969,
+   "compress_mbps": 130.42,
+   "decompress_mbps": 942.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 207803,
+   "ratio": 0.2018,
+   "compress_mbps": 84.44,
+   "decompress_mbps": 954.1
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 205270,
+   "ratio": 0.1993,
+   "compress_mbps": 27.28,
+   "decompress_mbps": 981.19
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 209951,
+   "ratio": 0.2039,
+   "compress_mbps": 19.33,
+   "decompress_mbps": 997.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 209656,
+   "ratio": 0.2036,
+   "compress_mbps": 12.25,
+   "decompress_mbps": 1008.86
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 209189,
+   "ratio": 0.2031,
+   "compress_mbps": 8.96,
+   "decompress_mbps": 1009.49
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 208640,
+   "ratio": 0.4889,
+   "compress_mbps": 157.34,
+   "decompress_mbps": 424.83
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 167329,
+   "ratio": 0.3921,
+   "compress_mbps": 138.54,
+   "decompress_mbps": 464.58
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 151097,
+   "ratio": 0.3541,
+   "compress_mbps": 73.57,
+   "decompress_mbps": 510.84
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 150035,
+   "ratio": 0.3516,
+   "compress_mbps": 66.59,
+   "decompress_mbps": 511.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 147375,
+   "ratio": 0.3453,
+   "compress_mbps": 48.11,
+   "decompress_mbps": 508.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144908,
+   "ratio": 0.3396,
+   "compress_mbps": 28.06,
+   "decompress_mbps": 519.16
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144562,
+   "ratio": 0.3387,
+   "compress_mbps": 24.64,
+   "decompress_mbps": 517.99
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144449,
+   "ratio": 0.3385,
+   "compress_mbps": 22.41,
+   "decompress_mbps": 518.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144438,
+   "ratio": 0.3385,
+   "compress_mbps": 22.31,
+   "decompress_mbps": 518.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 264549,
+   "ratio": 0.549,
+   "compress_mbps": 135.43,
+   "decompress_mbps": 376.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 223724,
+   "ratio": 0.4643,
+   "compress_mbps": 118.93,
+   "decompress_mbps": 422.83
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 204825,
+   "ratio": 0.4251,
+   "compress_mbps": 60.63,
+   "decompress_mbps": 478.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 203945,
+   "ratio": 0.4232,
+   "compress_mbps": 53.94,
+   "decompress_mbps": 474.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 199780,
+   "ratio": 0.4146,
+   "compress_mbps": 37.91,
+   "decompress_mbps": 457.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 195417,
+   "ratio": 0.4055,
+   "compress_mbps": 21.2,
+   "decompress_mbps": 468.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 194796,
+   "ratio": 0.4043,
+   "compress_mbps": 17.9,
+   "decompress_mbps": 467.61
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 194543,
+   "ratio": 0.4037,
+   "compress_mbps": 15.72,
+   "decompress_mbps": 467.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 194460,
+   "ratio": 0.4036,
+   "compress_mbps": 15.05,
+   "decompress_mbps": 468.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 67436,
+   "ratio": 0.1314,
+   "compress_mbps": 627.54,
+   "decompress_mbps": 1004.41
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 59257,
+   "ratio": 0.1155,
+   "compress_mbps": 278.61,
+   "decompress_mbps": 1060.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 58316,
+   "ratio": 0.1136,
+   "compress_mbps": 181.72,
+   "decompress_mbps": 1145.04
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 56291,
+   "ratio": 0.1097,
+   "compress_mbps": 185.03,
+   "decompress_mbps": 1154.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 56220,
+   "ratio": 0.1095,
+   "compress_mbps": 146.23,
+   "decompress_mbps": 1207.72
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55972,
+   "ratio": 0.1091,
+   "compress_mbps": 74.5,
+   "decompress_mbps": 1263.85
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 55121,
+   "ratio": 0.1074,
+   "compress_mbps": 52.14,
+   "decompress_mbps": 1305.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 54124,
+   "ratio": 0.1055,
+   "compress_mbps": 36.7,
+   "decompress_mbps": 1378.02
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 53699,
+   "ratio": 0.1046,
+   "compress_mbps": 28.66,
+   "decompress_mbps": 1411.67
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 15612,
+   "ratio": 0.4083,
+   "compress_mbps": 502.51,
+   "decompress_mbps": 850.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 14133,
+   "ratio": 0.3696,
+   "compress_mbps": 145.19,
+   "decompress_mbps": 890.56
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13341,
+   "ratio": 0.3489,
+   "compress_mbps": 88.72,
+   "decompress_mbps": 911.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13289,
+   "ratio": 0.3475,
+   "compress_mbps": 83.64,
+   "decompress_mbps": 941.29
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13052,
+   "ratio": 0.3413,
+   "compress_mbps": 66.83,
+   "decompress_mbps": 973.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12996,
+   "ratio": 0.3399,
+   "compress_mbps": 37.14,
+   "decompress_mbps": 986.7
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12972,
+   "ratio": 0.3392,
+   "compress_mbps": 27.2,
+   "decompress_mbps": 990.88
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12951,
+   "ratio": 0.3387,
+   "compress_mbps": 19.04,
+   "decompress_mbps": 996.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12933,
+   "ratio": 0.3382,
+   "compress_mbps": 14.86,
+   "decompress_mbps": 1010.18
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1988,
+   "ratio": 0.4703,
+   "compress_mbps": 340.18,
+   "decompress_mbps": 548.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1802,
+   "ratio": 0.4263,
+   "compress_mbps": 218.94,
+   "decompress_mbps": 554.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 205.58,
+   "decompress_mbps": 558.57
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1732,
+   "ratio": 0.4097,
+   "compress_mbps": 171.81,
+   "decompress_mbps": 573.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 167.66,
+   "decompress_mbps": 582.37
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 166.66,
+   "decompress_mbps": 582.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 166.44,
+   "decompress_mbps": 580.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 167.1,
+   "decompress_mbps": 579.86
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1730,
+   "ratio": 0.4093,
+   "compress_mbps": 166.8,
+   "decompress_mbps": 579.36
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 59790,
+   "ratio": 0.3931,
+   "compress_mbps": 262.72,
+   "decompress_mbps": 1002.92
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 57173,
+   "ratio": 0.3759,
+   "compress_mbps": 181.24,
+   "decompress_mbps": 1076.37
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 56189,
+   "ratio": 0.3694,
+   "compress_mbps": 150.83,
+   "decompress_mbps": 1150.52
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 55816,
+   "ratio": 0.367,
+   "compress_mbps": 138.22,
+   "decompress_mbps": 1189.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54758,
+   "ratio": 0.36,
+   "compress_mbps": 109.12,
+   "decompress_mbps": 1241.07
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54220,
+   "ratio": 0.3565,
+   "compress_mbps": 84.01,
+   "decompress_mbps": 1281.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 53801,
+   "ratio": 0.3537,
+   "compress_mbps": 61.34,
+   "decompress_mbps": 1284.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 53573,
+   "ratio": 0.3522,
+   "compress_mbps": 38.99,
+   "decompress_mbps": 1281.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 53546,
+   "ratio": 0.3521,
+   "compress_mbps": 34.49,
+   "decompress_mbps": 1286.38
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 52276,
+   "ratio": 0.4176,
+   "compress_mbps": 244.27,
+   "decompress_mbps": 941.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50534,
+   "ratio": 0.4037,
+   "compress_mbps": 169.26,
+   "decompress_mbps": 994.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 49919,
+   "ratio": 0.3988,
+   "compress_mbps": 142.29,
+   "decompress_mbps": 1056.87
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 49715,
+   "ratio": 0.3972,
+   "compress_mbps": 131.62,
+   "decompress_mbps": 1092.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48735,
+   "ratio": 0.3893,
+   "compress_mbps": 101.28,
+   "decompress_mbps": 1138.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48422,
+   "ratio": 0.3868,
+   "compress_mbps": 79.56,
+   "decompress_mbps": 1159.77
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48249,
+   "ratio": 0.3854,
+   "compress_mbps": 61.42,
+   "decompress_mbps": 1167.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 47977,
+   "ratio": 0.3833,
+   "compress_mbps": 43.01,
+   "decompress_mbps": 1163.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 47971,
+   "ratio": 0.3832,
+   "compress_mbps": 41.05,
+   "decompress_mbps": 1168.97
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8385,
+   "ratio": 0.3408,
+   "compress_mbps": 694.12,
+   "decompress_mbps": 956.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8380,
+   "ratio": 0.3406,
+   "compress_mbps": 439.72,
+   "decompress_mbps": 974.59
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8286,
+   "ratio": 0.3368,
+   "compress_mbps": 403.73,
+   "decompress_mbps": 993.24
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8163,
+   "ratio": 0.3318,
+   "compress_mbps": 378.68,
+   "decompress_mbps": 1003.78
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8053,
+   "ratio": 0.3273,
+   "compress_mbps": 335.07,
+   "decompress_mbps": 1027.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7986,
+   "ratio": 0.3246,
+   "compress_mbps": 277.67,
+   "decompress_mbps": 1035.81
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7954,
+   "ratio": 0.3233,
+   "compress_mbps": 191.05,
+   "decompress_mbps": 1026.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 129.56,
+   "decompress_mbps": 1035.17
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 125.42,
+   "decompress_mbps": 1013.27
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3401,
+   "ratio": 0.305,
+   "compress_mbps": 586.93,
+   "decompress_mbps": 768.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3307,
+   "ratio": 0.2966,
+   "compress_mbps": 398.24,
+   "decompress_mbps": 792.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3242,
+   "ratio": 0.2908,
+   "compress_mbps": 371.5,
+   "decompress_mbps": 810.66
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3205,
+   "ratio": 0.2874,
+   "compress_mbps": 349.62,
+   "decompress_mbps": 821.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3150,
+   "ratio": 0.2825,
+   "compress_mbps": 313.81,
+   "decompress_mbps": 837.48
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3126,
+   "ratio": 0.2804,
+   "compress_mbps": 267.83,
+   "decompress_mbps": 842.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3106,
+   "ratio": 0.2786,
+   "compress_mbps": 206.71,
+   "decompress_mbps": 846.01
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3102,
+   "ratio": 0.2782,
+   "compress_mbps": 147.91,
+   "decompress_mbps": 842.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3102,
+   "ratio": 0.2782,
+   "compress_mbps": 140.39,
+   "decompress_mbps": 846.34
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1251,
+   "ratio": 0.3362,
+   "compress_mbps": 377.39,
+   "decompress_mbps": 426.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1228,
+   "ratio": 0.33,
+   "compress_mbps": 267.66,
+   "decompress_mbps": 433.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1219,
+   "ratio": 0.3276,
+   "compress_mbps": 258.72,
+   "decompress_mbps": 433.23
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1220,
+   "ratio": 0.3279,
+   "compress_mbps": 253.94,
+   "decompress_mbps": 439.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 240.44,
+   "decompress_mbps": 443.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 222.65,
+   "decompress_mbps": 441.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 203.53,
+   "decompress_mbps": 438.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1204,
+   "ratio": 0.3236,
+   "compress_mbps": 169.68,
+   "decompress_mbps": 444.08
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1204,
+   "ratio": 0.3236,
+   "compress_mbps": 169.88,
+   "decompress_mbps": 438.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 221813,
+   "ratio": 0.2154,
+   "compress_mbps": 593.83,
+   "decompress_mbps": 1009.94
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 199825,
+   "ratio": 0.1941,
+   "compress_mbps": 409.25,
+   "decompress_mbps": 1460.57
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 195675,
+   "ratio": 0.19,
+   "compress_mbps": 283.23,
+   "decompress_mbps": 1526.64
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 195664,
+   "ratio": 0.19,
+   "compress_mbps": 279.77,
+   "decompress_mbps": 1536.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 198900,
+   "ratio": 0.1932,
+   "compress_mbps": 239.94,
+   "decompress_mbps": 1127.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 199347,
+   "ratio": 0.1936,
+   "compress_mbps": 204.69,
+   "decompress_mbps": 1130.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 199777,
+   "ratio": 0.194,
+   "compress_mbps": 123.53,
+   "decompress_mbps": 1190.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 182094,
+   "ratio": 0.1768,
+   "compress_mbps": 25.66,
+   "decompress_mbps": 1169.78
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 181451,
+   "ratio": 0.1762,
+   "compress_mbps": 13.61,
+   "decompress_mbps": 1173.47
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 159063,
+   "ratio": 0.3727,
+   "compress_mbps": 263.86,
+   "decompress_mbps": 1029.34
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 152115,
+   "ratio": 0.3564,
+   "compress_mbps": 187.44,
+   "decompress_mbps": 1105.52
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 149162,
+   "ratio": 0.3495,
+   "compress_mbps": 156.82,
+   "decompress_mbps": 1189.07
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 148359,
+   "ratio": 0.3476,
+   "compress_mbps": 142.61,
+   "decompress_mbps": 1033.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145353,
+   "ratio": 0.3406,
+   "compress_mbps": 113.35,
+   "decompress_mbps": 997.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144209,
+   "ratio": 0.3379,
+   "compress_mbps": 87.48,
+   "decompress_mbps": 1037.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 143604,
+   "ratio": 0.3365,
+   "compress_mbps": 66.64,
+   "decompress_mbps": 1039.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 142086,
+   "ratio": 0.3329,
+   "compress_mbps": 44.24,
+   "decompress_mbps": 1035.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 142027,
+   "ratio": 0.3328,
+   "compress_mbps": 40.46,
+   "decompress_mbps": 1038.75
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 210662,
+   "ratio": 0.4372,
+   "compress_mbps": 228.71,
+   "decompress_mbps": 869.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 202881,
+   "ratio": 0.421,
+   "compress_mbps": 158.66,
+   "decompress_mbps": 939.95
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 200409,
+   "ratio": 0.4159,
+   "compress_mbps": 132.96,
+   "decompress_mbps": 1019.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 199678,
+   "ratio": 0.4144,
+   "compress_mbps": 122.96,
+   "decompress_mbps": 839.63
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 195798,
+   "ratio": 0.4063,
+   "compress_mbps": 93.4,
+   "decompress_mbps": 789.36
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 194029,
+   "ratio": 0.4027,
+   "compress_mbps": 71.6,
+   "decompress_mbps": 813.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 192773,
+   "ratio": 0.4001,
+   "compress_mbps": 50.41,
+   "decompress_mbps": 835.88
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 191739,
+   "ratio": 0.3979,
+   "compress_mbps": 33.69,
+   "decompress_mbps": 841.06
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 191676,
+   "ratio": 0.3978,
+   "compress_mbps": 31.1,
+   "decompress_mbps": 839.65
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 58079,
+   "ratio": 0.1132,
+   "compress_mbps": 373.38,
+   "decompress_mbps": 1687.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 57838,
+   "ratio": 0.1127,
+   "compress_mbps": 413.69,
+   "decompress_mbps": 1800.72
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 57554,
+   "ratio": 0.1121,
+   "compress_mbps": 394.76,
+   "decompress_mbps": 1899.42
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57064,
+   "ratio": 0.1112,
+   "compress_mbps": 374.05,
+   "decompress_mbps": 1741.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 55743,
+   "ratio": 0.1086,
+   "compress_mbps": 343.45,
+   "decompress_mbps": 1793.36
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55102,
+   "ratio": 0.1074,
+   "compress_mbps": 285.08,
+   "decompress_mbps": 1869.89
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 54742,
+   "ratio": 0.1067,
+   "compress_mbps": 193.03,
+   "decompress_mbps": 1929.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 53133,
+   "ratio": 0.1035,
+   "compress_mbps": 102.77,
+   "decompress_mbps": 1996.36
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 52186,
+   "ratio": 0.1017,
+   "compress_mbps": 72.32,
+   "decompress_mbps": 2031.74
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14122,
+   "ratio": 0.3693,
+   "compress_mbps": 648.66,
+   "decompress_mbps": 823.66
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13374,
+   "ratio": 0.3497,
+   "compress_mbps": 338.62,
+   "decompress_mbps": 879.23
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13293,
+   "ratio": 0.3476,
+   "compress_mbps": 257.73,
+   "decompress_mbps": 960.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13259,
+   "ratio": 0.3467,
+   "compress_mbps": 263.83,
+   "decompress_mbps": 960.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 12641,
+   "ratio": 0.3306,
+   "compress_mbps": 190.13,
+   "decompress_mbps": 990.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 12432,
+   "ratio": 0.3251,
+   "compress_mbps": 164.05,
+   "decompress_mbps": 1006.67
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 12439,
+   "ratio": 0.3253,
+   "compress_mbps": 122.43,
+   "decompress_mbps": 1013.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 12579,
+   "ratio": 0.3289,
+   "compress_mbps": 67.61,
+   "decompress_mbps": 1025.92
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 12574,
+   "ratio": 0.3288,
+   "compress_mbps": 47.47,
+   "decompress_mbps": 1031.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1777,
+   "ratio": 0.4204,
+   "compress_mbps": 386.35,
+   "decompress_mbps": 403.24
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1756,
+   "ratio": 0.4154,
+   "compress_mbps": 260.77,
+   "decompress_mbps": 408.51
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1746,
+   "ratio": 0.4131,
+   "compress_mbps": 257.14,
+   "decompress_mbps": 410.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1740,
+   "ratio": 0.4116,
+   "compress_mbps": 254.99,
+   "decompress_mbps": 414.73
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1722,
+   "ratio": 0.4074,
+   "compress_mbps": 240.47,
+   "decompress_mbps": 415.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1721,
+   "ratio": 0.4071,
+   "compress_mbps": 235.91,
+   "decompress_mbps": 415.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 234.75,
+   "decompress_mbps": 415.41
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1717,
+   "ratio": 0.4062,
+   "compress_mbps": 217.57,
+   "decompress_mbps": 417.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1717,
+   "ratio": 0.4062,
+   "compress_mbps": 216.75,
+   "decompress_mbps": 416.19
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4259644,
+   "ratio": 0.4179,
+   "compress_mbps": 64.37,
+   "decompress_mbps": 104.44
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 3977395,
+   "ratio": 0.3902,
+   "compress_mbps": 46.09,
+   "decompress_mbps": 112.42
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3945296,
+   "ratio": 0.3871,
+   "compress_mbps": 40.62,
+   "decompress_mbps": 124.05
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3882303,
+   "ratio": 0.3809,
+   "compress_mbps": 28.85,
+   "decompress_mbps": 127.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3870984,
+   "ratio": 0.3798,
+   "compress_mbps": 24.17,
+   "decompress_mbps": 133.76
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3878499,
+   "ratio": 0.3805,
+   "compress_mbps": 22.88,
+   "decompress_mbps": 137.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3865234,
+   "ratio": 0.3792,
+   "compress_mbps": 19.79,
+   "decompress_mbps": 138.26
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3864805,
+   "ratio": 0.3792,
+   "compress_mbps": 19.27,
+   "decompress_mbps": 138.48
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3766584,
+   "ratio": 0.3695,
+   "compress_mbps": 3.91,
+   "decompress_mbps": 141.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 21267086,
+   "ratio": 0.4152,
+   "compress_mbps": 79.63,
+   "decompress_mbps": 133.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20802983,
+   "ratio": 0.4061,
+   "compress_mbps": 62.78,
+   "decompress_mbps": 139.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 20665485,
+   "ratio": 0.4035,
+   "compress_mbps": 58.36,
+   "decompress_mbps": 144.17
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 20393572,
+   "ratio": 0.3982,
+   "compress_mbps": 44.37,
+   "decompress_mbps": 151.14
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 20264932,
+   "ratio": 0.3956,
+   "compress_mbps": 32.78,
+   "decompress_mbps": 159.0
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19208910,
+   "ratio": 0.375,
+   "compress_mbps": 17.38,
+   "decompress_mbps": 162.84
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19177573,
+   "ratio": 0.3744,
+   "compress_mbps": 14.29,
+   "decompress_mbps": 162.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19172591,
+   "ratio": 0.3743,
+   "compress_mbps": 12.5,
+   "decompress_mbps": 163.23
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 18686872,
+   "ratio": 0.3648,
+   "compress_mbps": 3.7,
+   "decompress_mbps": 160.91
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3864163,
+   "ratio": 0.3876,
+   "compress_mbps": 78.52,
+   "decompress_mbps": 119.16
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3734957,
+   "ratio": 0.3746,
+   "compress_mbps": 60.64,
+   "decompress_mbps": 127.35
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3708443,
+   "ratio": 0.3719,
+   "compress_mbps": 52.17,
+   "decompress_mbps": 136.42
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3707604,
+   "ratio": 0.3719,
+   "compress_mbps": 33.69,
+   "decompress_mbps": 131.84
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3705174,
+   "ratio": 0.3716,
+   "compress_mbps": 26.53,
+   "decompress_mbps": 137.21
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3612809,
+   "ratio": 0.3623,
+   "compress_mbps": 20.92,
+   "decompress_mbps": 143.5
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3608980,
+   "ratio": 0.362,
+   "compress_mbps": 18.15,
+   "decompress_mbps": 140.28
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3609490,
+   "ratio": 0.362,
+   "compress_mbps": 16.68,
+   "decompress_mbps": 147.84
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3581441,
+   "ratio": 0.3592,
+   "compress_mbps": 4.16,
+   "decompress_mbps": 153.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3785443,
+   "ratio": 0.1128,
+   "compress_mbps": 230.8,
+   "decompress_mbps": 363.92
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3761560,
+   "ratio": 0.1121,
+   "compress_mbps": 146.53,
+   "decompress_mbps": 408.91
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3606997,
+   "ratio": 0.1075,
+   "compress_mbps": 125.19,
+   "decompress_mbps": 456.32
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3225450,
+   "ratio": 0.0961,
+   "compress_mbps": 93.46,
+   "decompress_mbps": 468.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3145121,
+   "ratio": 0.0937,
+   "compress_mbps": 62.98,
+   "decompress_mbps": 531.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3158854,
+   "ratio": 0.0941,
+   "compress_mbps": 60.2,
+   "decompress_mbps": 570.48
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3124878,
+   "ratio": 0.0931,
+   "compress_mbps": 42.63,
+   "decompress_mbps": 584.57
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3112207,
+   "ratio": 0.0928,
+   "compress_mbps": 34.69,
+   "decompress_mbps": 604.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3034875,
+   "ratio": 0.0904,
+   "compress_mbps": 3.09,
+   "decompress_mbps": 584.63
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3357083,
+   "ratio": 0.5457,
+   "compress_mbps": 55.93,
+   "decompress_mbps": 92.43
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3285077,
+   "ratio": 0.534,
+   "compress_mbps": 45.95,
+   "decompress_mbps": 94.26
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3272746,
+   "ratio": 0.532,
+   "compress_mbps": 44.2,
+   "decompress_mbps": 97.27
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3237094,
+   "ratio": 0.5262,
+   "compress_mbps": 35.38,
+   "decompress_mbps": 105.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3233792,
+   "ratio": 0.5256,
+   "compress_mbps": 31.77,
+   "decompress_mbps": 109.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3168386,
+   "ratio": 0.515,
+   "compress_mbps": 17.85,
+   "decompress_mbps": 111.4
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3165783,
+   "ratio": 0.5146,
+   "compress_mbps": 16.8,
+   "decompress_mbps": 111.69
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3165909,
+   "ratio": 0.5146,
+   "compress_mbps": 16.08,
+   "decompress_mbps": 111.13
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3048772,
+   "ratio": 0.4956,
+   "compress_mbps": 4.4,
+   "decompress_mbps": 114.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3838828,
+   "ratio": 0.3806,
+   "compress_mbps": 88.99,
+   "decompress_mbps": 158.22
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3792520,
+   "ratio": 0.376,
+   "compress_mbps": 66.25,
+   "decompress_mbps": 163.33
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3783171,
+   "ratio": 0.3751,
+   "compress_mbps": 63.87,
+   "decompress_mbps": 168.09
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3706928,
+   "ratio": 0.3675,
+   "compress_mbps": 55.6,
+   "decompress_mbps": 180.99
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3707010,
+   "ratio": 0.3676,
+   "compress_mbps": 50.86,
+   "decompress_mbps": 179.41
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3707065,
+   "ratio": 0.3676,
+   "compress_mbps": 37.72,
+   "decompress_mbps": 185.98
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3706769,
+   "ratio": 0.3675,
+   "compress_mbps": 37.91,
+   "decompress_mbps": 187.82
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3706769,
+   "ratio": 0.3675,
+   "compress_mbps": 37.97,
+   "decompress_mbps": 188.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3665069,
+   "ratio": 0.3634,
+   "compress_mbps": 5.27,
+   "decompress_mbps": 196.08
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2254442,
+   "ratio": 0.3402,
+   "compress_mbps": 81.68,
+   "decompress_mbps": 130.87
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2044843,
+   "ratio": 0.3086,
+   "compress_mbps": 55.66,
+   "decompress_mbps": 142.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 1992105,
+   "ratio": 0.3006,
+   "compress_mbps": 45.73,
+   "decompress_mbps": 156.86
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1901081,
+   "ratio": 0.2869,
+   "compress_mbps": 28.08,
+   "decompress_mbps": 160.66
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1874829,
+   "ratio": 0.2829,
+   "compress_mbps": 17.02,
+   "decompress_mbps": 173.53
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1867098,
+   "ratio": 0.2817,
+   "compress_mbps": 19.97,
+   "decompress_mbps": 183.88
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1843421,
+   "ratio": 0.2782,
+   "compress_mbps": 13.35,
+   "decompress_mbps": 187.36
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1841388,
+   "ratio": 0.2779,
+   "compress_mbps": 11.63,
+   "decompress_mbps": 189.17
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1773447,
+   "ratio": 0.2676,
+   "compress_mbps": 2.72,
+   "decompress_mbps": 193.34
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6406301,
+   "ratio": 0.2965,
+   "compress_mbps": 109.31,
+   "decompress_mbps": 197.32
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6102377,
+   "ratio": 0.2824,
+   "compress_mbps": 81.19,
+   "decompress_mbps": 209.64
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 6022184,
+   "ratio": 0.2787,
+   "compress_mbps": 73.76,
+   "decompress_mbps": 218.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5880979,
+   "ratio": 0.2722,
+   "compress_mbps": 54.55,
+   "decompress_mbps": 227.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5839944,
+   "ratio": 0.2703,
+   "compress_mbps": 41.71,
+   "decompress_mbps": 239.66
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5425813,
+   "ratio": 0.2511,
+   "compress_mbps": 29.44,
+   "decompress_mbps": 245.66
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5409983,
+   "ratio": 0.2504,
+   "compress_mbps": 26.01,
+   "decompress_mbps": 247.56
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5407066,
+   "ratio": 0.2503,
+   "compress_mbps": 24.22,
+   "decompress_mbps": 250.24
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5235865,
+   "ratio": 0.2423,
+   "compress_mbps": 4.25,
+   "decompress_mbps": 248.59
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5612204,
+   "ratio": 0.7739,
+   "compress_mbps": 46.71,
+   "decompress_mbps": 93.0
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5533875,
+   "ratio": 0.7631,
+   "compress_mbps": 38.35,
+   "decompress_mbps": 94.53
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5522436,
+   "ratio": 0.7615,
+   "compress_mbps": 36.95,
+   "decompress_mbps": 97.04
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5498823,
+   "ratio": 0.7583,
+   "compress_mbps": 29.8,
+   "decompress_mbps": 99.85
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5496802,
+   "ratio": 0.758,
+   "compress_mbps": 27.85,
+   "decompress_mbps": 103.53
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5478405,
+   "ratio": 0.7554,
+   "compress_mbps": 20.36,
+   "decompress_mbps": 104.28
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5474648,
+   "ratio": 0.7549,
+   "compress_mbps": 19.55,
+   "decompress_mbps": 106.49
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5474139,
+   "ratio": 0.7549,
+   "compress_mbps": 19.29,
+   "decompress_mbps": 104.42
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5284536,
+   "ratio": 0.7287,
+   "compress_mbps": 4.21,
+   "decompress_mbps": 105.91
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 13727247,
+   "ratio": 0.3311,
+   "compress_mbps": 82.21,
+   "decompress_mbps": 138.26
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 12940398,
+   "ratio": 0.3121,
+   "compress_mbps": 60.65,
+   "decompress_mbps": 149.81
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12703756,
+   "ratio": 0.3064,
+   "compress_mbps": 55.82,
+   "decompress_mbps": 160.94
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12229398,
+   "ratio": 0.295,
+   "compress_mbps": 40.46,
+   "decompress_mbps": 168.23
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12123671,
+   "ratio": 0.2924,
+   "compress_mbps": 29.57,
+   "decompress_mbps": 176.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12167341,
+   "ratio": 0.2935,
+   "compress_mbps": 29.67,
+   "decompress_mbps": 182.28
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12109369,
+   "ratio": 0.2921,
+   "compress_mbps": 24.26,
+   "decompress_mbps": 183.33
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12106058,
+   "ratio": 0.292,
+   "compress_mbps": 23.33,
+   "decompress_mbps": 183.7
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11806466,
+   "ratio": 0.2848,
+   "compress_mbps": 3.63,
+   "decompress_mbps": 184.1
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6438176,
+   "ratio": 0.7597,
+   "compress_mbps": 43.02,
+   "decompress_mbps": 77.66
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6392101,
+   "ratio": 0.7543,
+   "compress_mbps": 41.08,
+   "decompress_mbps": 78.45
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6392124,
+   "ratio": 0.7543,
+   "compress_mbps": 41.18,
+   "decompress_mbps": 79.96
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6368719,
+   "ratio": 0.7515,
+   "compress_mbps": 38.7,
+   "decompress_mbps": 79.78
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6368717,
+   "ratio": 0.7515,
+   "compress_mbps": 38.36,
+   "decompress_mbps": 81.48
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 9.65,
+   "decompress_mbps": 82.82
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 9.96,
+   "decompress_mbps": 81.88
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6278507,
+   "ratio": 0.7409,
+   "compress_mbps": 9.95,
+   "decompress_mbps": 82.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5952505,
+   "ratio": 0.7024,
+   "compress_mbps": 5.1,
+   "decompress_mbps": 84.15
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 858525,
+   "ratio": 0.1606,
+   "compress_mbps": 173.77,
+   "decompress_mbps": 270.67
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 846807,
+   "ratio": 0.1584,
+   "compress_mbps": 112.96,
+   "decompress_mbps": 303.92
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 806798,
+   "ratio": 0.1509,
+   "compress_mbps": 103.39,
+   "decompress_mbps": 339.29
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 721655,
+   "ratio": 0.135,
+   "compress_mbps": 73.68,
+   "decompress_mbps": 331.87
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 710636,
+   "ratio": 0.1329,
+   "compress_mbps": 53.74,
+   "decompress_mbps": 377.65
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 688375,
+   "ratio": 0.1288,
+   "compress_mbps": 47.17,
+   "decompress_mbps": 395.7
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 676544,
+   "ratio": 0.1266,
+   "compress_mbps": 38.03,
+   "decompress_mbps": 412.72
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 674362,
+   "ratio": 0.1262,
+   "compress_mbps": 32.89,
+   "decompress_mbps": 418.05
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 659417,
+   "ratio": 0.1234,
+   "compress_mbps": 4.14,
+   "decompress_mbps": 440.57
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4585612,
+   "ratio": 0.4499,
+   "compress_mbps": 113.67,
+   "decompress_mbps": 354.82
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4389474,
+   "ratio": 0.4307,
+   "compress_mbps": 96.07,
+   "decompress_mbps": 375.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4192079,
+   "ratio": 0.4113,
+   "compress_mbps": 59.36,
+   "decompress_mbps": 412.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4095021,
+   "ratio": 0.4018,
+   "compress_mbps": 66.19,
+   "decompress_mbps": 389.42
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3949169,
+   "ratio": 0.3875,
+   "compress_mbps": 35.97,
+   "decompress_mbps": 376.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3871628,
+   "ratio": 0.3799,
+   "compress_mbps": 21.24,
+   "decompress_mbps": 384.89
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3858876,
+   "ratio": 0.3786,
+   "compress_mbps": 17.58,
+   "decompress_mbps": 387.13
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3854729,
+   "ratio": 0.3782,
+   "compress_mbps": 15.07,
+   "decompress_mbps": 385.46
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3854729,
+   "ratio": 0.3782,
+   "compress_mbps": 15.07,
+   "decompress_mbps": 391.3
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20577220,
+   "ratio": 0.4017,
+   "compress_mbps": 113.25,
+   "decompress_mbps": 364.49
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20247697,
+   "ratio": 0.3953,
+   "compress_mbps": 100.51,
+   "decompress_mbps": 370.0
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19987880,
+   "ratio": 0.3902,
+   "compress_mbps": 75.64,
+   "decompress_mbps": 340.24
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19512665,
+   "ratio": 0.381,
+   "compress_mbps": 71.76,
+   "decompress_mbps": 363.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19213507,
+   "ratio": 0.3751,
+   "compress_mbps": 51.35,
+   "decompress_mbps": 370.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19089118,
+   "ratio": 0.3727,
+   "compress_mbps": 33.44,
+   "decompress_mbps": 376.59
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19061204,
+   "ratio": 0.3721,
+   "compress_mbps": 27.31,
+   "decompress_mbps": 380.14
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19040998,
+   "ratio": 0.3717,
+   "compress_mbps": 15.24,
+   "decompress_mbps": 379.76
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19044390,
+   "ratio": 0.3718,
+   "compress_mbps": 9.54,
+   "decompress_mbps": 385.45
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3828360,
+   "ratio": 0.384,
+   "compress_mbps": 144.91,
+   "decompress_mbps": 453.29
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3798539,
+   "ratio": 0.381,
+   "compress_mbps": 128.29,
+   "decompress_mbps": 497.36
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3674568,
+   "ratio": 0.3685,
+   "compress_mbps": 80.47,
+   "decompress_mbps": 515.99
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3680923,
+   "ratio": 0.3692,
+   "compress_mbps": 89.36,
+   "decompress_mbps": 457.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3698707,
+   "ratio": 0.371,
+   "compress_mbps": 48.13,
+   "decompress_mbps": 427.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3675935,
+   "ratio": 0.3687,
+   "compress_mbps": 26.41,
+   "decompress_mbps": 437.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3670281,
+   "ratio": 0.3681,
+   "compress_mbps": 20.84,
+   "decompress_mbps": 444.31
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3661103,
+   "ratio": 0.3672,
+   "compress_mbps": 10.94,
+   "decompress_mbps": 458.18
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3660788,
+   "ratio": 0.3672,
+   "compress_mbps": 9.47,
+   "decompress_mbps": 459.79
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4624591,
+   "ratio": 0.1378,
+   "compress_mbps": 332.0,
+   "decompress_mbps": 831.27
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4303176,
+   "ratio": 0.1282,
+   "compress_mbps": 310.37,
+   "decompress_mbps": 841.9
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 4010156,
+   "ratio": 0.1195,
+   "compress_mbps": 257.47,
+   "decompress_mbps": 926.52
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3713866,
+   "ratio": 0.1107,
+   "compress_mbps": 212.08,
+   "decompress_mbps": 896.37
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3378136,
+   "ratio": 0.1007,
+   "compress_mbps": 166.1,
+   "decompress_mbps": 954.98
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3200182,
+   "ratio": 0.0954,
+   "compress_mbps": 113.17,
+   "decompress_mbps": 986.8
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3141278,
+   "ratio": 0.0936,
+   "compress_mbps": 90.33,
+   "decompress_mbps": 999.02
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3031199,
+   "ratio": 0.0903,
+   "compress_mbps": 39.16,
+   "decompress_mbps": 1017.12
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2987995,
+   "ratio": 0.0891,
+   "compress_mbps": 21.44,
+   "decompress_mbps": 1033.52
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3290526,
+   "ratio": 0.5349,
+   "compress_mbps": 79.06,
+   "decompress_mbps": 257.16
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3238282,
+   "ratio": 0.5264,
+   "compress_mbps": 72.38,
+   "decompress_mbps": 263.21
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3193366,
+   "ratio": 0.5191,
+   "compress_mbps": 57.0,
+   "decompress_mbps": 265.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3158012,
+   "ratio": 0.5133,
+   "compress_mbps": 55.65,
+   "decompress_mbps": 268.5
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3115309,
+   "ratio": 0.5064,
+   "compress_mbps": 39.25,
+   "decompress_mbps": 269.0
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3097288,
+   "ratio": 0.5034,
+   "compress_mbps": 26.28,
+   "decompress_mbps": 264.86
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3094363,
+   "ratio": 0.503,
+   "compress_mbps": 21.86,
+   "decompress_mbps": 268.09
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3093026,
+   "ratio": 0.5028,
+   "compress_mbps": 16.97,
+   "decompress_mbps": 270.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3092920,
+   "ratio": 0.5027,
+   "compress_mbps": 15.53,
+   "decompress_mbps": 269.1
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4076385,
+   "ratio": 0.4042,
+   "compress_mbps": 125.81,
+   "decompress_mbps": 474.99
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3991014,
+   "ratio": 0.3957,
+   "compress_mbps": 117.17,
+   "decompress_mbps": 494.44
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3934055,
+   "ratio": 0.3901,
+   "compress_mbps": 93.6,
+   "decompress_mbps": 511.59
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3825092,
+   "ratio": 0.3793,
+   "compress_mbps": 85.49,
+   "decompress_mbps": 513.7
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3752932,
+   "ratio": 0.3721,
+   "compress_mbps": 64.41,
+   "decompress_mbps": 496.1
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3695164,
+   "ratio": 0.3664,
+   "compress_mbps": 49.22,
+   "decompress_mbps": 507.36
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3676881,
+   "ratio": 0.3646,
+   "compress_mbps": 38.17,
+   "decompress_mbps": 515.91
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3673171,
+   "ratio": 0.3642,
+   "compress_mbps": 31.92,
+   "decompress_mbps": 519.6
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3673171,
+   "ratio": 0.3642,
+   "compress_mbps": 31.92,
+   "decompress_mbps": 519.23
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2376424,
+   "ratio": 0.3586,
+   "compress_mbps": 130.38,
+   "decompress_mbps": 393.75
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2259060,
+   "ratio": 0.3409,
+   "compress_mbps": 112.03,
+   "decompress_mbps": 411.76
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2135664,
+   "ratio": 0.3223,
+   "compress_mbps": 72.25,
+   "decompress_mbps": 435.29
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2052793,
+   "ratio": 0.3098,
+   "compress_mbps": 81.67,
+   "decompress_mbps": 430.73
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1932127,
+   "ratio": 0.2915,
+   "compress_mbps": 45.23,
+   "decompress_mbps": 432.43
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1860865,
+   "ratio": 0.2808,
+   "compress_mbps": 22.82,
+   "decompress_mbps": 440.25
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1838671,
+   "ratio": 0.2774,
+   "compress_mbps": 15.96,
+   "decompress_mbps": 441.72
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1823235,
+   "ratio": 0.2751,
+   "compress_mbps": 8.12,
+   "decompress_mbps": 436.13
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1823190,
+   "ratio": 0.2751,
+   "compress_mbps": 8.15,
+   "decompress_mbps": 439.5
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6329449,
+   "ratio": 0.2929,
+   "compress_mbps": 169.74,
+   "decompress_mbps": 460.79
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6128866,
+   "ratio": 0.2837,
+   "compress_mbps": 155.55,
+   "decompress_mbps": 557.06
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5982546,
+   "ratio": 0.2769,
+   "compress_mbps": 125.39,
+   "decompress_mbps": 581.02
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5656400,
+   "ratio": 0.2618,
+   "compress_mbps": 116.92,
+   "decompress_mbps": 576.69
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5511352,
+   "ratio": 0.2551,
+   "compress_mbps": 82.58,
+   "decompress_mbps": 587.65
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5451399,
+   "ratio": 0.2523,
+   "compress_mbps": 56.59,
+   "decompress_mbps": 593.88
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5417123,
+   "ratio": 0.2507,
+   "compress_mbps": 46.71,
+   "decompress_mbps": 596.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5404364,
+   "ratio": 0.2501,
+   "compress_mbps": 32.73,
+   "decompress_mbps": 602.78
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5402704,
+   "ratio": 0.2501,
+   "compress_mbps": 29.69,
+   "decompress_mbps": 390.04
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5567768,
+   "ratio": 0.7678,
+   "compress_mbps": 32.89,
+   "decompress_mbps": 211.48
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5504009,
+   "ratio": 0.759,
+   "compress_mbps": 38.32,
+   "decompress_mbps": 168.63
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5439339,
+   "ratio": 0.7501,
+   "compress_mbps": 29.43,
+   "decompress_mbps": 230.72
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5394604,
+   "ratio": 0.7439,
+   "compress_mbps": 32.68,
+   "decompress_mbps": 256.53
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5370116,
+   "ratio": 0.7405,
+   "compress_mbps": 28.44,
+   "decompress_mbps": 312.67
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5331793,
+   "ratio": 0.7352,
+   "compress_mbps": 20.53,
+   "decompress_mbps": 329.4
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5327677,
+   "ratio": 0.7347,
+   "compress_mbps": 21.16,
+   "decompress_mbps": 348.44
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5325914,
+   "ratio": 0.7344,
+   "compress_mbps": 18.96,
+   "decompress_mbps": 349.29
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5325914,
+   "ratio": 0.7344,
+   "compress_mbps": 18.95,
+   "decompress_mbps": 346.98
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 14991236,
+   "ratio": 0.3616,
+   "compress_mbps": 136.65,
+   "decompress_mbps": 380.3
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 14249692,
+   "ratio": 0.3437,
+   "compress_mbps": 120.34,
+   "decompress_mbps": 401.81
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13627761,
+   "ratio": 0.3287,
+   "compress_mbps": 87.73,
+   "decompress_mbps": 414.55
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 13001990,
+   "ratio": 0.3136,
+   "compress_mbps": 85.4,
+   "decompress_mbps": 395.8
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12445991,
+   "ratio": 0.3002,
+   "compress_mbps": 55.03,
+   "decompress_mbps": 392.94
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12213941,
+   "ratio": 0.2946,
+   "compress_mbps": 36.53,
+   "decompress_mbps": 400.31
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12130416,
+   "ratio": 0.2926,
+   "compress_mbps": 29.65,
+   "decompress_mbps": 401.43
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12073697,
+   "ratio": 0.2912,
+   "compress_mbps": 21.5,
+   "decompress_mbps": 403.07
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12073469,
+   "ratio": 0.2912,
+   "compress_mbps": 21.33,
+   "decompress_mbps": 403.44
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6033926,
+   "ratio": 0.712,
+   "compress_mbps": 75.49,
+   "decompress_mbps": 294.33
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 5997474,
+   "ratio": 0.7077,
+   "compress_mbps": 68.78,
+   "decompress_mbps": 305.32
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 5966621,
+   "ratio": 0.7041,
+   "compress_mbps": 55.63,
+   "decompress_mbps": 312.38
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6091108,
+   "ratio": 0.7188,
+   "compress_mbps": 46.09,
+   "decompress_mbps": 267.15
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6053566,
+   "ratio": 0.7143,
+   "compress_mbps": 37.26,
+   "decompress_mbps": 274.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6045111,
+   "ratio": 0.7134,
+   "compress_mbps": 34.97,
+   "decompress_mbps": 276.79
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6045034,
+   "ratio": 0.7133,
+   "compress_mbps": 34.92,
+   "decompress_mbps": 278.07
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6045032,
+   "ratio": 0.7133,
+   "compress_mbps": 34.97,
+   "decompress_mbps": 277.28
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6045032,
+   "ratio": 0.7133,
+   "compress_mbps": 34.94,
+   "decompress_mbps": 277.39
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 965242,
+   "ratio": 0.1806,
+   "compress_mbps": 264.31,
+   "decompress_mbps": 697.56
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 887265,
+   "ratio": 0.166,
+   "compress_mbps": 246.22,
+   "decompress_mbps": 752.4
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 822167,
+   "ratio": 0.1538,
+   "compress_mbps": 191.48,
+   "decompress_mbps": 797.39
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 807518,
+   "ratio": 0.1511,
+   "compress_mbps": 169.01,
+   "decompress_mbps": 768.34
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 730574,
+   "ratio": 0.1367,
+   "compress_mbps": 121.75,
+   "decompress_mbps": 815.59
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 687991,
+   "ratio": 0.1287,
+   "compress_mbps": 79.31,
+   "decompress_mbps": 872.54
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 673933,
+   "ratio": 0.1261,
+   "compress_mbps": 64.99,
+   "decompress_mbps": 887.93
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 659518,
+   "ratio": 0.1234,
+   "compress_mbps": 43.0,
+   "decompress_mbps": 884.96
+  },
+  {
+   "compressor": "zlib",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 658899,
+   "ratio": 0.1233,
+   "compress_mbps": 39.85,
+   "decompress_mbps": 896.88
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 5363862,
+   "ratio": 0.5263,
+   "compress_mbps": 141.65,
+   "decompress_mbps": 389.91
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4438205,
+   "ratio": 0.4354,
+   "compress_mbps": 128.9,
+   "decompress_mbps": 428.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4054333,
+   "ratio": 0.3978,
+   "compress_mbps": 63.86,
+   "decompress_mbps": 475.64
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4038550,
+   "ratio": 0.3962,
+   "compress_mbps": 57.76,
+   "decompress_mbps": 469.09
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3954920,
+   "ratio": 0.388,
+   "compress_mbps": 40.27,
+   "decompress_mbps": 462.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3872874,
+   "ratio": 0.38,
+   "compress_mbps": 22.58,
+   "decompress_mbps": 470.25
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3859937,
+   "ratio": 0.3787,
+   "compress_mbps": 18.83,
+   "decompress_mbps": 472.38
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3855935,
+   "ratio": 0.3783,
+   "compress_mbps": 17.07,
+   "decompress_mbps": 469.47
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3855791,
+   "ratio": 0.3783,
+   "compress_mbps": 17.01,
+   "decompress_mbps": 470.52
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 22334882,
+   "ratio": 0.4361,
+   "compress_mbps": 233.89,
+   "decompress_mbps": 370.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20150366,
+   "ratio": 0.3934,
+   "compress_mbps": 119.97,
+   "decompress_mbps": 375.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19495014,
+   "ratio": 0.3806,
+   "compress_mbps": 70.13,
+   "decompress_mbps": 389.58
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19424978,
+   "ratio": 0.3792,
+   "compress_mbps": 71.02,
+   "decompress_mbps": 402.97
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19298736,
+   "ratio": 0.3768,
+   "compress_mbps": 54.1,
+   "decompress_mbps": 393.93
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19179167,
+   "ratio": 0.3744,
+   "compress_mbps": 29.69,
+   "decompress_mbps": 422.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19151324,
+   "ratio": 0.3739,
+   "compress_mbps": 21.89,
+   "decompress_mbps": 422.25
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19144373,
+   "ratio": 0.3738,
+   "compress_mbps": 16.59,
+   "decompress_mbps": 407.62
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19141383,
+   "ratio": 0.3737,
+   "compress_mbps": 14.17,
+   "decompress_mbps": 420.85
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 4249731,
+   "ratio": 0.4262,
+   "compress_mbps": 313.35,
+   "decompress_mbps": 528.94
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3775479,
+   "ratio": 0.3787,
+   "compress_mbps": 156.84,
+   "decompress_mbps": 517.84
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3656966,
+   "ratio": 0.3668,
+   "compress_mbps": 79.84,
+   "decompress_mbps": 574.15
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3740378,
+   "ratio": 0.3751,
+   "compress_mbps": 67.57,
+   "decompress_mbps": 534.79
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3713604,
+   "ratio": 0.3725,
+   "compress_mbps": 48.45,
+   "decompress_mbps": 501.84
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3683556,
+   "ratio": 0.3694,
+   "compress_mbps": 24.87,
+   "decompress_mbps": 515.42
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3683797,
+   "ratio": 0.3695,
+   "compress_mbps": 18.98,
+   "decompress_mbps": 521.98
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3684477,
+   "ratio": 0.3695,
+   "compress_mbps": 14.34,
+   "decompress_mbps": 540.16
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3679414,
+   "ratio": 0.369,
+   "compress_mbps": 12.34,
+   "decompress_mbps": 542.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 5594622,
+   "ratio": 0.1667,
+   "compress_mbps": 433.55,
+   "decompress_mbps": 834.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4179532,
+   "ratio": 0.1246,
+   "compress_mbps": 327.38,
+   "decompress_mbps": 926.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3542329,
+   "ratio": 0.1056,
+   "compress_mbps": 211.33,
+   "decompress_mbps": 842.8
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3323363,
+   "ratio": 0.099,
+   "compress_mbps": 197.38,
+   "decompress_mbps": 872.41
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3230343,
+   "ratio": 0.0963,
+   "compress_mbps": 161.61,
+   "decompress_mbps": 952.97
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3123421,
+   "ratio": 0.0931,
+   "compress_mbps": 95.69,
+   "decompress_mbps": 997.1
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3093778,
+   "ratio": 0.0922,
+   "compress_mbps": 70.53,
+   "decompress_mbps": 972.37
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3067318,
+   "ratio": 0.0914,
+   "compress_mbps": 50.06,
+   "decompress_mbps": 1013.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3050695,
+   "ratio": 0.0909,
+   "compress_mbps": 41.98,
+   "decompress_mbps": 1022.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3543611,
+   "ratio": 0.576,
+   "compress_mbps": 169.2,
+   "decompress_mbps": 269.98
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3226818,
+   "ratio": 0.5245,
+   "compress_mbps": 86.03,
+   "decompress_mbps": 287.07
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3144140,
+   "ratio": 0.5111,
+   "compress_mbps": 52.6,
+   "decompress_mbps": 297.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3129833,
+   "ratio": 0.5087,
+   "compress_mbps": 51.39,
+   "decompress_mbps": 324.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3114809,
+   "ratio": 0.5063,
+   "compress_mbps": 40.29,
+   "decompress_mbps": 338.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3095705,
+   "ratio": 0.5032,
+   "compress_mbps": 25.04,
+   "decompress_mbps": 345.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3090055,
+   "ratio": 0.5023,
+   "compress_mbps": 20.39,
+   "decompress_mbps": 345.41
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3087665,
+   "ratio": 0.5019,
+   "compress_mbps": 17.41,
+   "decompress_mbps": 345.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3087158,
+   "ratio": 0.5018,
+   "compress_mbps": 16.29,
+   "decompress_mbps": 345.8
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 5419510,
+   "ratio": 0.5373,
+   "compress_mbps": 243.36,
+   "decompress_mbps": 535.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3982547,
+   "ratio": 0.3949,
+   "compress_mbps": 122.38,
+   "decompress_mbps": 550.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3806102,
+   "ratio": 0.3774,
+   "compress_mbps": 80.86,
+   "decompress_mbps": 568.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3761477,
+   "ratio": 0.373,
+   "compress_mbps": 78.11,
+   "decompress_mbps": 603.06
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3740298,
+   "ratio": 0.3709,
+   "compress_mbps": 67.07,
+   "decompress_mbps": 611.24
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3686116,
+   "ratio": 0.3655,
+   "compress_mbps": 49.52,
+   "decompress_mbps": 637.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3668442,
+   "ratio": 0.3637,
+   "compress_mbps": 38.85,
+   "decompress_mbps": 662.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3665072,
+   "ratio": 0.3634,
+   "compress_mbps": 33.15,
+   "decompress_mbps": 657.03
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3665057,
+   "ratio": 0.3634,
+   "compress_mbps": 32.94,
+   "decompress_mbps": 653.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2842321,
+   "ratio": 0.4289,
+   "compress_mbps": 193.08,
+   "decompress_mbps": 443.97
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2232180,
+   "ratio": 0.3368,
+   "compress_mbps": 151.04,
+   "decompress_mbps": 514.91
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2003056,
+   "ratio": 0.3022,
+   "compress_mbps": 81.92,
+   "decompress_mbps": 551.48
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1985375,
+   "ratio": 0.2996,
+   "compress_mbps": 74.08,
+   "decompress_mbps": 566.46
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1933775,
+   "ratio": 0.2918,
+   "compress_mbps": 51.93,
+   "decompress_mbps": 538.73
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1858103,
+   "ratio": 0.2804,
+   "compress_mbps": 22.05,
+   "decompress_mbps": 541.6
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1840414,
+   "ratio": 0.2777,
+   "compress_mbps": 15.15,
+   "decompress_mbps": 550.69
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1831679,
+   "ratio": 0.2764,
+   "compress_mbps": 11.76,
+   "decompress_mbps": 543.82
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1827137,
+   "ratio": 0.2757,
+   "compress_mbps": 10.16,
+   "decompress_mbps": 544.36
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 7089759,
+   "ratio": 0.3281,
+   "compress_mbps": 290.79,
+   "decompress_mbps": 557.71
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5966231,
+   "ratio": 0.2761,
+   "compress_mbps": 174.66,
+   "decompress_mbps": 619.46
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5611838,
+   "ratio": 0.2597,
+   "compress_mbps": 111.67,
+   "decompress_mbps": 648.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5535436,
+   "ratio": 0.2562,
+   "compress_mbps": 105.54,
+   "decompress_mbps": 672.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5480971,
+   "ratio": 0.2537,
+   "compress_mbps": 81.52,
+   "decompress_mbps": 680.77
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5437556,
+   "ratio": 0.2517,
+   "compress_mbps": 49.47,
+   "decompress_mbps": 697.31
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5432108,
+   "ratio": 0.2514,
+   "compress_mbps": 40.48,
+   "decompress_mbps": 694.27
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5428571,
+   "ratio": 0.2512,
+   "compress_mbps": 33.62,
+   "decompress_mbps": 700.3
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5425526,
+   "ratio": 0.2511,
+   "compress_mbps": 30.51,
+   "decompress_mbps": 703.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5900800,
+   "ratio": 0.8137,
+   "compress_mbps": 188.47,
+   "decompress_mbps": 324.35
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5523611,
+   "ratio": 0.7617,
+   "compress_mbps": 69.45,
+   "decompress_mbps": 340.66
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5393086,
+   "ratio": 0.7437,
+   "compress_mbps": 40.33,
+   "decompress_mbps": 351.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5401582,
+   "ratio": 0.7448,
+   "compress_mbps": 40.72,
+   "decompress_mbps": 367.5
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5371274,
+   "ratio": 0.7407,
+   "compress_mbps": 31.31,
+   "decompress_mbps": 358.37
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5330096,
+   "ratio": 0.735,
+   "compress_mbps": 20.8,
+   "decompress_mbps": 365.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5325437,
+   "ratio": 0.7343,
+   "compress_mbps": 18.98,
+   "decompress_mbps": 366.05
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5323934,
+   "ratio": 0.7341,
+   "compress_mbps": 18.05,
+   "decompress_mbps": 364.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5323621,
+   "ratio": 0.7341,
+   "compress_mbps": 17.67,
+   "decompress_mbps": 364.02
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 17587173,
+   "ratio": 0.4242,
+   "compress_mbps": 185.73,
+   "decompress_mbps": 379.13
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 14171707,
+   "ratio": 0.3418,
+   "compress_mbps": 149.15,
+   "decompress_mbps": 409.08
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12774851,
+   "ratio": 0.3081,
+   "compress_mbps": 85.71,
+   "decompress_mbps": 440.79
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12612554,
+   "ratio": 0.3042,
+   "compress_mbps": 76.13,
+   "decompress_mbps": 444.75
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12392339,
+   "ratio": 0.2989,
+   "compress_mbps": 58.1,
+   "decompress_mbps": 457.17
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12158314,
+   "ratio": 0.2933,
+   "compress_mbps": 34.41,
+   "decompress_mbps": 463.08
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12107840,
+   "ratio": 0.292,
+   "compress_mbps": 27.64,
+   "decompress_mbps": 466.33
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12081311,
+   "ratio": 0.2914,
+   "compress_mbps": 22.88,
+   "decompress_mbps": 462.63
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12081011,
+   "ratio": 0.2914,
+   "compress_mbps": 22.78,
+   "decompress_mbps": 460.01
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6527324,
+   "ratio": 0.7703,
+   "compress_mbps": 238.95,
+   "decompress_mbps": 330.7
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6051483,
+   "ratio": 0.7141,
+   "compress_mbps": 75.62,
+   "decompress_mbps": 332.39
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6010123,
+   "ratio": 0.7092,
+   "compress_mbps": 52.06,
+   "decompress_mbps": 334.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6024815,
+   "ratio": 0.711,
+   "compress_mbps": 44.63,
+   "decompress_mbps": 286.25
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6005181,
+   "ratio": 0.7086,
+   "compress_mbps": 40.44,
+   "decompress_mbps": 293.0
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5997508,
+   "ratio": 0.7077,
+   "compress_mbps": 37.97,
+   "decompress_mbps": 295.42
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.87,
+   "decompress_mbps": 295.69
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.82,
+   "decompress_mbps": 295.45
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5997403,
+   "ratio": 0.7077,
+   "compress_mbps": 37.76,
+   "decompress_mbps": 292.96
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 1147652,
+   "ratio": 0.2147,
+   "compress_mbps": 388.67,
+   "decompress_mbps": 761.65
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 919639,
+   "ratio": 0.172,
+   "compress_mbps": 262.86,
+   "decompress_mbps": 956.95
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 752341,
+   "ratio": 0.1407,
+   "compress_mbps": 167.46,
+   "decompress_mbps": 1057.51
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 735537,
+   "ratio": 0.1376,
+   "compress_mbps": 161.37,
+   "decompress_mbps": 1037.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 706789,
+   "ratio": 0.1322,
+   "compress_mbps": 123.5,
+   "decompress_mbps": 1129.34
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 676279,
+   "ratio": 0.1265,
+   "compress_mbps": 69.53,
+   "decompress_mbps": 1219.4
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 668772,
+   "ratio": 0.1251,
+   "compress_mbps": 55.97,
+   "decompress_mbps": 1208.21
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 665340,
+   "ratio": 0.1245,
+   "compress_mbps": 47.61,
+   "decompress_mbps": 1208.14
+  },
+  {
+   "compressor": "miniz_oxide",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 664273,
+   "ratio": 0.1243,
+   "compress_mbps": 45.85,
+   "decompress_mbps": 1218.11
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4217525,
+   "ratio": 0.4138,
+   "compress_mbps": 243.85,
+   "decompress_mbps": 801.13
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4053259,
+   "ratio": 0.3977,
+   "compress_mbps": 170.19,
+   "decompress_mbps": 864.66
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3989875,
+   "ratio": 0.3915,
+   "compress_mbps": 140.0,
+   "decompress_mbps": 934.98
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3972869,
+   "ratio": 0.3898,
+   "compress_mbps": 127.83,
+   "decompress_mbps": 825.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3894026,
+   "ratio": 0.3821,
+   "compress_mbps": 99.29,
+   "decompress_mbps": 791.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3859436,
+   "ratio": 0.3787,
+   "compress_mbps": 75.65,
+   "decompress_mbps": 819.18
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3837515,
+   "ratio": 0.3765,
+   "compress_mbps": 55.71,
+   "decompress_mbps": 796.16
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3811467,
+   "ratio": 0.374,
+   "compress_mbps": 36.03,
+   "decompress_mbps": 816.32
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3810354,
+   "ratio": 0.3738,
+   "compress_mbps": 32.76,
+   "decompress_mbps": 816.68
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20192961,
+   "ratio": 0.3942,
+   "compress_mbps": 242.16,
+   "decompress_mbps": 676.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19374226,
+   "ratio": 0.3783,
+   "compress_mbps": 185.69,
+   "decompress_mbps": 710.78
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19234937,
+   "ratio": 0.3755,
+   "compress_mbps": 173.04,
+   "decompress_mbps": 727.76
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19145385,
+   "ratio": 0.3738,
+   "compress_mbps": 162.62,
+   "decompress_mbps": 728.74
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 18878875,
+   "ratio": 0.3686,
+   "compress_mbps": 142.62,
+   "decompress_mbps": 741.83
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 18805391,
+   "ratio": 0.3671,
+   "compress_mbps": 117.71,
+   "decompress_mbps": 750.56
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 18749947,
+   "ratio": 0.3661,
+   "compress_mbps": 87.16,
+   "decompress_mbps": 759.3
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 18718540,
+   "ratio": 0.3655,
+   "compress_mbps": 47.56,
+   "decompress_mbps": 766.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 18713659,
+   "ratio": 0.3654,
+   "compress_mbps": 33.49,
+   "decompress_mbps": 676.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3740775,
+   "ratio": 0.3752,
+   "compress_mbps": 293.42,
+   "decompress_mbps": 755.42
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3707407,
+   "ratio": 0.3718,
+   "compress_mbps": 217.45,
+   "decompress_mbps": 768.84
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3672389,
+   "ratio": 0.3683,
+   "compress_mbps": 185.43,
+   "decompress_mbps": 809.7
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3660011,
+   "ratio": 0.3671,
+   "compress_mbps": 171.62,
+   "decompress_mbps": 751.11
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3664245,
+   "ratio": 0.3675,
+   "compress_mbps": 141.37,
+   "decompress_mbps": 712.85
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3648644,
+   "ratio": 0.3659,
+   "compress_mbps": 106.84,
+   "decompress_mbps": 739.26
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3635323,
+   "ratio": 0.3646,
+   "compress_mbps": 68.34,
+   "decompress_mbps": 735.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3624778,
+   "ratio": 0.3635,
+   "compress_mbps": 43.04,
+   "decompress_mbps": 773.18
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3625176,
+   "ratio": 0.3636,
+   "compress_mbps": 38.87,
+   "decompress_mbps": 757.44
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3837577,
+   "ratio": 0.1144,
+   "compress_mbps": 609.02,
+   "decompress_mbps": 1491.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3714632,
+   "ratio": 0.1107,
+   "compress_mbps": 462.85,
+   "decompress_mbps": 1747.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3599455,
+   "ratio": 0.1073,
+   "compress_mbps": 427.07,
+   "decompress_mbps": 1882.3
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3431843,
+   "ratio": 0.1023,
+   "compress_mbps": 388.74,
+   "decompress_mbps": 1763.39
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3268188,
+   "ratio": 0.0974,
+   "compress_mbps": 346.67,
+   "decompress_mbps": 1777.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3091741,
+   "ratio": 0.0921,
+   "compress_mbps": 264.16,
+   "decompress_mbps": 1787.13
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3032499,
+   "ratio": 0.0904,
+   "compress_mbps": 186.41,
+   "decompress_mbps": 1846.22
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2949097,
+   "ratio": 0.0879,
+   "compress_mbps": 97.63,
+   "decompress_mbps": 1789.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2925243,
+   "ratio": 0.0872,
+   "compress_mbps": 69.23,
+   "decompress_mbps": 1757.94
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3275124,
+   "ratio": 0.5324,
+   "compress_mbps": 166.26,
+   "decompress_mbps": 462.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3150806,
+   "ratio": 0.5121,
+   "compress_mbps": 128.39,
+   "decompress_mbps": 483.21
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3137061,
+   "ratio": 0.5099,
+   "compress_mbps": 120.82,
+   "decompress_mbps": 502.43
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3129676,
+   "ratio": 0.5087,
+   "compress_mbps": 116.89,
+   "decompress_mbps": 518.56
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3079277,
+   "ratio": 0.5005,
+   "compress_mbps": 99.99,
+   "decompress_mbps": 536.74
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3072378,
+   "ratio": 0.4994,
+   "compress_mbps": 88.82,
+   "decompress_mbps": 533.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3068123,
+   "ratio": 0.4987,
+   "compress_mbps": 76.38,
+   "decompress_mbps": 542.11
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3067299,
+   "ratio": 0.4986,
+   "compress_mbps": 55.33,
+   "decompress_mbps": 533.57
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3066968,
+   "ratio": 0.4985,
+   "compress_mbps": 49.23,
+   "decompress_mbps": 507.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3868663,
+   "ratio": 0.3836,
+   "compress_mbps": 285.16,
+   "decompress_mbps": 772.78
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3839158,
+   "ratio": 0.3807,
+   "compress_mbps": 213.22,
+   "decompress_mbps": 914.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3818964,
+   "ratio": 0.3787,
+   "compress_mbps": 197.74,
+   "decompress_mbps": 936.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3789325,
+   "ratio": 0.3757,
+   "compress_mbps": 179.66,
+   "decompress_mbps": 954.8
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3666476,
+   "ratio": 0.3635,
+   "compress_mbps": 157.89,
+   "decompress_mbps": 942.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3660266,
+   "ratio": 0.3629,
+   "compress_mbps": 142.43,
+   "decompress_mbps": 987.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3659491,
+   "ratio": 0.3628,
+   "compress_mbps": 135.11,
+   "decompress_mbps": 999.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3654863,
+   "ratio": 0.3624,
+   "compress_mbps": 114.32,
+   "decompress_mbps": 1009.23
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3654860,
+   "ratio": 0.3624,
+   "compress_mbps": 114.27,
+   "decompress_mbps": 1001.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2197055,
+   "ratio": 0.3315,
+   "compress_mbps": 300.85,
+   "decompress_mbps": 858.37
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2082309,
+   "ratio": 0.3142,
+   "compress_mbps": 214.77,
+   "decompress_mbps": 1130.12
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2021047,
+   "ratio": 0.305,
+   "compress_mbps": 178.67,
+   "decompress_mbps": 1236.6
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1990952,
+   "ratio": 0.3004,
+   "compress_mbps": 157.4,
+   "decompress_mbps": 1146.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1921113,
+   "ratio": 0.2899,
+   "compress_mbps": 127.99,
+   "decompress_mbps": 1093.81
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1876257,
+   "ratio": 0.2831,
+   "compress_mbps": 86.94,
+   "decompress_mbps": 1090.38
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1832695,
+   "ratio": 0.2765,
+   "compress_mbps": 46.02,
+   "decompress_mbps": 1103.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1809967,
+   "ratio": 0.2731,
+   "compress_mbps": 24.27,
+   "decompress_mbps": 1063.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1806374,
+   "ratio": 0.2726,
+   "compress_mbps": 19.83,
+   "decompress_mbps": 1054.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 5866517,
+   "ratio": 0.2715,
+   "compress_mbps": 338.52,
+   "decompress_mbps": 979.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5695942,
+   "ratio": 0.2636,
+   "compress_mbps": 258.0,
+   "decompress_mbps": 1031.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5605878,
+   "ratio": 0.2595,
+   "compress_mbps": 233.32,
+   "decompress_mbps": 1100.86
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5553432,
+   "ratio": 0.257,
+   "compress_mbps": 216.59,
+   "decompress_mbps": 1079.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5416713,
+   "ratio": 0.2507,
+   "compress_mbps": 186.71,
+   "decompress_mbps": 1066.93
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5337149,
+   "ratio": 0.247,
+   "compress_mbps": 142.78,
+   "decompress_mbps": 1079.29
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5310181,
+   "ratio": 0.2458,
+   "compress_mbps": 100.23,
+   "decompress_mbps": 1069.71
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5272761,
+   "ratio": 0.244,
+   "compress_mbps": 62.39,
+   "decompress_mbps": 1089.17
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5270405,
+   "ratio": 0.2439,
+   "compress_mbps": 50.04,
+   "decompress_mbps": 1101.61
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5575128,
+   "ratio": 0.7688,
+   "compress_mbps": 162.23,
+   "decompress_mbps": 485.07
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5417142,
+   "ratio": 0.747,
+   "compress_mbps": 116.65,
+   "decompress_mbps": 518.27
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5397999,
+   "ratio": 0.7444,
+   "compress_mbps": 105.25,
+   "decompress_mbps": 528.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5391125,
+   "ratio": 0.7434,
+   "compress_mbps": 99.31,
+   "decompress_mbps": 542.53
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5352212,
+   "ratio": 0.738,
+   "compress_mbps": 87.58,
+   "decompress_mbps": 513.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5335405,
+   "ratio": 0.7357,
+   "compress_mbps": 73.79,
+   "decompress_mbps": 526.1
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5325697,
+   "ratio": 0.7344,
+   "compress_mbps": 63.45,
+   "decompress_mbps": 513.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5324004,
+   "ratio": 0.7341,
+   "compress_mbps": 52.34,
+   "decompress_mbps": 522.62
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5323197,
+   "ratio": 0.734,
+   "compress_mbps": 50.85,
+   "decompress_mbps": 511.04
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 13550569,
+   "ratio": 0.3268,
+   "compress_mbps": 266.06,
+   "decompress_mbps": 891.09
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13130705,
+   "ratio": 0.3167,
+   "compress_mbps": 199.84,
+   "decompress_mbps": 973.65
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12839361,
+   "ratio": 0.3097,
+   "compress_mbps": 176.74,
+   "decompress_mbps": 1015.15
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12601933,
+   "ratio": 0.304,
+   "compress_mbps": 161.98,
+   "decompress_mbps": 899.79
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12310776,
+   "ratio": 0.2969,
+   "compress_mbps": 131.58,
+   "decompress_mbps": 879.58
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12140474,
+   "ratio": 0.2928,
+   "compress_mbps": 104.62,
+   "decompress_mbps": 887.92
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12025296,
+   "ratio": 0.2901,
+   "compress_mbps": 75.01,
+   "decompress_mbps": 892.91
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 11893824,
+   "ratio": 0.2869,
+   "compress_mbps": 45.87,
+   "decompress_mbps": 886.31
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11882496,
+   "ratio": 0.2866,
+   "compress_mbps": 39.46,
+   "decompress_mbps": 930.2
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6293390,
+   "ratio": 0.7426,
+   "compress_mbps": 145.39,
+   "decompress_mbps": 523.59
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6058412,
+   "ratio": 0.7149,
+   "compress_mbps": 120.35,
+   "decompress_mbps": 529.46
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6058381,
+   "ratio": 0.7149,
+   "compress_mbps": 120.3,
+   "decompress_mbps": 539.19
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6058363,
+   "ratio": 0.7149,
+   "compress_mbps": 120.03,
+   "decompress_mbps": 437.57
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 5998400,
+   "ratio": 0.7078,
+   "compress_mbps": 108.52,
+   "decompress_mbps": 459.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5998438,
+   "ratio": 0.7078,
+   "compress_mbps": 108.55,
+   "decompress_mbps": 463.75
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5998439,
+   "ratio": 0.7078,
+   "compress_mbps": 108.18,
+   "decompress_mbps": 462.69
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5986859,
+   "ratio": 0.7065,
+   "compress_mbps": 90.15,
+   "decompress_mbps": 462.82
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5986859,
+   "ratio": 0.7065,
+   "compress_mbps": 90.18,
+   "decompress_mbps": 454.72
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 887708,
+   "ratio": 0.1661,
+   "compress_mbps": 492.83,
+   "decompress_mbps": 1270.45
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 843475,
+   "ratio": 0.1578,
+   "compress_mbps": 363.79,
+   "decompress_mbps": 1801.54
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 793388,
+   "ratio": 0.1484,
+   "compress_mbps": 337.16,
+   "decompress_mbps": 1867.27
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 747602,
+   "ratio": 0.1399,
+   "compress_mbps": 304.24,
+   "decompress_mbps": 1819.5
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 718615,
+   "ratio": 0.1344,
+   "compress_mbps": 263.07,
+   "decompress_mbps": 1830.67
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 684405,
+   "ratio": 0.128,
+   "compress_mbps": 206.4,
+   "decompress_mbps": 1920.08
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 664859,
+   "ratio": 0.1244,
+   "compress_mbps": 142.72,
+   "decompress_mbps": 1906.99
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 650835,
+   "ratio": 0.1218,
+   "compress_mbps": 81.56,
+   "decompress_mbps": 1892.16
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 649494,
+   "ratio": 0.1215,
+   "compress_mbps": 68.13,
+   "decompress_mbps": 1902.14
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 65708,
+   "ratio": 0.432,
+   "compress_mbps": 42.56,
+   "decompress_mbps": 61.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 60259,
+   "ratio": 0.3962,
+   "compress_mbps": 26.21,
+   "decompress_mbps": 68.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 58544,
+   "ratio": 0.3849,
+   "compress_mbps": 21.92,
+   "decompress_mbps": 69.11
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56238,
+   "ratio": 0.3698,
+   "compress_mbps": 21.46,
+   "decompress_mbps": 70.96
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54764,
+   "ratio": 0.3601,
+   "compress_mbps": 16.16,
+   "decompress_mbps": 71.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54311,
+   "ratio": 0.3571,
+   "compress_mbps": 10.7,
+   "decompress_mbps": 71.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54262,
+   "ratio": 0.3568,
+   "compress_mbps": 9.8,
+   "decompress_mbps": 72.02
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 54247,
+   "ratio": 0.3567,
+   "compress_mbps": 9.57,
+   "decompress_mbps": 72.02
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 54247,
+   "ratio": 0.3567,
+   "compress_mbps": 9.65,
+   "decompress_mbps": 72.57
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 56882,
+   "ratio": 0.4544,
+   "compress_mbps": 37.25,
+   "decompress_mbps": 55.92
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 52826,
+   "ratio": 0.422,
+   "compress_mbps": 23.05,
+   "decompress_mbps": 62.21
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51625,
+   "ratio": 0.4124,
+   "compress_mbps": 22.69,
+   "decompress_mbps": 65.27
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50034,
+   "ratio": 0.3997,
+   "compress_mbps": 22.5,
+   "decompress_mbps": 65.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48912,
+   "ratio": 0.3907,
+   "compress_mbps": 12.62,
+   "decompress_mbps": 65.42
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48738,
+   "ratio": 0.3893,
+   "compress_mbps": 11.77,
+   "decompress_mbps": 65.61
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48719,
+   "ratio": 0.3892,
+   "compress_mbps": 9.97,
+   "decompress_mbps": 65.88
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48716,
+   "ratio": 0.3892,
+   "compress_mbps": 9.9,
+   "decompress_mbps": 68.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48716,
+   "ratio": 0.3892,
+   "compress_mbps": 12.58,
+   "decompress_mbps": 64.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8988,
+   "ratio": 0.3653,
+   "compress_mbps": 36.94,
+   "decompress_mbps": 103.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8564,
+   "ratio": 0.3481,
+   "compress_mbps": 43.51,
+   "decompress_mbps": 102.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8390,
+   "ratio": 0.341,
+   "compress_mbps": 28.97,
+   "decompress_mbps": 97.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8167,
+   "ratio": 0.332,
+   "compress_mbps": 37.49,
+   "decompress_mbps": 98.37
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7965,
+   "ratio": 0.3237,
+   "compress_mbps": 28.72,
+   "decompress_mbps": 88.78
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7916,
+   "ratio": 0.3217,
+   "compress_mbps": 22.76,
+   "decompress_mbps": 104.8
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 21.67,
+   "decompress_mbps": 85.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 20.13,
+   "decompress_mbps": 105.7
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7900,
+   "ratio": 0.3211,
+   "compress_mbps": 27.55,
+   "decompress_mbps": 92.8
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3731,
+   "ratio": 0.3346,
+   "compress_mbps": 18.9,
+   "decompress_mbps": 80.13
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3491,
+   "ratio": 0.3131,
+   "compress_mbps": 23.63,
+   "decompress_mbps": 84.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3384,
+   "ratio": 0.3035,
+   "compress_mbps": 22.04,
+   "decompress_mbps": 89.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3220,
+   "ratio": 0.2888,
+   "compress_mbps": 21.08,
+   "decompress_mbps": 86.53
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3138,
+   "ratio": 0.2814,
+   "compress_mbps": 17.11,
+   "decompress_mbps": 93.05
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3118,
+   "ratio": 0.2796,
+   "compress_mbps": 15.03,
+   "decompress_mbps": 100.03
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 14.26,
+   "decompress_mbps": 96.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 14.4,
+   "decompress_mbps": 104.06
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3116,
+   "ratio": 0.2795,
+   "compress_mbps": 15.81,
+   "decompress_mbps": 101.86
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1352,
+   "ratio": 0.3633,
+   "compress_mbps": 8.47,
+   "decompress_mbps": 63.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1287,
+   "ratio": 0.3459,
+   "compress_mbps": 11.63,
+   "decompress_mbps": 60.62
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1284,
+   "ratio": 0.3451,
+   "compress_mbps": 11.67,
+   "decompress_mbps": 62.5
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1226,
+   "ratio": 0.3295,
+   "compress_mbps": 11.31,
+   "decompress_mbps": 66.96
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 9.84,
+   "decompress_mbps": 63.24
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 10.84,
+   "decompress_mbps": 63.7
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 10.02,
+   "decompress_mbps": 64.11
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 10.74,
+   "decompress_mbps": 80.94
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1211,
+   "ratio": 0.3255,
+   "compress_mbps": 11.17,
+   "decompress_mbps": 63.88
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 245423,
+   "ratio": 0.2383,
+   "compress_mbps": 123.71,
+   "decompress_mbps": 127.4
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 229642,
+   "ratio": 0.223,
+   "compress_mbps": 92.84,
+   "decompress_mbps": 151.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 225678,
+   "ratio": 0.2192,
+   "compress_mbps": 109.83,
+   "decompress_mbps": 153.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 218218,
+   "ratio": 0.2119,
+   "compress_mbps": 99.82,
+   "decompress_mbps": 163.61
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 210550,
+   "ratio": 0.2045,
+   "compress_mbps": 48.7,
+   "decompress_mbps": 154.12
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 207949,
+   "ratio": 0.2019,
+   "compress_mbps": 27.88,
+   "decompress_mbps": 168.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 207413,
+   "ratio": 0.2014,
+   "compress_mbps": 18.82,
+   "decompress_mbps": 151.74
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 207478,
+   "ratio": 0.2015,
+   "compress_mbps": 6.77,
+   "decompress_mbps": 153.16
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 207482,
+   "ratio": 0.2015,
+   "compress_mbps": 3.56,
+   "decompress_mbps": 157.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 175980,
+   "ratio": 0.4124,
+   "compress_mbps": 43.31,
+   "decompress_mbps": 64.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 160455,
+   "ratio": 0.376,
+   "compress_mbps": 70.41,
+   "decompress_mbps": 72.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 156690,
+   "ratio": 0.3672,
+   "compress_mbps": 32.21,
+   "decompress_mbps": 74.1
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 149064,
+   "ratio": 0.3493,
+   "compress_mbps": 36.48,
+   "decompress_mbps": 75.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145616,
+   "ratio": 0.3412,
+   "compress_mbps": 20.01,
+   "decompress_mbps": 76.95
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144773,
+   "ratio": 0.3392,
+   "compress_mbps": 17.53,
+   "decompress_mbps": 76.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 144603,
+   "ratio": 0.3388,
+   "compress_mbps": 19.93,
+   "decompress_mbps": 75.91
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 144573,
+   "ratio": 0.3388,
+   "compress_mbps": 16.49,
+   "decompress_mbps": 80.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 144570,
+   "ratio": 0.3388,
+   "compress_mbps": 15.68,
+   "decompress_mbps": 75.93
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 228837,
+   "ratio": 0.4749,
+   "compress_mbps": 35.31,
+   "decompress_mbps": 54.63
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 211248,
+   "ratio": 0.4384,
+   "compress_mbps": 31.57,
+   "decompress_mbps": 61.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 205619,
+   "ratio": 0.4267,
+   "compress_mbps": 25.52,
+   "decompress_mbps": 67.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 200595,
+   "ratio": 0.4163,
+   "compress_mbps": 34.86,
+   "decompress_mbps": 66.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 195418,
+   "ratio": 0.4055,
+   "compress_mbps": 18.88,
+   "decompress_mbps": 65.35
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 194148,
+   "ratio": 0.4029,
+   "compress_mbps": 15.2,
+   "decompress_mbps": 66.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 193994,
+   "ratio": 0.4026,
+   "compress_mbps": 16.61,
+   "decompress_mbps": 66.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 193991,
+   "ratio": 0.4026,
+   "compress_mbps": 14.97,
+   "decompress_mbps": 65.37
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 193991,
+   "ratio": 0.4026,
+   "compress_mbps": 14.75,
+   "decompress_mbps": 80.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60990,
+   "ratio": 0.1188,
+   "compress_mbps": 240.46,
+   "decompress_mbps": 173.43
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 61650,
+   "ratio": 0.1201,
+   "compress_mbps": 103.12,
+   "decompress_mbps": 188.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 60035,
+   "ratio": 0.117,
+   "compress_mbps": 90.48,
+   "decompress_mbps": 205.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57005,
+   "ratio": 0.1111,
+   "compress_mbps": 91.56,
+   "decompress_mbps": 195.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 55779,
+   "ratio": 0.1087,
+   "compress_mbps": 81.64,
+   "decompress_mbps": 263.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 54970,
+   "ratio": 0.1071,
+   "compress_mbps": 69.16,
+   "decompress_mbps": 204.84
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 53922,
+   "ratio": 0.1051,
+   "compress_mbps": 76.91,
+   "decompress_mbps": 217.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 51977,
+   "ratio": 0.1013,
+   "compress_mbps": 17.63,
+   "decompress_mbps": 275.85
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 51474,
+   "ratio": 0.1003,
+   "compress_mbps": 6.71,
+   "decompress_mbps": 239.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14783,
+   "ratio": 0.3866,
+   "compress_mbps": 32.71,
+   "decompress_mbps": 70.98
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 14101,
+   "ratio": 0.3688,
+   "compress_mbps": 33.16,
+   "decompress_mbps": 78.17
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13975,
+   "ratio": 0.3655,
+   "compress_mbps": 28.17,
+   "decompress_mbps": 75.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13632,
+   "ratio": 0.3565,
+   "compress_mbps": 30.93,
+   "decompress_mbps": 100.62
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13302,
+   "ratio": 0.3479,
+   "compress_mbps": 25.78,
+   "decompress_mbps": 79.98
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13279,
+   "ratio": 0.3473,
+   "compress_mbps": 21.9,
+   "decompress_mbps": 77.99
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13274,
+   "ratio": 0.3471,
+   "compress_mbps": 19.14,
+   "decompress_mbps": 84.74
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13260,
+   "ratio": 0.3468,
+   "compress_mbps": 7.15,
+   "decompress_mbps": 80.47
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13260,
+   "ratio": 0.3468,
+   "compress_mbps": 4.57,
+   "decompress_mbps": 79.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1862,
+   "ratio": 0.4405,
+   "compress_mbps": 9.05,
+   "decompress_mbps": 61.67
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1803,
+   "ratio": 0.4265,
+   "compress_mbps": 12.61,
+   "decompress_mbps": 58.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1791,
+   "ratio": 0.4237,
+   "compress_mbps": 12.87,
+   "decompress_mbps": 60.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1746,
+   "ratio": 0.4131,
+   "compress_mbps": 12.23,
+   "decompress_mbps": 60.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 10.95,
+   "decompress_mbps": 59.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 11.32,
+   "decompress_mbps": 59.78
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 10.98,
+   "decompress_mbps": 65.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 11.09,
+   "decompress_mbps": 61.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1725,
+   "ratio": 0.4081,
+   "compress_mbps": 11.55,
+   "decompress_mbps": 61.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4623589,
+   "ratio": 0.4536,
+   "compress_mbps": 87.88,
+   "decompress_mbps": 121.47
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4241525,
+   "ratio": 0.4161,
+   "compress_mbps": 59.05,
+   "decompress_mbps": 124.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4123202,
+   "ratio": 0.4045,
+   "compress_mbps": 61.06,
+   "decompress_mbps": 116.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3985937,
+   "ratio": 0.3911,
+   "compress_mbps": 60.91,
+   "decompress_mbps": 204.23
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3883839,
+   "ratio": 0.3811,
+   "compress_mbps": 35.59,
+   "decompress_mbps": 119.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3860437,
+   "ratio": 0.3788,
+   "compress_mbps": 27.93,
+   "decompress_mbps": 202.6
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3857076,
+   "ratio": 0.3784,
+   "compress_mbps": 25.13,
+   "decompress_mbps": 126.89
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3856651,
+   "ratio": 0.3784,
+   "compress_mbps": 24.66,
+   "decompress_mbps": 202.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3856651,
+   "ratio": 0.3784,
+   "compress_mbps": 24.68,
+   "decompress_mbps": 116.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 21508211,
+   "ratio": 0.4199,
+   "compress_mbps": 143.1,
+   "decompress_mbps": 239.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 20538783,
+   "ratio": 0.401,
+   "compress_mbps": 103.18,
+   "decompress_mbps": 229.73
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 20334352,
+   "ratio": 0.397,
+   "compress_mbps": 88.51,
+   "decompress_mbps": 208.07
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19886937,
+   "ratio": 0.3883,
+   "compress_mbps": 86.76,
+   "decompress_mbps": 244.41
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19582363,
+   "ratio": 0.3823,
+   "compress_mbps": 65.59,
+   "decompress_mbps": 239.15
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19512479,
+   "ratio": 0.381,
+   "compress_mbps": 43.56,
+   "decompress_mbps": 220.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19489160,
+   "ratio": 0.3805,
+   "compress_mbps": 32.93,
+   "decompress_mbps": 227.82
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19475109,
+   "ratio": 0.3802,
+   "compress_mbps": 18.63,
+   "decompress_mbps": 225.38
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19476276,
+   "ratio": 0.3802,
+   "compress_mbps": 10.28,
+   "decompress_mbps": 247.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3967718,
+   "ratio": 0.3979,
+   "compress_mbps": 146.76,
+   "decompress_mbps": 172.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3773274,
+   "ratio": 0.3784,
+   "compress_mbps": 105.47,
+   "decompress_mbps": 124.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3670460,
+   "ratio": 0.3681,
+   "compress_mbps": 77.56,
+   "decompress_mbps": 182.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3655100,
+   "ratio": 0.3666,
+   "compress_mbps": 87.36,
+   "decompress_mbps": 107.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3620881,
+   "ratio": 0.3632,
+   "compress_mbps": 51.01,
+   "decompress_mbps": 125.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3606626,
+   "ratio": 0.3617,
+   "compress_mbps": 33.83,
+   "decompress_mbps": 183.58
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3605405,
+   "ratio": 0.3616,
+   "compress_mbps": 31.23,
+   "decompress_mbps": 130.79
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3601635,
+   "ratio": 0.3612,
+   "compress_mbps": 26.28,
+   "decompress_mbps": 133.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3601151,
+   "ratio": 0.3612,
+   "compress_mbps": 19.51,
+   "decompress_mbps": 120.72
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4501482,
+   "ratio": 0.1342,
+   "compress_mbps": 294.72,
+   "decompress_mbps": 451.24
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3875891,
+   "ratio": 0.1155,
+   "compress_mbps": 315.51,
+   "decompress_mbps": 356.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3731525,
+   "ratio": 0.1112,
+   "compress_mbps": 288.4,
+   "decompress_mbps": 372.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3542242,
+   "ratio": 0.1056,
+   "compress_mbps": 236.86,
+   "decompress_mbps": 484.44
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3239184,
+   "ratio": 0.0965,
+   "compress_mbps": 175.14,
+   "decompress_mbps": 539.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3113927,
+   "ratio": 0.0928,
+   "compress_mbps": 120.53,
+   "decompress_mbps": 330.65
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3063520,
+   "ratio": 0.0913,
+   "compress_mbps": 84.76,
+   "decompress_mbps": 331.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2961320,
+   "ratio": 0.0883,
+   "compress_mbps": 29.61,
+   "decompress_mbps": 401.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2940087,
+   "ratio": 0.0876,
+   "compress_mbps": 20.54,
+   "decompress_mbps": 474.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3462708,
+   "ratio": 0.5628,
+   "compress_mbps": 65.77,
+   "decompress_mbps": 109.92
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3327399,
+   "ratio": 0.5408,
+   "compress_mbps": 71.78,
+   "decompress_mbps": 84.48
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3297422,
+   "ratio": 0.536,
+   "compress_mbps": 66.06,
+   "decompress_mbps": 89.69
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3249485,
+   "ratio": 0.5282,
+   "compress_mbps": 64.02,
+   "decompress_mbps": 122.88
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3220046,
+   "ratio": 0.5234,
+   "compress_mbps": 49.81,
+   "decompress_mbps": 90.58
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3213239,
+   "ratio": 0.5223,
+   "compress_mbps": 43.12,
+   "decompress_mbps": 91.3
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3212009,
+   "ratio": 0.5221,
+   "compress_mbps": 39.44,
+   "decompress_mbps": 177.12
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3211575,
+   "ratio": 0.522,
+   "compress_mbps": 27.92,
+   "decompress_mbps": 92.84
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3211561,
+   "ratio": 0.522,
+   "compress_mbps": 29.68,
+   "decompress_mbps": 92.12
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4334497,
+   "ratio": 0.4298,
+   "compress_mbps": 130.93,
+   "decompress_mbps": 133.29
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3900156,
+   "ratio": 0.3867,
+   "compress_mbps": 131.77,
+   "decompress_mbps": 116.9
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3876099,
+   "ratio": 0.3843,
+   "compress_mbps": 122.94,
+   "decompress_mbps": 133.81
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3782364,
+   "ratio": 0.375,
+   "compress_mbps": 110.84,
+   "decompress_mbps": 135.49
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3679310,
+   "ratio": 0.3648,
+   "compress_mbps": 89.42,
+   "decompress_mbps": 136.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3679424,
+   "ratio": 0.3648,
+   "compress_mbps": 87.41,
+   "decompress_mbps": 128.99
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3679163,
+   "ratio": 0.3648,
+   "compress_mbps": 83.39,
+   "decompress_mbps": 141.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3679169,
+   "ratio": 0.3648,
+   "compress_mbps": 82.21,
+   "decompress_mbps": 140.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3679169,
+   "ratio": 0.3648,
+   "compress_mbps": 81.84,
+   "decompress_mbps": 196.94
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2496363,
+   "ratio": 0.3767,
+   "compress_mbps": 96.93,
+   "decompress_mbps": 111.19
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2202601,
+   "ratio": 0.3324,
+   "compress_mbps": 92.65,
+   "decompress_mbps": 102.3
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2103089,
+   "ratio": 0.3173,
+   "compress_mbps": 49.73,
+   "decompress_mbps": 242.36
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1999697,
+   "ratio": 0.3017,
+   "compress_mbps": 75.29,
+   "decompress_mbps": 121.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1892143,
+   "ratio": 0.2855,
+   "compress_mbps": 37.29,
+   "decompress_mbps": 108.65
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1838372,
+   "ratio": 0.2774,
+   "compress_mbps": 20.3,
+   "decompress_mbps": 108.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1828850,
+   "ratio": 0.276,
+   "compress_mbps": 15.87,
+   "decompress_mbps": 115.22
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1823159,
+   "ratio": 0.2751,
+   "compress_mbps": 12.46,
+   "decompress_mbps": 114.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1823159,
+   "ratio": 0.2751,
+   "compress_mbps": 12.53,
+   "decompress_mbps": 97.46
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6447290,
+   "ratio": 0.2984,
+   "compress_mbps": 187.76,
+   "decompress_mbps": 292.5
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 6030257,
+   "ratio": 0.2791,
+   "compress_mbps": 147.85,
+   "decompress_mbps": 241.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5928121,
+   "ratio": 0.2744,
+   "compress_mbps": 128.5,
+   "decompress_mbps": 269.87
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5615804,
+   "ratio": 0.2599,
+   "compress_mbps": 121.57,
+   "decompress_mbps": 280.75
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5496738,
+   "ratio": 0.2544,
+   "compress_mbps": 80.22,
+   "decompress_mbps": 336.14
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5464184,
+   "ratio": 0.2529,
+   "compress_mbps": 62.73,
+   "decompress_mbps": 195.35
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5429645,
+   "ratio": 0.2513,
+   "compress_mbps": 47.93,
+   "decompress_mbps": 214.77
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5418135,
+   "ratio": 0.2508,
+   "compress_mbps": 36.65,
+   "decompress_mbps": 241.37
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5416628,
+   "ratio": 0.2507,
+   "compress_mbps": 33.67,
+   "decompress_mbps": 233.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5759187,
+   "ratio": 0.7942,
+   "compress_mbps": 91.27,
+   "decompress_mbps": 158.91
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5619390,
+   "ratio": 0.7749,
+   "compress_mbps": 49.54,
+   "decompress_mbps": 94.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5560914,
+   "ratio": 0.7668,
+   "compress_mbps": 43.81,
+   "decompress_mbps": 115.78
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5544069,
+   "ratio": 0.7645,
+   "compress_mbps": 44.58,
+   "decompress_mbps": 94.11
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5518257,
+   "ratio": 0.7609,
+   "compress_mbps": 36.73,
+   "decompress_mbps": 163.59
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5508662,
+   "ratio": 0.7596,
+   "compress_mbps": 33.77,
+   "decompress_mbps": 95.01
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5507534,
+   "ratio": 0.7595,
+   "compress_mbps": 35.09,
+   "decompress_mbps": 95.76
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5507183,
+   "ratio": 0.7594,
+   "compress_mbps": 32.41,
+   "decompress_mbps": 94.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5507183,
+   "ratio": 0.7594,
+   "compress_mbps": 32.5,
+   "decompress_mbps": 117.56
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 15230651,
+   "ratio": 0.3674,
+   "compress_mbps": 123.36,
+   "decompress_mbps": 184.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13822040,
+   "ratio": 0.3334,
+   "compress_mbps": 96.36,
+   "decompress_mbps": 194.1
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13397592,
+   "ratio": 0.3232,
+   "compress_mbps": 83.62,
+   "decompress_mbps": 202.34
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12759940,
+   "ratio": 0.3078,
+   "compress_mbps": 80.4,
+   "decompress_mbps": 223.21
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12274278,
+   "ratio": 0.2961,
+   "compress_mbps": 54.6,
+   "decompress_mbps": 216.16
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12131738,
+   "ratio": 0.2926,
+   "compress_mbps": 40.41,
+   "decompress_mbps": 218.2
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12060450,
+   "ratio": 0.2909,
+   "compress_mbps": 33.43,
+   "decompress_mbps": 203.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12036900,
+   "ratio": 0.2903,
+   "compress_mbps": 29.91,
+   "decompress_mbps": 206.04
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12036900,
+   "ratio": 0.2903,
+   "compress_mbps": 30.01,
+   "decompress_mbps": 223.31
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6653052,
+   "ratio": 0.7851,
+   "compress_mbps": 124.38,
+   "decompress_mbps": 152.55
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6305035,
+   "ratio": 0.744,
+   "compress_mbps": 53.84,
+   "decompress_mbps": 154.18
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6302730,
+   "ratio": 0.7438,
+   "compress_mbps": 52.94,
+   "decompress_mbps": 119.64
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6299134,
+   "ratio": 0.7433,
+   "compress_mbps": 52.14,
+   "decompress_mbps": 156.45
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6289022,
+   "ratio": 0.7421,
+   "compress_mbps": 64.63,
+   "decompress_mbps": 159.21
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6289013,
+   "ratio": 0.7421,
+   "compress_mbps": 50.64,
+   "decompress_mbps": 156.7
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6289013,
+   "ratio": 0.7421,
+   "compress_mbps": 50.91,
+   "decompress_mbps": 165.38
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6289012,
+   "ratio": 0.7421,
+   "compress_mbps": 64.4,
+   "decompress_mbps": 157.39
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6289012,
+   "ratio": 0.7421,
+   "compress_mbps": 64.37,
+   "decompress_mbps": 98.54
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 989456,
+   "ratio": 0.1851,
+   "compress_mbps": 243.16,
+   "decompress_mbps": 153.25
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 839766,
+   "ratio": 0.1571,
+   "compress_mbps": 178.46,
+   "decompress_mbps": 169.75
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 800619,
+   "ratio": 0.1498,
+   "compress_mbps": 181.16,
+   "decompress_mbps": 178.28
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 776397,
+   "ratio": 0.1452,
+   "compress_mbps": 149.67,
+   "decompress_mbps": 185.03
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 712679,
+   "ratio": 0.1333,
+   "compress_mbps": 103.54,
+   "decompress_mbps": 199.06
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 683707,
+   "ratio": 0.1279,
+   "compress_mbps": 93.5,
+   "decompress_mbps": 512.66
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 668601,
+   "ratio": 0.1251,
+   "compress_mbps": 70.7,
+   "decompress_mbps": 209.33
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 659106,
+   "ratio": 0.1233,
+   "compress_mbps": 42.04,
+   "decompress_mbps": 216.57
+  },
+  {
+   "compressor": "go",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 658920,
+   "ratio": 0.1233,
+   "compress_mbps": 42.13,
+   "decompress_mbps": 256.07
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 62797,
+   "ratio": 0.4129,
+   "compress_mbps": 75.96,
+   "decompress_mbps": 132.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 59605,
+   "ratio": 0.3919,
+   "compress_mbps": 62.87,
+   "decompress_mbps": 131.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 57675,
+   "ratio": 0.3792,
+   "compress_mbps": 53.89,
+   "decompress_mbps": 124.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56500,
+   "ratio": 0.3715,
+   "compress_mbps": 38.93,
+   "decompress_mbps": 131.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 56440,
+   "ratio": 0.3711,
+   "compress_mbps": 38.82,
+   "decompress_mbps": 130.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 55443,
+   "ratio": 0.3645,
+   "compress_mbps": 32.14,
+   "decompress_mbps": 146.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 55373,
+   "ratio": 0.3641,
+   "compress_mbps": 31.65,
+   "decompress_mbps": 130.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 55352,
+   "ratio": 0.3639,
+   "compress_mbps": 31.32,
+   "decompress_mbps": 136.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 55352,
+   "ratio": 0.3639,
+   "compress_mbps": 31.37,
+   "decompress_mbps": 135.72
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 55063,
+   "ratio": 0.4399,
+   "compress_mbps": 74.97,
+   "decompress_mbps": 117.68
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 52932,
+   "ratio": 0.4229,
+   "compress_mbps": 60.75,
+   "decompress_mbps": 116.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 51597,
+   "ratio": 0.4122,
+   "compress_mbps": 44.1,
+   "decompress_mbps": 116.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50780,
+   "ratio": 0.4057,
+   "compress_mbps": 43.18,
+   "decompress_mbps": 120.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 50767,
+   "ratio": 0.4056,
+   "compress_mbps": 42.85,
+   "decompress_mbps": 122.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 50160,
+   "ratio": 0.4007,
+   "compress_mbps": 33.03,
+   "decompress_mbps": 128.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 31.52,
+   "decompress_mbps": 124.51
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 32.14,
+   "decompress_mbps": 125.83
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 50138,
+   "ratio": 0.4005,
+   "compress_mbps": 35.79,
+   "decompress_mbps": 124.35
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8730,
+   "ratio": 0.3548,
+   "compress_mbps": 46.94,
+   "decompress_mbps": 123.4
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8457,
+   "ratio": 0.3437,
+   "compress_mbps": 43.65,
+   "decompress_mbps": 119.12
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8353,
+   "ratio": 0.3395,
+   "compress_mbps": 64.98,
+   "decompress_mbps": 109.7
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8301,
+   "ratio": 0.3374,
+   "compress_mbps": 42.45,
+   "decompress_mbps": 124.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8212,
+   "ratio": 0.3338,
+   "compress_mbps": 58.84,
+   "decompress_mbps": 103.81
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 8172,
+   "ratio": 0.3322,
+   "compress_mbps": 48.55,
+   "decompress_mbps": 108.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 50.28,
+   "decompress_mbps": 109.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 49.23,
+   "decompress_mbps": 109.09
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 8171,
+   "ratio": 0.3321,
+   "compress_mbps": 53.75,
+   "decompress_mbps": 109.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3475,
+   "ratio": 0.3117,
+   "compress_mbps": 109.11,
+   "decompress_mbps": 96.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3305,
+   "ratio": 0.2964,
+   "compress_mbps": 102.67,
+   "decompress_mbps": 101.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3225,
+   "ratio": 0.2892,
+   "compress_mbps": 91.21,
+   "decompress_mbps": 104.25
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3192,
+   "ratio": 0.2863,
+   "compress_mbps": 100.3,
+   "decompress_mbps": 104.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3180,
+   "ratio": 0.2852,
+   "compress_mbps": 100.47,
+   "decompress_mbps": 98.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 94.55,
+   "decompress_mbps": 99.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 95.62,
+   "decompress_mbps": 95.6
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 91.52,
+   "decompress_mbps": 121.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3168,
+   "ratio": 0.2841,
+   "compress_mbps": 83.09,
+   "decompress_mbps": 95.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1275,
+   "ratio": 0.3426,
+   "compress_mbps": 59.58,
+   "decompress_mbps": 44.37
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1247,
+   "ratio": 0.3351,
+   "compress_mbps": 59.47,
+   "decompress_mbps": 52.13
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1239,
+   "ratio": 0.333,
+   "compress_mbps": 56.69,
+   "decompress_mbps": 51.11
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1238,
+   "ratio": 0.3327,
+   "compress_mbps": 58.55,
+   "decompress_mbps": 50.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1239,
+   "ratio": 0.333,
+   "compress_mbps": 48.99,
+   "decompress_mbps": 51.01
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 56.51,
+   "decompress_mbps": 50.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 55.71,
+   "decompress_mbps": 51.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 50.22,
+   "decompress_mbps": 48.37
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1237,
+   "ratio": 0.3324,
+   "compress_mbps": 55.39,
+   "decompress_mbps": 48.56
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 226284,
+   "ratio": 0.2197,
+   "compress_mbps": 113.28,
+   "decompress_mbps": 183.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 221369,
+   "ratio": 0.215,
+   "compress_mbps": 90.24,
+   "decompress_mbps": 255.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 218607,
+   "ratio": 0.2123,
+   "compress_mbps": 78.67,
+   "decompress_mbps": 187.61
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 217919,
+   "ratio": 0.2116,
+   "compress_mbps": 69.94,
+   "decompress_mbps": 195.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 217919,
+   "ratio": 0.2116,
+   "compress_mbps": 70.92,
+   "decompress_mbps": 195.59
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 217312,
+   "ratio": 0.211,
+   "compress_mbps": 44.09,
+   "decompress_mbps": 191.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 215966,
+   "ratio": 0.2097,
+   "compress_mbps": 31.15,
+   "decompress_mbps": 191.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 215930,
+   "ratio": 0.2097,
+   "compress_mbps": 14.32,
+   "decompress_mbps": 194.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 215912,
+   "ratio": 0.2097,
+   "compress_mbps": 11.1,
+   "decompress_mbps": 210.59
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 167622,
+   "ratio": 0.3928,
+   "compress_mbps": 64.39,
+   "decompress_mbps": 116.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 158003,
+   "ratio": 0.3702,
+   "compress_mbps": 64.34,
+   "decompress_mbps": 139.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 152928,
+   "ratio": 0.3584,
+   "compress_mbps": 46.67,
+   "decompress_mbps": 141.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 149886,
+   "ratio": 0.3512,
+   "compress_mbps": 33.71,
+   "decompress_mbps": 136.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 149767,
+   "ratio": 0.3509,
+   "compress_mbps": 39.31,
+   "decompress_mbps": 138
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 147818,
+   "ratio": 0.3464,
+   "compress_mbps": 33.18,
+   "decompress_mbps": 150.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 147733,
+   "ratio": 0.3462,
+   "compress_mbps": 32.42,
+   "decompress_mbps": 154.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 147709,
+   "ratio": 0.3461,
+   "compress_mbps": 32.15,
+   "decompress_mbps": 151.45
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 147705,
+   "ratio": 0.3461,
+   "compress_mbps": 32.65,
+   "decompress_mbps": 138.19
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 222866,
+   "ratio": 0.4625,
+   "compress_mbps": 58.92,
+   "decompress_mbps": 105.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 212925,
+   "ratio": 0.4419,
+   "compress_mbps": 49.52,
+   "decompress_mbps": 118.08
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 206913,
+   "ratio": 0.4294,
+   "compress_mbps": 40.5,
+   "decompress_mbps": 116.88
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 202875,
+   "ratio": 0.421,
+   "compress_mbps": 33.54,
+   "decompress_mbps": 111.31
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 202867,
+   "ratio": 0.421,
+   "compress_mbps": 33.57,
+   "decompress_mbps": 117.4
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 199818,
+   "ratio": 0.4147,
+   "compress_mbps": 28.4,
+   "decompress_mbps": 114.8
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 199664,
+   "ratio": 0.4144,
+   "compress_mbps": 27.76,
+   "decompress_mbps": 105.02
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 199634,
+   "ratio": 0.4143,
+   "compress_mbps": 28.19,
+   "decompress_mbps": 106.5
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 199634,
+   "ratio": 0.4143,
+   "compress_mbps": 27.99,
+   "decompress_mbps": 121
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 60580,
+   "ratio": 0.118,
+   "compress_mbps": 118.15,
+   "decompress_mbps": 253.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 59663,
+   "ratio": 0.1163,
+   "compress_mbps": 131.11,
+   "decompress_mbps": 295.73
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 59465,
+   "ratio": 0.1159,
+   "compress_mbps": 100.74,
+   "decompress_mbps": 295.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 59353,
+   "ratio": 0.1156,
+   "compress_mbps": 95.09,
+   "decompress_mbps": 302.88
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 58830,
+   "ratio": 0.1146,
+   "compress_mbps": 107.76,
+   "decompress_mbps": 221.47
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 57884,
+   "ratio": 0.1128,
+   "compress_mbps": 56.85,
+   "decompress_mbps": 285.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 57206,
+   "ratio": 0.1115,
+   "compress_mbps": 46.17,
+   "decompress_mbps": 299.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 56545,
+   "ratio": 0.1102,
+   "compress_mbps": 23.09,
+   "decompress_mbps": 280.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 56454,
+   "ratio": 0.11,
+   "compress_mbps": 9.11,
+   "decompress_mbps": 300.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 14194,
+   "ratio": 0.3712,
+   "compress_mbps": 83.27,
+   "decompress_mbps": 134.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13770,
+   "ratio": 0.3601,
+   "compress_mbps": 74.14,
+   "decompress_mbps": 116.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13611,
+   "ratio": 0.3559,
+   "compress_mbps": 66.24,
+   "decompress_mbps": 115.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13534,
+   "ratio": 0.3539,
+   "compress_mbps": 61.31,
+   "decompress_mbps": 117.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13527,
+   "ratio": 0.3537,
+   "compress_mbps": 61.97,
+   "decompress_mbps": 148.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13438,
+   "ratio": 0.3514,
+   "compress_mbps": 51.17,
+   "decompress_mbps": 142.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13419,
+   "ratio": 0.3509,
+   "compress_mbps": 47.83,
+   "decompress_mbps": 125.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13404,
+   "ratio": 0.3505,
+   "compress_mbps": 41.2,
+   "decompress_mbps": 118.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13390,
+   "ratio": 0.3502,
+   "compress_mbps": 35.78,
+   "decompress_mbps": 116.99
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1832,
+   "ratio": 0.4334,
+   "compress_mbps": 41.01,
+   "decompress_mbps": 45
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1776,
+   "ratio": 0.4202,
+   "compress_mbps": 58.71,
+   "decompress_mbps": 64.9
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1764,
+   "ratio": 0.4173,
+   "compress_mbps": 57.37,
+   "decompress_mbps": 62.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1763,
+   "ratio": 0.4171,
+   "compress_mbps": 56.88,
+   "decompress_mbps": 53.28
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 59.36,
+   "decompress_mbps": 48.79
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 40.25,
+   "decompress_mbps": 47.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 57.06,
+   "decompress_mbps": 48.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 58.67,
+   "decompress_mbps": 52.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1760,
+   "ratio": 0.4164,
+   "compress_mbps": 58.3,
+   "decompress_mbps": 62.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 4462632,
+   "ratio": 0.4378,
+   "compress_mbps": 61.62,
+   "decompress_mbps": 170.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4244833,
+   "ratio": 0.4165,
+   "compress_mbps": 50.24,
+   "decompress_mbps": 201.42
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4112285,
+   "ratio": 0.4035,
+   "compress_mbps": 42.04,
+   "decompress_mbps": 178.21
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4020435,
+   "ratio": 0.3945,
+   "compress_mbps": 35.5,
+   "decompress_mbps": 142.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 4019177,
+   "ratio": 0.3943,
+   "compress_mbps": 35.31,
+   "decompress_mbps": 170.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3956464,
+   "ratio": 0.3882,
+   "compress_mbps": 28.75,
+   "decompress_mbps": 164.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3953310,
+   "ratio": 0.3879,
+   "compress_mbps": 28.47,
+   "decompress_mbps": 198.87
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3952872,
+   "ratio": 0.3878,
+   "compress_mbps": 29.08,
+   "decompress_mbps": 220.53
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3952872,
+   "ratio": 0.3878,
+   "compress_mbps": 29.21,
+   "decompress_mbps": 218.12
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 20177423,
+   "ratio": 0.3939,
+   "compress_mbps": 72.68,
+   "decompress_mbps": 209.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19759467,
+   "ratio": 0.3858,
+   "compress_mbps": 63.85,
+   "decompress_mbps": 193.45
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19583171,
+   "ratio": 0.3823,
+   "compress_mbps": 57.14,
+   "decompress_mbps": 206.47
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19479125,
+   "ratio": 0.3803,
+   "compress_mbps": 51.03,
+   "decompress_mbps": 205.14
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19423693,
+   "ratio": 0.3792,
+   "compress_mbps": 49.13,
+   "decompress_mbps": 200.07
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19337683,
+   "ratio": 0.3775,
+   "compress_mbps": 36.05,
+   "decompress_mbps": 188.48
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19323922,
+   "ratio": 0.3773,
+   "compress_mbps": 29.08,
+   "decompress_mbps": 193.94
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19314797,
+   "ratio": 0.3771,
+   "compress_mbps": 19.5,
+   "decompress_mbps": 225.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19312663,
+   "ratio": 0.377,
+   "compress_mbps": 11.12,
+   "decompress_mbps": 219.23
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3762978,
+   "ratio": 0.3774,
+   "compress_mbps": 78.68,
+   "decompress_mbps": 163.86
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3711615,
+   "ratio": 0.3723,
+   "compress_mbps": 68.1,
+   "decompress_mbps": 196.85
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3663131,
+   "ratio": 0.3674,
+   "compress_mbps": 57.01,
+   "decompress_mbps": 241.11
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3631512,
+   "ratio": 0.3642,
+   "compress_mbps": 49.21,
+   "decompress_mbps": 221.03
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3630867,
+   "ratio": 0.3642,
+   "compress_mbps": 48.78,
+   "decompress_mbps": 216.62
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3615953,
+   "ratio": 0.3627,
+   "compress_mbps": 37.72,
+   "decompress_mbps": 247.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3615518,
+   "ratio": 0.3626,
+   "compress_mbps": 35.3,
+   "decompress_mbps": 189.82
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3613845,
+   "ratio": 0.3625,
+   "compress_mbps": 30.03,
+   "decompress_mbps": 255.34
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3614283,
+   "ratio": 0.3625,
+   "compress_mbps": 26.24,
+   "decompress_mbps": 222.16
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4418800,
+   "ratio": 0.1317,
+   "compress_mbps": 133,
+   "decompress_mbps": 338.57
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4026774,
+   "ratio": 0.12,
+   "compress_mbps": 123.44,
+   "decompress_mbps": 339.7
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3837798,
+   "ratio": 0.1144,
+   "compress_mbps": 116.34,
+   "decompress_mbps": 370.54
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3751023,
+   "ratio": 0.1118,
+   "compress_mbps": 110.1,
+   "decompress_mbps": 361.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3643468,
+   "ratio": 0.1086,
+   "compress_mbps": 101.98,
+   "decompress_mbps": 371.36
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3379481,
+   "ratio": 0.1007,
+   "compress_mbps": 68.99,
+   "decompress_mbps": 366.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3354082,
+   "ratio": 0.1,
+   "compress_mbps": 61.49,
+   "decompress_mbps": 366.51
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3330028,
+   "ratio": 0.0992,
+   "compress_mbps": 49.65,
+   "decompress_mbps": 396.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3327482,
+   "ratio": 0.0992,
+   "compress_mbps": 37.41,
+   "decompress_mbps": 367.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3233790,
+   "ratio": 0.5256,
+   "compress_mbps": 52.65,
+   "decompress_mbps": 141.02
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3184644,
+   "ratio": 0.5176,
+   "compress_mbps": 48.35,
+   "decompress_mbps": 141.34
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3160521,
+   "ratio": 0.5137,
+   "compress_mbps": 44.16,
+   "decompress_mbps": 134.37
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3141929,
+   "ratio": 0.5107,
+   "compress_mbps": 40.04,
+   "decompress_mbps": 150.29
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3138514,
+   "ratio": 0.5101,
+   "compress_mbps": 39.11,
+   "decompress_mbps": 134.68
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3126843,
+   "ratio": 0.5082,
+   "compress_mbps": 32.81,
+   "decompress_mbps": 149.93
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3126796,
+   "ratio": 0.5082,
+   "compress_mbps": 30.63,
+   "decompress_mbps": 145.05
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3126322,
+   "ratio": 0.5082,
+   "compress_mbps": 27.28,
+   "decompress_mbps": 153.07
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3126286,
+   "ratio": 0.5082,
+   "compress_mbps": 23.43,
+   "decompress_mbps": 154.77
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4076349,
+   "ratio": 0.4042,
+   "compress_mbps": 79.56,
+   "decompress_mbps": 217.72
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3914739,
+   "ratio": 0.3881,
+   "compress_mbps": 72.11,
+   "decompress_mbps": 235.6
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3845160,
+   "ratio": 0.3812,
+   "compress_mbps": 68.92,
+   "decompress_mbps": 265.95
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3822047,
+   "ratio": 0.379,
+   "compress_mbps": 65.9,
+   "decompress_mbps": 249.1
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3799472,
+   "ratio": 0.3767,
+   "compress_mbps": 60.47,
+   "decompress_mbps": 196.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3783861,
+   "ratio": 0.3752,
+   "compress_mbps": 59.24,
+   "decompress_mbps": 206.2
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3783432,
+   "ratio": 0.3751,
+   "compress_mbps": 57.5,
+   "decompress_mbps": 276.55
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3783342,
+   "ratio": 0.3751,
+   "compress_mbps": 57.79,
+   "decompress_mbps": 278.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3783342,
+   "ratio": 0.3751,
+   "compress_mbps": 57.86,
+   "decompress_mbps": 279.64
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2261112,
+   "ratio": 0.3412,
+   "compress_mbps": 71.4,
+   "decompress_mbps": 216.97
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2128691,
+   "ratio": 0.3212,
+   "compress_mbps": 58.57,
+   "decompress_mbps": 197.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2049023,
+   "ratio": 0.3092,
+   "compress_mbps": 48.53,
+   "decompress_mbps": 209.61
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 1990249,
+   "ratio": 0.3003,
+   "compress_mbps": 41.12,
+   "decompress_mbps": 207.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1975224,
+   "ratio": 0.298,
+   "compress_mbps": 39.61,
+   "decompress_mbps": 151.52
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1910262,
+   "ratio": 0.2882,
+   "compress_mbps": 28.21,
+   "decompress_mbps": 164.32
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1902923,
+   "ratio": 0.2871,
+   "compress_mbps": 25.04,
+   "decompress_mbps": 221.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1900964,
+   "ratio": 0.2868,
+   "compress_mbps": 23.45,
+   "decompress_mbps": 227.66
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1900958,
+   "ratio": 0.2868,
+   "compress_mbps": 24.4,
+   "decompress_mbps": 207.65
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 6016919,
+   "ratio": 0.2785,
+   "compress_mbps": 92.31,
+   "decompress_mbps": 250.38
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5767272,
+   "ratio": 0.2669,
+   "compress_mbps": 81.02,
+   "decompress_mbps": 287.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5669548,
+   "ratio": 0.2624,
+   "compress_mbps": 75.87,
+   "decompress_mbps": 211.21
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5619947,
+   "ratio": 0.2601,
+   "compress_mbps": 68.8,
+   "decompress_mbps": 271.25
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5586034,
+   "ratio": 0.2585,
+   "compress_mbps": 64.77,
+   "decompress_mbps": 270.13
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5540130,
+   "ratio": 0.2564,
+   "compress_mbps": 50.72,
+   "decompress_mbps": 269.04
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5537271,
+   "ratio": 0.2563,
+   "compress_mbps": 45.58,
+   "decompress_mbps": 209.67
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5530686,
+   "ratio": 0.256,
+   "compress_mbps": 35.75,
+   "decompress_mbps": 303.18
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5529823,
+   "ratio": 0.2559,
+   "compress_mbps": 31.59,
+   "decompress_mbps": 227.31
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5602819,
+   "ratio": 0.7726,
+   "compress_mbps": 47.72,
+   "decompress_mbps": 166.89
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5504019,
+   "ratio": 0.759,
+   "compress_mbps": 42.76,
+   "decompress_mbps": 153.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5452816,
+   "ratio": 0.7519,
+   "compress_mbps": 38.01,
+   "decompress_mbps": 153.91
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5425752,
+   "ratio": 0.7482,
+   "compress_mbps": 35.6,
+   "decompress_mbps": 177.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5425752,
+   "ratio": 0.7482,
+   "compress_mbps": 36.17,
+   "decompress_mbps": 176.78
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5407602,
+   "ratio": 0.7457,
+   "compress_mbps": 30.72,
+   "decompress_mbps": 153.42
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5406417,
+   "ratio": 0.7455,
+   "compress_mbps": 30.08,
+   "decompress_mbps": 155.44
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5406380,
+   "ratio": 0.7455,
+   "compress_mbps": 30.76,
+   "decompress_mbps": 154.32
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5406380,
+   "ratio": 0.7455,
+   "compress_mbps": 30.68,
+   "decompress_mbps": 117.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 14342407,
+   "ratio": 0.3459,
+   "compress_mbps": 73.52,
+   "decompress_mbps": 197.71
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 13424966,
+   "ratio": 0.3238,
+   "compress_mbps": 63.27,
+   "decompress_mbps": 213.25
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 13061399,
+   "ratio": 0.315,
+   "compress_mbps": 56.27,
+   "decompress_mbps": 222.06
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12877207,
+   "ratio": 0.3106,
+   "compress_mbps": 49.84,
+   "decompress_mbps": 208.96
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12671090,
+   "ratio": 0.3056,
+   "compress_mbps": 47.71,
+   "decompress_mbps": 209.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12511088,
+   "ratio": 0.3018,
+   "compress_mbps": 40.67,
+   "decompress_mbps": 235.26
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12503313,
+   "ratio": 0.3016,
+   "compress_mbps": 39.02,
+   "decompress_mbps": 224.89
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12502263,
+   "ratio": 0.3016,
+   "compress_mbps": 39.56,
+   "decompress_mbps": 227.39
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12502263,
+   "ratio": 0.3016,
+   "compress_mbps": 39.56,
+   "decompress_mbps": 225.48
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6022390,
+   "ratio": 0.7107,
+   "compress_mbps": 54.31,
+   "decompress_mbps": 145.97
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 5997124,
+   "ratio": 0.7077,
+   "compress_mbps": 48.84,
+   "decompress_mbps": 145.24
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 5979254,
+   "ratio": 0.7056,
+   "compress_mbps": 43.2,
+   "decompress_mbps": 149.3
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 5967955,
+   "ratio": 0.7042,
+   "compress_mbps": 42.03,
+   "decompress_mbps": 178.27
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 5967953,
+   "ratio": 0.7042,
+   "compress_mbps": 42.1,
+   "decompress_mbps": 155.23
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 5965386,
+   "ratio": 0.7039,
+   "compress_mbps": 41.26,
+   "decompress_mbps": 150.17
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 41,
+   "decompress_mbps": 152.03
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 40.8,
+   "decompress_mbps": 151.14
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 5965383,
+   "ratio": 0.7039,
+   "compress_mbps": 41.86,
+   "decompress_mbps": 155
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 985606,
+   "ratio": 0.1844,
+   "compress_mbps": 111.12,
+   "decompress_mbps": 305.94
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 852636,
+   "ratio": 0.1595,
+   "compress_mbps": 102.74,
+   "decompress_mbps": 250.95
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 814293,
+   "ratio": 0.1523,
+   "compress_mbps": 96.19,
+   "decompress_mbps": 221.84
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 788388,
+   "ratio": 0.1475,
+   "compress_mbps": 89.39,
+   "decompress_mbps": 250.71
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 749390,
+   "ratio": 0.1402,
+   "compress_mbps": 83.47,
+   "decompress_mbps": 304.92
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 706892,
+   "ratio": 0.1322,
+   "compress_mbps": 64.12,
+   "decompress_mbps": 266.99
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 705695,
+   "ratio": 0.132,
+   "compress_mbps": 64.27,
+   "decompress_mbps": 329.56
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 703904,
+   "ratio": 0.1317,
+   "compress_mbps": 61.16,
+   "decompress_mbps": 268.63
+  },
+  {
+   "compressor": "js",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 703900,
+   "ratio": 0.1317,
+   "compress_mbps": 60.89,
+   "decompress_mbps": 396.78
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 88.44,
+   "decompress_mbps": 310.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 87.92,
+   "decompress_mbps": 310.59
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 88.84,
+   "decompress_mbps": 310.08
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 56099,
+   "ratio": 0.3689,
+   "compress_mbps": 88.64,
+   "decompress_mbps": 314.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 54531,
+   "ratio": 0.3585,
+   "compress_mbps": 55.46,
+   "decompress_mbps": 303.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 54068,
+   "ratio": 0.3555,
+   "compress_mbps": 42.11,
+   "decompress_mbps": 310.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 54003,
+   "ratio": 0.3551,
+   "compress_mbps": 37.45,
+   "decompress_mbps": 307.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 53974,
+   "ratio": 0.3549,
+   "compress_mbps": 33.15,
+   "decompress_mbps": 306.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 53974,
+   "ratio": 0.3549,
+   "compress_mbps": 33.03,
+   "decompress_mbps": 307.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 82.91,
+   "decompress_mbps": 273.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 83.46,
+   "decompress_mbps": 272.35
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 84.13,
+   "decompress_mbps": 272.98
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 50031,
+   "ratio": 0.3997,
+   "compress_mbps": 83.95,
+   "decompress_mbps": 268.75
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 48753,
+   "ratio": 0.3895,
+   "compress_mbps": 50.79,
+   "decompress_mbps": 277.44
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 48557,
+   "ratio": 0.3879,
+   "compress_mbps": 40.8,
+   "decompress_mbps": 274.84
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 48523,
+   "ratio": 0.3876,
+   "compress_mbps": 38.65,
+   "decompress_mbps": 273.33
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 48522,
+   "ratio": 0.3876,
+   "compress_mbps": 37.86,
+   "decompress_mbps": 276.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 48522,
+   "ratio": 0.3876,
+   "compress_mbps": 37.9,
+   "decompress_mbps": 276.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 164.27,
+   "decompress_mbps": 279.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 172.17,
+   "decompress_mbps": 279.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 171.79,
+   "decompress_mbps": 279.43
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8182,
+   "ratio": 0.3326,
+   "compress_mbps": 170.54,
+   "decompress_mbps": 279.22
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 7965,
+   "ratio": 0.3237,
+   "compress_mbps": 110.55,
+   "decompress_mbps": 288.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 7914,
+   "ratio": 0.3217,
+   "compress_mbps": 87.16,
+   "decompress_mbps": 290.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 7895,
+   "ratio": 0.3209,
+   "compress_mbps": 80.21,
+   "decompress_mbps": 290.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 7896,
+   "ratio": 0.3209,
+   "compress_mbps": 73.83,
+   "decompress_mbps": 287.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 7896,
+   "ratio": 0.3209,
+   "compress_mbps": 74.8,
+   "decompress_mbps": 285.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 167.43,
+   "decompress_mbps": 252.93
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 171.07,
+   "decompress_mbps": 257.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 171.82,
+   "decompress_mbps": 258.29
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3218,
+   "ratio": 0.2886,
+   "compress_mbps": 166.85,
+   "decompress_mbps": 256.2
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3136,
+   "ratio": 0.2813,
+   "compress_mbps": 143.33,
+   "decompress_mbps": 259.73
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3115,
+   "ratio": 0.2794,
+   "compress_mbps": 126.88,
+   "decompress_mbps": 263.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 116.0,
+   "decompress_mbps": 266.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 105.81,
+   "decompress_mbps": 262.03
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3112,
+   "ratio": 0.2791,
+   "compress_mbps": 108.16,
+   "decompress_mbps": 263.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 119.04,
+   "decompress_mbps": 119.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 114.29,
+   "decompress_mbps": 121.57
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 111.93,
+   "decompress_mbps": 114.91
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1221,
+   "ratio": 0.3281,
+   "compress_mbps": 113.37,
+   "decompress_mbps": 116.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 104.47,
+   "decompress_mbps": 117.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 101.17,
+   "decompress_mbps": 116.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 99.01,
+   "decompress_mbps": 115.26
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 100.66,
+   "decompress_mbps": 116.17
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1207,
+   "ratio": 0.3244,
+   "compress_mbps": 100.75,
+   "decompress_mbps": 117.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 226.33,
+   "decompress_mbps": 462.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 232.22,
+   "decompress_mbps": 461.76
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 226.95,
+   "decompress_mbps": 462.59
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 227063,
+   "ratio": 0.2205,
+   "compress_mbps": 231.82,
+   "decompress_mbps": 462.46
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 218313,
+   "ratio": 0.212,
+   "compress_mbps": 163.75,
+   "decompress_mbps": 447.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 215095,
+   "ratio": 0.2089,
+   "compress_mbps": 107.22,
+   "decompress_mbps": 448.7
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 213213,
+   "ratio": 0.2071,
+   "compress_mbps": 73.07,
+   "decompress_mbps": 450.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 210955,
+   "ratio": 0.2049,
+   "compress_mbps": 9.42,
+   "decompress_mbps": 452.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 210981,
+   "ratio": 0.2049,
+   "compress_mbps": 4.64,
+   "decompress_mbps": 454.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.55,
+   "decompress_mbps": 304.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.89,
+   "decompress_mbps": 306.86
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.22,
+   "decompress_mbps": 306.2
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 148927,
+   "ratio": 0.349,
+   "compress_mbps": 92.33,
+   "decompress_mbps": 304.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 145024,
+   "ratio": 0.3398,
+   "compress_mbps": 57.83,
+   "decompress_mbps": 305.53
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 144159,
+   "ratio": 0.3378,
+   "compress_mbps": 44.56,
+   "decompress_mbps": 304.1
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 143991,
+   "ratio": 0.3374,
+   "compress_mbps": 40.14,
+   "decompress_mbps": 306.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 143941,
+   "ratio": 0.3373,
+   "compress_mbps": 36.87,
+   "decompress_mbps": 306.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 143939,
+   "ratio": 0.3373,
+   "compress_mbps": 37.03,
+   "decompress_mbps": 305.69
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 81.26,
+   "decompress_mbps": 255.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 80.9,
+   "decompress_mbps": 255.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 81.21,
+   "decompress_mbps": 255.67
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 200074,
+   "ratio": 0.4152,
+   "compress_mbps": 81.07,
+   "decompress_mbps": 256.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 194496,
+   "ratio": 0.4036,
+   "compress_mbps": 46.0,
+   "decompress_mbps": 247.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 193176,
+   "ratio": 0.4009,
+   "compress_mbps": 34.56,
+   "decompress_mbps": 253.55
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 192991,
+   "ratio": 0.4005,
+   "compress_mbps": 31.43,
+   "decompress_mbps": 250.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 192980,
+   "ratio": 0.4005,
+   "compress_mbps": 29.91,
+   "decompress_mbps": 251.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 192980,
+   "ratio": 0.4005,
+   "compress_mbps": 29.82,
+   "decompress_mbps": 253.98
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 294.39,
+   "decompress_mbps": 724.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 294.6,
+   "decompress_mbps": 721.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 294.93,
+   "decompress_mbps": 721.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 57484,
+   "ratio": 0.112,
+   "compress_mbps": 295.58,
+   "decompress_mbps": 727.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 56050,
+   "ratio": 0.1092,
+   "compress_mbps": 229.82,
+   "decompress_mbps": 759.78
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 55292,
+   "ratio": 0.1077,
+   "compress_mbps": 153.4,
+   "decompress_mbps": 778.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 54651,
+   "ratio": 0.1065,
+   "compress_mbps": 124.47,
+   "decompress_mbps": 790.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 52583,
+   "ratio": 0.1025,
+   "compress_mbps": 46.92,
+   "decompress_mbps": 823.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 51816,
+   "ratio": 0.101,
+   "compress_mbps": 15.63,
+   "decompress_mbps": 833.02
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 119.63,
+   "decompress_mbps": 301.35
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 118.87,
+   "decompress_mbps": 304.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 120.64,
+   "decompress_mbps": 303.05
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13765,
+   "ratio": 0.36,
+   "compress_mbps": 118.25,
+   "decompress_mbps": 303.27
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13290,
+   "ratio": 0.3475,
+   "compress_mbps": 89.99,
+   "decompress_mbps": 316.05
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13258,
+   "ratio": 0.3467,
+   "compress_mbps": 68.72,
+   "decompress_mbps": 317.08
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13246,
+   "ratio": 0.3464,
+   "compress_mbps": 57.01,
+   "decompress_mbps": 319.69
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13236,
+   "ratio": 0.3461,
+   "compress_mbps": 25.4,
+   "decompress_mbps": 320.24
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13233,
+   "ratio": 0.3461,
+   "compress_mbps": 16.12,
+   "decompress_mbps": 322.36
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 95.7,
+   "decompress_mbps": 132.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 98.31,
+   "decompress_mbps": 133.01
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 97.54,
+   "decompress_mbps": 132.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 1742,
+   "ratio": 0.4121,
+   "compress_mbps": 100.39,
+   "decompress_mbps": 132.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 95.29,
+   "decompress_mbps": 132.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 95.54,
+   "decompress_mbps": 134.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 93.18,
+   "decompress_mbps": 133.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 95.09,
+   "decompress_mbps": 134.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 1720,
+   "ratio": 0.4069,
+   "compress_mbps": 92.21,
+   "decompress_mbps": 134.59
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 84.07,
+   "decompress_mbps": 273.96
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 84.3,
+   "decompress_mbps": 273.56
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 83.99,
+   "decompress_mbps": 274.36
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 3974126,
+   "ratio": 0.3899,
+   "compress_mbps": 84.24,
+   "decompress_mbps": 272.3
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 3863846,
+   "ratio": 0.3791,
+   "compress_mbps": 49.03,
+   "decompress_mbps": 267.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3838854,
+   "ratio": 0.3766,
+   "compress_mbps": 37.71,
+   "decompress_mbps": 272.4
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3835182,
+   "ratio": 0.3763,
+   "compress_mbps": 33.64,
+   "decompress_mbps": 271.15
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3834518,
+   "ratio": 0.3762,
+   "compress_mbps": 31.63,
+   "decompress_mbps": 269.9
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3834518,
+   "ratio": 0.3762,
+   "compress_mbps": 31.46,
+   "decompress_mbps": 270.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.55,
+   "decompress_mbps": 250.87
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.76,
+   "decompress_mbps": 251.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.86,
+   "decompress_mbps": 251.37
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 19877952,
+   "ratio": 0.3881,
+   "compress_mbps": 103.63,
+   "decompress_mbps": 251.14
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 19578840,
+   "ratio": 0.3822,
+   "compress_mbps": 78.52,
+   "decompress_mbps": 258.92
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 19492445,
+   "ratio": 0.3806,
+   "compress_mbps": 58.0,
+   "decompress_mbps": 261.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 19463481,
+   "ratio": 0.38,
+   "compress_mbps": 46.5,
+   "decompress_mbps": 263.14
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 19444704,
+   "ratio": 0.3796,
+   "compress_mbps": 22.81,
+   "decompress_mbps": 262.15
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 19440748,
+   "ratio": 0.3796,
+   "compress_mbps": 13.07,
+   "decompress_mbps": 263.2
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.24,
+   "decompress_mbps": 259.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.65,
+   "decompress_mbps": 260.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 111.43,
+   "decompress_mbps": 257.26
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3662279,
+   "ratio": 0.3673,
+   "compress_mbps": 112.43,
+   "decompress_mbps": 258.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3637736,
+   "ratio": 0.3648,
+   "compress_mbps": 65.79,
+   "decompress_mbps": 267.17
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3621530,
+   "ratio": 0.3632,
+   "compress_mbps": 46.42,
+   "decompress_mbps": 268.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3623924,
+   "ratio": 0.3635,
+   "compress_mbps": 42.48,
+   "decompress_mbps": 270.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3623112,
+   "ratio": 0.3634,
+   "compress_mbps": 33.07,
+   "decompress_mbps": 270.31
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3623382,
+   "ratio": 0.3634,
+   "compress_mbps": 24.87,
+   "decompress_mbps": 268.67
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 306.93,
+   "decompress_mbps": 882.12
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 309.49,
+   "decompress_mbps": 879.51
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 306.65,
+   "decompress_mbps": 865.76
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3580057,
+   "ratio": 0.1067,
+   "compress_mbps": 309.44,
+   "decompress_mbps": 876.41
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3268887,
+   "ratio": 0.0974,
+   "compress_mbps": 229.13,
+   "decompress_mbps": 923.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3131445,
+   "ratio": 0.0933,
+   "compress_mbps": 163.5,
+   "decompress_mbps": 955.29
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3080217,
+   "ratio": 0.0918,
+   "compress_mbps": 129.46,
+   "decompress_mbps": 960.33
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 2978354,
+   "ratio": 0.0888,
+   "compress_mbps": 57.16,
+   "decompress_mbps": 973.32
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 2947971,
+   "ratio": 0.0879,
+   "compress_mbps": 34.51,
+   "decompress_mbps": 973.37
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.44,
+   "decompress_mbps": 182.53
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.2,
+   "decompress_mbps": 182.46
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.32,
+   "decompress_mbps": 182.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3221973,
+   "ratio": 0.5237,
+   "compress_mbps": 72.36,
+   "decompress_mbps": 183.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3178914,
+   "ratio": 0.5167,
+   "compress_mbps": 55.82,
+   "decompress_mbps": 189.9
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3174170,
+   "ratio": 0.5159,
+   "compress_mbps": 49.39,
+   "decompress_mbps": 191.24
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3172734,
+   "ratio": 0.5157,
+   "compress_mbps": 45.82,
+   "decompress_mbps": 191.56
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3171353,
+   "ratio": 0.5155,
+   "compress_mbps": 38.64,
+   "decompress_mbps": 191.37
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3171299,
+   "ratio": 0.5155,
+   "compress_mbps": 34.82,
+   "decompress_mbps": 191.12
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 123.34,
+   "decompress_mbps": 273.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 122.2,
+   "decompress_mbps": 272.47
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 121.33,
+   "decompress_mbps": 269.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3791952,
+   "ratio": 0.376,
+   "compress_mbps": 122.45,
+   "decompress_mbps": 274.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3654027,
+   "ratio": 0.3623,
+   "compress_mbps": 95.52,
+   "decompress_mbps": 276.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3652732,
+   "ratio": 0.3622,
+   "compress_mbps": 91.8,
+   "decompress_mbps": 276.29
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3652496,
+   "ratio": 0.3621,
+   "compress_mbps": 87.07,
+   "decompress_mbps": 275.95
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3652505,
+   "ratio": 0.3621,
+   "compress_mbps": 87.05,
+   "decompress_mbps": 277.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3652505,
+   "ratio": 0.3621,
+   "compress_mbps": 87.07,
+   "decompress_mbps": 276.53
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 100.62,
+   "decompress_mbps": 354.06
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 100.0,
+   "decompress_mbps": 353.82
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 99.59,
+   "decompress_mbps": 351.77
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2009824,
+   "ratio": 0.3033,
+   "compress_mbps": 99.81,
+   "decompress_mbps": 354.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1892183,
+   "ratio": 0.2855,
+   "compress_mbps": 53.63,
+   "decompress_mbps": 353.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1837957,
+   "ratio": 0.2773,
+   "compress_mbps": 30.64,
+   "decompress_mbps": 360.81
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1826603,
+   "ratio": 0.2756,
+   "compress_mbps": 24.41,
+   "decompress_mbps": 362.4
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1818702,
+   "ratio": 0.2744,
+   "compress_mbps": 16.09,
+   "decompress_mbps": 362.85
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1818702,
+   "ratio": 0.2744,
+   "compress_mbps": 15.95,
+   "decompress_mbps": 359.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 146.11,
+   "decompress_mbps": 399.24
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 145.88,
+   "decompress_mbps": 400.49
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 146.06,
+   "decompress_mbps": 396.62
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 5633558,
+   "ratio": 0.2607,
+   "compress_mbps": 144.39,
+   "decompress_mbps": 379.0
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 5501344,
+   "ratio": 0.2546,
+   "compress_mbps": 103.33,
+   "decompress_mbps": 402.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5464646,
+   "ratio": 0.2529,
+   "compress_mbps": 79.54,
+   "decompress_mbps": 407.14
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5429975,
+   "ratio": 0.2513,
+   "compress_mbps": 66.81,
+   "decompress_mbps": 408.73
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5419566,
+   "ratio": 0.2508,
+   "compress_mbps": 49.41,
+   "decompress_mbps": 410.08
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5417952,
+   "ratio": 0.2508,
+   "compress_mbps": 45.54,
+   "decompress_mbps": 407.63
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.47,
+   "decompress_mbps": 161.38
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.25,
+   "decompress_mbps": 161.25
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.34,
+   "decompress_mbps": 161.47
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5481930,
+   "ratio": 0.7559,
+   "compress_mbps": 60.28,
+   "decompress_mbps": 159.84
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5450496,
+   "ratio": 0.7516,
+   "compress_mbps": 46.56,
+   "decompress_mbps": 163.89
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5440281,
+   "ratio": 0.7502,
+   "compress_mbps": 42.07,
+   "decompress_mbps": 164.58
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5439077,
+   "ratio": 0.75,
+   "compress_mbps": 40.6,
+   "decompress_mbps": 164.64
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5438787,
+   "ratio": 0.75,
+   "compress_mbps": 39.98,
+   "decompress_mbps": 163.79
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5438787,
+   "ratio": 0.75,
+   "compress_mbps": 39.92,
+   "decompress_mbps": 165.07
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.43,
+   "decompress_mbps": 313.19
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.96,
+   "decompress_mbps": 316.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.45,
+   "decompress_mbps": 312.18
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 12756531,
+   "ratio": 0.3077,
+   "compress_mbps": 108.89,
+   "decompress_mbps": 315.83
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12238874,
+   "ratio": 0.2952,
+   "compress_mbps": 72.34,
+   "decompress_mbps": 317.65
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12086531,
+   "ratio": 0.2915,
+   "compress_mbps": 53.58,
+   "decompress_mbps": 323.18
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12020742,
+   "ratio": 0.2899,
+   "compress_mbps": 46.37,
+   "decompress_mbps": 319.97
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 11987253,
+   "ratio": 0.2891,
+   "compress_mbps": 38.17,
+   "decompress_mbps": 322.52
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 11987245,
+   "ratio": 0.2891,
+   "compress_mbps": 38.15,
+   "decompress_mbps": 319.56
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.53,
+   "decompress_mbps": 146.13
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.39,
+   "decompress_mbps": 146.09
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.11,
+   "decompress_mbps": 146.99
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6273039,
+   "ratio": 0.7402,
+   "compress_mbps": 60.42,
+   "decompress_mbps": 146.5
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6244483,
+   "ratio": 0.7369,
+   "compress_mbps": 55.4,
+   "decompress_mbps": 148.54
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6244482,
+   "ratio": 0.7369,
+   "compress_mbps": 55.47,
+   "decompress_mbps": 148.16
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6244482,
+   "ratio": 0.7369,
+   "compress_mbps": 55.08,
+   "decompress_mbps": 147.42
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6244480,
+   "ratio": 0.7369,
+   "compress_mbps": 55.49,
+   "decompress_mbps": 148.22
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6244480,
+   "ratio": 0.7369,
+   "compress_mbps": 55.43,
+   "decompress_mbps": 147.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 230.66,
+   "decompress_mbps": 673.8
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 230.52,
+   "decompress_mbps": 670.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 231.93,
+   "decompress_mbps": 669.9
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 785041,
+   "ratio": 0.1469,
+   "compress_mbps": 230.28,
+   "decompress_mbps": 671.23
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 716461,
+   "ratio": 0.134,
+   "compress_mbps": 166.09,
+   "decompress_mbps": 710.38
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 687053,
+   "ratio": 0.1285,
+   "compress_mbps": 124.29,
+   "decompress_mbps": 733.86
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 673597,
+   "ratio": 0.126,
+   "compress_mbps": 100.95,
+   "decompress_mbps": 744.02
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 662156,
+   "ratio": 0.1239,
+   "compress_mbps": 65.08,
+   "decompress_mbps": 750.21
+  },
+  {
+   "compressor": "zig",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 661610,
+   "ratio": 0.1238,
+   "compress_mbps": 61.06,
+   "decompress_mbps": 754.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 1,
+   "out_size": 73589,
+   "ratio": 0.4839,
+   "compress_mbps": 33.76,
+   "decompress_mbps": 57.05
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 2,
+   "out_size": 69878,
+   "ratio": 0.4595,
+   "compress_mbps": 32.08,
+   "decompress_mbps": 58.09
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 3,
+   "out_size": 66917,
+   "ratio": 0.44,
+   "compress_mbps": 26.68,
+   "decompress_mbps": 66.6
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 4,
+   "out_size": 59388,
+   "ratio": 0.3905,
+   "compress_mbps": 31.26,
+   "decompress_mbps": 80.36
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 5,
+   "out_size": 57062,
+   "ratio": 0.3752,
+   "compress_mbps": 22.77,
+   "decompress_mbps": 80.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 6,
+   "out_size": 55472,
+   "ratio": 0.3647,
+   "compress_mbps": 16.23,
+   "decompress_mbps": 79.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 7,
+   "out_size": 55265,
+   "ratio": 0.3634,
+   "compress_mbps": 14.29,
+   "decompress_mbps": 79.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 8,
+   "out_size": 55168,
+   "ratio": 0.3627,
+   "compress_mbps": 11.91,
+   "decompress_mbps": 78.92
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 9,
+   "out_size": 55168,
+   "ratio": 0.3627,
+   "compress_mbps": 11.93,
+   "decompress_mbps": 78.52
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 1,
+   "out_size": 64551,
+   "ratio": 0.5157,
+   "compress_mbps": 31.89,
+   "decompress_mbps": 53.82
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 2,
+   "out_size": 62089,
+   "ratio": 0.496,
+   "compress_mbps": 30.15,
+   "decompress_mbps": 57.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 3,
+   "out_size": 58690,
+   "ratio": 0.4688,
+   "compress_mbps": 24.34,
+   "decompress_mbps": 59.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 4,
+   "out_size": 53521,
+   "ratio": 0.4276,
+   "compress_mbps": 30.1,
+   "decompress_mbps": 79.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 5,
+   "out_size": 51677,
+   "ratio": 0.4128,
+   "compress_mbps": 20.89,
+   "decompress_mbps": 78.97
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 6,
+   "out_size": 50638,
+   "ratio": 0.4045,
+   "compress_mbps": 14.85,
+   "decompress_mbps": 82.68
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 7,
+   "out_size": 50501,
+   "ratio": 0.4034,
+   "compress_mbps": 13.53,
+   "decompress_mbps": 79.57
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 8,
+   "out_size": 50452,
+   "ratio": 0.403,
+   "compress_mbps": 12.59,
+   "decompress_mbps": 81.82
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 9,
+   "out_size": 50452,
+   "ratio": 0.403,
+   "compress_mbps": 12.59,
+   "decompress_mbps": 81.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 1,
+   "out_size": 9859,
+   "ratio": 0.4007,
+   "compress_mbps": 43.03,
+   "decompress_mbps": 111.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 2,
+   "out_size": 10473,
+   "ratio": 0.4257,
+   "compress_mbps": 47.23,
+   "decompress_mbps": 149.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 3,
+   "out_size": 10172,
+   "ratio": 0.4134,
+   "compress_mbps": 42.85,
+   "decompress_mbps": 148.23
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 4,
+   "out_size": 8692,
+   "ratio": 0.3533,
+   "compress_mbps": 40.47,
+   "decompress_mbps": 152.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 5,
+   "out_size": 8440,
+   "ratio": 0.343,
+   "compress_mbps": 36.18,
+   "decompress_mbps": 157.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 6,
+   "out_size": 8385,
+   "ratio": 0.3408,
+   "compress_mbps": 31.88,
+   "decompress_mbps": 158.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 7,
+   "out_size": 8366,
+   "ratio": 0.34,
+   "compress_mbps": 29.95,
+   "decompress_mbps": 158.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 8,
+   "out_size": 8367,
+   "ratio": 0.3401,
+   "compress_mbps": 28.71,
+   "decompress_mbps": 157.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 9,
+   "out_size": 8367,
+   "ratio": 0.3401,
+   "compress_mbps": 28.72,
+   "decompress_mbps": 156.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 1,
+   "out_size": 4822,
+   "ratio": 0.4325,
+   "compress_mbps": 54.35,
+   "decompress_mbps": 187.68
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 2,
+   "out_size": 4593,
+   "ratio": 0.4119,
+   "compress_mbps": 52.8,
+   "decompress_mbps": 193.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 3,
+   "out_size": 4381,
+   "ratio": 0.3929,
+   "compress_mbps": 49.8,
+   "decompress_mbps": 200.8
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 4,
+   "out_size": 3725,
+   "ratio": 0.3341,
+   "compress_mbps": 51.8,
+   "decompress_mbps": 202.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 5,
+   "out_size": 3614,
+   "ratio": 0.3241,
+   "compress_mbps": 43.83,
+   "decompress_mbps": 208.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 6,
+   "out_size": 3578,
+   "ratio": 0.3209,
+   "compress_mbps": 39.35,
+   "decompress_mbps": 209.91
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 7,
+   "out_size": 3572,
+   "ratio": 0.3204,
+   "compress_mbps": 36.83,
+   "decompress_mbps": 210.72
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 8,
+   "out_size": 3568,
+   "ratio": 0.32,
+   "compress_mbps": 34.7,
+   "decompress_mbps": 208.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 9,
+   "out_size": 3568,
+   "ratio": 0.32,
+   "compress_mbps": 33.66,
+   "decompress_mbps": 206.14
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 1,
+   "out_size": 1738,
+   "ratio": 0.4671,
+   "compress_mbps": 30.09,
+   "decompress_mbps": 176.72
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 2,
+   "out_size": 1709,
+   "ratio": 0.4593,
+   "compress_mbps": 30.1,
+   "decompress_mbps": 174.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 3,
+   "out_size": 1694,
+   "ratio": 0.4553,
+   "compress_mbps": 31.7,
+   "decompress_mbps": 180.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 4,
+   "out_size": 1458,
+   "ratio": 0.3918,
+   "compress_mbps": 29.73,
+   "decompress_mbps": 187.58
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 5,
+   "out_size": 1441,
+   "ratio": 0.3873,
+   "compress_mbps": 28.44,
+   "decompress_mbps": 189.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 6,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.18,
+   "decompress_mbps": 189.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 7,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.68,
+   "decompress_mbps": 190.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 8,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 26.12,
+   "decompress_mbps": 189.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 9,
+   "out_size": 1440,
+   "ratio": 0.387,
+   "compress_mbps": 27.78,
+   "decompress_mbps": 191.2
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 1,
+   "out_size": 260073,
+   "ratio": 0.2526,
+   "compress_mbps": 52.45,
+   "decompress_mbps": 56.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 2,
+   "out_size": 296764,
+   "ratio": 0.2882,
+   "compress_mbps": 48.94,
+   "decompress_mbps": 76.97
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 3,
+   "out_size": 288989,
+   "ratio": 0.2806,
+   "compress_mbps": 37.59,
+   "decompress_mbps": 77.33
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 4,
+   "out_size": 246442,
+   "ratio": 0.2393,
+   "compress_mbps": 54.71,
+   "decompress_mbps": 83.32
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 5,
+   "out_size": 218888,
+   "ratio": 0.2126,
+   "compress_mbps": 40.79,
+   "decompress_mbps": 76.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 6,
+   "out_size": 217830,
+   "ratio": 0.2115,
+   "compress_mbps": 24.16,
+   "decompress_mbps": 88.24
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 7,
+   "out_size": 221437,
+   "ratio": 0.215,
+   "compress_mbps": 19.26,
+   "decompress_mbps": 86.6
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 8,
+   "out_size": 219666,
+   "ratio": 0.2133,
+   "compress_mbps": 5.49,
+   "decompress_mbps": 86.51
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 9,
+   "out_size": 219921,
+   "ratio": 0.2136,
+   "compress_mbps": 2.77,
+   "decompress_mbps": 85.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 1,
+   "out_size": 194588,
+   "ratio": 0.456,
+   "compress_mbps": 34.47,
+   "decompress_mbps": 51.9
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 2,
+   "out_size": 185757,
+   "ratio": 0.4353,
+   "compress_mbps": 32.92,
+   "decompress_mbps": 49.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 3,
+   "out_size": 175850,
+   "ratio": 0.4121,
+   "compress_mbps": 27.11,
+   "decompress_mbps": 59.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 4,
+   "out_size": 155951,
+   "ratio": 0.3654,
+   "compress_mbps": 31.95,
+   "decompress_mbps": 73.02
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 5,
+   "out_size": 150274,
+   "ratio": 0.3521,
+   "compress_mbps": 23.12,
+   "decompress_mbps": 71.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 6,
+   "out_size": 147958,
+   "ratio": 0.3467,
+   "compress_mbps": 16.73,
+   "decompress_mbps": 72.74
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 7,
+   "out_size": 147522,
+   "ratio": 0.3457,
+   "compress_mbps": 14.93,
+   "decompress_mbps": 70.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 8,
+   "out_size": 147331,
+   "ratio": 0.3452,
+   "compress_mbps": 13.5,
+   "decompress_mbps": 68.78
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 9,
+   "out_size": 147328,
+   "ratio": 0.3452,
+   "compress_mbps": 13.48,
+   "decompress_mbps": 70.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 1,
+   "out_size": 256904,
+   "ratio": 0.5331,
+   "compress_mbps": 29.73,
+   "decompress_mbps": 46.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 2,
+   "out_size": 245675,
+   "ratio": 0.5098,
+   "compress_mbps": 28.42,
+   "decompress_mbps": 50.05
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 3,
+   "out_size": 231519,
+   "ratio": 0.4805,
+   "compress_mbps": 22.58,
+   "decompress_mbps": 56.23
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 4,
+   "out_size": 210028,
+   "ratio": 0.4359,
+   "compress_mbps": 27.54,
+   "decompress_mbps": 64.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 5,
+   "out_size": 203312,
+   "ratio": 0.4219,
+   "compress_mbps": 18.52,
+   "decompress_mbps": 61.6
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 6,
+   "out_size": 199287,
+   "ratio": 0.4136,
+   "compress_mbps": 12.88,
+   "decompress_mbps": 65.73
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 7,
+   "out_size": 198474,
+   "ratio": 0.4119,
+   "compress_mbps": 11.21,
+   "decompress_mbps": 66.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 8,
+   "out_size": 198080,
+   "ratio": 0.4111,
+   "compress_mbps": 8.88,
+   "decompress_mbps": 65.36
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 9,
+   "out_size": 198080,
+   "ratio": 0.4111,
+   "compress_mbps": 8.84,
+   "decompress_mbps": 65.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 1,
+   "out_size": 71229,
+   "ratio": 0.1388,
+   "compress_mbps": 82.96,
+   "decompress_mbps": 136.59
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 2,
+   "out_size": 69946,
+   "ratio": 0.1363,
+   "compress_mbps": 78.92,
+   "decompress_mbps": 137.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 3,
+   "out_size": 68538,
+   "ratio": 0.1335,
+   "compress_mbps": 69.23,
+   "decompress_mbps": 151.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 4,
+   "out_size": 61320,
+   "ratio": 0.1195,
+   "compress_mbps": 65.87,
+   "decompress_mbps": 164.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 5,
+   "out_size": 59993,
+   "ratio": 0.1169,
+   "compress_mbps": 57.15,
+   "decompress_mbps": 169.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 6,
+   "out_size": 58637,
+   "ratio": 0.1143,
+   "compress_mbps": 41.42,
+   "decompress_mbps": 166.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 7,
+   "out_size": 58209,
+   "ratio": 0.1134,
+   "compress_mbps": 35.38,
+   "decompress_mbps": 173.09
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 8,
+   "out_size": 55749,
+   "ratio": 0.1086,
+   "compress_mbps": 19.35,
+   "decompress_mbps": 176.71
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 9,
+   "out_size": 54927,
+   "ratio": 0.107,
+   "compress_mbps": 7.52,
+   "decompress_mbps": 176.17
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 1,
+   "out_size": 16399,
+   "ratio": 0.4288,
+   "compress_mbps": 36.37,
+   "decompress_mbps": 86.67
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 2,
+   "out_size": 15933,
+   "ratio": 0.4167,
+   "compress_mbps": 33.72,
+   "decompress_mbps": 88.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 3,
+   "out_size": 15739,
+   "ratio": 0.4116,
+   "compress_mbps": 28.05,
+   "decompress_mbps": 87.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 4,
+   "out_size": 13834,
+   "ratio": 0.3618,
+   "compress_mbps": 31.73,
+   "decompress_mbps": 108.86
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 5,
+   "out_size": 13463,
+   "ratio": 0.3521,
+   "compress_mbps": 25.96,
+   "decompress_mbps": 111.56
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 6,
+   "out_size": 13353,
+   "ratio": 0.3492,
+   "compress_mbps": 18.86,
+   "decompress_mbps": 111.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 7,
+   "out_size": 13317,
+   "ratio": 0.3482,
+   "compress_mbps": 15.93,
+   "decompress_mbps": 113.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 8,
+   "out_size": 13255,
+   "ratio": 0.3466,
+   "compress_mbps": 8.38,
+   "decompress_mbps": 110.11
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 9,
+   "out_size": 13171,
+   "ratio": 0.3444,
+   "compress_mbps": 4.16,
+   "decompress_mbps": 114.39
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 1,
+   "out_size": 2512,
+   "ratio": 0.5943,
+   "compress_mbps": 29.63,
+   "decompress_mbps": 155.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 2,
+   "out_size": 2477,
+   "ratio": 0.586,
+   "compress_mbps": 29.51,
+   "decompress_mbps": 158.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 3,
+   "out_size": 2452,
+   "ratio": 0.5801,
+   "compress_mbps": 30.37,
+   "decompress_mbps": 157.34
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 4,
+   "out_size": 2110,
+   "ratio": 0.4992,
+   "compress_mbps": 29.99,
+   "decompress_mbps": 162.81
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 5,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.87,
+   "decompress_mbps": 169.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 6,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.86,
+   "decompress_mbps": 167.98
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 7,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.5,
+   "decompress_mbps": 169.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 8,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 27.54,
+   "decompress_mbps": 169.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 9,
+   "out_size": 2086,
+   "ratio": 0.4935,
+   "compress_mbps": 28.63,
+   "decompress_mbps": 169.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 1,
+   "out_size": 5183792,
+   "ratio": 0.5086,
+   "compress_mbps": 31.31,
+   "decompress_mbps": 40.47
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 2,
+   "out_size": 4956750,
+   "ratio": 0.4863,
+   "compress_mbps": 29.97,
+   "decompress_mbps": 43.45
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 3,
+   "out_size": 4644095,
+   "ratio": 0.4556,
+   "compress_mbps": 24.06,
+   "decompress_mbps": 47.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 4,
+   "out_size": 4178564,
+   "ratio": 0.41,
+   "compress_mbps": 29.06,
+   "decompress_mbps": 61.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 5,
+   "out_size": 4034632,
+   "ratio": 0.3958,
+   "compress_mbps": 19.92,
+   "decompress_mbps": 61.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 6,
+   "out_size": 3952244,
+   "ratio": 0.3878,
+   "compress_mbps": 13.83,
+   "decompress_mbps": 61.12
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 7,
+   "out_size": 3938822,
+   "ratio": 0.3864,
+   "compress_mbps": 12.23,
+   "decompress_mbps": 62.83
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 8,
+   "out_size": 3935171,
+   "ratio": 0.3861,
+   "compress_mbps": 10.76,
+   "decompress_mbps": 60.2
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 9,
+   "out_size": 3935171,
+   "ratio": 0.3861,
+   "compress_mbps": 10.72,
+   "decompress_mbps": 60.89
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 1,
+   "out_size": 25320013,
+   "ratio": 0.4943,
+   "compress_mbps": 31.71,
+   "decompress_mbps": 34.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 2,
+   "out_size": 24804084,
+   "ratio": 0.4843,
+   "compress_mbps": 30.3,
+   "decompress_mbps": 36.64
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 3,
+   "out_size": 24241121,
+   "ratio": 0.4733,
+   "compress_mbps": 25.73,
+   "decompress_mbps": 37.97
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 4,
+   "out_size": 20950547,
+   "ratio": 0.409,
+   "compress_mbps": 28.84,
+   "decompress_mbps": 44.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 5,
+   "out_size": 20592289,
+   "ratio": 0.402,
+   "compress_mbps": 24.29,
+   "decompress_mbps": 46.14
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 6,
+   "out_size": 20445232,
+   "ratio": 0.3992,
+   "compress_mbps": 18.69,
+   "decompress_mbps": 46.11
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 7,
+   "out_size": 20407676,
+   "ratio": 0.3984,
+   "compress_mbps": 15.95,
+   "decompress_mbps": 46.63
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 8,
+   "out_size": 20389473,
+   "ratio": 0.3981,
+   "compress_mbps": 10.13,
+   "decompress_mbps": 45.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 9,
+   "out_size": 20386824,
+   "ratio": 0.398,
+   "compress_mbps": 6.82,
+   "decompress_mbps": 46.45
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 1,
+   "out_size": 3964698,
+   "ratio": 0.3976,
+   "compress_mbps": 37.98,
+   "decompress_mbps": 48.02
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 2,
+   "out_size": 3936391,
+   "ratio": 0.3948,
+   "compress_mbps": 35.52,
+   "decompress_mbps": 47.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 3,
+   "out_size": 3823540,
+   "ratio": 0.3835,
+   "compress_mbps": 27.78,
+   "decompress_mbps": 51.72
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 4,
+   "out_size": 3799601,
+   "ratio": 0.3811,
+   "compress_mbps": 33.02,
+   "decompress_mbps": 63.69
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 5,
+   "out_size": 3830938,
+   "ratio": 0.3842,
+   "compress_mbps": 22.58,
+   "decompress_mbps": 58.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 6,
+   "out_size": 3808303,
+   "ratio": 0.382,
+   "compress_mbps": 14.79,
+   "decompress_mbps": 57.61
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 7,
+   "out_size": 3802814,
+   "ratio": 0.3814,
+   "compress_mbps": 12.14,
+   "decompress_mbps": 57.87
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 8,
+   "out_size": 3800355,
+   "ratio": 0.3812,
+   "compress_mbps": 6.76,
+   "decompress_mbps": 59.01
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 9,
+   "out_size": 3799676,
+   "ratio": 0.3811,
+   "compress_mbps": 6.05,
+   "decompress_mbps": 59.07
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 1,
+   "out_size": 4899547,
+   "ratio": 0.146,
+   "compress_mbps": 95.3,
+   "decompress_mbps": 131.63
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 2,
+   "out_size": 4587004,
+   "ratio": 0.1367,
+   "compress_mbps": 94.92,
+   "decompress_mbps": 142.96
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 3,
+   "out_size": 4229035,
+   "ratio": 0.126,
+   "compress_mbps": 90.43,
+   "decompress_mbps": 152.33
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 4,
+   "out_size": 3791322,
+   "ratio": 0.113,
+   "compress_mbps": 81.61,
+   "decompress_mbps": 160.66
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 5,
+   "out_size": 3449193,
+   "ratio": 0.1028,
+   "compress_mbps": 72.81,
+   "decompress_mbps": 168.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 6,
+   "out_size": 3269452,
+   "ratio": 0.0974,
+   "compress_mbps": 58.66,
+   "decompress_mbps": 173.37
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 7,
+   "out_size": 3211286,
+   "ratio": 0.0957,
+   "compress_mbps": 50.59,
+   "decompress_mbps": 173.62
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 8,
+   "out_size": 3101534,
+   "ratio": 0.0924,
+   "compress_mbps": 27.5,
+   "decompress_mbps": 174.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 9,
+   "out_size": 3058177,
+   "ratio": 0.0911,
+   "compress_mbps": 16.6,
+   "decompress_mbps": 177.54
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 1,
+   "out_size": 4024327,
+   "ratio": 0.6541,
+   "compress_mbps": 22.81,
+   "decompress_mbps": 29.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 2,
+   "out_size": 3953722,
+   "ratio": 0.6427,
+   "compress_mbps": 21.66,
+   "decompress_mbps": 30.5
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 3,
+   "out_size": 3887921,
+   "ratio": 0.632,
+   "compress_mbps": 18.47,
+   "decompress_mbps": 31.15
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 4,
+   "out_size": 3320440,
+   "ratio": 0.5397,
+   "compress_mbps": 21.3,
+   "decompress_mbps": 37.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 5,
+   "out_size": 3279338,
+   "ratio": 0.533,
+   "compress_mbps": 17.83,
+   "decompress_mbps": 38.07
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 6,
+   "out_size": 3254309,
+   "ratio": 0.529,
+   "compress_mbps": 14.0,
+   "decompress_mbps": 37.9
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 7,
+   "out_size": 3250139,
+   "ratio": 0.5283,
+   "compress_mbps": 12.22,
+   "decompress_mbps": 38.09
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 8,
+   "out_size": 3247018,
+   "ratio": 0.5278,
+   "compress_mbps": 10.17,
+   "decompress_mbps": 38.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 9,
+   "out_size": 3246865,
+   "ratio": 0.5278,
+   "compress_mbps": 9.51,
+   "decompress_mbps": 38.0
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 1,
+   "out_size": 4471091,
+   "ratio": 0.4433,
+   "compress_mbps": 34.91,
+   "decompress_mbps": 69.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 2,
+   "out_size": 4372105,
+   "ratio": 0.4335,
+   "compress_mbps": 33.82,
+   "decompress_mbps": 71.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 3,
+   "out_size": 4305270,
+   "ratio": 0.4269,
+   "compress_mbps": 30.7,
+   "decompress_mbps": 73.16
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 4,
+   "out_size": 3920495,
+   "ratio": 0.3887,
+   "compress_mbps": 30.3,
+   "decompress_mbps": 64.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 5,
+   "out_size": 3853177,
+   "ratio": 0.382,
+   "compress_mbps": 26.63,
+   "decompress_mbps": 63.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 6,
+   "out_size": 3780878,
+   "ratio": 0.3749,
+   "compress_mbps": 23.38,
+   "decompress_mbps": 64.31
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 7,
+   "out_size": 3763880,
+   "ratio": 0.3732,
+   "compress_mbps": 20.2,
+   "decompress_mbps": 72.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 8,
+   "out_size": 3757719,
+   "ratio": 0.3726,
+   "compress_mbps": 18.3,
+   "decompress_mbps": 73.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 9,
+   "out_size": 3757719,
+   "ratio": 0.3726,
+   "compress_mbps": 18.25,
+   "decompress_mbps": 72.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 1,
+   "out_size": 2722387,
+   "ratio": 0.4108,
+   "compress_mbps": 38.01,
+   "decompress_mbps": 64.73
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 2,
+   "out_size": 2572544,
+   "ratio": 0.3882,
+   "compress_mbps": 36.87,
+   "decompress_mbps": 70.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 3,
+   "out_size": 2384328,
+   "ratio": 0.3598,
+   "compress_mbps": 29.15,
+   "decompress_mbps": 78.64
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 4,
+   "out_size": 2112060,
+   "ratio": 0.3187,
+   "compress_mbps": 36.42,
+   "decompress_mbps": 85.62
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 5,
+   "out_size": 1991581,
+   "ratio": 0.3005,
+   "compress_mbps": 25.34,
+   "decompress_mbps": 91.01
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 6,
+   "out_size": 1917866,
+   "ratio": 0.2894,
+   "compress_mbps": 15.03,
+   "decompress_mbps": 90.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 7,
+   "out_size": 1895353,
+   "ratio": 0.286,
+   "compress_mbps": 11.08,
+   "decompress_mbps": 90.48
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 8,
+   "out_size": 1880740,
+   "ratio": 0.2838,
+   "compress_mbps": 5.59,
+   "decompress_mbps": 90.95
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 9,
+   "out_size": 1880711,
+   "ratio": 0.2838,
+   "compress_mbps": 5.56,
+   "decompress_mbps": 92.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 1,
+   "out_size": 7441483,
+   "ratio": 0.3444,
+   "compress_mbps": 43.78,
+   "decompress_mbps": 66.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 2,
+   "out_size": 7229248,
+   "ratio": 0.3346,
+   "compress_mbps": 43.14,
+   "decompress_mbps": 69.03
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 3,
+   "out_size": 7083451,
+   "ratio": 0.3278,
+   "compress_mbps": 38.92,
+   "decompress_mbps": 71.31
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 4,
+   "out_size": 6189639,
+   "ratio": 0.2865,
+   "compress_mbps": 42.2,
+   "decompress_mbps": 92.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 5,
+   "out_size": 6053058,
+   "ratio": 0.2802,
+   "compress_mbps": 35.08,
+   "decompress_mbps": 96.18
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 6,
+   "out_size": 5988137,
+   "ratio": 0.2771,
+   "compress_mbps": 28.51,
+   "decompress_mbps": 101.1
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 7,
+   "out_size": 5949908,
+   "ratio": 0.2754,
+   "compress_mbps": 25.19,
+   "decompress_mbps": 103.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 8,
+   "out_size": 5936656,
+   "ratio": 0.2748,
+   "compress_mbps": 19.22,
+   "decompress_mbps": 106.46
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 9,
+   "out_size": 5934701,
+   "ratio": 0.2747,
+   "compress_mbps": 17.98,
+   "decompress_mbps": 105.25
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 1,
+   "out_size": 6335542,
+   "ratio": 0.8736,
+   "compress_mbps": 18.44,
+   "decompress_mbps": 31.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 2,
+   "out_size": 6247260,
+   "ratio": 0.8615,
+   "compress_mbps": 17.59,
+   "decompress_mbps": 48.2
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 3,
+   "out_size": 6064713,
+   "ratio": 0.8363,
+   "compress_mbps": 15.15,
+   "decompress_mbps": 56.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 4,
+   "out_size": 5568111,
+   "ratio": 0.7678,
+   "compress_mbps": 17.55,
+   "decompress_mbps": 58.99
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 5,
+   "out_size": 5544524,
+   "ratio": 0.7646,
+   "compress_mbps": 14.42,
+   "decompress_mbps": 64.88
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 6,
+   "out_size": 5513056,
+   "ratio": 0.7602,
+   "compress_mbps": 11.94,
+   "decompress_mbps": 62.87
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 7,
+   "out_size": 5508915,
+   "ratio": 0.7596,
+   "compress_mbps": 11.32,
+   "decompress_mbps": 64.42
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 8,
+   "out_size": 5508365,
+   "ratio": 0.7596,
+   "compress_mbps": 10.52,
+   "decompress_mbps": 65.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 9,
+   "out_size": 5508365,
+   "ratio": 0.7596,
+   "compress_mbps": 10.57,
+   "decompress_mbps": 64.3
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 1,
+   "out_size": 16776095,
+   "ratio": 0.4046,
+   "compress_mbps": 37.73,
+   "decompress_mbps": 50.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 2,
+   "out_size": 16032651,
+   "ratio": 0.3867,
+   "compress_mbps": 36.24,
+   "decompress_mbps": 54.65
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 3,
+   "out_size": 15180334,
+   "ratio": 0.3662,
+   "compress_mbps": 31.28,
+   "decompress_mbps": 51.85
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 4,
+   "out_size": 13261924,
+   "ratio": 0.3199,
+   "compress_mbps": 35.24,
+   "decompress_mbps": 68.67
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 5,
+   "out_size": 12706028,
+   "ratio": 0.3065,
+   "compress_mbps": 27.63,
+   "decompress_mbps": 70.4
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 6,
+   "out_size": 12464158,
+   "ratio": 0.3006,
+   "compress_mbps": 21.0,
+   "decompress_mbps": 70.64
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 7,
+   "out_size": 12375954,
+   "ratio": 0.2985,
+   "compress_mbps": 18.31,
+   "decompress_mbps": 73.55
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 8,
+   "out_size": 12321552,
+   "ratio": 0.2972,
+   "compress_mbps": 14.45,
+   "decompress_mbps": 70.76
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 9,
+   "out_size": 12320276,
+   "ratio": 0.2972,
+   "compress_mbps": 14.41,
+   "decompress_mbps": 70.34
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 1,
+   "out_size": 6799201,
+   "ratio": 0.8023,
+   "compress_mbps": 18.34,
+   "decompress_mbps": 18.29
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 2,
+   "out_size": 6800500,
+   "ratio": 0.8025,
+   "compress_mbps": 16.95,
+   "decompress_mbps": 18.49
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 3,
+   "out_size": 6803212,
+   "ratio": 0.8028,
+   "compress_mbps": 14.91,
+   "decompress_mbps": 18.44
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 4,
+   "out_size": 6264611,
+   "ratio": 0.7393,
+   "compress_mbps": 17.32,
+   "decompress_mbps": 24.91
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 5,
+   "out_size": 6217901,
+   "ratio": 0.7337,
+   "compress_mbps": 15.76,
+   "decompress_mbps": 25.36
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 6,
+   "out_size": 6201999,
+   "ratio": 0.7319,
+   "compress_mbps": 15.32,
+   "decompress_mbps": 25.35
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 7,
+   "out_size": 6201883,
+   "ratio": 0.7319,
+   "compress_mbps": 15.24,
+   "decompress_mbps": 25.06
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 8,
+   "out_size": 6201887,
+   "ratio": 0.7319,
+   "compress_mbps": 15.22,
+   "decompress_mbps": 24.94
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 9,
+   "out_size": 6201887,
+   "ratio": 0.7319,
+   "compress_mbps": 15.3,
+   "decompress_mbps": 24.93
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 1,
+   "out_size": 1081679,
+   "ratio": 0.2024,
+   "compress_mbps": 74.26,
+   "decompress_mbps": 106.26
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 2,
+   "out_size": 1001890,
+   "ratio": 0.1874,
+   "compress_mbps": 74.05,
+   "decompress_mbps": 118.21
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 3,
+   "out_size": 921722,
+   "ratio": 0.1724,
+   "compress_mbps": 67.22,
+   "decompress_mbps": 127.75
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 4,
+   "out_size": 849263,
+   "ratio": 0.1589,
+   "compress_mbps": 64.23,
+   "decompress_mbps": 142.53
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 5,
+   "out_size": 771964,
+   "ratio": 0.1444,
+   "compress_mbps": 54.81,
+   "decompress_mbps": 144.22
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 6,
+   "out_size": 728098,
+   "ratio": 0.1362,
+   "compress_mbps": 43.49,
+   "decompress_mbps": 150.41
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 7,
+   "out_size": 713635,
+   "ratio": 0.1335,
+   "compress_mbps": 37.23,
+   "decompress_mbps": 154.84
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 8,
+   "out_size": 699093,
+   "ratio": 0.1308,
+   "compress_mbps": 27.08,
+   "decompress_mbps": 146.56
+  },
+  {
+   "compressor": "ocaml",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 9,
+   "out_size": 698459,
+   "ratio": 0.1307,
+   "compress_mbps": 25.17,
+   "decompress_mbps": 148.81
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 10,
+   "out_size": 51721,
+   "ratio": 0.3401,
+   "compress_mbps": 12.25,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 11,
+   "out_size": 51662,
+   "ratio": 0.3397,
+   "compress_mbps": 8.43,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 12,
+   "out_size": 51662,
+   "ratio": 0.3397,
+   "compress_mbps": 5.17,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 10,
+   "out_size": 46657,
+   "ratio": 0.3727,
+   "compress_mbps": 13.72,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 11,
+   "out_size": 46515,
+   "ratio": 0.3716,
+   "compress_mbps": 9.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 12,
+   "out_size": 46469,
+   "ratio": 0.3712,
+   "compress_mbps": 7.14,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 10,
+   "out_size": 7725,
+   "ratio": 0.314,
+   "compress_mbps": 15.97,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 11,
+   "out_size": 7727,
+   "ratio": 0.3141,
+   "compress_mbps": 10.79,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 12,
+   "out_size": 7723,
+   "ratio": 0.3139,
+   "compress_mbps": 7.17,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 10,
+   "out_size": 3026,
+   "ratio": 0.2714,
+   "compress_mbps": 17.74,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 11,
+   "out_size": 3024,
+   "ratio": 0.2712,
+   "compress_mbps": 14.13,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 12,
+   "out_size": 3024,
+   "ratio": 0.2712,
+   "compress_mbps": 10.64,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 10,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 41.49,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 11,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 33.55,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 12,
+   "out_size": 1186,
+   "ratio": 0.3187,
+   "compress_mbps": 24.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 10,
+   "out_size": 179347,
+   "ratio": 0.1742,
+   "compress_mbps": 30.91,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 11,
+   "out_size": 179096,
+   "ratio": 0.1739,
+   "compress_mbps": 20.04,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 12,
+   "out_size": 179049,
+   "ratio": 0.1739,
+   "compress_mbps": 15.47,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 10,
+   "out_size": 138116,
+   "ratio": 0.3236,
+   "compress_mbps": 12.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 11,
+   "out_size": 137923,
+   "ratio": 0.3232,
+   "compress_mbps": 8.78,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 12,
+   "out_size": 137921,
+   "ratio": 0.3232,
+   "compress_mbps": 7.43,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 10,
+   "out_size": 185328,
+   "ratio": 0.3846,
+   "compress_mbps": 12.88,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 11,
+   "out_size": 184440,
+   "ratio": 0.3828,
+   "compress_mbps": 9.1,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 12,
+   "out_size": 184371,
+   "ratio": 0.3826,
+   "compress_mbps": 5.56,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 10,
+   "out_size": 51319,
+   "ratio": 0.1,
+   "compress_mbps": 12.87,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 11,
+   "out_size": 49675,
+   "ratio": 0.0968,
+   "compress_mbps": 6.13,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 12,
+   "out_size": 49194,
+   "ratio": 0.0959,
+   "compress_mbps": 3.65,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 10,
+   "out_size": 11975,
+   "ratio": 0.3132,
+   "compress_mbps": 20.05,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 11,
+   "out_size": 11966,
+   "ratio": 0.3129,
+   "compress_mbps": 13.4,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 12,
+   "out_size": 11965,
+   "ratio": 0.3129,
+   "compress_mbps": 10.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 10,
+   "out_size": 1692,
+   "ratio": 0.4003,
+   "compress_mbps": 54.22,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 11,
+   "out_size": 1690,
+   "ratio": 0.3998,
+   "compress_mbps": 45.3,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 12,
+   "out_size": 1690,
+   "ratio": 0.3998,
+   "compress_mbps": 29.74,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 10,
+   "out_size": 3681797,
+   "ratio": 0.3612,
+   "compress_mbps": 12.62,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 11,
+   "out_size": 3679289,
+   "ratio": 0.361,
+   "compress_mbps": 9.26,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 12,
+   "out_size": 3679105,
+   "ratio": 0.361,
+   "compress_mbps": 7.67,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 10,
+   "out_size": 18268811,
+   "ratio": 0.3567,
+   "compress_mbps": 16.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 11,
+   "out_size": 18245674,
+   "ratio": 0.3562,
+   "compress_mbps": 11.71,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 12,
+   "out_size": 18241312,
+   "ratio": 0.3561,
+   "compress_mbps": 9.35,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 10,
+   "out_size": 3461494,
+   "ratio": 0.3472,
+   "compress_mbps": 18.28,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 11,
+   "out_size": 3446053,
+   "ratio": 0.3456,
+   "compress_mbps": 10.54,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 12,
+   "out_size": 3447985,
+   "ratio": 0.3458,
+   "compress_mbps": 5.38,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 10,
+   "out_size": 2782465,
+   "ratio": 0.0829,
+   "compress_mbps": 8.49,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 11,
+   "out_size": 2751857,
+   "ratio": 0.082,
+   "compress_mbps": 5.54,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 12,
+   "out_size": 2748273,
+   "ratio": 0.0819,
+   "compress_mbps": 4.07,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 10,
+   "out_size": 2995902,
+   "ratio": 0.487,
+   "compress_mbps": 19.22,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 11,
+   "out_size": 2994386,
+   "ratio": 0.4867,
+   "compress_mbps": 14.58,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 12,
+   "out_size": 2994086,
+   "ratio": 0.4867,
+   "compress_mbps": 12.48,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 10,
+   "out_size": 3608746,
+   "ratio": 0.3578,
+   "compress_mbps": 19.08,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 11,
+   "out_size": 3608161,
+   "ratio": 0.3578,
+   "compress_mbps": 14.81,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 12,
+   "out_size": 3608138,
+   "ratio": 0.3577,
+   "compress_mbps": 13.22,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 10,
+   "out_size": 1697693,
+   "ratio": 0.2562,
+   "compress_mbps": 8.9,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 11,
+   "out_size": 1696742,
+   "ratio": 0.256,
+   "compress_mbps": 6.68,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 12,
+   "out_size": 1696488,
+   "ratio": 0.256,
+   "compress_mbps": 5.74,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 10,
+   "out_size": 5137640,
+   "ratio": 0.2378,
+   "compress_mbps": 16.05,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 11,
+   "out_size": 5122694,
+   "ratio": 0.2371,
+   "compress_mbps": 9.68,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 12,
+   "out_size": 5118130,
+   "ratio": 0.2369,
+   "compress_mbps": 7.0,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 10,
+   "out_size": 5250862,
+   "ratio": 0.7241,
+   "compress_mbps": 25.53,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 11,
+   "out_size": 5250747,
+   "ratio": 0.724,
+   "compress_mbps": 20.83,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 12,
+   "out_size": 5250745,
+   "ratio": 0.724,
+   "compress_mbps": 19.39,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 10,
+   "out_size": 11526846,
+   "ratio": 0.278,
+   "compress_mbps": 10.51,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 11,
+   "out_size": 11520969,
+   "ratio": 0.2779,
+   "compress_mbps": 7.08,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 12,
+   "out_size": 11520871,
+   "ratio": 0.2779,
+   "compress_mbps": 6.12,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 10,
+   "out_size": 5748096,
+   "ratio": 0.6783,
+   "compress_mbps": 38.25,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 11,
+   "out_size": 5747172,
+   "ratio": 0.6782,
+   "compress_mbps": 29.45,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 12,
+   "out_size": 5747146,
+   "ratio": 0.6782,
+   "compress_mbps": 26.58,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 10,
+   "out_size": 637425,
+   "ratio": 0.1193,
+   "compress_mbps": 12.15,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 11,
+   "out_size": 630827,
+   "ratio": 0.118,
+   "compress_mbps": 7.32,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "libdeflate",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 12,
+   "out_size": 629349,
+   "ratio": 0.1177,
+   "compress_mbps": 4.73,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/alice29.txt",
+   "size": 152089,
+   "level": 10,
+   "out_size": 52078,
+   "ratio": 0.3424,
+   "compress_mbps": 2.25,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/asyoulik.txt",
+   "size": 125179,
+   "level": 10,
+   "out_size": 46865,
+   "ratio": 0.3744,
+   "compress_mbps": 2.63,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/cp.html",
+   "size": 24603,
+   "level": 10,
+   "out_size": 7737,
+   "ratio": 0.3145,
+   "compress_mbps": 2.63,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/fields.c",
+   "size": 11150,
+   "level": 10,
+   "out_size": 3032,
+   "ratio": 0.2719,
+   "compress_mbps": 2.58,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/grammar.lsp",
+   "size": 3721,
+   "level": 10,
+   "out_size": 1191,
+   "ratio": 0.3201,
+   "compress_mbps": 2.16,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/kennedy.xls",
+   "size": 1029744,
+   "level": 10,
+   "out_size": 178067,
+   "ratio": 0.1729,
+   "compress_mbps": 1.31,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/lcet10.txt",
+   "size": 426754,
+   "level": 10,
+   "out_size": 138830,
+   "ratio": 0.3253,
+   "compress_mbps": 2.36,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/plrabn12.txt",
+   "size": 481861,
+   "level": 10,
+   "out_size": 186147,
+   "ratio": 0.3863,
+   "compress_mbps": 2.3,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/ptt5",
+   "size": 513216,
+   "level": 10,
+   "out_size": 52234,
+   "ratio": 0.1018,
+   "compress_mbps": 3.33,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/sum",
+   "size": 38240,
+   "level": 10,
+   "out_size": 12274,
+   "ratio": 0.321,
+   "compress_mbps": 2.53,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "canterbury/xargs.1",
+   "size": 4227,
+   "level": 10,
+   "out_size": 1693,
+   "ratio": 0.4005,
+   "compress_mbps": 2.47,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/dickens",
+   "size": 10192446,
+   "level": 10,
+   "out_size": 3711172,
+   "ratio": 0.3641,
+   "compress_mbps": 2.32,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mozilla",
+   "size": 51220480,
+   "level": 10,
+   "out_size": 18539905,
+   "ratio": 0.362,
+   "compress_mbps": 2.09,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/mr",
+   "size": 9970564,
+   "level": 10,
+   "out_size": 3512886,
+   "ratio": 0.3523,
+   "compress_mbps": 2.62,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/nci",
+   "size": 33553445,
+   "level": 10,
+   "out_size": 2902186,
+   "ratio": 0.0865,
+   "compress_mbps": 1.84,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/ooffice",
+   "size": 6152192,
+   "level": 10,
+   "out_size": 3021986,
+   "ratio": 0.4912,
+   "compress_mbps": 2.86,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/osdb",
+   "size": 10085684,
+   "level": 10,
+   "out_size": 3647321,
+   "ratio": 0.3616,
+   "compress_mbps": 3.07,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/reymont",
+   "size": 6627202,
+   "level": 10,
+   "out_size": 1718500,
+   "ratio": 0.2593,
+   "compress_mbps": 1.49,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/samba",
+   "size": 21606400,
+   "level": 10,
+   "out_size": 5177560,
+   "ratio": 0.2396,
+   "compress_mbps": 2.4,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/sao",
+   "size": 7251944,
+   "level": 10,
+   "out_size": 5262319,
+   "ratio": 0.7256,
+   "compress_mbps": 3.14,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/webster",
+   "size": 41458703,
+   "level": 10,
+   "out_size": 11636727,
+   "ratio": 0.2807,
+   "compress_mbps": 1.92,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/x-ray",
+   "size": 8474240,
+   "level": 10,
+   "out_size": 5848663,
+   "ratio": 0.6902,
+   "compress_mbps": 3.77,
+   "decompress_mbps": null
+  },
+  {
+   "compressor": "native",
+   "pattern": "silesia/xml",
+   "size": 5345280,
+   "level": 10,
+   "out_size": 643093,
+   "ratio": 0.1203,
+   "compress_mbps": 2.84,
+   "decompress_mbps": null
+  }
+ ]
+}

--- a/bench/results/cross-machine-chungus-to-chungus2.md
+++ b/bench/results/cross-machine-chungus-to-chungus2.md
@@ -1,0 +1,89 @@
+# Cross-machine benchmark consistency: chungus → chungus2
+
+The canonical Track D benchmark machine is moving from **chungus** to
+**chungus2**. This note records how the two machines compare, so the historical
+dashboard stays interpretable across the move. Regenerate the tables with:
+
+```
+python3 bench/cross_machine.py \
+  bench/results/archive/latest.chungus.7e98994a.json \
+  bench/results/latest.json
+```
+
+- **OLD**: `Linux chungus x86_64` @ `7e98994a` (2026-07-05T08:48Z) — archived at
+  [`archive/latest.chungus.7e98994a.json`](archive/latest.chungus.7e98994a.json)
+- **NEW**: `Linux chungus2 x86_64` @ `9c93b270` (2026-07-05) — the current
+  [`latest.json`](latest.json)
+- 1748 `(compressor, corpus/file, level)` cells compared, across all 8 compressors.
+
+## Verdict
+
+**chungus2 ≈ chungus; the move is sound.** Across the six comparators whose
+toolchain version is stable across the move (`native`, `libdeflate`,
+`miniz_oxide`, `zig`, `zlib`, `ocaml` — 1334 cells) the throughput geomean is
+**1.0004× compress / 0.9967× decompress** — the two machines are
+indistinguishable (within ~0.3%) on identical code. Compression **ratio is
+byte-identical on both machines for every compressor** (`max |Δratio| =
+0.000000` across all 1748 cells, including `native` — the native speed-only
+commits between `7e98994a` and `9c93b270` changed no output). Existing dashboard
+numbers therefore stay directly comparable to fresh chungus2 numbers.
+
+## Being fair to go and js: best versions
+
+Each language should run on its best current release, not whatever an old channel
+happened to pin. On chungus2 that is **go 1.26.3** (via `nix-shell -p go`, the
+newest) and **Node v26.3.0** (via `nodejs_latest` — `comparators/build_all.sh`
+and `run.sh` were switched from the older default `nodejs`, which was v24; v26's
+V8 is ~+22% on JS compress). The old chungus snapshot used *older* go and node,
+so the `go`/`js` rows below move with the **compiler version**, not the machine:
+
+- **`go`: +77% compress / +133% decompress.** Old chungus benchmarked an older
+  Go; chungus2 uses go 1.26.3, whose `compress/flate` and codegen are much
+  faster. A compiler win, correctly credited to Go now that it runs its best.
+- **`js`: 0.93× compress / 0.72× decompress.** Even on the newest Node, V8
+  throughput is highly CPU- and session-sensitive and carries by far the widest
+  run-to-run variance of any comparator here. The chungus2 js rows are a
+  **max-of-3 clean sequential passes** (the three agreed to within 4% compress /
+  0.5% decompress); the residual gap vs the old chungus snapshot is dominated by
+  cross-session V8 variance, not a stable machine difference. Read js as
+  indicative only.
+
+`zig` (pinned `zig_0_14`) lands at 0.99×, confirming a version-stable comparator
+is flat across the move.
+
+> Going forward both `go` and `js` track the newest release (`-p go`,
+> `nodejs_latest`), so each language is always represented at its best. If strict
+> run-to-run reproducibility is later wanted, pin them to a concrete version the
+> way `zig_0_14` is — but that trades "best" for "frozen".
+
+## Throughput: chungus2 / chungus (geomean over shared cells)
+
+| compressor | cells | compress× | decompress× | version across the move |
+|---|---|---|---|---|
+| go | 207 | **1.775x** | **2.330x** | older Go → go 1.26.3 (newest) |
+| js | 207 | **0.930x** | **0.722x** | older node → v26.3.0 (newest); high V8 variance |
+| libdeflate | 276 | 0.995x | 0.978x | stable |
+| miniz_oxide | 207 | 0.997x | 0.993x | stable |
+| native | 230 | 1.001x | 1.003x | stable (lean toolchain) |
+| ocaml | 207 | 1.011x | 1.002x | stable |
+| zig | 207 | 0.992x | 1.005x | stable (`zig_0_14`) |
+| zlib | 207 | 1.008x | 1.000x | stable |
+
+**Version-stable comparators only (the clean machine factor): compress 1.0004×,
+decompress 0.9967×** — chungus2 and chungus are the same speed to within 0.3%.
+
+## Compression ratio consistency (deterministic → machine-independent)
+
+Every compressor: `max |Δratio| = 0.000000`, 0 cells differing — output is fully
+reproducible across both machines and both commits.
+
+| compressor | cells | max \|Δratio\| |
+|---|---|---|
+| go | 207 | 0.000000 |
+| js | 207 | 0.000000 |
+| libdeflate | 276 | 0.000000 |
+| miniz_oxide | 207 | 0.000000 |
+| native | 230 | 0.000000 |
+| ocaml | 207 | 0.000000 |
+| zig | 207 | 0.000000 |
+| zlib | 207 | 0.000000 |

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,17491 +1,17491 @@
 {
- "meta": {
-  "date": "2026-07-05T08:48:39Z",
-  "machine": "Linux chungus x86_64",
-  "git_commit": "7e98994a",
-  "toolchain": "leanprover/lean4:v4.30.0-rc2",
-  "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
- },
- "results": [
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 60455,
-   "ratio": 0.3975,
-   "compress_mbps": 63.04,
-   "decompress_mbps": 111.7
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 56316,
-   "ratio": 0.3703,
-   "compress_mbps": 46.82,
-   "decompress_mbps": 124.01
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 55646,
-   "ratio": 0.3659,
-   "compress_mbps": 42.01,
-   "decompress_mbps": 134.99
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 54681,
-   "ratio": 0.3595,
-   "compress_mbps": 31.16,
-   "decompress_mbps": 138.45
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 54437,
-   "ratio": 0.3579,
-   "compress_mbps": 24.45,
-   "decompress_mbps": 146.02
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54348,
-   "ratio": 0.3573,
-   "compress_mbps": 21.77,
-   "decompress_mbps": 150.37
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54140,
-   "ratio": 0.356,
-   "compress_mbps": 19.02,
-   "decompress_mbps": 151.14
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 54127,
-   "ratio": 0.3559,
-   "compress_mbps": 18.45,
-   "decompress_mbps": 150.6
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 52732,
-   "ratio": 0.3467,
-   "compress_mbps": 4.0,
-   "decompress_mbps": 151.63
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 53135,
-   "ratio": 0.4245,
-   "compress_mbps": 57.53,
-   "decompress_mbps": 105.64
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 50187,
-   "ratio": 0.4009,
-   "compress_mbps": 43.62,
-   "decompress_mbps": 113.11
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 49810,
-   "ratio": 0.3979,
-   "compress_mbps": 39.7,
-   "decompress_mbps": 122.43
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 48992,
-   "ratio": 0.3914,
-   "compress_mbps": 29.19,
-   "decompress_mbps": 127.06
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 48891,
-   "ratio": 0.3906,
-   "compress_mbps": 25.21,
-   "decompress_mbps": 132.93
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48715,
-   "ratio": 0.3892,
-   "compress_mbps": 20.59,
-   "decompress_mbps": 135.72
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48634,
-   "ratio": 0.3885,
-   "compress_mbps": 19.4,
-   "decompress_mbps": 136.04
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 48634,
-   "ratio": 0.3885,
-   "compress_mbps": 19.36,
-   "decompress_mbps": 136.31
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 47430,
-   "ratio": 0.3789,
-   "compress_mbps": 4.32,
-   "decompress_mbps": 136.31
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8476,
-   "ratio": 0.3445,
-   "compress_mbps": 43.15,
-   "decompress_mbps": 125.02
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8271,
-   "ratio": 0.3362,
-   "compress_mbps": 37.84,
-   "decompress_mbps": 128.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8158,
-   "ratio": 0.3316,
-   "compress_mbps": 36.94,
-   "decompress_mbps": 131.86
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 7961,
-   "ratio": 0.3236,
-   "compress_mbps": 33.05,
-   "decompress_mbps": 137.31
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 7932,
-   "ratio": 0.3224,
-   "compress_mbps": 28.32,
-   "decompress_mbps": 141.52
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7938,
-   "ratio": 0.3226,
-   "compress_mbps": 24.25,
-   "decompress_mbps": 143.14
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7929,
-   "ratio": 0.3223,
-   "compress_mbps": 23.21,
-   "decompress_mbps": 144.24
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7929,
-   "ratio": 0.3223,
-   "compress_mbps": 23.29,
-   "decompress_mbps": 144.24
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7803,
-   "ratio": 0.3172,
-   "compress_mbps": 4.38,
-   "decompress_mbps": 143.8
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3509,
-   "ratio": 0.3147,
-   "compress_mbps": 27.91,
-   "decompress_mbps": 99.27
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3269,
-   "ratio": 0.2932,
-   "compress_mbps": 25.47,
-   "decompress_mbps": 101.95
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3208,
-   "ratio": 0.2877,
-   "compress_mbps": 24.44,
-   "decompress_mbps": 105.09
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3141,
-   "ratio": 0.2817,
-   "compress_mbps": 23.49,
-   "decompress_mbps": 107.25
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3128,
-   "ratio": 0.2805,
-   "compress_mbps": 21.23,
-   "decompress_mbps": 109.39
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3135,
-   "ratio": 0.2812,
-   "compress_mbps": 19.37,
-   "decompress_mbps": 110.02
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3128,
-   "ratio": 0.2805,
-   "compress_mbps": 18.53,
-   "decompress_mbps": 110.02
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3128,
-   "ratio": 0.2805,
-   "compress_mbps": 18.78,
-   "decompress_mbps": 110.22
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3056,
-   "ratio": 0.2741,
-   "compress_mbps": 4.5,
-   "decompress_mbps": 110.9
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1282,
-   "ratio": 0.3445,
-   "compress_mbps": 12.49,
-   "decompress_mbps": 55.38
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1225,
-   "ratio": 0.3292,
-   "compress_mbps": 12.51,
-   "decompress_mbps": 56.17
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1220,
-   "ratio": 0.3279,
-   "compress_mbps": 12.47,
-   "decompress_mbps": 56.18
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1213,
-   "ratio": 0.326,
-   "compress_mbps": 11.69,
-   "decompress_mbps": 57.35
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1209,
-   "ratio": 0.3249,
-   "compress_mbps": 11.51,
-   "decompress_mbps": 57.34
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1209,
-   "ratio": 0.3249,
-   "compress_mbps": 10.41,
-   "decompress_mbps": 57.6
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1209,
-   "ratio": 0.3249,
-   "compress_mbps": 10.44,
-   "decompress_mbps": 57.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1209,
-   "ratio": 0.3249,
-   "compress_mbps": 10.42,
-   "decompress_mbps": 57.47
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1205,
-   "ratio": 0.3238,
-   "compress_mbps": 3.47,
-   "decompress_mbps": 57.1
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 251793,
-   "ratio": 0.2445,
-   "compress_mbps": 122.48,
-   "decompress_mbps": 207.04
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 242565,
-   "ratio": 0.2356,
-   "compress_mbps": 85.61,
-   "decompress_mbps": 222.66
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 242532,
-   "ratio": 0.2355,
-   "compress_mbps": 73.13,
-   "decompress_mbps": 231.51
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 239804,
-   "ratio": 0.2329,
-   "compress_mbps": 68.75,
-   "decompress_mbps": 238.61
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 215530,
-   "ratio": 0.2093,
-   "compress_mbps": 39.0,
-   "decompress_mbps": 234.82
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 201414,
-   "ratio": 0.1956,
-   "compress_mbps": 22.49,
-   "decompress_mbps": 242.38
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 200711,
-   "ratio": 0.1949,
-   "compress_mbps": 16.39,
-   "decompress_mbps": 245.06
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 200719,
-   "ratio": 0.1949,
-   "compress_mbps": 12.26,
-   "decompress_mbps": 247.86
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 182508,
-   "ratio": 0.1772,
-   "compress_mbps": 2.89,
-   "decompress_mbps": 248.49
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 160674,
-   "ratio": 0.3765,
-   "compress_mbps": 71.1,
-   "decompress_mbps": 119.49
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 149787,
-   "ratio": 0.351,
-   "compress_mbps": 51.25,
-   "decompress_mbps": 128.69
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 148055,
-   "ratio": 0.3469,
-   "compress_mbps": 45.71,
-   "decompress_mbps": 141.58
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 145631,
-   "ratio": 0.3413,
-   "compress_mbps": 33.73,
-   "decompress_mbps": 146.27
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 145321,
-   "ratio": 0.3405,
-   "compress_mbps": 27.29,
-   "decompress_mbps": 153.96
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 145046,
-   "ratio": 0.3399,
-   "compress_mbps": 23.64,
-   "decompress_mbps": 157.37
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 144554,
-   "ratio": 0.3387,
-   "compress_mbps": 21.18,
-   "decompress_mbps": 158.35
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 144540,
-   "ratio": 0.3387,
-   "compress_mbps": 20.77,
-   "decompress_mbps": 158.7
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 140322,
-   "ratio": 0.3288,
-   "compress_mbps": 3.94,
-   "decompress_mbps": 158.99
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 212588,
-   "ratio": 0.4412,
-   "compress_mbps": 60.56,
-   "decompress_mbps": 99.14
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 199981,
-   "ratio": 0.415,
-   "compress_mbps": 43.79,
-   "decompress_mbps": 107.94
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 198551,
-   "ratio": 0.4121,
-   "compress_mbps": 39.2,
-   "decompress_mbps": 118.12
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 195460,
-   "ratio": 0.4056,
-   "compress_mbps": 26.42,
-   "decompress_mbps": 122.03
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 194902,
-   "ratio": 0.4045,
-   "compress_mbps": 22.11,
-   "decompress_mbps": 128.83
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 195177,
-   "ratio": 0.405,
-   "compress_mbps": 20.45,
-   "decompress_mbps": 131.99
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 194385,
-   "ratio": 0.4034,
-   "compress_mbps": 18.08,
-   "decompress_mbps": 132.71
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 194380,
-   "ratio": 0.4034,
-   "compress_mbps": 17.87,
-   "decompress_mbps": 132.77
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 189365,
-   "ratio": 0.393,
-   "compress_mbps": 3.8,
-   "decompress_mbps": 132.81
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 60161,
-   "ratio": 0.1172,
-   "compress_mbps": 181.49,
-   "decompress_mbps": 338.36
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 58873,
-   "ratio": 0.1147,
-   "compress_mbps": 139.69,
-   "decompress_mbps": 359.14
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 58327,
-   "ratio": 0.1137,
-   "compress_mbps": 122.73,
-   "decompress_mbps": 382.33
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 55673,
-   "ratio": 0.1085,
-   "compress_mbps": 83.52,
-   "decompress_mbps": 351.06
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 54950,
-   "ratio": 0.1071,
-   "compress_mbps": 58.12,
-   "decompress_mbps": 374.88
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 55259,
-   "ratio": 0.1077,
-   "compress_mbps": 39.26,
-   "decompress_mbps": 403.13
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 53713,
-   "ratio": 0.1047,
-   "compress_mbps": 30.0,
-   "decompress_mbps": 425.68
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 52897,
-   "ratio": 0.1031,
-   "compress_mbps": 25.77,
-   "decompress_mbps": 456.29
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 52729,
-   "ratio": 0.1027,
-   "compress_mbps": 4.94,
-   "decompress_mbps": 470.01
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 14249,
-   "ratio": 0.3726,
-   "compress_mbps": 31.28,
-   "decompress_mbps": 113.25
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 13825,
-   "ratio": 0.3615,
-   "compress_mbps": 28.98,
-   "decompress_mbps": 115.97
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13751,
-   "ratio": 0.3596,
-   "compress_mbps": 28.18,
-   "decompress_mbps": 117.26
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13366,
-   "ratio": 0.3495,
-   "compress_mbps": 25.39,
-   "decompress_mbps": 123.39
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13346,
-   "ratio": 0.349,
-   "compress_mbps": 22.57,
-   "decompress_mbps": 130.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 13040,
-   "ratio": 0.341,
-   "compress_mbps": 9.91,
-   "decompress_mbps": 132.49
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 13035,
-   "ratio": 0.3409,
-   "compress_mbps": 9.38,
-   "decompress_mbps": 133.77
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 13028,
-   "ratio": 0.3407,
-   "compress_mbps": 8.71,
-   "decompress_mbps": 134.94
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 12427,
-   "ratio": 0.325,
-   "compress_mbps": 4.21,
-   "decompress_mbps": 136.8
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1800,
-   "ratio": 0.4258,
-   "compress_mbps": 14.63,
-   "decompress_mbps": 57.2
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1750,
-   "ratio": 0.414,
-   "compress_mbps": 14.0,
-   "decompress_mbps": 57.67
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 13.37,
-   "decompress_mbps": 57.48
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1732,
-   "ratio": 0.4097,
-   "compress_mbps": 13.11,
-   "decompress_mbps": 58.8
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1729,
-   "ratio": 0.409,
-   "compress_mbps": 13.09,
-   "decompress_mbps": 59.26
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1729,
-   "ratio": 0.409,
-   "compress_mbps": 11.39,
-   "decompress_mbps": 59.21
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1729,
-   "ratio": 0.409,
-   "compress_mbps": 11.41,
-   "decompress_mbps": 59.29
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1729,
-   "ratio": 0.409,
-   "compress_mbps": 11.4,
-   "decompress_mbps": 59.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1708,
-   "ratio": 0.4041,
-   "compress_mbps": 3.95,
-   "decompress_mbps": 59.18
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 65130,
-   "ratio": 0.4282,
-   "compress_mbps": 118.84,
-   "decompress_mbps": 399.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 62270,
-   "ratio": 0.4094,
-   "compress_mbps": 101.78,
-   "decompress_mbps": 418.8
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 59488,
-   "ratio": 0.3911,
-   "compress_mbps": 67.0,
-   "decompress_mbps": 435.28
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 57679,
-   "ratio": 0.3792,
-   "compress_mbps": 71.67,
-   "decompress_mbps": 414.35
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 55616,
-   "ratio": 0.3657,
-   "compress_mbps": 41.81,
-   "decompress_mbps": 408.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54398,
-   "ratio": 0.3577,
-   "compress_mbps": 25.53,
-   "decompress_mbps": 421.51
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54253,
-   "ratio": 0.3567,
-   "compress_mbps": 21.45,
-   "decompress_mbps": 423.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 54164,
-   "ratio": 0.3561,
-   "compress_mbps": 16.99,
-   "decompress_mbps": 425.54
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 54164,
-   "ratio": 0.3561,
-   "compress_mbps": 16.98,
-   "decompress_mbps": 423.92
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 56791,
-   "ratio": 0.4537,
-   "compress_mbps": 115.6,
-   "decompress_mbps": 394.7
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 54652,
-   "ratio": 0.4366,
-   "compress_mbps": 97.78,
-   "decompress_mbps": 407.38
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 52663,
-   "ratio": 0.4207,
-   "compress_mbps": 62.36,
-   "decompress_mbps": 428.67
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 51266,
-   "ratio": 0.4095,
-   "compress_mbps": 67.4,
-   "decompress_mbps": 398.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 49622,
-   "ratio": 0.3964,
-   "compress_mbps": 37.32,
-   "decompress_mbps": 386.08
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48891,
-   "ratio": 0.3906,
-   "compress_mbps": 22.81,
-   "decompress_mbps": 395.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48801,
-   "ratio": 0.3898,
-   "compress_mbps": 20.02,
-   "decompress_mbps": 397.56
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 48772,
-   "ratio": 0.3896,
-   "compress_mbps": 18.15,
-   "decompress_mbps": 395.81
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 48772,
-   "ratio": 0.3896,
-   "compress_mbps": 18.14,
-   "decompress_mbps": 399.23
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 9028,
-   "ratio": 0.3669,
-   "compress_mbps": 414.75,
-   "decompress_mbps": 1058.33
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8811,
-   "ratio": 0.3581,
-   "compress_mbps": 218.08,
-   "decompress_mbps": 1085.71
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8616,
-   "ratio": 0.3502,
-   "compress_mbps": 163.26,
-   "decompress_mbps": 1104.41
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8219,
-   "ratio": 0.3341,
-   "compress_mbps": 116.35,
-   "decompress_mbps": 1113.96
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 8001,
-   "ratio": 0.3252,
-   "compress_mbps": 84.93,
-   "decompress_mbps": 1146.67
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7955,
-   "ratio": 0.3233,
-   "compress_mbps": 68.91,
-   "decompress_mbps": 1156.51
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7933,
-   "ratio": 0.3224,
-   "compress_mbps": 62.88,
-   "decompress_mbps": 1159.42
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7934,
-   "ratio": 0.3225,
-   "compress_mbps": 58.08,
-   "decompress_mbps": 1161.26
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7934,
-   "ratio": 0.3225,
-   "compress_mbps": 58.09,
-   "decompress_mbps": 1160.11
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3647,
-   "ratio": 0.3271,
-   "compress_mbps": 426.79,
-   "decompress_mbps": 1073.55
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3501,
-   "ratio": 0.314,
-   "compress_mbps": 408.84,
-   "decompress_mbps": 1117.67
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3393,
-   "ratio": 0.3043,
-   "compress_mbps": 338.35,
-   "decompress_mbps": 1147.08
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3215,
-   "ratio": 0.2883,
-   "compress_mbps": 271.93,
-   "decompress_mbps": 1175.75
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3140,
-   "ratio": 0.2816,
-   "compress_mbps": 205.2,
-   "decompress_mbps": 1205.2
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3116,
-   "ratio": 0.2795,
-   "compress_mbps": 154.1,
-   "decompress_mbps": 1215.53
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 131.87,
-   "decompress_mbps": 1216.78
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3109,
-   "ratio": 0.2788,
-   "compress_mbps": 111.18,
-   "decompress_mbps": 1216.5
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3109,
-   "ratio": 0.2788,
-   "compress_mbps": 110.92,
-   "decompress_mbps": 1220.83
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1326,
-   "ratio": 0.3564,
-   "compress_mbps": 317.29,
-   "decompress_mbps": 787.88
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1306,
-   "ratio": 0.351,
-   "compress_mbps": 310.71,
-   "decompress_mbps": 796.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1301,
-   "ratio": 0.3496,
-   "compress_mbps": 291.04,
-   "decompress_mbps": 799.42
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1228,
-   "ratio": 0.33,
-   "compress_mbps": 233.69,
-   "decompress_mbps": 825.26
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 198.9,
-   "decompress_mbps": 831.06
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 177.77,
-   "decompress_mbps": 832.23
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 170.71,
-   "decompress_mbps": 821.82
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 167.8,
-   "decompress_mbps": 826.61
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 168.26,
-   "decompress_mbps": 828.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 242293,
-   "ratio": 0.2353,
-   "compress_mbps": 261.91,
-   "decompress_mbps": 834.71
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 233553,
-   "ratio": 0.2268,
-   "compress_mbps": 248.46,
-   "decompress_mbps": 990.64
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 228222,
-   "ratio": 0.2216,
-   "compress_mbps": 195.71,
-   "decompress_mbps": 1047.56
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 223668,
-   "ratio": 0.2172,
-   "compress_mbps": 177.25,
-   "decompress_mbps": 1079.08
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 205994,
-   "ratio": 0.2,
-   "compress_mbps": 110.7,
-   "decompress_mbps": 1038.46
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 203986,
-   "ratio": 0.1981,
-   "compress_mbps": 50.06,
-   "decompress_mbps": 1033.64
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 207681,
-   "ratio": 0.2017,
-   "compress_mbps": 37.08,
-   "decompress_mbps": 1027.99
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 206827,
-   "ratio": 0.2009,
-   "compress_mbps": 7.29,
-   "decompress_mbps": 1001.69
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 207023,
-   "ratio": 0.201,
-   "compress_mbps": 3.43,
-   "decompress_mbps": 1007.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 174124,
-   "ratio": 0.408,
-   "compress_mbps": 124.52,
-   "decompress_mbps": 403.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 166150,
-   "ratio": 0.3893,
-   "compress_mbps": 105.75,
-   "decompress_mbps": 410.83
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 158784,
-   "ratio": 0.3721,
-   "compress_mbps": 70.62,
-   "decompress_mbps": 431.19
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 152782,
-   "ratio": 0.358,
-   "compress_mbps": 74.37,
-   "decompress_mbps": 417.63
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 147196,
-   "ratio": 0.3449,
-   "compress_mbps": 43.69,
-   "decompress_mbps": 412.43
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 144898,
-   "ratio": 0.3395,
-   "compress_mbps": 26.54,
-   "decompress_mbps": 422.22
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 144589,
-   "ratio": 0.3388,
-   "compress_mbps": 23.0,
-   "decompress_mbps": 422.54
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 144436,
-   "ratio": 0.3385,
-   "compress_mbps": 19.77,
-   "decompress_mbps": 426.62
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 144433,
-   "ratio": 0.3384,
-   "compress_mbps": 19.7,
-   "decompress_mbps": 427.06
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 228883,
-   "ratio": 0.475,
-   "compress_mbps": 108.85,
-   "decompress_mbps": 379.18
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 219047,
-   "ratio": 0.4546,
-   "compress_mbps": 91.35,
-   "decompress_mbps": 396.75
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 209408,
-   "ratio": 0.4346,
-   "compress_mbps": 55.73,
-   "decompress_mbps": 408.77
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 205916,
-   "ratio": 0.4273,
-   "compress_mbps": 62.79,
-   "decompress_mbps": 384.06
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 199188,
-   "ratio": 0.4134,
-   "compress_mbps": 33.23,
-   "decompress_mbps": 365.25
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 195255,
-   "ratio": 0.4052,
-   "compress_mbps": 19.51,
-   "decompress_mbps": 371.54
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 194657,
-   "ratio": 0.404,
-   "compress_mbps": 16.52,
-   "decompress_mbps": 368.04
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 194326,
-   "ratio": 0.4033,
-   "compress_mbps": 13.04,
-   "decompress_mbps": 372.62
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 194326,
-   "ratio": 0.4033,
-   "compress_mbps": 13.03,
-   "decompress_mbps": 376.86
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 65553,
-   "ratio": 0.1277,
-   "compress_mbps": 277.05,
-   "decompress_mbps": 898.35
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 63891,
-   "ratio": 0.1245,
-   "compress_mbps": 249.81,
-   "decompress_mbps": 925.37
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 62515,
-   "ratio": 0.1218,
-   "compress_mbps": 196.22,
-   "decompress_mbps": 996.47
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 58451,
-   "ratio": 0.1139,
-   "compress_mbps": 170.56,
-   "decompress_mbps": 705.74
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 57410,
-   "ratio": 0.1119,
-   "compress_mbps": 131.27,
-   "decompress_mbps": 733.83
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 56459,
-   "ratio": 0.11,
-   "compress_mbps": 77.73,
-   "decompress_mbps": 785.69
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 55358,
-   "ratio": 0.1079,
-   "compress_mbps": 60.89,
-   "decompress_mbps": 824.41
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 52991,
-   "ratio": 0.1033,
-   "compress_mbps": 27.8,
-   "decompress_mbps": 878.92
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 52215,
-   "ratio": 0.1017,
-   "compress_mbps": 9.91,
-   "decompress_mbps": 892.75
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 14112,
-   "ratio": 0.369,
-   "compress_mbps": 130.36,
-   "decompress_mbps": 944.12
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 13815,
-   "ratio": 0.3613,
-   "compress_mbps": 110.11,
-   "decompress_mbps": 978.68
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13795,
-   "ratio": 0.3607,
-   "compress_mbps": 79.64,
-   "decompress_mbps": 1014.48
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13375,
-   "ratio": 0.3498,
-   "compress_mbps": 81.09,
-   "decompress_mbps": 997.82
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13062,
-   "ratio": 0.3416,
-   "compress_mbps": 56.15,
-   "decompress_mbps": 1040.2
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 12984,
-   "ratio": 0.3395,
-   "compress_mbps": 33.24,
-   "decompress_mbps": 1062.14
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 12949,
-   "ratio": 0.3386,
-   "compress_mbps": 25.62,
-   "decompress_mbps": 1070.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 12894,
-   "ratio": 0.3372,
-   "compress_mbps": 11.1,
-   "decompress_mbps": 1080.36
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 12832,
-   "ratio": 0.3356,
-   "compress_mbps": 5.1,
-   "decompress_mbps": 1081.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1846,
-   "ratio": 0.4367,
-   "compress_mbps": 290.31,
-   "decompress_mbps": 710.34
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1820,
-   "ratio": 0.4306,
-   "compress_mbps": 284.39,
-   "decompress_mbps": 723.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1808,
-   "ratio": 0.4277,
-   "compress_mbps": 272.54,
-   "decompress_mbps": 726.34
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1749,
-   "ratio": 0.4138,
-   "compress_mbps": 226.28,
-   "decompress_mbps": 749.43
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 202.59,
-   "decompress_mbps": 753.91
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 199.81,
-   "decompress_mbps": 754.2
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 196.62,
-   "decompress_mbps": 753.91
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 197.1,
-   "decompress_mbps": 754.2
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 197.89,
-   "decompress_mbps": 752.93
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 76470,
-   "ratio": 0.5028,
-   "compress_mbps": 156.81,
-   "decompress_mbps": 442.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 62765,
-   "ratio": 0.4127,
-   "compress_mbps": 133.14,
-   "decompress_mbps": 491.57
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 57162,
-   "ratio": 0.3758,
-   "compress_mbps": 72.46,
-   "decompress_mbps": 549.38
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 56826,
-   "ratio": 0.3736,
-   "compress_mbps": 64.54,
-   "decompress_mbps": 540.99
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 55696,
-   "ratio": 0.3662,
-   "compress_mbps": 46.93,
-   "decompress_mbps": 528.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54440,
-   "ratio": 0.3579,
-   "compress_mbps": 26.59,
-   "decompress_mbps": 545.39
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54283,
-   "ratio": 0.3569,
-   "compress_mbps": 22.46,
-   "decompress_mbps": 546.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 54221,
-   "ratio": 0.3565,
-   "compress_mbps": 19.77,
-   "decompress_mbps": 546.31
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 54217,
-   "ratio": 0.3565,
-   "compress_mbps": 19.52,
-   "decompress_mbps": 546.07
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 64926,
-   "ratio": 0.5187,
-   "compress_mbps": 150.76,
-   "decompress_mbps": 420.61
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 54985,
-   "ratio": 0.4393,
-   "compress_mbps": 124.87,
-   "decompress_mbps": 468.91
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 51148,
-   "ratio": 0.4086,
-   "compress_mbps": 67.28,
-   "decompress_mbps": 536.64
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 50599,
-   "ratio": 0.4042,
-   "compress_mbps": 59.25,
-   "decompress_mbps": 526.29
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 49775,
-   "ratio": 0.3976,
-   "compress_mbps": 42.72,
-   "decompress_mbps": 513.76
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48967,
-   "ratio": 0.3912,
-   "compress_mbps": 25.03,
-   "decompress_mbps": 524.3
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48870,
-   "ratio": 0.3904,
-   "compress_mbps": 22.21,
-   "decompress_mbps": 523.8
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 48845,
-   "ratio": 0.3902,
-   "compress_mbps": 20.95,
-   "decompress_mbps": 522.13
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 48845,
-   "ratio": 0.3902,
-   "compress_mbps": 20.95,
-   "decompress_mbps": 524.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 10024,
-   "ratio": 0.4074,
-   "compress_mbps": 568.72,
-   "decompress_mbps": 906.86
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8577,
-   "ratio": 0.3486,
-   "compress_mbps": 269.07,
-   "decompress_mbps": 929.83
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8168,
-   "ratio": 0.332,
-   "compress_mbps": 155.49,
-   "decompress_mbps": 951.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8069,
-   "ratio": 0.328,
-   "compress_mbps": 116.17,
-   "decompress_mbps": 969.68
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 7997,
-   "ratio": 0.325,
-   "compress_mbps": 100.13,
-   "decompress_mbps": 1001.46
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7952,
-   "ratio": 0.3232,
-   "compress_mbps": 74.99,
-   "decompress_mbps": 1003.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7947,
-   "ratio": 0.323,
-   "compress_mbps": 72.24,
-   "decompress_mbps": 1009.09
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7947,
-   "ratio": 0.323,
-   "compress_mbps": 71.2,
-   "decompress_mbps": 1009.52
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7947,
-   "ratio": 0.323,
-   "compress_mbps": 70.94,
-   "decompress_mbps": 1010.39
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 4061,
-   "ratio": 0.3642,
-   "compress_mbps": 505.27,
-   "decompress_mbps": 857.33
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3446,
-   "ratio": 0.3091,
-   "compress_mbps": 303.09,
-   "decompress_mbps": 902.14
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3201,
-   "ratio": 0.2871,
-   "compress_mbps": 235.32,
-   "decompress_mbps": 933.5
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3168,
-   "ratio": 0.2841,
-   "compress_mbps": 196.56,
-   "decompress_mbps": 955.13
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3139,
-   "ratio": 0.2815,
-   "compress_mbps": 162.35,
-   "decompress_mbps": 979.95
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3115,
-   "ratio": 0.2794,
-   "compress_mbps": 116.87,
-   "decompress_mbps": 990.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 106.87,
-   "decompress_mbps": 991.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 103.44,
-   "decompress_mbps": 992.11
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 103.35,
-   "decompress_mbps": 992.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1410,
-   "ratio": 0.3789,
-   "compress_mbps": 365.35,
-   "decompress_mbps": 595.71
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1262,
-   "ratio": 0.3392,
-   "compress_mbps": 234.59,
-   "decompress_mbps": 602.38
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1238,
-   "ratio": 0.3327,
-   "compress_mbps": 206.3,
-   "decompress_mbps": 606.19
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1219,
-   "ratio": 0.3276,
-   "compress_mbps": 178.27,
-   "decompress_mbps": 624.32
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 163.31,
-   "decompress_mbps": 633.68
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 147.91,
-   "decompress_mbps": 631.88
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 147.05,
-   "decompress_mbps": 632.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 147.52,
-   "decompress_mbps": 634.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1216,
-   "ratio": 0.3268,
-   "compress_mbps": 147.39,
-   "decompress_mbps": 634.93
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 274412,
-   "ratio": 0.2665,
-   "compress_mbps": 452.12,
-   "decompress_mbps": 796.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 213239,
-   "ratio": 0.2071,
-   "compress_mbps": 274.72,
-   "decompress_mbps": 895.56
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 232107,
-   "ratio": 0.2254,
-   "compress_mbps": 137.22,
-   "decompress_mbps": 936.66
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 202733,
-   "ratio": 0.1969,
-   "compress_mbps": 130.42,
-   "decompress_mbps": 942.52
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 207803,
-   "ratio": 0.2018,
-   "compress_mbps": 84.44,
-   "decompress_mbps": 954.1
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 205270,
-   "ratio": 0.1993,
-   "compress_mbps": 27.28,
-   "decompress_mbps": 981.19
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 209951,
-   "ratio": 0.2039,
-   "compress_mbps": 19.33,
-   "decompress_mbps": 997.67
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 209656,
-   "ratio": 0.2036,
-   "compress_mbps": 12.25,
-   "decompress_mbps": 1008.86
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 209189,
-   "ratio": 0.2031,
-   "compress_mbps": 8.96,
-   "decompress_mbps": 1009.49
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 208640,
-   "ratio": 0.4889,
-   "compress_mbps": 157.34,
-   "decompress_mbps": 424.83
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 167329,
-   "ratio": 0.3921,
-   "compress_mbps": 138.54,
-   "decompress_mbps": 464.58
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 151097,
-   "ratio": 0.3541,
-   "compress_mbps": 73.57,
-   "decompress_mbps": 510.84
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 150035,
-   "ratio": 0.3516,
-   "compress_mbps": 66.59,
-   "decompress_mbps": 511.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 147375,
-   "ratio": 0.3453,
-   "compress_mbps": 48.11,
-   "decompress_mbps": 508.07
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 144908,
-   "ratio": 0.3396,
-   "compress_mbps": 28.06,
-   "decompress_mbps": 519.16
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 144562,
-   "ratio": 0.3387,
-   "compress_mbps": 24.64,
-   "decompress_mbps": 517.99
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 144449,
-   "ratio": 0.3385,
-   "compress_mbps": 22.41,
-   "decompress_mbps": 518.6
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 144438,
-   "ratio": 0.3385,
-   "compress_mbps": 22.31,
-   "decompress_mbps": 518.95
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 264549,
-   "ratio": 0.549,
-   "compress_mbps": 135.43,
-   "decompress_mbps": 376.95
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 223724,
-   "ratio": 0.4643,
-   "compress_mbps": 118.93,
-   "decompress_mbps": 422.83
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 204825,
-   "ratio": 0.4251,
-   "compress_mbps": 60.63,
-   "decompress_mbps": 478.39
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 203945,
-   "ratio": 0.4232,
-   "compress_mbps": 53.94,
-   "decompress_mbps": 474.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 199780,
-   "ratio": 0.4146,
-   "compress_mbps": 37.91,
-   "decompress_mbps": 457.62
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 195417,
-   "ratio": 0.4055,
-   "compress_mbps": 21.2,
-   "decompress_mbps": 468.93
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 194796,
-   "ratio": 0.4043,
-   "compress_mbps": 17.9,
-   "decompress_mbps": 467.61
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 194543,
-   "ratio": 0.4037,
-   "compress_mbps": 15.72,
-   "decompress_mbps": 467.24
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 194460,
-   "ratio": 0.4036,
-   "compress_mbps": 15.05,
-   "decompress_mbps": 468.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 67436,
-   "ratio": 0.1314,
-   "compress_mbps": 627.54,
-   "decompress_mbps": 1004.41
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 59257,
-   "ratio": 0.1155,
-   "compress_mbps": 278.61,
-   "decompress_mbps": 1060.4
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 58316,
-   "ratio": 0.1136,
-   "compress_mbps": 181.72,
-   "decompress_mbps": 1145.04
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 56291,
-   "ratio": 0.1097,
-   "compress_mbps": 185.03,
-   "decompress_mbps": 1154.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 56220,
-   "ratio": 0.1095,
-   "compress_mbps": 146.23,
-   "decompress_mbps": 1207.72
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 55972,
-   "ratio": 0.1091,
-   "compress_mbps": 74.5,
-   "decompress_mbps": 1263.85
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 55121,
-   "ratio": 0.1074,
-   "compress_mbps": 52.14,
-   "decompress_mbps": 1305.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 54124,
-   "ratio": 0.1055,
-   "compress_mbps": 36.7,
-   "decompress_mbps": 1378.02
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 53699,
-   "ratio": 0.1046,
-   "compress_mbps": 28.66,
-   "decompress_mbps": 1411.67
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 15612,
-   "ratio": 0.4083,
-   "compress_mbps": 502.51,
-   "decompress_mbps": 850.6
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 14133,
-   "ratio": 0.3696,
-   "compress_mbps": 145.19,
-   "decompress_mbps": 890.56
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13341,
-   "ratio": 0.3489,
-   "compress_mbps": 88.72,
-   "decompress_mbps": 911.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13289,
-   "ratio": 0.3475,
-   "compress_mbps": 83.64,
-   "decompress_mbps": 941.29
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13052,
-   "ratio": 0.3413,
-   "compress_mbps": 66.83,
-   "decompress_mbps": 973.4
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 12996,
-   "ratio": 0.3399,
-   "compress_mbps": 37.14,
-   "decompress_mbps": 986.7
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 12972,
-   "ratio": 0.3392,
-   "compress_mbps": 27.2,
-   "decompress_mbps": 990.88
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 12951,
-   "ratio": 0.3387,
-   "compress_mbps": 19.04,
-   "decompress_mbps": 996.63
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 12933,
-   "ratio": 0.3382,
-   "compress_mbps": 14.86,
-   "decompress_mbps": 1010.18
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1988,
-   "ratio": 0.4703,
-   "compress_mbps": 340.18,
-   "decompress_mbps": 548.09
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1802,
-   "ratio": 0.4263,
-   "compress_mbps": 218.94,
-   "decompress_mbps": 554.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 205.58,
-   "decompress_mbps": 558.57
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1732,
-   "ratio": 0.4097,
-   "compress_mbps": 171.81,
-   "decompress_mbps": 573.34
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 167.66,
-   "decompress_mbps": 582.37
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 166.66,
-   "decompress_mbps": 582.62
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 166.44,
-   "decompress_mbps": 580.03
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 167.1,
-   "decompress_mbps": 579.86
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1730,
-   "ratio": 0.4093,
-   "compress_mbps": 166.8,
-   "decompress_mbps": 579.36
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 59790,
-   "ratio": 0.3931,
-   "compress_mbps": 262.72,
-   "decompress_mbps": 1002.92
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 57173,
-   "ratio": 0.3759,
-   "compress_mbps": 181.24,
-   "decompress_mbps": 1076.37
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 56189,
-   "ratio": 0.3694,
-   "compress_mbps": 150.83,
-   "decompress_mbps": 1150.52
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 55816,
-   "ratio": 0.367,
-   "compress_mbps": 138.22,
-   "decompress_mbps": 1189.04
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 54758,
-   "ratio": 0.36,
-   "compress_mbps": 109.12,
-   "decompress_mbps": 1241.07
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54220,
-   "ratio": 0.3565,
-   "compress_mbps": 84.01,
-   "decompress_mbps": 1281.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 53801,
-   "ratio": 0.3537,
-   "compress_mbps": 61.34,
-   "decompress_mbps": 1284.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 53573,
-   "ratio": 0.3522,
-   "compress_mbps": 38.99,
-   "decompress_mbps": 1281.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 53546,
-   "ratio": 0.3521,
-   "compress_mbps": 34.49,
-   "decompress_mbps": 1286.38
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 52276,
-   "ratio": 0.4176,
-   "compress_mbps": 244.27,
-   "decompress_mbps": 941.62
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 50534,
-   "ratio": 0.4037,
-   "compress_mbps": 169.26,
-   "decompress_mbps": 994.53
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 49919,
-   "ratio": 0.3988,
-   "compress_mbps": 142.29,
-   "decompress_mbps": 1056.87
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 49715,
-   "ratio": 0.3972,
-   "compress_mbps": 131.62,
-   "decompress_mbps": 1092.43
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 48735,
-   "ratio": 0.3893,
-   "compress_mbps": 101.28,
-   "decompress_mbps": 1138.39
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48422,
-   "ratio": 0.3868,
-   "compress_mbps": 79.56,
-   "decompress_mbps": 1159.77
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48249,
-   "ratio": 0.3854,
-   "compress_mbps": 61.42,
-   "decompress_mbps": 1167.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 47977,
-   "ratio": 0.3833,
-   "compress_mbps": 43.01,
-   "decompress_mbps": 1163.26
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 47971,
-   "ratio": 0.3832,
-   "compress_mbps": 41.05,
-   "decompress_mbps": 1168.97
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8385,
-   "ratio": 0.3408,
-   "compress_mbps": 694.12,
-   "decompress_mbps": 956.86
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8380,
-   "ratio": 0.3406,
-   "compress_mbps": 439.72,
-   "decompress_mbps": 974.59
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8286,
-   "ratio": 0.3368,
-   "compress_mbps": 403.73,
-   "decompress_mbps": 993.24
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8163,
-   "ratio": 0.3318,
-   "compress_mbps": 378.68,
-   "decompress_mbps": 1003.78
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 8053,
-   "ratio": 0.3273,
-   "compress_mbps": 335.07,
-   "decompress_mbps": 1027.69
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7986,
-   "ratio": 0.3246,
-   "compress_mbps": 277.67,
-   "decompress_mbps": 1035.81
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7954,
-   "ratio": 0.3233,
-   "compress_mbps": 191.05,
-   "decompress_mbps": 1026.12
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7916,
-   "ratio": 0.3217,
-   "compress_mbps": 129.56,
-   "decompress_mbps": 1035.17
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7916,
-   "ratio": 0.3217,
-   "compress_mbps": 125.42,
-   "decompress_mbps": 1013.27
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3401,
-   "ratio": 0.305,
-   "compress_mbps": 586.93,
-   "decompress_mbps": 768.98
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3307,
-   "ratio": 0.2966,
-   "compress_mbps": 398.24,
-   "decompress_mbps": 792.95
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3242,
-   "ratio": 0.2908,
-   "compress_mbps": 371.5,
-   "decompress_mbps": 810.66
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3205,
-   "ratio": 0.2874,
-   "compress_mbps": 349.62,
-   "decompress_mbps": 821.62
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3150,
-   "ratio": 0.2825,
-   "compress_mbps": 313.81,
-   "decompress_mbps": 837.48
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3126,
-   "ratio": 0.2804,
-   "compress_mbps": 267.83,
-   "decompress_mbps": 842.46
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3106,
-   "ratio": 0.2786,
-   "compress_mbps": 206.71,
-   "decompress_mbps": 846.01
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3102,
-   "ratio": 0.2782,
-   "compress_mbps": 147.91,
-   "decompress_mbps": 842.39
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3102,
-   "ratio": 0.2782,
-   "compress_mbps": 140.39,
-   "decompress_mbps": 846.34
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1251,
-   "ratio": 0.3362,
-   "compress_mbps": 377.39,
-   "decompress_mbps": 426.98
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1228,
-   "ratio": 0.33,
-   "compress_mbps": 267.66,
-   "decompress_mbps": 433.76
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1219,
-   "ratio": 0.3276,
-   "compress_mbps": 258.72,
-   "decompress_mbps": 433.23
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1220,
-   "ratio": 0.3279,
-   "compress_mbps": 253.94,
-   "decompress_mbps": 439.29
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 240.44,
-   "decompress_mbps": 443.8
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 222.65,
-   "decompress_mbps": 441.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 203.53,
-   "decompress_mbps": 438.86
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1204,
-   "ratio": 0.3236,
-   "compress_mbps": 169.68,
-   "decompress_mbps": 444.08
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1204,
-   "ratio": 0.3236,
-   "compress_mbps": 169.88,
-   "decompress_mbps": 438.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 221813,
-   "ratio": 0.2154,
-   "compress_mbps": 593.83,
-   "decompress_mbps": 1009.94
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 199825,
-   "ratio": 0.1941,
-   "compress_mbps": 409.25,
-   "decompress_mbps": 1460.57
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 195675,
-   "ratio": 0.19,
-   "compress_mbps": 283.23,
-   "decompress_mbps": 1526.64
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 195664,
-   "ratio": 0.19,
-   "compress_mbps": 279.77,
-   "decompress_mbps": 1536.83
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 198900,
-   "ratio": 0.1932,
-   "compress_mbps": 239.94,
-   "decompress_mbps": 1127.82
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 199347,
-   "ratio": 0.1936,
-   "compress_mbps": 204.69,
-   "decompress_mbps": 1130.61
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 199777,
-   "ratio": 0.194,
-   "compress_mbps": 123.53,
-   "decompress_mbps": 1190.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 182094,
-   "ratio": 0.1768,
-   "compress_mbps": 25.66,
-   "decompress_mbps": 1169.78
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 181451,
-   "ratio": 0.1762,
-   "compress_mbps": 13.61,
-   "decompress_mbps": 1173.47
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 159063,
-   "ratio": 0.3727,
-   "compress_mbps": 263.86,
-   "decompress_mbps": 1029.34
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 152115,
-   "ratio": 0.3564,
-   "compress_mbps": 187.44,
-   "decompress_mbps": 1105.52
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 149162,
-   "ratio": 0.3495,
-   "compress_mbps": 156.82,
-   "decompress_mbps": 1189.07
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 148359,
-   "ratio": 0.3476,
-   "compress_mbps": 142.61,
-   "decompress_mbps": 1033.04
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 145353,
-   "ratio": 0.3406,
-   "compress_mbps": 113.35,
-   "decompress_mbps": 997.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 144209,
-   "ratio": 0.3379,
-   "compress_mbps": 87.48,
-   "decompress_mbps": 1037.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 143604,
-   "ratio": 0.3365,
-   "compress_mbps": 66.64,
-   "decompress_mbps": 1039.31
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 142086,
-   "ratio": 0.3329,
-   "compress_mbps": 44.24,
-   "decompress_mbps": 1035.21
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 142027,
-   "ratio": 0.3328,
-   "compress_mbps": 40.46,
-   "decompress_mbps": 1038.75
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 210662,
-   "ratio": 0.4372,
-   "compress_mbps": 228.71,
-   "decompress_mbps": 869.83
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 202881,
-   "ratio": 0.421,
-   "compress_mbps": 158.66,
-   "decompress_mbps": 939.95
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 200409,
-   "ratio": 0.4159,
-   "compress_mbps": 132.96,
-   "decompress_mbps": 1019.12
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 199678,
-   "ratio": 0.4144,
-   "compress_mbps": 122.96,
-   "decompress_mbps": 839.63
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 195798,
-   "ratio": 0.4063,
-   "compress_mbps": 93.4,
-   "decompress_mbps": 789.36
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 194029,
-   "ratio": 0.4027,
-   "compress_mbps": 71.6,
-   "decompress_mbps": 813.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 192773,
-   "ratio": 0.4001,
-   "compress_mbps": 50.41,
-   "decompress_mbps": 835.88
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 191739,
-   "ratio": 0.3979,
-   "compress_mbps": 33.69,
-   "decompress_mbps": 841.06
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 191676,
-   "ratio": 0.3978,
-   "compress_mbps": 31.1,
-   "decompress_mbps": 839.65
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 58079,
-   "ratio": 0.1132,
-   "compress_mbps": 373.38,
-   "decompress_mbps": 1687.98
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 57838,
-   "ratio": 0.1127,
-   "compress_mbps": 413.69,
-   "decompress_mbps": 1800.72
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 57554,
-   "ratio": 0.1121,
-   "compress_mbps": 394.76,
-   "decompress_mbps": 1899.42
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 57064,
-   "ratio": 0.1112,
-   "compress_mbps": 374.05,
-   "decompress_mbps": 1741.26
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 55743,
-   "ratio": 0.1086,
-   "compress_mbps": 343.45,
-   "decompress_mbps": 1793.36
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 55102,
-   "ratio": 0.1074,
-   "compress_mbps": 285.08,
-   "decompress_mbps": 1869.89
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 54742,
-   "ratio": 0.1067,
-   "compress_mbps": 193.03,
-   "decompress_mbps": 1929.26
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 53133,
-   "ratio": 0.1035,
-   "compress_mbps": 102.77,
-   "decompress_mbps": 1996.36
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 52186,
-   "ratio": 0.1017,
-   "compress_mbps": 72.32,
-   "decompress_mbps": 2031.74
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 14122,
-   "ratio": 0.3693,
-   "compress_mbps": 648.66,
-   "decompress_mbps": 823.66
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 13374,
-   "ratio": 0.3497,
-   "compress_mbps": 338.62,
-   "decompress_mbps": 879.23
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13293,
-   "ratio": 0.3476,
-   "compress_mbps": 257.73,
-   "decompress_mbps": 960.76
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13259,
-   "ratio": 0.3467,
-   "compress_mbps": 263.83,
-   "decompress_mbps": 960.86
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 12641,
-   "ratio": 0.3306,
-   "compress_mbps": 190.13,
-   "decompress_mbps": 990.29
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 12432,
-   "ratio": 0.3251,
-   "compress_mbps": 164.05,
-   "decompress_mbps": 1006.67
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 12439,
-   "ratio": 0.3253,
-   "compress_mbps": 122.43,
-   "decompress_mbps": 1013.21
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 12579,
-   "ratio": 0.3289,
-   "compress_mbps": 67.61,
-   "decompress_mbps": 1025.92
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 12574,
-   "ratio": 0.3288,
-   "compress_mbps": 47.47,
-   "decompress_mbps": 1031.58
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1777,
-   "ratio": 0.4204,
-   "compress_mbps": 386.35,
-   "decompress_mbps": 403.24
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1756,
-   "ratio": 0.4154,
-   "compress_mbps": 260.77,
-   "decompress_mbps": 408.51
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1746,
-   "ratio": 0.4131,
-   "compress_mbps": 257.14,
-   "decompress_mbps": 410.93
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1740,
-   "ratio": 0.4116,
-   "compress_mbps": 254.99,
-   "decompress_mbps": 414.73
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1722,
-   "ratio": 0.4074,
-   "compress_mbps": 240.47,
-   "decompress_mbps": 415.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1721,
-   "ratio": 0.4071,
-   "compress_mbps": 235.91,
-   "decompress_mbps": 415.29
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 234.75,
-   "decompress_mbps": 415.41
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1717,
-   "ratio": 0.4062,
-   "compress_mbps": 217.57,
-   "decompress_mbps": 417.83
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1717,
-   "ratio": 0.4062,
-   "compress_mbps": 216.75,
-   "decompress_mbps": 416.19
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4259644,
-   "ratio": 0.4179,
-   "compress_mbps": 64.37,
-   "decompress_mbps": 104.44
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 3977395,
-   "ratio": 0.3902,
-   "compress_mbps": 46.09,
-   "decompress_mbps": 112.42
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3945296,
-   "ratio": 0.3871,
-   "compress_mbps": 40.62,
-   "decompress_mbps": 124.05
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 3882303,
-   "ratio": 0.3809,
-   "compress_mbps": 28.85,
-   "decompress_mbps": 127.43
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3870984,
-   "ratio": 0.3798,
-   "compress_mbps": 24.17,
-   "decompress_mbps": 133.76
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3878499,
-   "ratio": 0.3805,
-   "compress_mbps": 22.88,
-   "decompress_mbps": 137.81
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3865234,
-   "ratio": 0.3792,
-   "compress_mbps": 19.79,
-   "decompress_mbps": 138.26
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3864805,
-   "ratio": 0.3792,
-   "compress_mbps": 19.27,
-   "decompress_mbps": 138.48
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3766584,
-   "ratio": 0.3695,
-   "compress_mbps": 3.91,
-   "decompress_mbps": 141.96
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 21267086,
-   "ratio": 0.4152,
-   "compress_mbps": 79.63,
-   "decompress_mbps": 133.35
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 20802983,
-   "ratio": 0.4061,
-   "compress_mbps": 62.78,
-   "decompress_mbps": 139.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 20665485,
-   "ratio": 0.4035,
-   "compress_mbps": 58.36,
-   "decompress_mbps": 144.17
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 20393572,
-   "ratio": 0.3982,
-   "compress_mbps": 44.37,
-   "decompress_mbps": 151.14
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 20264932,
-   "ratio": 0.3956,
-   "compress_mbps": 32.78,
-   "decompress_mbps": 159.0
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19208910,
-   "ratio": 0.375,
-   "compress_mbps": 17.38,
-   "decompress_mbps": 162.84
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19177573,
-   "ratio": 0.3744,
-   "compress_mbps": 14.29,
-   "decompress_mbps": 162.5
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19172591,
-   "ratio": 0.3743,
-   "compress_mbps": 12.5,
-   "decompress_mbps": 163.23
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18686872,
-   "ratio": 0.3648,
-   "compress_mbps": 3.7,
-   "decompress_mbps": 160.91
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3864163,
-   "ratio": 0.3876,
-   "compress_mbps": 78.52,
-   "decompress_mbps": 119.16
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3734957,
-   "ratio": 0.3746,
-   "compress_mbps": 60.64,
-   "decompress_mbps": 127.35
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3708443,
-   "ratio": 0.3719,
-   "compress_mbps": 52.17,
-   "decompress_mbps": 136.42
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3707604,
-   "ratio": 0.3719,
-   "compress_mbps": 33.69,
-   "decompress_mbps": 131.84
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3705174,
-   "ratio": 0.3716,
-   "compress_mbps": 26.53,
-   "decompress_mbps": 137.21
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3612809,
-   "ratio": 0.3623,
-   "compress_mbps": 20.92,
-   "decompress_mbps": 143.5
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3608980,
-   "ratio": 0.362,
-   "compress_mbps": 18.15,
-   "decompress_mbps": 140.28
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3609490,
-   "ratio": 0.362,
-   "compress_mbps": 16.68,
-   "decompress_mbps": 147.84
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3581441,
-   "ratio": 0.3592,
-   "compress_mbps": 4.16,
-   "decompress_mbps": 153.49
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3785443,
-   "ratio": 0.1128,
-   "compress_mbps": 230.8,
-   "decompress_mbps": 363.92
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 3761560,
-   "ratio": 0.1121,
-   "compress_mbps": 146.53,
-   "decompress_mbps": 408.91
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3606997,
-   "ratio": 0.1075,
-   "compress_mbps": 125.19,
-   "decompress_mbps": 456.32
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3225450,
-   "ratio": 0.0961,
-   "compress_mbps": 93.46,
-   "decompress_mbps": 468.13
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3145121,
-   "ratio": 0.0937,
-   "compress_mbps": 62.98,
-   "decompress_mbps": 531.04
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3158854,
-   "ratio": 0.0941,
-   "compress_mbps": 60.2,
-   "decompress_mbps": 570.48
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3124878,
-   "ratio": 0.0931,
-   "compress_mbps": 42.63,
-   "decompress_mbps": 584.57
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3112207,
-   "ratio": 0.0928,
-   "compress_mbps": 34.69,
-   "decompress_mbps": 604.27
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 3034875,
-   "ratio": 0.0904,
-   "compress_mbps": 3.09,
-   "decompress_mbps": 584.63
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3357083,
-   "ratio": 0.5457,
-   "compress_mbps": 55.93,
-   "decompress_mbps": 92.43
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3285077,
-   "ratio": 0.534,
-   "compress_mbps": 45.95,
-   "decompress_mbps": 94.26
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3272746,
-   "ratio": 0.532,
-   "compress_mbps": 44.2,
-   "decompress_mbps": 97.27
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3237094,
-   "ratio": 0.5262,
-   "compress_mbps": 35.38,
-   "decompress_mbps": 105.09
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3233792,
-   "ratio": 0.5256,
-   "compress_mbps": 31.77,
-   "decompress_mbps": 109.67
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3168386,
-   "ratio": 0.515,
-   "compress_mbps": 17.85,
-   "decompress_mbps": 111.4
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3165783,
-   "ratio": 0.5146,
-   "compress_mbps": 16.8,
-   "decompress_mbps": 111.69
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3165909,
-   "ratio": 0.5146,
-   "compress_mbps": 16.08,
-   "decompress_mbps": 111.13
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3048772,
-   "ratio": 0.4956,
-   "compress_mbps": 4.4,
-   "decompress_mbps": 114.09
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3838828,
-   "ratio": 0.3806,
-   "compress_mbps": 88.99,
-   "decompress_mbps": 158.22
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3792520,
-   "ratio": 0.376,
-   "compress_mbps": 66.25,
-   "decompress_mbps": 163.33
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3783171,
-   "ratio": 0.3751,
-   "compress_mbps": 63.87,
-   "decompress_mbps": 168.09
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3706928,
-   "ratio": 0.3675,
-   "compress_mbps": 55.6,
-   "decompress_mbps": 180.99
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3707010,
-   "ratio": 0.3676,
-   "compress_mbps": 50.86,
-   "decompress_mbps": 179.41
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3707065,
-   "ratio": 0.3676,
-   "compress_mbps": 37.72,
-   "decompress_mbps": 185.98
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3706769,
-   "ratio": 0.3675,
-   "compress_mbps": 37.91,
-   "decompress_mbps": 187.82
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3706769,
-   "ratio": 0.3675,
-   "compress_mbps": 37.97,
-   "decompress_mbps": 188.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3665069,
-   "ratio": 0.3634,
-   "compress_mbps": 5.27,
-   "decompress_mbps": 196.08
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2254442,
-   "ratio": 0.3402,
-   "compress_mbps": 81.68,
-   "decompress_mbps": 130.87
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2044843,
-   "ratio": 0.3086,
-   "compress_mbps": 55.66,
-   "decompress_mbps": 142.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 1992105,
-   "ratio": 0.3006,
-   "compress_mbps": 45.73,
-   "decompress_mbps": 156.86
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 1901081,
-   "ratio": 0.2869,
-   "compress_mbps": 28.08,
-   "decompress_mbps": 160.66
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1874829,
-   "ratio": 0.2829,
-   "compress_mbps": 17.02,
-   "decompress_mbps": 173.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1867098,
-   "ratio": 0.2817,
-   "compress_mbps": 19.97,
-   "decompress_mbps": 183.88
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1843421,
-   "ratio": 0.2782,
-   "compress_mbps": 13.35,
-   "decompress_mbps": 187.36
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1841388,
-   "ratio": 0.2779,
-   "compress_mbps": 11.63,
-   "decompress_mbps": 189.17
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1773447,
-   "ratio": 0.2676,
-   "compress_mbps": 2.72,
-   "decompress_mbps": 193.34
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 6406301,
-   "ratio": 0.2965,
-   "compress_mbps": 109.31,
-   "decompress_mbps": 197.32
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 6102377,
-   "ratio": 0.2824,
-   "compress_mbps": 81.19,
-   "decompress_mbps": 209.64
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 6022184,
-   "ratio": 0.2787,
-   "compress_mbps": 73.76,
-   "decompress_mbps": 218.24
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5880979,
-   "ratio": 0.2722,
-   "compress_mbps": 54.55,
-   "decompress_mbps": 227.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5839944,
-   "ratio": 0.2703,
-   "compress_mbps": 41.71,
-   "decompress_mbps": 239.66
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5425813,
-   "ratio": 0.2511,
-   "compress_mbps": 29.44,
-   "decompress_mbps": 245.66
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5409983,
-   "ratio": 0.2504,
-   "compress_mbps": 26.01,
-   "decompress_mbps": 247.56
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5407066,
-   "ratio": 0.2503,
-   "compress_mbps": 24.22,
-   "decompress_mbps": 250.24
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5235865,
-   "ratio": 0.2423,
-   "compress_mbps": 4.25,
-   "decompress_mbps": 248.59
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5612204,
-   "ratio": 0.7739,
-   "compress_mbps": 46.71,
-   "decompress_mbps": 93.0
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5533875,
-   "ratio": 0.7631,
-   "compress_mbps": 38.35,
-   "decompress_mbps": 94.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5522436,
-   "ratio": 0.7615,
-   "compress_mbps": 36.95,
-   "decompress_mbps": 97.04
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5498823,
-   "ratio": 0.7583,
-   "compress_mbps": 29.8,
-   "decompress_mbps": 99.85
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5496802,
-   "ratio": 0.758,
-   "compress_mbps": 27.85,
-   "decompress_mbps": 103.53
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5478405,
-   "ratio": 0.7554,
-   "compress_mbps": 20.36,
-   "decompress_mbps": 104.28
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5474648,
-   "ratio": 0.7549,
-   "compress_mbps": 19.55,
-   "decompress_mbps": 106.49
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5474139,
-   "ratio": 0.7549,
-   "compress_mbps": 19.29,
-   "decompress_mbps": 104.42
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5284536,
-   "ratio": 0.7287,
-   "compress_mbps": 4.21,
-   "decompress_mbps": 105.91
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13727247,
-   "ratio": 0.3311,
-   "compress_mbps": 82.21,
-   "decompress_mbps": 138.26
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 12940398,
-   "ratio": 0.3121,
-   "compress_mbps": 60.65,
-   "decompress_mbps": 149.81
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12703756,
-   "ratio": 0.3064,
-   "compress_mbps": 55.82,
-   "decompress_mbps": 160.94
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12229398,
-   "ratio": 0.295,
-   "compress_mbps": 40.46,
-   "decompress_mbps": 168.23
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12123671,
-   "ratio": 0.2924,
-   "compress_mbps": 29.57,
-   "decompress_mbps": 176.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12167341,
-   "ratio": 0.2935,
-   "compress_mbps": 29.67,
-   "decompress_mbps": 182.28
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12109369,
-   "ratio": 0.2921,
-   "compress_mbps": 24.26,
-   "decompress_mbps": 183.33
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12106058,
-   "ratio": 0.292,
-   "compress_mbps": 23.33,
-   "decompress_mbps": 183.7
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11806466,
-   "ratio": 0.2848,
-   "compress_mbps": 3.63,
-   "decompress_mbps": 184.1
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6438176,
-   "ratio": 0.7597,
-   "compress_mbps": 43.02,
-   "decompress_mbps": 77.66
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6392101,
-   "ratio": 0.7543,
-   "compress_mbps": 41.08,
-   "decompress_mbps": 78.45
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6392124,
-   "ratio": 0.7543,
-   "compress_mbps": 41.18,
-   "decompress_mbps": 79.96
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6368719,
-   "ratio": 0.7515,
-   "compress_mbps": 38.7,
-   "decompress_mbps": 79.78
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6368717,
-   "ratio": 0.7515,
-   "compress_mbps": 38.36,
-   "decompress_mbps": 81.48
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 6278507,
-   "ratio": 0.7409,
-   "compress_mbps": 9.65,
-   "decompress_mbps": 82.82
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 6278507,
-   "ratio": 0.7409,
-   "compress_mbps": 9.96,
-   "decompress_mbps": 81.88
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 6278507,
-   "ratio": 0.7409,
-   "compress_mbps": 9.95,
-   "decompress_mbps": 82.67
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5952505,
-   "ratio": 0.7024,
-   "compress_mbps": 5.1,
-   "decompress_mbps": 84.15
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 858525,
-   "ratio": 0.1606,
-   "compress_mbps": 173.77,
-   "decompress_mbps": 270.67
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 846807,
-   "ratio": 0.1584,
-   "compress_mbps": 112.96,
-   "decompress_mbps": 303.92
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 806798,
-   "ratio": 0.1509,
-   "compress_mbps": 103.39,
-   "decompress_mbps": 339.29
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 721655,
-   "ratio": 0.135,
-   "compress_mbps": 73.68,
-   "decompress_mbps": 331.87
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 710636,
-   "ratio": 0.1329,
-   "compress_mbps": 53.74,
-   "decompress_mbps": 377.65
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 688375,
-   "ratio": 0.1288,
-   "compress_mbps": 47.17,
-   "decompress_mbps": 395.7
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 676544,
-   "ratio": 0.1266,
-   "compress_mbps": 38.03,
-   "decompress_mbps": 412.72
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 674362,
-   "ratio": 0.1262,
-   "compress_mbps": 32.89,
-   "decompress_mbps": 418.05
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 659417,
-   "ratio": 0.1234,
-   "compress_mbps": 4.14,
-   "decompress_mbps": 440.57
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4585612,
-   "ratio": 0.4499,
-   "compress_mbps": 113.67,
-   "decompress_mbps": 354.82
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4389474,
-   "ratio": 0.4307,
-   "compress_mbps": 96.07,
-   "decompress_mbps": 375.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 4192079,
-   "ratio": 0.4113,
-   "compress_mbps": 59.36,
-   "decompress_mbps": 412.28
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 4095021,
-   "ratio": 0.4018,
-   "compress_mbps": 66.19,
-   "decompress_mbps": 389.42
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3949169,
-   "ratio": 0.3875,
-   "compress_mbps": 35.97,
-   "decompress_mbps": 376.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3871628,
-   "ratio": 0.3799,
-   "compress_mbps": 21.24,
-   "decompress_mbps": 384.89
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3858876,
-   "ratio": 0.3786,
-   "compress_mbps": 17.58,
-   "decompress_mbps": 387.13
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3854729,
-   "ratio": 0.3782,
-   "compress_mbps": 15.07,
-   "decompress_mbps": 385.46
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3854729,
-   "ratio": 0.3782,
-   "compress_mbps": 15.07,
-   "decompress_mbps": 391.3
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20577220,
-   "ratio": 0.4017,
-   "compress_mbps": 113.25,
-   "decompress_mbps": 364.49
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 20247697,
-   "ratio": 0.3953,
-   "compress_mbps": 100.51,
-   "decompress_mbps": 370.0
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19987880,
-   "ratio": 0.3902,
-   "compress_mbps": 75.64,
-   "decompress_mbps": 340.24
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19512665,
-   "ratio": 0.381,
-   "compress_mbps": 71.76,
-   "decompress_mbps": 363.34
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 19213507,
-   "ratio": 0.3751,
-   "compress_mbps": 51.35,
-   "decompress_mbps": 370.37
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19089118,
-   "ratio": 0.3727,
-   "compress_mbps": 33.44,
-   "decompress_mbps": 376.59
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19061204,
-   "ratio": 0.3721,
-   "compress_mbps": 27.31,
-   "decompress_mbps": 380.14
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19040998,
-   "ratio": 0.3717,
-   "compress_mbps": 15.24,
-   "decompress_mbps": 379.76
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 19044390,
-   "ratio": 0.3718,
-   "compress_mbps": 9.54,
-   "decompress_mbps": 385.45
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3828360,
-   "ratio": 0.384,
-   "compress_mbps": 144.91,
-   "decompress_mbps": 453.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3798539,
-   "ratio": 0.381,
-   "compress_mbps": 128.29,
-   "decompress_mbps": 497.36
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3674568,
-   "ratio": 0.3685,
-   "compress_mbps": 80.47,
-   "decompress_mbps": 515.99
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3680923,
-   "ratio": 0.3692,
-   "compress_mbps": 89.36,
-   "decompress_mbps": 457.6
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3698707,
-   "ratio": 0.371,
-   "compress_mbps": 48.13,
-   "decompress_mbps": 427.63
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3675935,
-   "ratio": 0.3687,
-   "compress_mbps": 26.41,
-   "decompress_mbps": 437.75
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3670281,
-   "ratio": 0.3681,
-   "compress_mbps": 20.84,
-   "decompress_mbps": 444.31
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3661103,
-   "ratio": 0.3672,
-   "compress_mbps": 10.94,
-   "decompress_mbps": 458.18
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3660788,
-   "ratio": 0.3672,
-   "compress_mbps": 9.47,
-   "decompress_mbps": 459.79
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 4624591,
-   "ratio": 0.1378,
-   "compress_mbps": 332.0,
-   "decompress_mbps": 831.27
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 4303176,
-   "ratio": 0.1282,
-   "compress_mbps": 310.37,
-   "decompress_mbps": 841.9
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 4010156,
-   "ratio": 0.1195,
-   "compress_mbps": 257.47,
-   "decompress_mbps": 926.52
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3713866,
-   "ratio": 0.1107,
-   "compress_mbps": 212.08,
-   "decompress_mbps": 896.37
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3378136,
-   "ratio": 0.1007,
-   "compress_mbps": 166.1,
-   "decompress_mbps": 954.98
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3200182,
-   "ratio": 0.0954,
-   "compress_mbps": 113.17,
-   "decompress_mbps": 986.8
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3141278,
-   "ratio": 0.0936,
-   "compress_mbps": 90.33,
-   "decompress_mbps": 999.02
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3031199,
-   "ratio": 0.0903,
-   "compress_mbps": 39.16,
-   "decompress_mbps": 1017.12
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2987995,
-   "ratio": 0.0891,
-   "compress_mbps": 21.44,
-   "decompress_mbps": 1033.52
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3290526,
-   "ratio": 0.5349,
-   "compress_mbps": 79.06,
-   "decompress_mbps": 257.16
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3238282,
-   "ratio": 0.5264,
-   "compress_mbps": 72.38,
-   "decompress_mbps": 263.21
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3193366,
-   "ratio": 0.5191,
-   "compress_mbps": 57.0,
-   "decompress_mbps": 265.33
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3158012,
-   "ratio": 0.5133,
-   "compress_mbps": 55.65,
-   "decompress_mbps": 268.5
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3115309,
-   "ratio": 0.5064,
-   "compress_mbps": 39.25,
-   "decompress_mbps": 269.0
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3097288,
-   "ratio": 0.5034,
-   "compress_mbps": 26.28,
-   "decompress_mbps": 264.86
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3094363,
-   "ratio": 0.503,
-   "compress_mbps": 21.86,
-   "decompress_mbps": 268.09
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3093026,
-   "ratio": 0.5028,
-   "compress_mbps": 16.97,
-   "decompress_mbps": 270.33
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3092920,
-   "ratio": 0.5027,
-   "compress_mbps": 15.53,
-   "decompress_mbps": 269.1
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 4076385,
-   "ratio": 0.4042,
-   "compress_mbps": 125.81,
-   "decompress_mbps": 474.99
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3991014,
-   "ratio": 0.3957,
-   "compress_mbps": 117.17,
-   "decompress_mbps": 494.44
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3934055,
-   "ratio": 0.3901,
-   "compress_mbps": 93.6,
-   "decompress_mbps": 511.59
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3825092,
-   "ratio": 0.3793,
-   "compress_mbps": 85.49,
-   "decompress_mbps": 513.7
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3752932,
-   "ratio": 0.3721,
-   "compress_mbps": 64.41,
-   "decompress_mbps": 496.1
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3695164,
-   "ratio": 0.3664,
-   "compress_mbps": 49.22,
-   "decompress_mbps": 507.36
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3676881,
-   "ratio": 0.3646,
-   "compress_mbps": 38.17,
-   "decompress_mbps": 515.91
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3673171,
-   "ratio": 0.3642,
-   "compress_mbps": 31.92,
-   "decompress_mbps": 519.6
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3673171,
-   "ratio": 0.3642,
-   "compress_mbps": 31.92,
-   "decompress_mbps": 519.23
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2376424,
-   "ratio": 0.3586,
-   "compress_mbps": 130.38,
-   "decompress_mbps": 393.75
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2259060,
-   "ratio": 0.3409,
-   "compress_mbps": 112.03,
-   "decompress_mbps": 411.76
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2135664,
-   "ratio": 0.3223,
-   "compress_mbps": 72.25,
-   "decompress_mbps": 435.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 2052793,
-   "ratio": 0.3098,
-   "compress_mbps": 81.67,
-   "decompress_mbps": 430.73
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1932127,
-   "ratio": 0.2915,
-   "compress_mbps": 45.23,
-   "decompress_mbps": 432.43
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1860865,
-   "ratio": 0.2808,
-   "compress_mbps": 22.82,
-   "decompress_mbps": 440.25
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1838671,
-   "ratio": 0.2774,
-   "compress_mbps": 15.96,
-   "decompress_mbps": 441.72
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1823235,
-   "ratio": 0.2751,
-   "compress_mbps": 8.12,
-   "decompress_mbps": 436.13
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1823190,
-   "ratio": 0.2751,
-   "compress_mbps": 8.15,
-   "decompress_mbps": 439.5
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 6329449,
-   "ratio": 0.2929,
-   "compress_mbps": 169.74,
-   "decompress_mbps": 460.79
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 6128866,
-   "ratio": 0.2837,
-   "compress_mbps": 155.55,
-   "decompress_mbps": 557.06
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5982546,
-   "ratio": 0.2769,
-   "compress_mbps": 125.39,
-   "decompress_mbps": 581.02
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5656400,
-   "ratio": 0.2618,
-   "compress_mbps": 116.92,
-   "decompress_mbps": 576.69
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5511352,
-   "ratio": 0.2551,
-   "compress_mbps": 82.58,
-   "decompress_mbps": 587.65
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5451399,
-   "ratio": 0.2523,
-   "compress_mbps": 56.59,
-   "decompress_mbps": 593.88
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5417123,
-   "ratio": 0.2507,
-   "compress_mbps": 46.71,
-   "decompress_mbps": 596.81
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5404364,
-   "ratio": 0.2501,
-   "compress_mbps": 32.73,
-   "decompress_mbps": 602.78
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5402704,
-   "ratio": 0.2501,
-   "compress_mbps": 29.69,
-   "decompress_mbps": 390.04
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5567768,
-   "ratio": 0.7678,
-   "compress_mbps": 32.89,
-   "decompress_mbps": 211.48
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5504009,
-   "ratio": 0.759,
-   "compress_mbps": 38.32,
-   "decompress_mbps": 168.63
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5439339,
-   "ratio": 0.7501,
-   "compress_mbps": 29.43,
-   "decompress_mbps": 230.72
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5394604,
-   "ratio": 0.7439,
-   "compress_mbps": 32.68,
-   "decompress_mbps": 256.53
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5370116,
-   "ratio": 0.7405,
-   "compress_mbps": 28.44,
-   "decompress_mbps": 312.67
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5331793,
-   "ratio": 0.7352,
-   "compress_mbps": 20.53,
-   "decompress_mbps": 329.4
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5327677,
-   "ratio": 0.7347,
-   "compress_mbps": 21.16,
-   "decompress_mbps": 348.44
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5325914,
-   "ratio": 0.7344,
-   "compress_mbps": 18.96,
-   "decompress_mbps": 349.29
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5325914,
-   "ratio": 0.7344,
-   "compress_mbps": 18.95,
-   "decompress_mbps": 346.98
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 14991236,
-   "ratio": 0.3616,
-   "compress_mbps": 136.65,
-   "decompress_mbps": 380.3
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 14249692,
-   "ratio": 0.3437,
-   "compress_mbps": 120.34,
-   "decompress_mbps": 401.81
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 13627761,
-   "ratio": 0.3287,
-   "compress_mbps": 87.73,
-   "decompress_mbps": 414.55
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 13001990,
-   "ratio": 0.3136,
-   "compress_mbps": 85.4,
-   "decompress_mbps": 395.8
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12445991,
-   "ratio": 0.3002,
-   "compress_mbps": 55.03,
-   "decompress_mbps": 392.94
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12213941,
-   "ratio": 0.2946,
-   "compress_mbps": 36.53,
-   "decompress_mbps": 400.31
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12130416,
-   "ratio": 0.2926,
-   "compress_mbps": 29.65,
-   "decompress_mbps": 401.43
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12073697,
-   "ratio": 0.2912,
-   "compress_mbps": 21.5,
-   "decompress_mbps": 403.07
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 12073469,
-   "ratio": 0.2912,
-   "compress_mbps": 21.33,
-   "decompress_mbps": 403.44
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6033926,
-   "ratio": 0.712,
-   "compress_mbps": 75.49,
-   "decompress_mbps": 294.33
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 5997474,
-   "ratio": 0.7077,
-   "compress_mbps": 68.78,
-   "decompress_mbps": 305.32
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 5966621,
-   "ratio": 0.7041,
-   "compress_mbps": 55.63,
-   "decompress_mbps": 312.38
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6091108,
-   "ratio": 0.7188,
-   "compress_mbps": 46.09,
-   "decompress_mbps": 267.15
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6053566,
-   "ratio": 0.7143,
-   "compress_mbps": 37.26,
-   "decompress_mbps": 274.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 6045111,
-   "ratio": 0.7134,
-   "compress_mbps": 34.97,
-   "decompress_mbps": 276.79
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 6045034,
-   "ratio": 0.7133,
-   "compress_mbps": 34.92,
-   "decompress_mbps": 278.07
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 6045032,
-   "ratio": 0.7133,
-   "compress_mbps": 34.97,
-   "decompress_mbps": 277.28
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 6045032,
-   "ratio": 0.7133,
-   "compress_mbps": 34.94,
-   "decompress_mbps": 277.39
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 965242,
-   "ratio": 0.1806,
-   "compress_mbps": 264.31,
-   "decompress_mbps": 697.56
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 887265,
-   "ratio": 0.166,
-   "compress_mbps": 246.22,
-   "decompress_mbps": 752.4
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 822167,
-   "ratio": 0.1538,
-   "compress_mbps": 191.48,
-   "decompress_mbps": 797.39
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 807518,
-   "ratio": 0.1511,
-   "compress_mbps": 169.01,
-   "decompress_mbps": 768.34
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 730574,
-   "ratio": 0.1367,
-   "compress_mbps": 121.75,
-   "decompress_mbps": 815.59
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 687991,
-   "ratio": 0.1287,
-   "compress_mbps": 79.31,
-   "decompress_mbps": 872.54
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 673933,
-   "ratio": 0.1261,
-   "compress_mbps": 64.99,
-   "decompress_mbps": 887.93
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 659518,
-   "ratio": 0.1234,
-   "compress_mbps": 43.0,
-   "decompress_mbps": 884.96
-  },
-  {
-   "compressor": "zlib",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 658899,
-   "ratio": 0.1233,
-   "compress_mbps": 39.85,
-   "decompress_mbps": 896.88
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 5363862,
-   "ratio": 0.5263,
-   "compress_mbps": 141.65,
-   "decompress_mbps": 389.91
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4438205,
-   "ratio": 0.4354,
-   "compress_mbps": 128.9,
-   "decompress_mbps": 428.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 4054333,
-   "ratio": 0.3978,
-   "compress_mbps": 63.86,
-   "decompress_mbps": 475.64
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 4038550,
-   "ratio": 0.3962,
-   "compress_mbps": 57.76,
-   "decompress_mbps": 469.09
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3954920,
-   "ratio": 0.388,
-   "compress_mbps": 40.27,
-   "decompress_mbps": 462.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3872874,
-   "ratio": 0.38,
-   "compress_mbps": 22.58,
-   "decompress_mbps": 470.25
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3859937,
-   "ratio": 0.3787,
-   "compress_mbps": 18.83,
-   "decompress_mbps": 472.38
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3855935,
-   "ratio": 0.3783,
-   "compress_mbps": 17.07,
-   "decompress_mbps": 469.47
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3855791,
-   "ratio": 0.3783,
-   "compress_mbps": 17.01,
-   "decompress_mbps": 470.52
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 22334882,
-   "ratio": 0.4361,
-   "compress_mbps": 233.89,
-   "decompress_mbps": 370.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 20150366,
-   "ratio": 0.3934,
-   "compress_mbps": 119.97,
-   "decompress_mbps": 375.66
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19495014,
-   "ratio": 0.3806,
-   "compress_mbps": 70.13,
-   "decompress_mbps": 389.58
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19424978,
-   "ratio": 0.3792,
-   "compress_mbps": 71.02,
-   "decompress_mbps": 402.97
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 19298736,
-   "ratio": 0.3768,
-   "compress_mbps": 54.1,
-   "decompress_mbps": 393.93
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19179167,
-   "ratio": 0.3744,
-   "compress_mbps": 29.69,
-   "decompress_mbps": 422.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19151324,
-   "ratio": 0.3739,
-   "compress_mbps": 21.89,
-   "decompress_mbps": 422.25
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19144373,
-   "ratio": 0.3738,
-   "compress_mbps": 16.59,
-   "decompress_mbps": 407.62
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 19141383,
-   "ratio": 0.3737,
-   "compress_mbps": 14.17,
-   "decompress_mbps": 420.85
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 4249731,
-   "ratio": 0.4262,
-   "compress_mbps": 313.35,
-   "decompress_mbps": 528.94
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3775479,
-   "ratio": 0.3787,
-   "compress_mbps": 156.84,
-   "decompress_mbps": 517.84
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3656966,
-   "ratio": 0.3668,
-   "compress_mbps": 79.84,
-   "decompress_mbps": 574.15
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3740378,
-   "ratio": 0.3751,
-   "compress_mbps": 67.57,
-   "decompress_mbps": 534.79
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3713604,
-   "ratio": 0.3725,
-   "compress_mbps": 48.45,
-   "decompress_mbps": 501.84
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3683556,
-   "ratio": 0.3694,
-   "compress_mbps": 24.87,
-   "decompress_mbps": 515.42
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3683797,
-   "ratio": 0.3695,
-   "compress_mbps": 18.98,
-   "decompress_mbps": 521.98
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3684477,
-   "ratio": 0.3695,
-   "compress_mbps": 14.34,
-   "decompress_mbps": 540.16
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3679414,
-   "ratio": 0.369,
-   "compress_mbps": 12.34,
-   "decompress_mbps": 542.45
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 5594622,
-   "ratio": 0.1667,
-   "compress_mbps": 433.55,
-   "decompress_mbps": 834.3
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 4179532,
-   "ratio": 0.1246,
-   "compress_mbps": 327.38,
-   "decompress_mbps": 926.24
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3542329,
-   "ratio": 0.1056,
-   "compress_mbps": 211.33,
-   "decompress_mbps": 842.8
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3323363,
-   "ratio": 0.099,
-   "compress_mbps": 197.38,
-   "decompress_mbps": 872.41
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3230343,
-   "ratio": 0.0963,
-   "compress_mbps": 161.61,
-   "decompress_mbps": 952.97
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3123421,
-   "ratio": 0.0931,
-   "compress_mbps": 95.69,
-   "decompress_mbps": 997.1
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3093778,
-   "ratio": 0.0922,
-   "compress_mbps": 70.53,
-   "decompress_mbps": 972.37
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3067318,
-   "ratio": 0.0914,
-   "compress_mbps": 50.06,
-   "decompress_mbps": 1013.07
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 3050695,
-   "ratio": 0.0909,
-   "compress_mbps": 41.98,
-   "decompress_mbps": 1022.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3543611,
-   "ratio": 0.576,
-   "compress_mbps": 169.2,
-   "decompress_mbps": 269.98
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3226818,
-   "ratio": 0.5245,
-   "compress_mbps": 86.03,
-   "decompress_mbps": 287.07
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3144140,
-   "ratio": 0.5111,
-   "compress_mbps": 52.6,
-   "decompress_mbps": 297.45
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3129833,
-   "ratio": 0.5087,
-   "compress_mbps": 51.39,
-   "decompress_mbps": 324.03
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3114809,
-   "ratio": 0.5063,
-   "compress_mbps": 40.29,
-   "decompress_mbps": 338.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3095705,
-   "ratio": 0.5032,
-   "compress_mbps": 25.04,
-   "decompress_mbps": 345.03
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3090055,
-   "ratio": 0.5023,
-   "compress_mbps": 20.39,
-   "decompress_mbps": 345.41
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3087665,
-   "ratio": 0.5019,
-   "compress_mbps": 17.41,
-   "decompress_mbps": 345.4
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3087158,
-   "ratio": 0.5018,
-   "compress_mbps": 16.29,
-   "decompress_mbps": 345.8
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 5419510,
-   "ratio": 0.5373,
-   "compress_mbps": 243.36,
-   "decompress_mbps": 535.63
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3982547,
-   "ratio": 0.3949,
-   "compress_mbps": 122.38,
-   "decompress_mbps": 550.66
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3806102,
-   "ratio": 0.3774,
-   "compress_mbps": 80.86,
-   "decompress_mbps": 568.24
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3761477,
-   "ratio": 0.373,
-   "compress_mbps": 78.11,
-   "decompress_mbps": 603.06
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3740298,
-   "ratio": 0.3709,
-   "compress_mbps": 67.07,
-   "decompress_mbps": 611.24
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3686116,
-   "ratio": 0.3655,
-   "compress_mbps": 49.52,
-   "decompress_mbps": 637.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3668442,
-   "ratio": 0.3637,
-   "compress_mbps": 38.85,
-   "decompress_mbps": 662.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3665072,
-   "ratio": 0.3634,
-   "compress_mbps": 33.15,
-   "decompress_mbps": 657.03
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3665057,
-   "ratio": 0.3634,
-   "compress_mbps": 32.94,
-   "decompress_mbps": 653.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2842321,
-   "ratio": 0.4289,
-   "compress_mbps": 193.08,
-   "decompress_mbps": 443.97
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2232180,
-   "ratio": 0.3368,
-   "compress_mbps": 151.04,
-   "decompress_mbps": 514.91
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2003056,
-   "ratio": 0.3022,
-   "compress_mbps": 81.92,
-   "decompress_mbps": 551.48
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 1985375,
-   "ratio": 0.2996,
-   "compress_mbps": 74.08,
-   "decompress_mbps": 566.46
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1933775,
-   "ratio": 0.2918,
-   "compress_mbps": 51.93,
-   "decompress_mbps": 538.73
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1858103,
-   "ratio": 0.2804,
-   "compress_mbps": 22.05,
-   "decompress_mbps": 541.6
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1840414,
-   "ratio": 0.2777,
-   "compress_mbps": 15.15,
-   "decompress_mbps": 550.69
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1831679,
-   "ratio": 0.2764,
-   "compress_mbps": 11.76,
-   "decompress_mbps": 543.82
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1827137,
-   "ratio": 0.2757,
-   "compress_mbps": 10.16,
-   "decompress_mbps": 544.36
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 7089759,
-   "ratio": 0.3281,
-   "compress_mbps": 290.79,
-   "decompress_mbps": 557.71
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 5966231,
-   "ratio": 0.2761,
-   "compress_mbps": 174.66,
-   "decompress_mbps": 619.46
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5611838,
-   "ratio": 0.2597,
-   "compress_mbps": 111.67,
-   "decompress_mbps": 648.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5535436,
-   "ratio": 0.2562,
-   "compress_mbps": 105.54,
-   "decompress_mbps": 672.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5480971,
-   "ratio": 0.2537,
-   "compress_mbps": 81.52,
-   "decompress_mbps": 680.77
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5437556,
-   "ratio": 0.2517,
-   "compress_mbps": 49.47,
-   "decompress_mbps": 697.31
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5432108,
-   "ratio": 0.2514,
-   "compress_mbps": 40.48,
-   "decompress_mbps": 694.27
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5428571,
-   "ratio": 0.2512,
-   "compress_mbps": 33.62,
-   "decompress_mbps": 700.3
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5425526,
-   "ratio": 0.2511,
-   "compress_mbps": 30.51,
-   "decompress_mbps": 703.33
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5900800,
-   "ratio": 0.8137,
-   "compress_mbps": 188.47,
-   "decompress_mbps": 324.35
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5523611,
-   "ratio": 0.7617,
-   "compress_mbps": 69.45,
-   "decompress_mbps": 340.66
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5393086,
-   "ratio": 0.7437,
-   "compress_mbps": 40.33,
-   "decompress_mbps": 351.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5401582,
-   "ratio": 0.7448,
-   "compress_mbps": 40.72,
-   "decompress_mbps": 367.5
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5371274,
-   "ratio": 0.7407,
-   "compress_mbps": 31.31,
-   "decompress_mbps": 358.37
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5330096,
-   "ratio": 0.735,
-   "compress_mbps": 20.8,
-   "decompress_mbps": 365.39
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5325437,
-   "ratio": 0.7343,
-   "compress_mbps": 18.98,
-   "decompress_mbps": 366.05
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5323934,
-   "ratio": 0.7341,
-   "compress_mbps": 18.05,
-   "decompress_mbps": 364.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323621,
-   "ratio": 0.7341,
-   "compress_mbps": 17.67,
-   "decompress_mbps": 364.02
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 17587173,
-   "ratio": 0.4242,
-   "compress_mbps": 185.73,
-   "decompress_mbps": 379.13
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 14171707,
-   "ratio": 0.3418,
-   "compress_mbps": 149.15,
-   "decompress_mbps": 409.08
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12774851,
-   "ratio": 0.3081,
-   "compress_mbps": 85.71,
-   "decompress_mbps": 440.79
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12612554,
-   "ratio": 0.3042,
-   "compress_mbps": 76.13,
-   "decompress_mbps": 444.75
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12392339,
-   "ratio": 0.2989,
-   "compress_mbps": 58.1,
-   "decompress_mbps": 457.17
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12158314,
-   "ratio": 0.2933,
-   "compress_mbps": 34.41,
-   "decompress_mbps": 463.08
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12107840,
-   "ratio": 0.292,
-   "compress_mbps": 27.64,
-   "decompress_mbps": 466.33
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12081311,
-   "ratio": 0.2914,
-   "compress_mbps": 22.88,
-   "decompress_mbps": 462.63
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 12081011,
-   "ratio": 0.2914,
-   "compress_mbps": 22.78,
-   "decompress_mbps": 460.01
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6527324,
-   "ratio": 0.7703,
-   "compress_mbps": 238.95,
-   "decompress_mbps": 330.7
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6051483,
-   "ratio": 0.7141,
-   "compress_mbps": 75.62,
-   "decompress_mbps": 332.39
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6010123,
-   "ratio": 0.7092,
-   "compress_mbps": 52.06,
-   "decompress_mbps": 334.45
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6024815,
-   "ratio": 0.711,
-   "compress_mbps": 44.63,
-   "decompress_mbps": 286.25
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6005181,
-   "ratio": 0.7086,
-   "compress_mbps": 40.44,
-   "decompress_mbps": 293.0
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5997508,
-   "ratio": 0.7077,
-   "compress_mbps": 37.97,
-   "decompress_mbps": 295.42
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 5997403,
-   "ratio": 0.7077,
-   "compress_mbps": 37.87,
-   "decompress_mbps": 295.69
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 5997403,
-   "ratio": 0.7077,
-   "compress_mbps": 37.82,
-   "decompress_mbps": 295.45
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5997403,
-   "ratio": 0.7077,
-   "compress_mbps": 37.76,
-   "decompress_mbps": 292.96
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 1147652,
-   "ratio": 0.2147,
-   "compress_mbps": 388.67,
-   "decompress_mbps": 761.65
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 919639,
-   "ratio": 0.172,
-   "compress_mbps": 262.86,
-   "decompress_mbps": 956.95
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 752341,
-   "ratio": 0.1407,
-   "compress_mbps": 167.46,
-   "decompress_mbps": 1057.51
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 735537,
-   "ratio": 0.1376,
-   "compress_mbps": 161.37,
-   "decompress_mbps": 1037.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 706789,
-   "ratio": 0.1322,
-   "compress_mbps": 123.5,
-   "decompress_mbps": 1129.34
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 676279,
-   "ratio": 0.1265,
-   "compress_mbps": 69.53,
-   "decompress_mbps": 1219.4
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 668772,
-   "ratio": 0.1251,
-   "compress_mbps": 55.97,
-   "decompress_mbps": 1208.21
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 665340,
-   "ratio": 0.1245,
-   "compress_mbps": 47.61,
-   "decompress_mbps": 1208.14
-  },
-  {
-   "compressor": "miniz_oxide",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 664273,
-   "ratio": 0.1243,
-   "compress_mbps": 45.85,
-   "decompress_mbps": 1218.11
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4217525,
-   "ratio": 0.4138,
-   "compress_mbps": 243.85,
-   "decompress_mbps": 801.13
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4053259,
-   "ratio": 0.3977,
-   "compress_mbps": 170.19,
-   "decompress_mbps": 864.66
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3989875,
-   "ratio": 0.3915,
-   "compress_mbps": 140.0,
-   "decompress_mbps": 934.98
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 3972869,
-   "ratio": 0.3898,
-   "compress_mbps": 127.83,
-   "decompress_mbps": 825.71
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3894026,
-   "ratio": 0.3821,
-   "compress_mbps": 99.29,
-   "decompress_mbps": 791.29
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3859436,
-   "ratio": 0.3787,
-   "compress_mbps": 75.65,
-   "decompress_mbps": 819.18
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3837515,
-   "ratio": 0.3765,
-   "compress_mbps": 55.71,
-   "decompress_mbps": 796.16
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3811467,
-   "ratio": 0.374,
-   "compress_mbps": 36.03,
-   "decompress_mbps": 816.32
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3810354,
-   "ratio": 0.3738,
-   "compress_mbps": 32.76,
-   "decompress_mbps": 816.68
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20192961,
-   "ratio": 0.3942,
-   "compress_mbps": 242.16,
-   "decompress_mbps": 676.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 19374226,
-   "ratio": 0.3783,
-   "compress_mbps": 185.69,
-   "decompress_mbps": 710.78
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19234937,
-   "ratio": 0.3755,
-   "compress_mbps": 173.04,
-   "decompress_mbps": 727.76
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19145385,
-   "ratio": 0.3738,
-   "compress_mbps": 162.62,
-   "decompress_mbps": 728.74
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 18878875,
-   "ratio": 0.3686,
-   "compress_mbps": 142.62,
-   "decompress_mbps": 741.83
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 18805391,
-   "ratio": 0.3671,
-   "compress_mbps": 117.71,
-   "decompress_mbps": 750.56
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 18749947,
-   "ratio": 0.3661,
-   "compress_mbps": 87.16,
-   "decompress_mbps": 759.3
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 18718540,
-   "ratio": 0.3655,
-   "compress_mbps": 47.56,
-   "decompress_mbps": 766.6
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 18713659,
-   "ratio": 0.3654,
-   "compress_mbps": 33.49,
-   "decompress_mbps": 676.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3740775,
-   "ratio": 0.3752,
-   "compress_mbps": 293.42,
-   "decompress_mbps": 755.42
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3707407,
-   "ratio": 0.3718,
-   "compress_mbps": 217.45,
-   "decompress_mbps": 768.84
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3672389,
-   "ratio": 0.3683,
-   "compress_mbps": 185.43,
-   "decompress_mbps": 809.7
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3660011,
-   "ratio": 0.3671,
-   "compress_mbps": 171.62,
-   "decompress_mbps": 751.11
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3664245,
-   "ratio": 0.3675,
-   "compress_mbps": 141.37,
-   "decompress_mbps": 712.85
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3648644,
-   "ratio": 0.3659,
-   "compress_mbps": 106.84,
-   "decompress_mbps": 739.26
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3635323,
-   "ratio": 0.3646,
-   "compress_mbps": 68.34,
-   "decompress_mbps": 735.43
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3624778,
-   "ratio": 0.3635,
-   "compress_mbps": 43.04,
-   "decompress_mbps": 773.18
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3625176,
-   "ratio": 0.3636,
-   "compress_mbps": 38.87,
-   "decompress_mbps": 757.44
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3837577,
-   "ratio": 0.1144,
-   "compress_mbps": 609.02,
-   "decompress_mbps": 1491.69
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 3714632,
-   "ratio": 0.1107,
-   "compress_mbps": 462.85,
-   "decompress_mbps": 1747.31
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3599455,
-   "ratio": 0.1073,
-   "compress_mbps": 427.07,
-   "decompress_mbps": 1882.3
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3431843,
-   "ratio": 0.1023,
-   "compress_mbps": 388.74,
-   "decompress_mbps": 1763.39
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3268188,
-   "ratio": 0.0974,
-   "compress_mbps": 346.67,
-   "decompress_mbps": 1777.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3091741,
-   "ratio": 0.0921,
-   "compress_mbps": 264.16,
-   "decompress_mbps": 1787.13
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3032499,
-   "ratio": 0.0904,
-   "compress_mbps": 186.41,
-   "decompress_mbps": 1846.22
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 2949097,
-   "ratio": 0.0879,
-   "compress_mbps": 97.63,
-   "decompress_mbps": 1789.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2925243,
-   "ratio": 0.0872,
-   "compress_mbps": 69.23,
-   "decompress_mbps": 1757.94
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3275124,
-   "ratio": 0.5324,
-   "compress_mbps": 166.26,
-   "decompress_mbps": 462.6
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3150806,
-   "ratio": 0.5121,
-   "compress_mbps": 128.39,
-   "decompress_mbps": 483.21
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3137061,
-   "ratio": 0.5099,
-   "compress_mbps": 120.82,
-   "decompress_mbps": 502.43
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3129676,
-   "ratio": 0.5087,
-   "compress_mbps": 116.89,
-   "decompress_mbps": 518.56
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3079277,
-   "ratio": 0.5005,
-   "compress_mbps": 99.99,
-   "decompress_mbps": 536.74
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3072378,
-   "ratio": 0.4994,
-   "compress_mbps": 88.82,
-   "decompress_mbps": 533.12
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3068123,
-   "ratio": 0.4987,
-   "compress_mbps": 76.38,
-   "decompress_mbps": 542.11
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3067299,
-   "ratio": 0.4986,
-   "compress_mbps": 55.33,
-   "decompress_mbps": 533.57
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3066968,
-   "ratio": 0.4985,
-   "compress_mbps": 49.23,
-   "decompress_mbps": 507.58
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3868663,
-   "ratio": 0.3836,
-   "compress_mbps": 285.16,
-   "decompress_mbps": 772.78
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3839158,
-   "ratio": 0.3807,
-   "compress_mbps": 213.22,
-   "decompress_mbps": 914.82
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3818964,
-   "ratio": 0.3787,
-   "compress_mbps": 197.74,
-   "decompress_mbps": 936.61
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3789325,
-   "ratio": 0.3757,
-   "compress_mbps": 179.66,
-   "decompress_mbps": 954.8
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3666476,
-   "ratio": 0.3635,
-   "compress_mbps": 157.89,
-   "decompress_mbps": 942.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3660266,
-   "ratio": 0.3629,
-   "compress_mbps": 142.43,
-   "decompress_mbps": 987.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3659491,
-   "ratio": 0.3628,
-   "compress_mbps": 135.11,
-   "decompress_mbps": 999.79
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3654863,
-   "ratio": 0.3624,
-   "compress_mbps": 114.32,
-   "decompress_mbps": 1009.23
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3654860,
-   "ratio": 0.3624,
-   "compress_mbps": 114.27,
-   "decompress_mbps": 1001.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2197055,
-   "ratio": 0.3315,
-   "compress_mbps": 300.85,
-   "decompress_mbps": 858.37
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2082309,
-   "ratio": 0.3142,
-   "compress_mbps": 214.77,
-   "decompress_mbps": 1130.12
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2021047,
-   "ratio": 0.305,
-   "compress_mbps": 178.67,
-   "decompress_mbps": 1236.6
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 1990952,
-   "ratio": 0.3004,
-   "compress_mbps": 157.4,
-   "decompress_mbps": 1146.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1921113,
-   "ratio": 0.2899,
-   "compress_mbps": 127.99,
-   "decompress_mbps": 1093.81
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1876257,
-   "ratio": 0.2831,
-   "compress_mbps": 86.94,
-   "decompress_mbps": 1090.38
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1832695,
-   "ratio": 0.2765,
-   "compress_mbps": 46.02,
-   "decompress_mbps": 1103.5
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1809967,
-   "ratio": 0.2731,
-   "compress_mbps": 24.27,
-   "decompress_mbps": 1063.53
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1806374,
-   "ratio": 0.2726,
-   "compress_mbps": 19.83,
-   "decompress_mbps": 1054.62
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5866517,
-   "ratio": 0.2715,
-   "compress_mbps": 338.52,
-   "decompress_mbps": 979.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 5695942,
-   "ratio": 0.2636,
-   "compress_mbps": 258.0,
-   "decompress_mbps": 1031.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5605878,
-   "ratio": 0.2595,
-   "compress_mbps": 233.32,
-   "decompress_mbps": 1100.86
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5553432,
-   "ratio": 0.257,
-   "compress_mbps": 216.59,
-   "decompress_mbps": 1079.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5416713,
-   "ratio": 0.2507,
-   "compress_mbps": 186.71,
-   "decompress_mbps": 1066.93
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5337149,
-   "ratio": 0.247,
-   "compress_mbps": 142.78,
-   "decompress_mbps": 1079.29
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5310181,
-   "ratio": 0.2458,
-   "compress_mbps": 100.23,
-   "decompress_mbps": 1069.71
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5272761,
-   "ratio": 0.244,
-   "compress_mbps": 62.39,
-   "decompress_mbps": 1089.17
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5270405,
-   "ratio": 0.2439,
-   "compress_mbps": 50.04,
-   "decompress_mbps": 1101.61
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5575128,
-   "ratio": 0.7688,
-   "compress_mbps": 162.23,
-   "decompress_mbps": 485.07
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5417142,
-   "ratio": 0.747,
-   "compress_mbps": 116.65,
-   "decompress_mbps": 518.27
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5397999,
-   "ratio": 0.7444,
-   "compress_mbps": 105.25,
-   "decompress_mbps": 528.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5391125,
-   "ratio": 0.7434,
-   "compress_mbps": 99.31,
-   "decompress_mbps": 542.53
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5352212,
-   "ratio": 0.738,
-   "compress_mbps": 87.58,
-   "decompress_mbps": 513.46
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5335405,
-   "ratio": 0.7357,
-   "compress_mbps": 73.79,
-   "decompress_mbps": 526.1
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5325697,
-   "ratio": 0.7344,
-   "compress_mbps": 63.45,
-   "decompress_mbps": 513.46
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5324004,
-   "ratio": 0.7341,
-   "compress_mbps": 52.34,
-   "decompress_mbps": 522.62
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5323197,
-   "ratio": 0.734,
-   "compress_mbps": 50.85,
-   "decompress_mbps": 511.04
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 13550569,
-   "ratio": 0.3268,
-   "compress_mbps": 266.06,
-   "decompress_mbps": 891.09
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 13130705,
-   "ratio": 0.3167,
-   "compress_mbps": 199.84,
-   "decompress_mbps": 973.65
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12839361,
-   "ratio": 0.3097,
-   "compress_mbps": 176.74,
-   "decompress_mbps": 1015.15
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12601933,
-   "ratio": 0.304,
-   "compress_mbps": 161.98,
-   "decompress_mbps": 899.79
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12310776,
-   "ratio": 0.2969,
-   "compress_mbps": 131.58,
-   "decompress_mbps": 879.58
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12140474,
-   "ratio": 0.2928,
-   "compress_mbps": 104.62,
-   "decompress_mbps": 887.92
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12025296,
-   "ratio": 0.2901,
-   "compress_mbps": 75.01,
-   "decompress_mbps": 892.91
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 11893824,
-   "ratio": 0.2869,
-   "compress_mbps": 45.87,
-   "decompress_mbps": 886.31
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11882496,
-   "ratio": 0.2866,
-   "compress_mbps": 39.46,
-   "decompress_mbps": 930.2
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6293390,
-   "ratio": 0.7426,
-   "compress_mbps": 145.39,
-   "decompress_mbps": 523.59
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6058412,
-   "ratio": 0.7149,
-   "compress_mbps": 120.35,
-   "decompress_mbps": 529.46
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6058381,
-   "ratio": 0.7149,
-   "compress_mbps": 120.3,
-   "decompress_mbps": 539.19
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6058363,
-   "ratio": 0.7149,
-   "compress_mbps": 120.03,
-   "decompress_mbps": 437.57
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 5998400,
-   "ratio": 0.7078,
-   "compress_mbps": 108.52,
-   "decompress_mbps": 459.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5998438,
-   "ratio": 0.7078,
-   "compress_mbps": 108.55,
-   "decompress_mbps": 463.75
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 5998439,
-   "ratio": 0.7078,
-   "compress_mbps": 108.18,
-   "decompress_mbps": 462.69
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": 90.15,
-   "decompress_mbps": 462.82
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5986859,
-   "ratio": 0.7065,
-   "compress_mbps": 90.18,
-   "decompress_mbps": 454.72
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 887708,
-   "ratio": 0.1661,
-   "compress_mbps": 492.83,
-   "decompress_mbps": 1270.45
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 843475,
-   "ratio": 0.1578,
-   "compress_mbps": 363.79,
-   "decompress_mbps": 1801.54
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 793388,
-   "ratio": 0.1484,
-   "compress_mbps": 337.16,
-   "decompress_mbps": 1867.27
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 747602,
-   "ratio": 0.1399,
-   "compress_mbps": 304.24,
-   "decompress_mbps": 1819.5
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 718615,
-   "ratio": 0.1344,
-   "compress_mbps": 263.07,
-   "decompress_mbps": 1830.67
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 684405,
-   "ratio": 0.128,
-   "compress_mbps": 206.4,
-   "decompress_mbps": 1920.08
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 664859,
-   "ratio": 0.1244,
-   "compress_mbps": 142.72,
-   "decompress_mbps": 1906.99
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 650835,
-   "ratio": 0.1218,
-   "compress_mbps": 81.56,
-   "decompress_mbps": 1892.16
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 649494,
-   "ratio": 0.1215,
-   "compress_mbps": 68.13,
-   "decompress_mbps": 1902.14
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 65708,
-   "ratio": 0.432,
-   "compress_mbps": 42.56,
-   "decompress_mbps": 61.17
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 60259,
-   "ratio": 0.3962,
-   "compress_mbps": 26.21,
-   "decompress_mbps": 68.33
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 58544,
-   "ratio": 0.3849,
-   "compress_mbps": 21.92,
-   "decompress_mbps": 69.11
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 56238,
-   "ratio": 0.3698,
-   "compress_mbps": 21.46,
-   "decompress_mbps": 70.96
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 54764,
-   "ratio": 0.3601,
-   "compress_mbps": 16.16,
-   "decompress_mbps": 71.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54311,
-   "ratio": 0.3571,
-   "compress_mbps": 10.7,
-   "decompress_mbps": 71.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54262,
-   "ratio": 0.3568,
-   "compress_mbps": 9.8,
-   "decompress_mbps": 72.02
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 54247,
-   "ratio": 0.3567,
-   "compress_mbps": 9.57,
-   "decompress_mbps": 72.02
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 54247,
-   "ratio": 0.3567,
-   "compress_mbps": 9.65,
-   "decompress_mbps": 72.57
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 56882,
-   "ratio": 0.4544,
-   "compress_mbps": 37.25,
-   "decompress_mbps": 55.92
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 52826,
-   "ratio": 0.422,
-   "compress_mbps": 23.05,
-   "decompress_mbps": 62.21
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 51625,
-   "ratio": 0.4124,
-   "compress_mbps": 22.69,
-   "decompress_mbps": 65.27
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 50034,
-   "ratio": 0.3997,
-   "compress_mbps": 22.5,
-   "decompress_mbps": 65.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 48912,
-   "ratio": 0.3907,
-   "compress_mbps": 12.62,
-   "decompress_mbps": 65.42
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48738,
-   "ratio": 0.3893,
-   "compress_mbps": 11.77,
-   "decompress_mbps": 65.61
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48719,
-   "ratio": 0.3892,
-   "compress_mbps": 9.97,
-   "decompress_mbps": 65.88
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 48716,
-   "ratio": 0.3892,
-   "compress_mbps": 9.9,
-   "decompress_mbps": 68.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 48716,
-   "ratio": 0.3892,
-   "compress_mbps": 12.58,
-   "decompress_mbps": 64.73
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8988,
-   "ratio": 0.3653,
-   "compress_mbps": 36.94,
-   "decompress_mbps": 103.46
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8564,
-   "ratio": 0.3481,
-   "compress_mbps": 43.51,
-   "decompress_mbps": 102.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8390,
-   "ratio": 0.341,
-   "compress_mbps": 28.97,
-   "decompress_mbps": 97.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8167,
-   "ratio": 0.332,
-   "compress_mbps": 37.49,
-   "decompress_mbps": 98.37
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 7965,
-   "ratio": 0.3237,
-   "compress_mbps": 28.72,
-   "decompress_mbps": 88.78
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7916,
-   "ratio": 0.3217,
-   "compress_mbps": 22.76,
-   "decompress_mbps": 104.8
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7900,
-   "ratio": 0.3211,
-   "compress_mbps": 21.67,
-   "decompress_mbps": 85.25
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7900,
-   "ratio": 0.3211,
-   "compress_mbps": 20.13,
-   "decompress_mbps": 105.7
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7900,
-   "ratio": 0.3211,
-   "compress_mbps": 27.55,
-   "decompress_mbps": 92.8
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3731,
-   "ratio": 0.3346,
-   "compress_mbps": 18.9,
-   "decompress_mbps": 80.13
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3491,
-   "ratio": 0.3131,
-   "compress_mbps": 23.63,
-   "decompress_mbps": 84.66
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3384,
-   "ratio": 0.3035,
-   "compress_mbps": 22.04,
-   "decompress_mbps": 89.77
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3220,
-   "ratio": 0.2888,
-   "compress_mbps": 21.08,
-   "decompress_mbps": 86.53
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3138,
-   "ratio": 0.2814,
-   "compress_mbps": 17.11,
-   "decompress_mbps": 93.05
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3118,
-   "ratio": 0.2796,
-   "compress_mbps": 15.03,
-   "decompress_mbps": 100.03
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3116,
-   "ratio": 0.2795,
-   "compress_mbps": 14.26,
-   "decompress_mbps": 96.56
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3116,
-   "ratio": 0.2795,
-   "compress_mbps": 14.4,
-   "decompress_mbps": 104.06
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3116,
-   "ratio": 0.2795,
-   "compress_mbps": 15.81,
-   "decompress_mbps": 101.86
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1352,
-   "ratio": 0.3633,
-   "compress_mbps": 8.47,
-   "decompress_mbps": 63.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1287,
-   "ratio": 0.3459,
-   "compress_mbps": 11.63,
-   "decompress_mbps": 60.62
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1284,
-   "ratio": 0.3451,
-   "compress_mbps": 11.67,
-   "decompress_mbps": 62.5
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1226,
-   "ratio": 0.3295,
-   "compress_mbps": 11.31,
-   "decompress_mbps": 66.96
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1211,
-   "ratio": 0.3255,
-   "compress_mbps": 9.84,
-   "decompress_mbps": 63.24
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1211,
-   "ratio": 0.3255,
-   "compress_mbps": 10.84,
-   "decompress_mbps": 63.7
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1211,
-   "ratio": 0.3255,
-   "compress_mbps": 10.02,
-   "decompress_mbps": 64.11
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1211,
-   "ratio": 0.3255,
-   "compress_mbps": 10.74,
-   "decompress_mbps": 80.94
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1211,
-   "ratio": 0.3255,
-   "compress_mbps": 11.17,
-   "decompress_mbps": 63.88
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 245423,
-   "ratio": 0.2383,
-   "compress_mbps": 123.71,
-   "decompress_mbps": 127.4
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 229642,
-   "ratio": 0.223,
-   "compress_mbps": 92.84,
-   "decompress_mbps": 151.73
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 225678,
-   "ratio": 0.2192,
-   "compress_mbps": 109.83,
-   "decompress_mbps": 153.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 218218,
-   "ratio": 0.2119,
-   "compress_mbps": 99.82,
-   "decompress_mbps": 163.61
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 210550,
-   "ratio": 0.2045,
-   "compress_mbps": 48.7,
-   "decompress_mbps": 154.12
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 207949,
-   "ratio": 0.2019,
-   "compress_mbps": 27.88,
-   "decompress_mbps": 168.6
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 207413,
-   "ratio": 0.2014,
-   "compress_mbps": 18.82,
-   "decompress_mbps": 151.74
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 207478,
-   "ratio": 0.2015,
-   "compress_mbps": 6.77,
-   "decompress_mbps": 153.16
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 207482,
-   "ratio": 0.2015,
-   "compress_mbps": 3.56,
-   "decompress_mbps": 157.49
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 175980,
-   "ratio": 0.4124,
-   "compress_mbps": 43.31,
-   "decompress_mbps": 64.49
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 160455,
-   "ratio": 0.376,
-   "compress_mbps": 70.41,
-   "decompress_mbps": 72.33
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 156690,
-   "ratio": 0.3672,
-   "compress_mbps": 32.21,
-   "decompress_mbps": 74.1
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 149064,
-   "ratio": 0.3493,
-   "compress_mbps": 36.48,
-   "decompress_mbps": 75.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 145616,
-   "ratio": 0.3412,
-   "compress_mbps": 20.01,
-   "decompress_mbps": 76.95
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 144773,
-   "ratio": 0.3392,
-   "compress_mbps": 17.53,
-   "decompress_mbps": 76.34
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 144603,
-   "ratio": 0.3388,
-   "compress_mbps": 19.93,
-   "decompress_mbps": 75.91
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 144573,
-   "ratio": 0.3388,
-   "compress_mbps": 16.49,
-   "decompress_mbps": 80.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 144570,
-   "ratio": 0.3388,
-   "compress_mbps": 15.68,
-   "decompress_mbps": 75.93
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 228837,
-   "ratio": 0.4749,
-   "compress_mbps": 35.31,
-   "decompress_mbps": 54.63
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 211248,
-   "ratio": 0.4384,
-   "compress_mbps": 31.57,
-   "decompress_mbps": 61.56
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 205619,
-   "ratio": 0.4267,
-   "compress_mbps": 25.52,
-   "decompress_mbps": 67.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 200595,
-   "ratio": 0.4163,
-   "compress_mbps": 34.86,
-   "decompress_mbps": 66.46
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 195418,
-   "ratio": 0.4055,
-   "compress_mbps": 18.88,
-   "decompress_mbps": 65.35
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 194148,
-   "ratio": 0.4029,
-   "compress_mbps": 15.2,
-   "decompress_mbps": 66.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 193994,
-   "ratio": 0.4026,
-   "compress_mbps": 16.61,
-   "decompress_mbps": 66.46
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 193991,
-   "ratio": 0.4026,
-   "compress_mbps": 14.97,
-   "decompress_mbps": 65.37
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 193991,
-   "ratio": 0.4026,
-   "compress_mbps": 14.75,
-   "decompress_mbps": 80.17
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 60990,
-   "ratio": 0.1188,
-   "compress_mbps": 240.46,
-   "decompress_mbps": 173.43
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 61650,
-   "ratio": 0.1201,
-   "compress_mbps": 103.12,
-   "decompress_mbps": 188.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 60035,
-   "ratio": 0.117,
-   "compress_mbps": 90.48,
-   "decompress_mbps": 205.17
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 57005,
-   "ratio": 0.1111,
-   "compress_mbps": 91.56,
-   "decompress_mbps": 195.56
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 55779,
-   "ratio": 0.1087,
-   "compress_mbps": 81.64,
-   "decompress_mbps": 263.29
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 54970,
-   "ratio": 0.1071,
-   "compress_mbps": 69.16,
-   "decompress_mbps": 204.84
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 53922,
-   "ratio": 0.1051,
-   "compress_mbps": 76.91,
-   "decompress_mbps": 217.15
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 51977,
-   "ratio": 0.1013,
-   "compress_mbps": 17.63,
-   "decompress_mbps": 275.85
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 51474,
-   "ratio": 0.1003,
-   "compress_mbps": 6.71,
-   "decompress_mbps": 239.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 14783,
-   "ratio": 0.3866,
-   "compress_mbps": 32.71,
-   "decompress_mbps": 70.98
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 14101,
-   "ratio": 0.3688,
-   "compress_mbps": 33.16,
-   "decompress_mbps": 78.17
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13975,
-   "ratio": 0.3655,
-   "compress_mbps": 28.17,
-   "decompress_mbps": 75.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13632,
-   "ratio": 0.3565,
-   "compress_mbps": 30.93,
-   "decompress_mbps": 100.62
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13302,
-   "ratio": 0.3479,
-   "compress_mbps": 25.78,
-   "decompress_mbps": 79.98
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 13279,
-   "ratio": 0.3473,
-   "compress_mbps": 21.9,
-   "decompress_mbps": 77.99
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 13274,
-   "ratio": 0.3471,
-   "compress_mbps": 19.14,
-   "decompress_mbps": 84.74
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 13260,
-   "ratio": 0.3468,
-   "compress_mbps": 7.15,
-   "decompress_mbps": 80.47
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 13260,
-   "ratio": 0.3468,
-   "compress_mbps": 4.57,
-   "decompress_mbps": 79.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1862,
-   "ratio": 0.4405,
-   "compress_mbps": 9.05,
-   "decompress_mbps": 61.67
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1803,
-   "ratio": 0.4265,
-   "compress_mbps": 12.61,
-   "decompress_mbps": 58.6
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1791,
-   "ratio": 0.4237,
-   "compress_mbps": 12.87,
-   "decompress_mbps": 60.15
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1746,
-   "ratio": 0.4131,
-   "compress_mbps": 12.23,
-   "decompress_mbps": 60.76
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1725,
-   "ratio": 0.4081,
-   "compress_mbps": 10.95,
-   "decompress_mbps": 59.77
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1725,
-   "ratio": 0.4081,
-   "compress_mbps": 11.32,
-   "decompress_mbps": 59.78
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1725,
-   "ratio": 0.4081,
-   "compress_mbps": 10.98,
-   "decompress_mbps": 65.28
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1725,
-   "ratio": 0.4081,
-   "compress_mbps": 11.09,
-   "decompress_mbps": 61.29
-  },
-  {
-   "compressor": "go",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1725,
-   "ratio": 0.4081,
-   "compress_mbps": 11.55,
-   "decompress_mbps": 61.79
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4623589,
-   "ratio": 0.4536,
-   "compress_mbps": 87.88,
-   "decompress_mbps": 121.47
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4241525,
-   "ratio": 0.4161,
-   "compress_mbps": 59.05,
-   "decompress_mbps": 124.77
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 4123202,
-   "ratio": 0.4045,
-   "compress_mbps": 61.06,
-   "decompress_mbps": 116.15
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 3985937,
-   "ratio": 0.3911,
-   "compress_mbps": 60.91,
-   "decompress_mbps": 204.23
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3883839,
-   "ratio": 0.3811,
-   "compress_mbps": 35.59,
-   "decompress_mbps": 119.76
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3860437,
-   "ratio": 0.3788,
-   "compress_mbps": 27.93,
-   "decompress_mbps": 202.6
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3857076,
-   "ratio": 0.3784,
-   "compress_mbps": 25.13,
-   "decompress_mbps": 126.89
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3856651,
-   "ratio": 0.3784,
-   "compress_mbps": 24.66,
-   "decompress_mbps": 202.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3856651,
-   "ratio": 0.3784,
-   "compress_mbps": 24.68,
-   "decompress_mbps": 116.01
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 21508211,
-   "ratio": 0.4199,
-   "compress_mbps": 143.1,
-   "decompress_mbps": 239.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 20538783,
-   "ratio": 0.401,
-   "compress_mbps": 103.18,
-   "decompress_mbps": 229.73
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 20334352,
-   "ratio": 0.397,
-   "compress_mbps": 88.51,
-   "decompress_mbps": 208.07
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19886937,
-   "ratio": 0.3883,
-   "compress_mbps": 86.76,
-   "decompress_mbps": 244.41
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 19582363,
-   "ratio": 0.3823,
-   "compress_mbps": 65.59,
-   "decompress_mbps": 239.15
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19512479,
-   "ratio": 0.381,
-   "compress_mbps": 43.56,
-   "decompress_mbps": 220.01
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19489160,
-   "ratio": 0.3805,
-   "compress_mbps": 32.93,
-   "decompress_mbps": 227.82
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19475109,
-   "ratio": 0.3802,
-   "compress_mbps": 18.63,
-   "decompress_mbps": 225.38
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 19476276,
-   "ratio": 0.3802,
-   "compress_mbps": 10.28,
-   "decompress_mbps": 247.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3967718,
-   "ratio": 0.3979,
-   "compress_mbps": 146.76,
-   "decompress_mbps": 172.01
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3773274,
-   "ratio": 0.3784,
-   "compress_mbps": 105.47,
-   "decompress_mbps": 124.64
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3670460,
-   "ratio": 0.3681,
-   "compress_mbps": 77.56,
-   "decompress_mbps": 182.34
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3655100,
-   "ratio": 0.3666,
-   "compress_mbps": 87.36,
-   "decompress_mbps": 107.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3620881,
-   "ratio": 0.3632,
-   "compress_mbps": 51.01,
-   "decompress_mbps": 125.34
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3606626,
-   "ratio": 0.3617,
-   "compress_mbps": 33.83,
-   "decompress_mbps": 183.58
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3605405,
-   "ratio": 0.3616,
-   "compress_mbps": 31.23,
-   "decompress_mbps": 130.79
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3601635,
-   "ratio": 0.3612,
-   "compress_mbps": 26.28,
-   "decompress_mbps": 133.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3601151,
-   "ratio": 0.3612,
-   "compress_mbps": 19.51,
-   "decompress_mbps": 120.72
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 4501482,
-   "ratio": 0.1342,
-   "compress_mbps": 294.72,
-   "decompress_mbps": 451.24
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 3875891,
-   "ratio": 0.1155,
-   "compress_mbps": 315.51,
-   "decompress_mbps": 356.45
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3731525,
-   "ratio": 0.1112,
-   "compress_mbps": 288.4,
-   "decompress_mbps": 372.55
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3542242,
-   "ratio": 0.1056,
-   "compress_mbps": 236.86,
-   "decompress_mbps": 484.44
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3239184,
-   "ratio": 0.0965,
-   "compress_mbps": 175.14,
-   "decompress_mbps": 539.55
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3113927,
-   "ratio": 0.0928,
-   "compress_mbps": 120.53,
-   "decompress_mbps": 330.65
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3063520,
-   "ratio": 0.0913,
-   "compress_mbps": 84.76,
-   "decompress_mbps": 331.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 2961320,
-   "ratio": 0.0883,
-   "compress_mbps": 29.61,
-   "decompress_mbps": 401.64
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2940087,
-   "ratio": 0.0876,
-   "compress_mbps": 20.54,
-   "decompress_mbps": 474.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3462708,
-   "ratio": 0.5628,
-   "compress_mbps": 65.77,
-   "decompress_mbps": 109.92
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3327399,
-   "ratio": 0.5408,
-   "compress_mbps": 71.78,
-   "decompress_mbps": 84.48
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3297422,
-   "ratio": 0.536,
-   "compress_mbps": 66.06,
-   "decompress_mbps": 89.69
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3249485,
-   "ratio": 0.5282,
-   "compress_mbps": 64.02,
-   "decompress_mbps": 122.88
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3220046,
-   "ratio": 0.5234,
-   "compress_mbps": 49.81,
-   "decompress_mbps": 90.58
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3213239,
-   "ratio": 0.5223,
-   "compress_mbps": 43.12,
-   "decompress_mbps": 91.3
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3212009,
-   "ratio": 0.5221,
-   "compress_mbps": 39.44,
-   "decompress_mbps": 177.12
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3211575,
-   "ratio": 0.522,
-   "compress_mbps": 27.92,
-   "decompress_mbps": 92.84
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3211561,
-   "ratio": 0.522,
-   "compress_mbps": 29.68,
-   "decompress_mbps": 92.12
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 4334497,
-   "ratio": 0.4298,
-   "compress_mbps": 130.93,
-   "decompress_mbps": 133.29
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3900156,
-   "ratio": 0.3867,
-   "compress_mbps": 131.77,
-   "decompress_mbps": 116.9
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3876099,
-   "ratio": 0.3843,
-   "compress_mbps": 122.94,
-   "decompress_mbps": 133.81
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3782364,
-   "ratio": 0.375,
-   "compress_mbps": 110.84,
-   "decompress_mbps": 135.49
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3679310,
-   "ratio": 0.3648,
-   "compress_mbps": 89.42,
-   "decompress_mbps": 136.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3679424,
-   "ratio": 0.3648,
-   "compress_mbps": 87.41,
-   "decompress_mbps": 128.99
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3679163,
-   "ratio": 0.3648,
-   "compress_mbps": 83.39,
-   "decompress_mbps": 141.56
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3679169,
-   "ratio": 0.3648,
-   "compress_mbps": 82.21,
-   "decompress_mbps": 140.66
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3679169,
-   "ratio": 0.3648,
-   "compress_mbps": 81.84,
-   "decompress_mbps": 196.94
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2496363,
-   "ratio": 0.3767,
-   "compress_mbps": 96.93,
-   "decompress_mbps": 111.19
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2202601,
-   "ratio": 0.3324,
-   "compress_mbps": 92.65,
-   "decompress_mbps": 102.3
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2103089,
-   "ratio": 0.3173,
-   "compress_mbps": 49.73,
-   "decompress_mbps": 242.36
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 1999697,
-   "ratio": 0.3017,
-   "compress_mbps": 75.29,
-   "decompress_mbps": 121.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1892143,
-   "ratio": 0.2855,
-   "compress_mbps": 37.29,
-   "decompress_mbps": 108.65
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1838372,
-   "ratio": 0.2774,
-   "compress_mbps": 20.3,
-   "decompress_mbps": 108.77
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1828850,
-   "ratio": 0.276,
-   "compress_mbps": 15.87,
-   "decompress_mbps": 115.22
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1823159,
-   "ratio": 0.2751,
-   "compress_mbps": 12.46,
-   "decompress_mbps": 114.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1823159,
-   "ratio": 0.2751,
-   "compress_mbps": 12.53,
-   "decompress_mbps": 97.46
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 6447290,
-   "ratio": 0.2984,
-   "compress_mbps": 187.76,
-   "decompress_mbps": 292.5
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 6030257,
-   "ratio": 0.2791,
-   "compress_mbps": 147.85,
-   "decompress_mbps": 241.28
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5928121,
-   "ratio": 0.2744,
-   "compress_mbps": 128.5,
-   "decompress_mbps": 269.87
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5615804,
-   "ratio": 0.2599,
-   "compress_mbps": 121.57,
-   "decompress_mbps": 280.75
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5496738,
-   "ratio": 0.2544,
-   "compress_mbps": 80.22,
-   "decompress_mbps": 336.14
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5464184,
-   "ratio": 0.2529,
-   "compress_mbps": 62.73,
-   "decompress_mbps": 195.35
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5429645,
-   "ratio": 0.2513,
-   "compress_mbps": 47.93,
-   "decompress_mbps": 214.77
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5418135,
-   "ratio": 0.2508,
-   "compress_mbps": 36.65,
-   "decompress_mbps": 241.37
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5416628,
-   "ratio": 0.2507,
-   "compress_mbps": 33.67,
-   "decompress_mbps": 233.28
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5759187,
-   "ratio": 0.7942,
-   "compress_mbps": 91.27,
-   "decompress_mbps": 158.91
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5619390,
-   "ratio": 0.7749,
-   "compress_mbps": 49.54,
-   "decompress_mbps": 94.64
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5560914,
-   "ratio": 0.7668,
-   "compress_mbps": 43.81,
-   "decompress_mbps": 115.78
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5544069,
-   "ratio": 0.7645,
-   "compress_mbps": 44.58,
-   "decompress_mbps": 94.11
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5518257,
-   "ratio": 0.7609,
-   "compress_mbps": 36.73,
-   "decompress_mbps": 163.59
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5508662,
-   "ratio": 0.7596,
-   "compress_mbps": 33.77,
-   "decompress_mbps": 95.01
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5507534,
-   "ratio": 0.7595,
-   "compress_mbps": 35.09,
-   "decompress_mbps": 95.76
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5507183,
-   "ratio": 0.7594,
-   "compress_mbps": 32.41,
-   "decompress_mbps": 94.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5507183,
-   "ratio": 0.7594,
-   "compress_mbps": 32.5,
-   "decompress_mbps": 117.56
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 15230651,
-   "ratio": 0.3674,
-   "compress_mbps": 123.36,
-   "decompress_mbps": 184.33
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 13822040,
-   "ratio": 0.3334,
-   "compress_mbps": 96.36,
-   "decompress_mbps": 194.1
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 13397592,
-   "ratio": 0.3232,
-   "compress_mbps": 83.62,
-   "decompress_mbps": 202.34
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12759940,
-   "ratio": 0.3078,
-   "compress_mbps": 80.4,
-   "decompress_mbps": 223.21
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12274278,
-   "ratio": 0.2961,
-   "compress_mbps": 54.6,
-   "decompress_mbps": 216.16
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12131738,
-   "ratio": 0.2926,
-   "compress_mbps": 40.41,
-   "decompress_mbps": 218.2
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12060450,
-   "ratio": 0.2909,
-   "compress_mbps": 33.43,
-   "decompress_mbps": 203.45
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12036900,
-   "ratio": 0.2903,
-   "compress_mbps": 29.91,
-   "decompress_mbps": 206.04
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 12036900,
-   "ratio": 0.2903,
-   "compress_mbps": 30.01,
-   "decompress_mbps": 223.31
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6653052,
-   "ratio": 0.7851,
-   "compress_mbps": 124.38,
-   "decompress_mbps": 152.55
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6305035,
-   "ratio": 0.744,
-   "compress_mbps": 53.84,
-   "decompress_mbps": 154.18
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6302730,
-   "ratio": 0.7438,
-   "compress_mbps": 52.94,
-   "decompress_mbps": 119.64
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6299134,
-   "ratio": 0.7433,
-   "compress_mbps": 52.14,
-   "decompress_mbps": 156.45
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6289022,
-   "ratio": 0.7421,
-   "compress_mbps": 64.63,
-   "decompress_mbps": 159.21
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 6289013,
-   "ratio": 0.7421,
-   "compress_mbps": 50.64,
-   "decompress_mbps": 156.7
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 6289013,
-   "ratio": 0.7421,
-   "compress_mbps": 50.91,
-   "decompress_mbps": 165.38
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 6289012,
-   "ratio": 0.7421,
-   "compress_mbps": 64.4,
-   "decompress_mbps": 157.39
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 6289012,
-   "ratio": 0.7421,
-   "compress_mbps": 64.37,
-   "decompress_mbps": 98.54
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 989456,
-   "ratio": 0.1851,
-   "compress_mbps": 243.16,
-   "decompress_mbps": 153.25
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 839766,
-   "ratio": 0.1571,
-   "compress_mbps": 178.46,
-   "decompress_mbps": 169.75
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 800619,
-   "ratio": 0.1498,
-   "compress_mbps": 181.16,
-   "decompress_mbps": 178.28
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 776397,
-   "ratio": 0.1452,
-   "compress_mbps": 149.67,
-   "decompress_mbps": 185.03
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 712679,
-   "ratio": 0.1333,
-   "compress_mbps": 103.54,
-   "decompress_mbps": 199.06
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 683707,
-   "ratio": 0.1279,
-   "compress_mbps": 93.5,
-   "decompress_mbps": 512.66
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 668601,
-   "ratio": 0.1251,
-   "compress_mbps": 70.7,
-   "decompress_mbps": 209.33
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 659106,
-   "ratio": 0.1233,
-   "compress_mbps": 42.04,
-   "decompress_mbps": 216.57
-  },
-  {
-   "compressor": "go",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 658920,
-   "ratio": 0.1233,
-   "compress_mbps": 42.13,
-   "decompress_mbps": 256.07
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 62797,
-   "ratio": 0.4129,
-   "compress_mbps": 75.96,
-   "decompress_mbps": 132.29
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 59605,
-   "ratio": 0.3919,
-   "compress_mbps": 62.87,
-   "decompress_mbps": 131.77
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 57675,
-   "ratio": 0.3792,
-   "compress_mbps": 53.89,
-   "decompress_mbps": 124.29
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 56500,
-   "ratio": 0.3715,
-   "compress_mbps": 38.93,
-   "decompress_mbps": 131.16
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 56440,
-   "ratio": 0.3711,
-   "compress_mbps": 38.82,
-   "decompress_mbps": 130.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 55443,
-   "ratio": 0.3645,
-   "compress_mbps": 32.14,
-   "decompress_mbps": 146.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 55373,
-   "ratio": 0.3641,
-   "compress_mbps": 31.65,
-   "decompress_mbps": 130.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 55352,
-   "ratio": 0.3639,
-   "compress_mbps": 31.32,
-   "decompress_mbps": 136.96
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 55352,
-   "ratio": 0.3639,
-   "compress_mbps": 31.37,
-   "decompress_mbps": 135.72
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 55063,
-   "ratio": 0.4399,
-   "compress_mbps": 74.97,
-   "decompress_mbps": 117.68
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 52932,
-   "ratio": 0.4229,
-   "compress_mbps": 60.75,
-   "decompress_mbps": 116.27
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 51597,
-   "ratio": 0.4122,
-   "compress_mbps": 44.1,
-   "decompress_mbps": 116.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 50780,
-   "ratio": 0.4057,
-   "compress_mbps": 43.18,
-   "decompress_mbps": 120.67
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 50767,
-   "ratio": 0.4056,
-   "compress_mbps": 42.85,
-   "decompress_mbps": 122.05
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 50160,
-   "ratio": 0.4007,
-   "compress_mbps": 33.03,
-   "decompress_mbps": 128.52
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 50138,
-   "ratio": 0.4005,
-   "compress_mbps": 31.52,
-   "decompress_mbps": 124.51
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 50138,
-   "ratio": 0.4005,
-   "compress_mbps": 32.14,
-   "decompress_mbps": 125.83
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 50138,
-   "ratio": 0.4005,
-   "compress_mbps": 35.79,
-   "decompress_mbps": 124.35
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8730,
-   "ratio": 0.3548,
-   "compress_mbps": 46.94,
-   "decompress_mbps": 123.4
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8457,
-   "ratio": 0.3437,
-   "compress_mbps": 43.65,
-   "decompress_mbps": 119.12
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8353,
-   "ratio": 0.3395,
-   "compress_mbps": 64.98,
-   "decompress_mbps": 109.7
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8301,
-   "ratio": 0.3374,
-   "compress_mbps": 42.45,
-   "decompress_mbps": 124.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 8212,
-   "ratio": 0.3338,
-   "compress_mbps": 58.84,
-   "decompress_mbps": 103.81
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 8172,
-   "ratio": 0.3322,
-   "compress_mbps": 48.55,
-   "decompress_mbps": 108.53
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 8171,
-   "ratio": 0.3321,
-   "compress_mbps": 50.28,
-   "decompress_mbps": 109.3
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 8171,
-   "ratio": 0.3321,
-   "compress_mbps": 49.23,
-   "decompress_mbps": 109.09
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 8171,
-   "ratio": 0.3321,
-   "compress_mbps": 53.75,
-   "decompress_mbps": 109.08
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3475,
-   "ratio": 0.3117,
-   "compress_mbps": 109.11,
-   "decompress_mbps": 96.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3305,
-   "ratio": 0.2964,
-   "compress_mbps": 102.67,
-   "decompress_mbps": 101.78
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3225,
-   "ratio": 0.2892,
-   "compress_mbps": 91.21,
-   "decompress_mbps": 104.25
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3192,
-   "ratio": 0.2863,
-   "compress_mbps": 100.3,
-   "decompress_mbps": 104.85
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3180,
-   "ratio": 0.2852,
-   "compress_mbps": 100.47,
-   "decompress_mbps": 98.18
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3168,
-   "ratio": 0.2841,
-   "compress_mbps": 94.55,
-   "decompress_mbps": 99.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3168,
-   "ratio": 0.2841,
-   "compress_mbps": 95.62,
-   "decompress_mbps": 95.6
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3168,
-   "ratio": 0.2841,
-   "compress_mbps": 91.52,
-   "decompress_mbps": 121.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3168,
-   "ratio": 0.2841,
-   "compress_mbps": 83.09,
-   "decompress_mbps": 95.05
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1275,
-   "ratio": 0.3426,
-   "compress_mbps": 59.58,
-   "decompress_mbps": 44.37
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1247,
-   "ratio": 0.3351,
-   "compress_mbps": 59.47,
-   "decompress_mbps": 52.13
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1239,
-   "ratio": 0.333,
-   "compress_mbps": 56.69,
-   "decompress_mbps": 51.11
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1238,
-   "ratio": 0.3327,
-   "compress_mbps": 58.55,
-   "decompress_mbps": 50.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1239,
-   "ratio": 0.333,
-   "compress_mbps": 48.99,
-   "decompress_mbps": 51.01
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1237,
-   "ratio": 0.3324,
-   "compress_mbps": 56.51,
-   "decompress_mbps": 50.1
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1237,
-   "ratio": 0.3324,
-   "compress_mbps": 55.71,
-   "decompress_mbps": 51.27
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1237,
-   "ratio": 0.3324,
-   "compress_mbps": 50.22,
-   "decompress_mbps": 48.37
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1237,
-   "ratio": 0.3324,
-   "compress_mbps": 55.39,
-   "decompress_mbps": 48.56
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 226284,
-   "ratio": 0.2197,
-   "compress_mbps": 113.28,
-   "decompress_mbps": 183.05
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 221369,
-   "ratio": 0.215,
-   "compress_mbps": 90.24,
-   "decompress_mbps": 255.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 218607,
-   "ratio": 0.2123,
-   "compress_mbps": 78.67,
-   "decompress_mbps": 187.61
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 217919,
-   "ratio": 0.2116,
-   "compress_mbps": 69.94,
-   "decompress_mbps": 195.29
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 217919,
-   "ratio": 0.2116,
-   "compress_mbps": 70.92,
-   "decompress_mbps": 195.59
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 217312,
-   "ratio": 0.211,
-   "compress_mbps": 44.09,
-   "decompress_mbps": 191.18
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 215966,
-   "ratio": 0.2097,
-   "compress_mbps": 31.15,
-   "decompress_mbps": 191.54
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 215930,
-   "ratio": 0.2097,
-   "compress_mbps": 14.32,
-   "decompress_mbps": 194.26
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 215912,
-   "ratio": 0.2097,
-   "compress_mbps": 11.1,
-   "decompress_mbps": 210.59
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 167622,
-   "ratio": 0.3928,
-   "compress_mbps": 64.39,
-   "decompress_mbps": 116.3
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 158003,
-   "ratio": 0.3702,
-   "compress_mbps": 64.34,
-   "decompress_mbps": 139.36
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 152928,
-   "ratio": 0.3584,
-   "compress_mbps": 46.67,
-   "decompress_mbps": 141.08
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 149886,
-   "ratio": 0.3512,
-   "compress_mbps": 33.71,
-   "decompress_mbps": 136.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 149767,
-   "ratio": 0.3509,
-   "compress_mbps": 39.31,
-   "decompress_mbps": 138
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 147818,
-   "ratio": 0.3464,
-   "compress_mbps": 33.18,
-   "decompress_mbps": 150.78
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 147733,
-   "ratio": 0.3462,
-   "compress_mbps": 32.42,
-   "decompress_mbps": 154.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 147709,
-   "ratio": 0.3461,
-   "compress_mbps": 32.15,
-   "decompress_mbps": 151.45
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 147705,
-   "ratio": 0.3461,
-   "compress_mbps": 32.65,
-   "decompress_mbps": 138.19
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 222866,
-   "ratio": 0.4625,
-   "compress_mbps": 58.92,
-   "decompress_mbps": 105.16
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 212925,
-   "ratio": 0.4419,
-   "compress_mbps": 49.52,
-   "decompress_mbps": 118.08
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 206913,
-   "ratio": 0.4294,
-   "compress_mbps": 40.5,
-   "decompress_mbps": 116.88
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 202875,
-   "ratio": 0.421,
-   "compress_mbps": 33.54,
-   "decompress_mbps": 111.31
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 202867,
-   "ratio": 0.421,
-   "compress_mbps": 33.57,
-   "decompress_mbps": 117.4
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 199818,
-   "ratio": 0.4147,
-   "compress_mbps": 28.4,
-   "decompress_mbps": 114.8
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 199664,
-   "ratio": 0.4144,
-   "compress_mbps": 27.76,
-   "decompress_mbps": 105.02
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 199634,
-   "ratio": 0.4143,
-   "compress_mbps": 28.19,
-   "decompress_mbps": 106.5
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 199634,
-   "ratio": 0.4143,
-   "compress_mbps": 27.99,
-   "decompress_mbps": 121
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 60580,
-   "ratio": 0.118,
-   "compress_mbps": 118.15,
-   "decompress_mbps": 253.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 59663,
-   "ratio": 0.1163,
-   "compress_mbps": 131.11,
-   "decompress_mbps": 295.73
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 59465,
-   "ratio": 0.1159,
-   "compress_mbps": 100.74,
-   "decompress_mbps": 295.91
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 59353,
-   "ratio": 0.1156,
-   "compress_mbps": 95.09,
-   "decompress_mbps": 302.88
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 58830,
-   "ratio": 0.1146,
-   "compress_mbps": 107.76,
-   "decompress_mbps": 221.47
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 57884,
-   "ratio": 0.1128,
-   "compress_mbps": 56.85,
-   "decompress_mbps": 285.29
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 57206,
-   "ratio": 0.1115,
-   "compress_mbps": 46.17,
-   "decompress_mbps": 299.77
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 56545,
-   "ratio": 0.1102,
-   "compress_mbps": 23.09,
-   "decompress_mbps": 280.1
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 56454,
-   "ratio": 0.11,
-   "compress_mbps": 9.11,
-   "decompress_mbps": 300.36
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 14194,
-   "ratio": 0.3712,
-   "compress_mbps": 83.27,
-   "decompress_mbps": 134.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 13770,
-   "ratio": 0.3601,
-   "compress_mbps": 74.14,
-   "decompress_mbps": 116.53
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13611,
-   "ratio": 0.3559,
-   "compress_mbps": 66.24,
-   "decompress_mbps": 115.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13534,
-   "ratio": 0.3539,
-   "compress_mbps": 61.31,
-   "decompress_mbps": 117.96
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13527,
-   "ratio": 0.3537,
-   "compress_mbps": 61.97,
-   "decompress_mbps": 148.27
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 13438,
-   "ratio": 0.3514,
-   "compress_mbps": 51.17,
-   "decompress_mbps": 142.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 13419,
-   "ratio": 0.3509,
-   "compress_mbps": 47.83,
-   "decompress_mbps": 125.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 13404,
-   "ratio": 0.3505,
-   "compress_mbps": 41.2,
-   "decompress_mbps": 118.77
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 13390,
-   "ratio": 0.3502,
-   "compress_mbps": 35.78,
-   "decompress_mbps": 116.99
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1832,
-   "ratio": 0.4334,
-   "compress_mbps": 41.01,
-   "decompress_mbps": 45
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1776,
-   "ratio": 0.4202,
-   "compress_mbps": 58.71,
-   "decompress_mbps": 64.9
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1764,
-   "ratio": 0.4173,
-   "compress_mbps": 57.37,
-   "decompress_mbps": 62.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1763,
-   "ratio": 0.4171,
-   "compress_mbps": 56.88,
-   "decompress_mbps": 53.28
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 59.36,
-   "decompress_mbps": 48.79
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 40.25,
-   "decompress_mbps": 47.27
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 57.06,
-   "decompress_mbps": 48.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 58.67,
-   "decompress_mbps": 52.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1760,
-   "ratio": 0.4164,
-   "compress_mbps": 58.3,
-   "decompress_mbps": 62.91
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 4462632,
-   "ratio": 0.4378,
-   "compress_mbps": 61.62,
-   "decompress_mbps": 170.85
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4244833,
-   "ratio": 0.4165,
-   "compress_mbps": 50.24,
-   "decompress_mbps": 201.42
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 4112285,
-   "ratio": 0.4035,
-   "compress_mbps": 42.04,
-   "decompress_mbps": 178.21
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 4020435,
-   "ratio": 0.3945,
-   "compress_mbps": 35.5,
-   "decompress_mbps": 142.52
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 4019177,
-   "ratio": 0.3943,
-   "compress_mbps": 35.31,
-   "decompress_mbps": 170.54
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3956464,
-   "ratio": 0.3882,
-   "compress_mbps": 28.75,
-   "decompress_mbps": 164.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3953310,
-   "ratio": 0.3879,
-   "compress_mbps": 28.47,
-   "decompress_mbps": 198.87
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3952872,
-   "ratio": 0.3878,
-   "compress_mbps": 29.08,
-   "decompress_mbps": 220.53
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3952872,
-   "ratio": 0.3878,
-   "compress_mbps": 29.21,
-   "decompress_mbps": 218.12
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 20177423,
-   "ratio": 0.3939,
-   "compress_mbps": 72.68,
-   "decompress_mbps": 209.54
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 19759467,
-   "ratio": 0.3858,
-   "compress_mbps": 63.85,
-   "decompress_mbps": 193.45
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19583171,
-   "ratio": 0.3823,
-   "compress_mbps": 57.14,
-   "decompress_mbps": 206.47
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19479125,
-   "ratio": 0.3803,
-   "compress_mbps": 51.03,
-   "decompress_mbps": 205.14
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 19423693,
-   "ratio": 0.3792,
-   "compress_mbps": 49.13,
-   "decompress_mbps": 200.07
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19337683,
-   "ratio": 0.3775,
-   "compress_mbps": 36.05,
-   "decompress_mbps": 188.48
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19323922,
-   "ratio": 0.3773,
-   "compress_mbps": 29.08,
-   "decompress_mbps": 193.94
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19314797,
-   "ratio": 0.3771,
-   "compress_mbps": 19.5,
-   "decompress_mbps": 225.36
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 19312663,
-   "ratio": 0.377,
-   "compress_mbps": 11.12,
-   "decompress_mbps": 219.23
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3762978,
-   "ratio": 0.3774,
-   "compress_mbps": 78.68,
-   "decompress_mbps": 163.86
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3711615,
-   "ratio": 0.3723,
-   "compress_mbps": 68.1,
-   "decompress_mbps": 196.85
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3663131,
-   "ratio": 0.3674,
-   "compress_mbps": 57.01,
-   "decompress_mbps": 241.11
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3631512,
-   "ratio": 0.3642,
-   "compress_mbps": 49.21,
-   "decompress_mbps": 221.03
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3630867,
-   "ratio": 0.3642,
-   "compress_mbps": 48.78,
-   "decompress_mbps": 216.62
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3615953,
-   "ratio": 0.3627,
-   "compress_mbps": 37.72,
-   "decompress_mbps": 247.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3615518,
-   "ratio": 0.3626,
-   "compress_mbps": 35.3,
-   "decompress_mbps": 189.82
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3613845,
-   "ratio": 0.3625,
-   "compress_mbps": 30.03,
-   "decompress_mbps": 255.34
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3614283,
-   "ratio": 0.3625,
-   "compress_mbps": 26.24,
-   "decompress_mbps": 222.16
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 4418800,
-   "ratio": 0.1317,
-   "compress_mbps": 133,
-   "decompress_mbps": 338.57
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 4026774,
-   "ratio": 0.12,
-   "compress_mbps": 123.44,
-   "decompress_mbps": 339.7
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3837798,
-   "ratio": 0.1144,
-   "compress_mbps": 116.34,
-   "decompress_mbps": 370.54
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3751023,
-   "ratio": 0.1118,
-   "compress_mbps": 110.1,
-   "decompress_mbps": 361.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3643468,
-   "ratio": 0.1086,
-   "compress_mbps": 101.98,
-   "decompress_mbps": 371.36
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3379481,
-   "ratio": 0.1007,
-   "compress_mbps": 68.99,
-   "decompress_mbps": 366.05
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3354082,
-   "ratio": 0.1,
-   "compress_mbps": 61.49,
-   "decompress_mbps": 366.51
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3330028,
-   "ratio": 0.0992,
-   "compress_mbps": 49.65,
-   "decompress_mbps": 396.52
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 3327482,
-   "ratio": 0.0992,
-   "compress_mbps": 37.41,
-   "decompress_mbps": 367.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3233790,
-   "ratio": 0.5256,
-   "compress_mbps": 52.65,
-   "decompress_mbps": 141.02
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3184644,
-   "ratio": 0.5176,
-   "compress_mbps": 48.35,
-   "decompress_mbps": 141.34
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3160521,
-   "ratio": 0.5137,
-   "compress_mbps": 44.16,
-   "decompress_mbps": 134.37
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3141929,
-   "ratio": 0.5107,
-   "compress_mbps": 40.04,
-   "decompress_mbps": 150.29
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3138514,
-   "ratio": 0.5101,
-   "compress_mbps": 39.11,
-   "decompress_mbps": 134.68
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3126843,
-   "ratio": 0.5082,
-   "compress_mbps": 32.81,
-   "decompress_mbps": 149.93
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3126796,
-   "ratio": 0.5082,
-   "compress_mbps": 30.63,
-   "decompress_mbps": 145.05
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3126322,
-   "ratio": 0.5082,
-   "compress_mbps": 27.28,
-   "decompress_mbps": 153.07
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3126286,
-   "ratio": 0.5082,
-   "compress_mbps": 23.43,
-   "decompress_mbps": 154.77
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 4076349,
-   "ratio": 0.4042,
-   "compress_mbps": 79.56,
-   "decompress_mbps": 217.72
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3914739,
-   "ratio": 0.3881,
-   "compress_mbps": 72.11,
-   "decompress_mbps": 235.6
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3845160,
-   "ratio": 0.3812,
-   "compress_mbps": 68.92,
-   "decompress_mbps": 265.95
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3822047,
-   "ratio": 0.379,
-   "compress_mbps": 65.9,
-   "decompress_mbps": 249.1
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3799472,
-   "ratio": 0.3767,
-   "compress_mbps": 60.47,
-   "decompress_mbps": 196.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3783861,
-   "ratio": 0.3752,
-   "compress_mbps": 59.24,
-   "decompress_mbps": 206.2
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3783432,
-   "ratio": 0.3751,
-   "compress_mbps": 57.5,
-   "decompress_mbps": 276.55
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3783342,
-   "ratio": 0.3751,
-   "compress_mbps": 57.79,
-   "decompress_mbps": 278.67
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3783342,
-   "ratio": 0.3751,
-   "compress_mbps": 57.86,
-   "decompress_mbps": 279.64
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2261112,
-   "ratio": 0.3412,
-   "compress_mbps": 71.4,
-   "decompress_mbps": 216.97
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2128691,
-   "ratio": 0.3212,
-   "compress_mbps": 58.57,
-   "decompress_mbps": 197.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2049023,
-   "ratio": 0.3092,
-   "compress_mbps": 48.53,
-   "decompress_mbps": 209.61
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 1990249,
-   "ratio": 0.3003,
-   "compress_mbps": 41.12,
-   "decompress_mbps": 207.91
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1975224,
-   "ratio": 0.298,
-   "compress_mbps": 39.61,
-   "decompress_mbps": 151.52
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1910262,
-   "ratio": 0.2882,
-   "compress_mbps": 28.21,
-   "decompress_mbps": 164.32
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1902923,
-   "ratio": 0.2871,
-   "compress_mbps": 25.04,
-   "decompress_mbps": 221.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1900964,
-   "ratio": 0.2868,
-   "compress_mbps": 23.45,
-   "decompress_mbps": 227.66
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1900958,
-   "ratio": 0.2868,
-   "compress_mbps": 24.4,
-   "decompress_mbps": 207.65
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 6016919,
-   "ratio": 0.2785,
-   "compress_mbps": 92.31,
-   "decompress_mbps": 250.38
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 5767272,
-   "ratio": 0.2669,
-   "compress_mbps": 81.02,
-   "decompress_mbps": 287.18
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5669548,
-   "ratio": 0.2624,
-   "compress_mbps": 75.87,
-   "decompress_mbps": 211.21
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5619947,
-   "ratio": 0.2601,
-   "compress_mbps": 68.8,
-   "decompress_mbps": 271.25
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5586034,
-   "ratio": 0.2585,
-   "compress_mbps": 64.77,
-   "decompress_mbps": 270.13
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5540130,
-   "ratio": 0.2564,
-   "compress_mbps": 50.72,
-   "decompress_mbps": 269.04
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5537271,
-   "ratio": 0.2563,
-   "compress_mbps": 45.58,
-   "decompress_mbps": 209.67
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5530686,
-   "ratio": 0.256,
-   "compress_mbps": 35.75,
-   "decompress_mbps": 303.18
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5529823,
-   "ratio": 0.2559,
-   "compress_mbps": 31.59,
-   "decompress_mbps": 227.31
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5602819,
-   "ratio": 0.7726,
-   "compress_mbps": 47.72,
-   "decompress_mbps": 166.89
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5504019,
-   "ratio": 0.759,
-   "compress_mbps": 42.76,
-   "decompress_mbps": 153.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5452816,
-   "ratio": 0.7519,
-   "compress_mbps": 38.01,
-   "decompress_mbps": 153.91
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5425752,
-   "ratio": 0.7482,
-   "compress_mbps": 35.6,
-   "decompress_mbps": 177.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5425752,
-   "ratio": 0.7482,
-   "compress_mbps": 36.17,
-   "decompress_mbps": 176.78
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5407602,
-   "ratio": 0.7457,
-   "compress_mbps": 30.72,
-   "decompress_mbps": 153.42
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5406417,
-   "ratio": 0.7455,
-   "compress_mbps": 30.08,
-   "decompress_mbps": 155.44
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5406380,
-   "ratio": 0.7455,
-   "compress_mbps": 30.76,
-   "decompress_mbps": 154.32
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5406380,
-   "ratio": 0.7455,
-   "compress_mbps": 30.68,
-   "decompress_mbps": 117.26
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 14342407,
-   "ratio": 0.3459,
-   "compress_mbps": 73.52,
-   "decompress_mbps": 197.71
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 13424966,
-   "ratio": 0.3238,
-   "compress_mbps": 63.27,
-   "decompress_mbps": 213.25
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 13061399,
-   "ratio": 0.315,
-   "compress_mbps": 56.27,
-   "decompress_mbps": 222.06
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12877207,
-   "ratio": 0.3106,
-   "compress_mbps": 49.84,
-   "decompress_mbps": 208.96
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12671090,
-   "ratio": 0.3056,
-   "compress_mbps": 47.71,
-   "decompress_mbps": 209.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12511088,
-   "ratio": 0.3018,
-   "compress_mbps": 40.67,
-   "decompress_mbps": 235.26
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12503313,
-   "ratio": 0.3016,
-   "compress_mbps": 39.02,
-   "decompress_mbps": 224.89
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12502263,
-   "ratio": 0.3016,
-   "compress_mbps": 39.56,
-   "decompress_mbps": 227.39
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 12502263,
-   "ratio": 0.3016,
-   "compress_mbps": 39.56,
-   "decompress_mbps": 225.48
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6022390,
-   "ratio": 0.7107,
-   "compress_mbps": 54.31,
-   "decompress_mbps": 145.97
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 5997124,
-   "ratio": 0.7077,
-   "compress_mbps": 48.84,
-   "decompress_mbps": 145.24
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 5979254,
-   "ratio": 0.7056,
-   "compress_mbps": 43.2,
-   "decompress_mbps": 149.3
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 5967955,
-   "ratio": 0.7042,
-   "compress_mbps": 42.03,
-   "decompress_mbps": 178.27
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 5967953,
-   "ratio": 0.7042,
-   "compress_mbps": 42.1,
-   "decompress_mbps": 155.23
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 5965386,
-   "ratio": 0.7039,
-   "compress_mbps": 41.26,
-   "decompress_mbps": 150.17
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 5965383,
-   "ratio": 0.7039,
-   "compress_mbps": 41,
-   "decompress_mbps": 152.03
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 5965383,
-   "ratio": 0.7039,
-   "compress_mbps": 40.8,
-   "decompress_mbps": 151.14
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 5965383,
-   "ratio": 0.7039,
-   "compress_mbps": 41.86,
-   "decompress_mbps": 155
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 985606,
-   "ratio": 0.1844,
-   "compress_mbps": 111.12,
-   "decompress_mbps": 305.94
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 852636,
-   "ratio": 0.1595,
-   "compress_mbps": 102.74,
-   "decompress_mbps": 250.95
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 814293,
-   "ratio": 0.1523,
-   "compress_mbps": 96.19,
-   "decompress_mbps": 221.84
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 788388,
-   "ratio": 0.1475,
-   "compress_mbps": 89.39,
-   "decompress_mbps": 250.71
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 749390,
-   "ratio": 0.1402,
-   "compress_mbps": 83.47,
-   "decompress_mbps": 304.92
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 706892,
-   "ratio": 0.1322,
-   "compress_mbps": 64.12,
-   "decompress_mbps": 266.99
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 705695,
-   "ratio": 0.132,
-   "compress_mbps": 64.27,
-   "decompress_mbps": 329.56
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 703904,
-   "ratio": 0.1317,
-   "compress_mbps": 61.16,
-   "decompress_mbps": 268.63
-  },
-  {
-   "compressor": "js",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 703900,
-   "ratio": 0.1317,
-   "compress_mbps": 60.89,
-   "decompress_mbps": 396.78
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 56099,
-   "ratio": 0.3689,
-   "compress_mbps": 88.44,
-   "decompress_mbps": 310.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 56099,
-   "ratio": 0.3689,
-   "compress_mbps": 87.92,
-   "decompress_mbps": 310.59
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 56099,
-   "ratio": 0.3689,
-   "compress_mbps": 88.84,
-   "decompress_mbps": 310.08
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 56099,
-   "ratio": 0.3689,
-   "compress_mbps": 88.64,
-   "decompress_mbps": 314.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 54531,
-   "ratio": 0.3585,
-   "compress_mbps": 55.46,
-   "decompress_mbps": 303.62
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 54068,
-   "ratio": 0.3555,
-   "compress_mbps": 42.11,
-   "decompress_mbps": 310.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 54003,
-   "ratio": 0.3551,
-   "compress_mbps": 37.45,
-   "decompress_mbps": 307.64
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 53974,
-   "ratio": 0.3549,
-   "compress_mbps": 33.15,
-   "decompress_mbps": 306.21
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 53974,
-   "ratio": 0.3549,
-   "compress_mbps": 33.03,
-   "decompress_mbps": 307.58
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 50031,
-   "ratio": 0.3997,
-   "compress_mbps": 82.91,
-   "decompress_mbps": 273.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 50031,
-   "ratio": 0.3997,
-   "compress_mbps": 83.46,
-   "decompress_mbps": 272.35
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 50031,
-   "ratio": 0.3997,
-   "compress_mbps": 84.13,
-   "decompress_mbps": 272.98
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 50031,
-   "ratio": 0.3997,
-   "compress_mbps": 83.95,
-   "decompress_mbps": 268.75
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 48753,
-   "ratio": 0.3895,
-   "compress_mbps": 50.79,
-   "decompress_mbps": 277.44
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 48557,
-   "ratio": 0.3879,
-   "compress_mbps": 40.8,
-   "decompress_mbps": 274.84
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 48523,
-   "ratio": 0.3876,
-   "compress_mbps": 38.65,
-   "decompress_mbps": 273.33
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 48522,
-   "ratio": 0.3876,
-   "compress_mbps": 37.86,
-   "decompress_mbps": 276.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 48522,
-   "ratio": 0.3876,
-   "compress_mbps": 37.9,
-   "decompress_mbps": 276.0
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 8182,
-   "ratio": 0.3326,
-   "compress_mbps": 164.27,
-   "decompress_mbps": 279.42
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 8182,
-   "ratio": 0.3326,
-   "compress_mbps": 172.17,
-   "decompress_mbps": 279.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 8182,
-   "ratio": 0.3326,
-   "compress_mbps": 171.79,
-   "decompress_mbps": 279.43
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8182,
-   "ratio": 0.3326,
-   "compress_mbps": 170.54,
-   "decompress_mbps": 279.22
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 7965,
-   "ratio": 0.3237,
-   "compress_mbps": 110.55,
-   "decompress_mbps": 288.06
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 7914,
-   "ratio": 0.3217,
-   "compress_mbps": 87.16,
-   "decompress_mbps": 290.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 7895,
-   "ratio": 0.3209,
-   "compress_mbps": 80.21,
-   "decompress_mbps": 290.06
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 7896,
-   "ratio": 0.3209,
-   "compress_mbps": 73.83,
-   "decompress_mbps": 287.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 7896,
-   "ratio": 0.3209,
-   "compress_mbps": 74.8,
-   "decompress_mbps": 285.58
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 3218,
-   "ratio": 0.2886,
-   "compress_mbps": 167.43,
-   "decompress_mbps": 252.93
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 3218,
-   "ratio": 0.2886,
-   "compress_mbps": 171.07,
-   "decompress_mbps": 257.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 3218,
-   "ratio": 0.2886,
-   "compress_mbps": 171.82,
-   "decompress_mbps": 258.29
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3218,
-   "ratio": 0.2886,
-   "compress_mbps": 166.85,
-   "decompress_mbps": 256.2
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3136,
-   "ratio": 0.2813,
-   "compress_mbps": 143.33,
-   "decompress_mbps": 259.73
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3115,
-   "ratio": 0.2794,
-   "compress_mbps": 126.88,
-   "decompress_mbps": 263.65
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 116.0,
-   "decompress_mbps": 266.62
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 105.81,
-   "decompress_mbps": 262.03
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3112,
-   "ratio": 0.2791,
-   "compress_mbps": 108.16,
-   "decompress_mbps": 263.41
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1221,
-   "ratio": 0.3281,
-   "compress_mbps": 119.04,
-   "decompress_mbps": 119.21
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1221,
-   "ratio": 0.3281,
-   "compress_mbps": 114.29,
-   "decompress_mbps": 121.57
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1221,
-   "ratio": 0.3281,
-   "compress_mbps": 111.93,
-   "decompress_mbps": 114.91
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1221,
-   "ratio": 0.3281,
-   "compress_mbps": 113.37,
-   "decompress_mbps": 116.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 104.47,
-   "decompress_mbps": 117.21
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 101.17,
-   "decompress_mbps": 116.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 99.01,
-   "decompress_mbps": 115.26
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 100.66,
-   "decompress_mbps": 116.17
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1207,
-   "ratio": 0.3244,
-   "compress_mbps": 100.75,
-   "decompress_mbps": 117.41
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 227063,
-   "ratio": 0.2205,
-   "compress_mbps": 226.33,
-   "decompress_mbps": 462.07
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 227063,
-   "ratio": 0.2205,
-   "compress_mbps": 232.22,
-   "decompress_mbps": 461.76
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 227063,
-   "ratio": 0.2205,
-   "compress_mbps": 226.95,
-   "decompress_mbps": 462.59
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 227063,
-   "ratio": 0.2205,
-   "compress_mbps": 231.82,
-   "decompress_mbps": 462.46
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 218313,
-   "ratio": 0.212,
-   "compress_mbps": 163.75,
-   "decompress_mbps": 447.06
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 215095,
-   "ratio": 0.2089,
-   "compress_mbps": 107.22,
-   "decompress_mbps": 448.7
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 213213,
-   "ratio": 0.2071,
-   "compress_mbps": 73.07,
-   "decompress_mbps": 450.65
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 210955,
-   "ratio": 0.2049,
-   "compress_mbps": 9.42,
-   "decompress_mbps": 452.49
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 210981,
-   "ratio": 0.2049,
-   "compress_mbps": 4.64,
-   "decompress_mbps": 454.09
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 148927,
-   "ratio": 0.349,
-   "compress_mbps": 92.55,
-   "decompress_mbps": 304.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 148927,
-   "ratio": 0.349,
-   "compress_mbps": 92.89,
-   "decompress_mbps": 306.86
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 148927,
-   "ratio": 0.349,
-   "compress_mbps": 92.22,
-   "decompress_mbps": 306.2
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 148927,
-   "ratio": 0.349,
-   "compress_mbps": 92.33,
-   "decompress_mbps": 304.41
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 145024,
-   "ratio": 0.3398,
-   "compress_mbps": 57.83,
-   "decompress_mbps": 305.53
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 144159,
-   "ratio": 0.3378,
-   "compress_mbps": 44.56,
-   "decompress_mbps": 304.1
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 143991,
-   "ratio": 0.3374,
-   "compress_mbps": 40.14,
-   "decompress_mbps": 306.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 143941,
-   "ratio": 0.3373,
-   "compress_mbps": 36.87,
-   "decompress_mbps": 306.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 143939,
-   "ratio": 0.3373,
-   "compress_mbps": 37.03,
-   "decompress_mbps": 305.69
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 200074,
-   "ratio": 0.4152,
-   "compress_mbps": 81.26,
-   "decompress_mbps": 255.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 200074,
-   "ratio": 0.4152,
-   "compress_mbps": 80.9,
-   "decompress_mbps": 255.49
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 200074,
-   "ratio": 0.4152,
-   "compress_mbps": 81.21,
-   "decompress_mbps": 255.67
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 200074,
-   "ratio": 0.4152,
-   "compress_mbps": 81.07,
-   "decompress_mbps": 256.32
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 194496,
-   "ratio": 0.4036,
-   "compress_mbps": 46.0,
-   "decompress_mbps": 247.64
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 193176,
-   "ratio": 0.4009,
-   "compress_mbps": 34.56,
-   "decompress_mbps": 253.55
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 192991,
-   "ratio": 0.4005,
-   "compress_mbps": 31.43,
-   "decompress_mbps": 250.63
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 192980,
-   "ratio": 0.4005,
-   "compress_mbps": 29.91,
-   "decompress_mbps": 251.77
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 192980,
-   "ratio": 0.4005,
-   "compress_mbps": 29.82,
-   "decompress_mbps": 253.98
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 57484,
-   "ratio": 0.112,
-   "compress_mbps": 294.39,
-   "decompress_mbps": 724.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 57484,
-   "ratio": 0.112,
-   "compress_mbps": 294.6,
-   "decompress_mbps": 721.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 57484,
-   "ratio": 0.112,
-   "compress_mbps": 294.93,
-   "decompress_mbps": 721.32
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 57484,
-   "ratio": 0.112,
-   "compress_mbps": 295.58,
-   "decompress_mbps": 727.0
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 56050,
-   "ratio": 0.1092,
-   "compress_mbps": 229.82,
-   "decompress_mbps": 759.78
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 55292,
-   "ratio": 0.1077,
-   "compress_mbps": 153.4,
-   "decompress_mbps": 778.62
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 54651,
-   "ratio": 0.1065,
-   "compress_mbps": 124.47,
-   "decompress_mbps": 790.77
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 52583,
-   "ratio": 0.1025,
-   "compress_mbps": 46.92,
-   "decompress_mbps": 823.54
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 51816,
-   "ratio": 0.101,
-   "compress_mbps": 15.63,
-   "decompress_mbps": 833.02
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 13765,
-   "ratio": 0.36,
-   "compress_mbps": 119.63,
-   "decompress_mbps": 301.35
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 13765,
-   "ratio": 0.36,
-   "compress_mbps": 118.87,
-   "decompress_mbps": 304.63
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 13765,
-   "ratio": 0.36,
-   "compress_mbps": 120.64,
-   "decompress_mbps": 303.05
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13765,
-   "ratio": 0.36,
-   "compress_mbps": 118.25,
-   "decompress_mbps": 303.27
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13290,
-   "ratio": 0.3475,
-   "compress_mbps": 89.99,
-   "decompress_mbps": 316.05
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 13258,
-   "ratio": 0.3467,
-   "compress_mbps": 68.72,
-   "decompress_mbps": 317.08
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 13246,
-   "ratio": 0.3464,
-   "compress_mbps": 57.01,
-   "decompress_mbps": 319.69
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 13236,
-   "ratio": 0.3461,
-   "compress_mbps": 25.4,
-   "decompress_mbps": 320.24
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 13233,
-   "ratio": 0.3461,
-   "compress_mbps": 16.12,
-   "decompress_mbps": 322.36
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 95.7,
-   "decompress_mbps": 132.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 98.31,
-   "decompress_mbps": 133.01
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 97.54,
-   "decompress_mbps": 132.07
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 1742,
-   "ratio": 0.4121,
-   "compress_mbps": 100.39,
-   "decompress_mbps": 132.0
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 95.29,
-   "decompress_mbps": 132.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 95.54,
-   "decompress_mbps": 134.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 93.18,
-   "decompress_mbps": 133.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 95.09,
-   "decompress_mbps": 134.19
-  },
-  {
-   "compressor": "zig",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 1720,
-   "ratio": 0.4069,
-   "compress_mbps": 92.21,
-   "decompress_mbps": 134.59
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 3974126,
-   "ratio": 0.3899,
-   "compress_mbps": 84.07,
-   "decompress_mbps": 273.96
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 3974126,
-   "ratio": 0.3899,
-   "compress_mbps": 84.3,
-   "decompress_mbps": 273.56
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 3974126,
-   "ratio": 0.3899,
-   "compress_mbps": 83.99,
-   "decompress_mbps": 274.36
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 3974126,
-   "ratio": 0.3899,
-   "compress_mbps": 84.24,
-   "decompress_mbps": 272.3
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 3863846,
-   "ratio": 0.3791,
-   "compress_mbps": 49.03,
-   "decompress_mbps": 267.64
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3838854,
-   "ratio": 0.3766,
-   "compress_mbps": 37.71,
-   "decompress_mbps": 272.4
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3835182,
-   "ratio": 0.3763,
-   "compress_mbps": 33.64,
-   "decompress_mbps": 271.15
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3834518,
-   "ratio": 0.3762,
-   "compress_mbps": 31.63,
-   "decompress_mbps": 269.9
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3834518,
-   "ratio": 0.3762,
-   "compress_mbps": 31.46,
-   "decompress_mbps": 270.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 19877952,
-   "ratio": 0.3881,
-   "compress_mbps": 103.55,
-   "decompress_mbps": 250.87
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 19877952,
-   "ratio": 0.3881,
-   "compress_mbps": 103.76,
-   "decompress_mbps": 251.19
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 19877952,
-   "ratio": 0.3881,
-   "compress_mbps": 103.86,
-   "decompress_mbps": 251.37
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 19877952,
-   "ratio": 0.3881,
-   "compress_mbps": 103.63,
-   "decompress_mbps": 251.14
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 19578840,
-   "ratio": 0.3822,
-   "compress_mbps": 78.52,
-   "decompress_mbps": 258.92
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 19492445,
-   "ratio": 0.3806,
-   "compress_mbps": 58.0,
-   "decompress_mbps": 261.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 19463481,
-   "ratio": 0.38,
-   "compress_mbps": 46.5,
-   "decompress_mbps": 263.14
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 19444704,
-   "ratio": 0.3796,
-   "compress_mbps": 22.81,
-   "decompress_mbps": 262.15
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 19440748,
-   "ratio": 0.3796,
-   "compress_mbps": 13.07,
-   "decompress_mbps": 263.2
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3662279,
-   "ratio": 0.3673,
-   "compress_mbps": 112.24,
-   "decompress_mbps": 259.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3662279,
-   "ratio": 0.3673,
-   "compress_mbps": 112.65,
-   "decompress_mbps": 260.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3662279,
-   "ratio": 0.3673,
-   "compress_mbps": 111.43,
-   "decompress_mbps": 257.26
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3662279,
-   "ratio": 0.3673,
-   "compress_mbps": 112.43,
-   "decompress_mbps": 258.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3637736,
-   "ratio": 0.3648,
-   "compress_mbps": 65.79,
-   "decompress_mbps": 267.17
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3621530,
-   "ratio": 0.3632,
-   "compress_mbps": 46.42,
-   "decompress_mbps": 268.5
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3623924,
-   "ratio": 0.3635,
-   "compress_mbps": 42.48,
-   "decompress_mbps": 270.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3623112,
-   "ratio": 0.3634,
-   "compress_mbps": 33.07,
-   "decompress_mbps": 270.31
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3623382,
-   "ratio": 0.3634,
-   "compress_mbps": 24.87,
-   "decompress_mbps": 268.67
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 3580057,
-   "ratio": 0.1067,
-   "compress_mbps": 306.93,
-   "decompress_mbps": 882.12
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 3580057,
-   "ratio": 0.1067,
-   "compress_mbps": 309.49,
-   "decompress_mbps": 879.51
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 3580057,
-   "ratio": 0.1067,
-   "compress_mbps": 306.65,
-   "decompress_mbps": 865.76
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3580057,
-   "ratio": 0.1067,
-   "compress_mbps": 309.44,
-   "decompress_mbps": 876.41
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3268887,
-   "ratio": 0.0974,
-   "compress_mbps": 229.13,
-   "decompress_mbps": 923.49
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3131445,
-   "ratio": 0.0933,
-   "compress_mbps": 163.5,
-   "decompress_mbps": 955.29
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3080217,
-   "ratio": 0.0918,
-   "compress_mbps": 129.46,
-   "decompress_mbps": 960.33
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 2978354,
-   "ratio": 0.0888,
-   "compress_mbps": 57.16,
-   "decompress_mbps": 973.32
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 2947971,
-   "ratio": 0.0879,
-   "compress_mbps": 34.51,
-   "decompress_mbps": 973.37
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 3221973,
-   "ratio": 0.5237,
-   "compress_mbps": 72.44,
-   "decompress_mbps": 182.53
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3221973,
-   "ratio": 0.5237,
-   "compress_mbps": 72.2,
-   "decompress_mbps": 182.46
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3221973,
-   "ratio": 0.5237,
-   "compress_mbps": 72.32,
-   "decompress_mbps": 182.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3221973,
-   "ratio": 0.5237,
-   "compress_mbps": 72.36,
-   "decompress_mbps": 183.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3178914,
-   "ratio": 0.5167,
-   "compress_mbps": 55.82,
-   "decompress_mbps": 189.9
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3174170,
-   "ratio": 0.5159,
-   "compress_mbps": 49.39,
-   "decompress_mbps": 191.24
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3172734,
-   "ratio": 0.5157,
-   "compress_mbps": 45.82,
-   "decompress_mbps": 191.56
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3171353,
-   "ratio": 0.5155,
-   "compress_mbps": 38.64,
-   "decompress_mbps": 191.37
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3171299,
-   "ratio": 0.5155,
-   "compress_mbps": 34.82,
-   "decompress_mbps": 191.12
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 3791952,
-   "ratio": 0.376,
-   "compress_mbps": 123.34,
-   "decompress_mbps": 273.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 3791952,
-   "ratio": 0.376,
-   "compress_mbps": 122.2,
-   "decompress_mbps": 272.47
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 3791952,
-   "ratio": 0.376,
-   "compress_mbps": 121.33,
-   "decompress_mbps": 269.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3791952,
-   "ratio": 0.376,
-   "compress_mbps": 122.45,
-   "decompress_mbps": 274.58
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3654027,
-   "ratio": 0.3623,
-   "compress_mbps": 95.52,
-   "decompress_mbps": 276.5
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3652732,
-   "ratio": 0.3622,
-   "compress_mbps": 91.8,
-   "decompress_mbps": 276.29
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3652496,
-   "ratio": 0.3621,
-   "compress_mbps": 87.07,
-   "decompress_mbps": 275.95
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3652505,
-   "ratio": 0.3621,
-   "compress_mbps": 87.05,
-   "decompress_mbps": 277.5
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3652505,
-   "ratio": 0.3621,
-   "compress_mbps": 87.07,
-   "decompress_mbps": 276.53
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2009824,
-   "ratio": 0.3033,
-   "compress_mbps": 100.62,
-   "decompress_mbps": 354.06
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2009824,
-   "ratio": 0.3033,
-   "compress_mbps": 100.0,
-   "decompress_mbps": 353.82
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2009824,
-   "ratio": 0.3033,
-   "compress_mbps": 99.59,
-   "decompress_mbps": 351.77
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 2009824,
-   "ratio": 0.3033,
-   "compress_mbps": 99.81,
-   "decompress_mbps": 354.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1892183,
-   "ratio": 0.2855,
-   "compress_mbps": 53.63,
-   "decompress_mbps": 353.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1837957,
-   "ratio": 0.2773,
-   "compress_mbps": 30.64,
-   "decompress_mbps": 360.81
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1826603,
-   "ratio": 0.2756,
-   "compress_mbps": 24.41,
-   "decompress_mbps": 362.4
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1818702,
-   "ratio": 0.2744,
-   "compress_mbps": 16.09,
-   "decompress_mbps": 362.85
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1818702,
-   "ratio": 0.2744,
-   "compress_mbps": 15.95,
-   "decompress_mbps": 359.54
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 5633558,
-   "ratio": 0.2607,
-   "compress_mbps": 146.11,
-   "decompress_mbps": 399.24
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 5633558,
-   "ratio": 0.2607,
-   "compress_mbps": 145.88,
-   "decompress_mbps": 400.49
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 5633558,
-   "ratio": 0.2607,
-   "compress_mbps": 146.06,
-   "decompress_mbps": 396.62
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 5633558,
-   "ratio": 0.2607,
-   "compress_mbps": 144.39,
-   "decompress_mbps": 379.0
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 5501344,
-   "ratio": 0.2546,
-   "compress_mbps": 103.33,
-   "decompress_mbps": 402.09
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5464646,
-   "ratio": 0.2529,
-   "compress_mbps": 79.54,
-   "decompress_mbps": 407.14
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5429975,
-   "ratio": 0.2513,
-   "compress_mbps": 66.81,
-   "decompress_mbps": 408.73
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5419566,
-   "ratio": 0.2508,
-   "compress_mbps": 49.41,
-   "decompress_mbps": 410.08
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5417952,
-   "ratio": 0.2508,
-   "compress_mbps": 45.54,
-   "decompress_mbps": 407.63
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 5481930,
-   "ratio": 0.7559,
-   "compress_mbps": 60.47,
-   "decompress_mbps": 161.38
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 5481930,
-   "ratio": 0.7559,
-   "compress_mbps": 60.25,
-   "decompress_mbps": 161.25
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 5481930,
-   "ratio": 0.7559,
-   "compress_mbps": 60.34,
-   "decompress_mbps": 161.47
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5481930,
-   "ratio": 0.7559,
-   "compress_mbps": 60.28,
-   "decompress_mbps": 159.84
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5450496,
-   "ratio": 0.7516,
-   "compress_mbps": 46.56,
-   "decompress_mbps": 163.89
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5440281,
-   "ratio": 0.7502,
-   "compress_mbps": 42.07,
-   "decompress_mbps": 164.58
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5439077,
-   "ratio": 0.75,
-   "compress_mbps": 40.6,
-   "decompress_mbps": 164.64
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5438787,
-   "ratio": 0.75,
-   "compress_mbps": 39.98,
-   "decompress_mbps": 163.79
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5438787,
-   "ratio": 0.75,
-   "compress_mbps": 39.92,
-   "decompress_mbps": 165.07
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 12756531,
-   "ratio": 0.3077,
-   "compress_mbps": 108.43,
-   "decompress_mbps": 313.19
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 12756531,
-   "ratio": 0.3077,
-   "compress_mbps": 108.96,
-   "decompress_mbps": 316.83
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 12756531,
-   "ratio": 0.3077,
-   "compress_mbps": 108.45,
-   "decompress_mbps": 312.18
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 12756531,
-   "ratio": 0.3077,
-   "compress_mbps": 108.89,
-   "decompress_mbps": 315.83
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12238874,
-   "ratio": 0.2952,
-   "compress_mbps": 72.34,
-   "decompress_mbps": 317.65
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12086531,
-   "ratio": 0.2915,
-   "compress_mbps": 53.58,
-   "decompress_mbps": 323.18
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12020742,
-   "ratio": 0.2899,
-   "compress_mbps": 46.37,
-   "decompress_mbps": 319.97
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 11987253,
-   "ratio": 0.2891,
-   "compress_mbps": 38.17,
-   "decompress_mbps": 322.52
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 11987245,
-   "ratio": 0.2891,
-   "compress_mbps": 38.15,
-   "decompress_mbps": 319.56
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6273039,
-   "ratio": 0.7402,
-   "compress_mbps": 60.53,
-   "decompress_mbps": 146.13
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6273039,
-   "ratio": 0.7402,
-   "compress_mbps": 60.39,
-   "decompress_mbps": 146.09
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6273039,
-   "ratio": 0.7402,
-   "compress_mbps": 60.11,
-   "decompress_mbps": 146.99
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6273039,
-   "ratio": 0.7402,
-   "compress_mbps": 60.42,
-   "decompress_mbps": 146.5
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6244483,
-   "ratio": 0.7369,
-   "compress_mbps": 55.4,
-   "decompress_mbps": 148.54
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 6244482,
-   "ratio": 0.7369,
-   "compress_mbps": 55.47,
-   "decompress_mbps": 148.16
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 6244482,
-   "ratio": 0.7369,
-   "compress_mbps": 55.08,
-   "decompress_mbps": 147.42
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 6244480,
-   "ratio": 0.7369,
-   "compress_mbps": 55.49,
-   "decompress_mbps": 148.22
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 6244480,
-   "ratio": 0.7369,
-   "compress_mbps": 55.43,
-   "decompress_mbps": 147.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 785041,
-   "ratio": 0.1469,
-   "compress_mbps": 230.66,
-   "decompress_mbps": 673.8
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 785041,
-   "ratio": 0.1469,
-   "compress_mbps": 230.52,
-   "decompress_mbps": 670.21
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 785041,
-   "ratio": 0.1469,
-   "compress_mbps": 231.93,
-   "decompress_mbps": 669.9
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 785041,
-   "ratio": 0.1469,
-   "compress_mbps": 230.28,
-   "decompress_mbps": 671.23
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 716461,
-   "ratio": 0.134,
-   "compress_mbps": 166.09,
-   "decompress_mbps": 710.38
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 687053,
-   "ratio": 0.1285,
-   "compress_mbps": 124.29,
-   "decompress_mbps": 733.86
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 673597,
-   "ratio": 0.126,
-   "compress_mbps": 100.95,
-   "decompress_mbps": 744.02
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 662156,
-   "ratio": 0.1239,
-   "compress_mbps": 65.08,
-   "decompress_mbps": 750.21
-  },
-  {
-   "compressor": "zig",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 661610,
-   "ratio": 0.1238,
-   "compress_mbps": 61.06,
-   "decompress_mbps": 754.5
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 1,
-   "out_size": 73589,
-   "ratio": 0.4839,
-   "compress_mbps": 33.76,
-   "decompress_mbps": 57.05
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 2,
-   "out_size": 69878,
-   "ratio": 0.4595,
-   "compress_mbps": 32.08,
-   "decompress_mbps": 58.09
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 3,
-   "out_size": 66917,
-   "ratio": 0.44,
-   "compress_mbps": 26.68,
-   "decompress_mbps": 66.6
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 4,
-   "out_size": 59388,
-   "ratio": 0.3905,
-   "compress_mbps": 31.26,
-   "decompress_mbps": 80.36
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 5,
-   "out_size": 57062,
-   "ratio": 0.3752,
-   "compress_mbps": 22.77,
-   "decompress_mbps": 80.1
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 6,
-   "out_size": 55472,
-   "ratio": 0.3647,
-   "compress_mbps": 16.23,
-   "decompress_mbps": 79.12
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 7,
-   "out_size": 55265,
-   "ratio": 0.3634,
-   "compress_mbps": 14.29,
-   "decompress_mbps": 79.84
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 8,
-   "out_size": 55168,
-   "ratio": 0.3627,
-   "compress_mbps": 11.91,
-   "decompress_mbps": 78.92
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 9,
-   "out_size": 55168,
-   "ratio": 0.3627,
-   "compress_mbps": 11.93,
-   "decompress_mbps": 78.52
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 1,
-   "out_size": 64551,
-   "ratio": 0.5157,
-   "compress_mbps": 31.89,
-   "decompress_mbps": 53.82
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 2,
-   "out_size": 62089,
-   "ratio": 0.496,
-   "compress_mbps": 30.15,
-   "decompress_mbps": 57.83
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 3,
-   "out_size": 58690,
-   "ratio": 0.4688,
-   "compress_mbps": 24.34,
-   "decompress_mbps": 59.96
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 4,
-   "out_size": 53521,
-   "ratio": 0.4276,
-   "compress_mbps": 30.1,
-   "decompress_mbps": 79.96
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 5,
-   "out_size": 51677,
-   "ratio": 0.4128,
-   "compress_mbps": 20.89,
-   "decompress_mbps": 78.97
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 6,
-   "out_size": 50638,
-   "ratio": 0.4045,
-   "compress_mbps": 14.85,
-   "decompress_mbps": 82.68
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 7,
-   "out_size": 50501,
-   "ratio": 0.4034,
-   "compress_mbps": 13.53,
-   "decompress_mbps": 79.57
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 8,
-   "out_size": 50452,
-   "ratio": 0.403,
-   "compress_mbps": 12.59,
-   "decompress_mbps": 81.82
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 9,
-   "out_size": 50452,
-   "ratio": 0.403,
-   "compress_mbps": 12.59,
-   "decompress_mbps": 81.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 1,
-   "out_size": 9859,
-   "ratio": 0.4007,
-   "compress_mbps": 43.03,
-   "decompress_mbps": 111.15
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 2,
-   "out_size": 10473,
-   "ratio": 0.4257,
-   "compress_mbps": 47.23,
-   "decompress_mbps": 149.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 3,
-   "out_size": 10172,
-   "ratio": 0.4134,
-   "compress_mbps": 42.85,
-   "decompress_mbps": 148.23
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 4,
-   "out_size": 8692,
-   "ratio": 0.3533,
-   "compress_mbps": 40.47,
-   "decompress_mbps": 152.86
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 5,
-   "out_size": 8440,
-   "ratio": 0.343,
-   "compress_mbps": 36.18,
-   "decompress_mbps": 157.16
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 6,
-   "out_size": 8385,
-   "ratio": 0.3408,
-   "compress_mbps": 31.88,
-   "decompress_mbps": 158.84
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 7,
-   "out_size": 8366,
-   "ratio": 0.34,
-   "compress_mbps": 29.95,
-   "decompress_mbps": 158.95
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 8,
-   "out_size": 8367,
-   "ratio": 0.3401,
-   "compress_mbps": 28.71,
-   "decompress_mbps": 157.48
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 9,
-   "out_size": 8367,
-   "ratio": 0.3401,
-   "compress_mbps": 28.72,
-   "decompress_mbps": 156.54
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 1,
-   "out_size": 4822,
-   "ratio": 0.4325,
-   "compress_mbps": 54.35,
-   "decompress_mbps": 187.68
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 2,
-   "out_size": 4593,
-   "ratio": 0.4119,
-   "compress_mbps": 52.8,
-   "decompress_mbps": 193.41
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 3,
-   "out_size": 4381,
-   "ratio": 0.3929,
-   "compress_mbps": 49.8,
-   "decompress_mbps": 200.8
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 4,
-   "out_size": 3725,
-   "ratio": 0.3341,
-   "compress_mbps": 51.8,
-   "decompress_mbps": 202.76
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 5,
-   "out_size": 3614,
-   "ratio": 0.3241,
-   "compress_mbps": 43.83,
-   "decompress_mbps": 208.48
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 6,
-   "out_size": 3578,
-   "ratio": 0.3209,
-   "compress_mbps": 39.35,
-   "decompress_mbps": 209.91
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 7,
-   "out_size": 3572,
-   "ratio": 0.3204,
-   "compress_mbps": 36.83,
-   "decompress_mbps": 210.72
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 8,
-   "out_size": 3568,
-   "ratio": 0.32,
-   "compress_mbps": 34.7,
-   "decompress_mbps": 208.41
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 9,
-   "out_size": 3568,
-   "ratio": 0.32,
-   "compress_mbps": 33.66,
-   "decompress_mbps": 206.14
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 1,
-   "out_size": 1738,
-   "ratio": 0.4671,
-   "compress_mbps": 30.09,
-   "decompress_mbps": 176.72
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 2,
-   "out_size": 1709,
-   "ratio": 0.4593,
-   "compress_mbps": 30.1,
-   "decompress_mbps": 174.49
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 3,
-   "out_size": 1694,
-   "ratio": 0.4553,
-   "compress_mbps": 31.7,
-   "decompress_mbps": 180.35
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 4,
-   "out_size": 1458,
-   "ratio": 0.3918,
-   "compress_mbps": 29.73,
-   "decompress_mbps": 187.58
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 5,
-   "out_size": 1441,
-   "ratio": 0.3873,
-   "compress_mbps": 28.44,
-   "decompress_mbps": 189.94
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 6,
-   "out_size": 1440,
-   "ratio": 0.387,
-   "compress_mbps": 27.18,
-   "decompress_mbps": 189.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 7,
-   "out_size": 1440,
-   "ratio": 0.387,
-   "compress_mbps": 27.68,
-   "decompress_mbps": 190.15
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 8,
-   "out_size": 1440,
-   "ratio": 0.387,
-   "compress_mbps": 26.12,
-   "decompress_mbps": 189.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 9,
-   "out_size": 1440,
-   "ratio": 0.387,
-   "compress_mbps": 27.78,
-   "decompress_mbps": 191.2
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 1,
-   "out_size": 260073,
-   "ratio": 0.2526,
-   "compress_mbps": 52.45,
-   "decompress_mbps": 56.85
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 2,
-   "out_size": 296764,
-   "ratio": 0.2882,
-   "compress_mbps": 48.94,
-   "decompress_mbps": 76.97
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 3,
-   "out_size": 288989,
-   "ratio": 0.2806,
-   "compress_mbps": 37.59,
-   "decompress_mbps": 77.33
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 4,
-   "out_size": 246442,
-   "ratio": 0.2393,
-   "compress_mbps": 54.71,
-   "decompress_mbps": 83.32
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 5,
-   "out_size": 218888,
-   "ratio": 0.2126,
-   "compress_mbps": 40.79,
-   "decompress_mbps": 76.86
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 6,
-   "out_size": 217830,
-   "ratio": 0.2115,
-   "compress_mbps": 24.16,
-   "decompress_mbps": 88.24
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 7,
-   "out_size": 221437,
-   "ratio": 0.215,
-   "compress_mbps": 19.26,
-   "decompress_mbps": 86.6
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 8,
-   "out_size": 219666,
-   "ratio": 0.2133,
-   "compress_mbps": 5.49,
-   "decompress_mbps": 86.51
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 9,
-   "out_size": 219921,
-   "ratio": 0.2136,
-   "compress_mbps": 2.77,
-   "decompress_mbps": 85.35
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 1,
-   "out_size": 194588,
-   "ratio": 0.456,
-   "compress_mbps": 34.47,
-   "decompress_mbps": 51.9
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 2,
-   "out_size": 185757,
-   "ratio": 0.4353,
-   "compress_mbps": 32.92,
-   "decompress_mbps": 49.65
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 3,
-   "out_size": 175850,
-   "ratio": 0.4121,
-   "compress_mbps": 27.11,
-   "decompress_mbps": 59.21
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 4,
-   "out_size": 155951,
-   "ratio": 0.3654,
-   "compress_mbps": 31.95,
-   "decompress_mbps": 73.02
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 5,
-   "out_size": 150274,
-   "ratio": 0.3521,
-   "compress_mbps": 23.12,
-   "decompress_mbps": 71.4
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 6,
-   "out_size": 147958,
-   "ratio": 0.3467,
-   "compress_mbps": 16.73,
-   "decompress_mbps": 72.74
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 7,
-   "out_size": 147522,
-   "ratio": 0.3457,
-   "compress_mbps": 14.93,
-   "decompress_mbps": 70.21
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 8,
-   "out_size": 147331,
-   "ratio": 0.3452,
-   "compress_mbps": 13.5,
-   "decompress_mbps": 68.78
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 9,
-   "out_size": 147328,
-   "ratio": 0.3452,
-   "compress_mbps": 13.48,
-   "decompress_mbps": 70.75
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 1,
-   "out_size": 256904,
-   "ratio": 0.5331,
-   "compress_mbps": 29.73,
-   "decompress_mbps": 46.55
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 2,
-   "out_size": 245675,
-   "ratio": 0.5098,
-   "compress_mbps": 28.42,
-   "decompress_mbps": 50.05
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 3,
-   "out_size": 231519,
-   "ratio": 0.4805,
-   "compress_mbps": 22.58,
-   "decompress_mbps": 56.23
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 4,
-   "out_size": 210028,
-   "ratio": 0.4359,
-   "compress_mbps": 27.54,
-   "decompress_mbps": 64.61
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 5,
-   "out_size": 203312,
-   "ratio": 0.4219,
-   "compress_mbps": 18.52,
-   "decompress_mbps": 61.6
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 6,
-   "out_size": 199287,
-   "ratio": 0.4136,
-   "compress_mbps": 12.88,
-   "decompress_mbps": 65.73
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 7,
-   "out_size": 198474,
-   "ratio": 0.4119,
-   "compress_mbps": 11.21,
-   "decompress_mbps": 66.4
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 8,
-   "out_size": 198080,
-   "ratio": 0.4111,
-   "compress_mbps": 8.88,
-   "decompress_mbps": 65.36
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 9,
-   "out_size": 198080,
-   "ratio": 0.4111,
-   "compress_mbps": 8.84,
-   "decompress_mbps": 65.03
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 1,
-   "out_size": 71229,
-   "ratio": 0.1388,
-   "compress_mbps": 82.96,
-   "decompress_mbps": 136.59
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 2,
-   "out_size": 69946,
-   "ratio": 0.1363,
-   "compress_mbps": 78.92,
-   "decompress_mbps": 137.96
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 3,
-   "out_size": 68538,
-   "ratio": 0.1335,
-   "compress_mbps": 69.23,
-   "decompress_mbps": 151.76
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 4,
-   "out_size": 61320,
-   "ratio": 0.1195,
-   "compress_mbps": 65.87,
-   "decompress_mbps": 164.26
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 5,
-   "out_size": 59993,
-   "ratio": 0.1169,
-   "compress_mbps": 57.15,
-   "decompress_mbps": 169.1
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 6,
-   "out_size": 58637,
-   "ratio": 0.1143,
-   "compress_mbps": 41.42,
-   "decompress_mbps": 166.25
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 7,
-   "out_size": 58209,
-   "ratio": 0.1134,
-   "compress_mbps": 35.38,
-   "decompress_mbps": 173.09
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 8,
-   "out_size": 55749,
-   "ratio": 0.1086,
-   "compress_mbps": 19.35,
-   "decompress_mbps": 176.71
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 9,
-   "out_size": 54927,
-   "ratio": 0.107,
-   "compress_mbps": 7.52,
-   "decompress_mbps": 176.17
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 1,
-   "out_size": 16399,
-   "ratio": 0.4288,
-   "compress_mbps": 36.37,
-   "decompress_mbps": 86.67
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 2,
-   "out_size": 15933,
-   "ratio": 0.4167,
-   "compress_mbps": 33.72,
-   "decompress_mbps": 88.83
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 3,
-   "out_size": 15739,
-   "ratio": 0.4116,
-   "compress_mbps": 28.05,
-   "decompress_mbps": 87.94
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 4,
-   "out_size": 13834,
-   "ratio": 0.3618,
-   "compress_mbps": 31.73,
-   "decompress_mbps": 108.86
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 5,
-   "out_size": 13463,
-   "ratio": 0.3521,
-   "compress_mbps": 25.96,
-   "decompress_mbps": 111.56
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 6,
-   "out_size": 13353,
-   "ratio": 0.3492,
-   "compress_mbps": 18.86,
-   "decompress_mbps": 111.15
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 7,
-   "out_size": 13317,
-   "ratio": 0.3482,
-   "compress_mbps": 15.93,
-   "decompress_mbps": 113.26
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 8,
-   "out_size": 13255,
-   "ratio": 0.3466,
-   "compress_mbps": 8.38,
-   "decompress_mbps": 110.11
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 9,
-   "out_size": 13171,
-   "ratio": 0.3444,
-   "compress_mbps": 4.16,
-   "decompress_mbps": 114.39
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 1,
-   "out_size": 2512,
-   "ratio": 0.5943,
-   "compress_mbps": 29.63,
-   "decompress_mbps": 155.88
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 2,
-   "out_size": 2477,
-   "ratio": 0.586,
-   "compress_mbps": 29.51,
-   "decompress_mbps": 158.96
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 3,
-   "out_size": 2452,
-   "ratio": 0.5801,
-   "compress_mbps": 30.37,
-   "decompress_mbps": 157.34
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 4,
-   "out_size": 2110,
-   "ratio": 0.4992,
-   "compress_mbps": 29.99,
-   "decompress_mbps": 162.81
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 5,
-   "out_size": 2086,
-   "ratio": 0.4935,
-   "compress_mbps": 28.87,
-   "decompress_mbps": 169.5
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 6,
-   "out_size": 2086,
-   "ratio": 0.4935,
-   "compress_mbps": 28.86,
-   "decompress_mbps": 167.98
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 7,
-   "out_size": 2086,
-   "ratio": 0.4935,
-   "compress_mbps": 28.5,
-   "decompress_mbps": 169.54
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 8,
-   "out_size": 2086,
-   "ratio": 0.4935,
-   "compress_mbps": 27.54,
-   "decompress_mbps": 169.65
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 9,
-   "out_size": 2086,
-   "ratio": 0.4935,
-   "compress_mbps": 28.63,
-   "decompress_mbps": 169.5
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 1,
-   "out_size": 5183792,
-   "ratio": 0.5086,
-   "compress_mbps": 31.31,
-   "decompress_mbps": 40.47
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 2,
-   "out_size": 4956750,
-   "ratio": 0.4863,
-   "compress_mbps": 29.97,
-   "decompress_mbps": 43.45
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 3,
-   "out_size": 4644095,
-   "ratio": 0.4556,
-   "compress_mbps": 24.06,
-   "decompress_mbps": 47.94
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 4,
-   "out_size": 4178564,
-   "ratio": 0.41,
-   "compress_mbps": 29.06,
-   "decompress_mbps": 61.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 5,
-   "out_size": 4034632,
-   "ratio": 0.3958,
-   "compress_mbps": 19.92,
-   "decompress_mbps": 61.3
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 6,
-   "out_size": 3952244,
-   "ratio": 0.3878,
-   "compress_mbps": 13.83,
-   "decompress_mbps": 61.12
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 7,
-   "out_size": 3938822,
-   "ratio": 0.3864,
-   "compress_mbps": 12.23,
-   "decompress_mbps": 62.83
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 8,
-   "out_size": 3935171,
-   "ratio": 0.3861,
-   "compress_mbps": 10.76,
-   "decompress_mbps": 60.2
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 9,
-   "out_size": 3935171,
-   "ratio": 0.3861,
-   "compress_mbps": 10.72,
-   "decompress_mbps": 60.89
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 1,
-   "out_size": 25320013,
-   "ratio": 0.4943,
-   "compress_mbps": 31.71,
-   "decompress_mbps": 34.88
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 2,
-   "out_size": 24804084,
-   "ratio": 0.4843,
-   "compress_mbps": 30.3,
-   "decompress_mbps": 36.64
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 3,
-   "out_size": 24241121,
-   "ratio": 0.4733,
-   "compress_mbps": 25.73,
-   "decompress_mbps": 37.97
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 4,
-   "out_size": 20950547,
-   "ratio": 0.409,
-   "compress_mbps": 28.84,
-   "decompress_mbps": 44.03
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 5,
-   "out_size": 20592289,
-   "ratio": 0.402,
-   "compress_mbps": 24.29,
-   "decompress_mbps": 46.14
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 6,
-   "out_size": 20445232,
-   "ratio": 0.3992,
-   "compress_mbps": 18.69,
-   "decompress_mbps": 46.11
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 7,
-   "out_size": 20407676,
-   "ratio": 0.3984,
-   "compress_mbps": 15.95,
-   "decompress_mbps": 46.63
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 8,
-   "out_size": 20389473,
-   "ratio": 0.3981,
-   "compress_mbps": 10.13,
-   "decompress_mbps": 45.4
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 9,
-   "out_size": 20386824,
-   "ratio": 0.398,
-   "compress_mbps": 6.82,
-   "decompress_mbps": 46.45
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 1,
-   "out_size": 3964698,
-   "ratio": 0.3976,
-   "compress_mbps": 37.98,
-   "decompress_mbps": 48.02
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 2,
-   "out_size": 3936391,
-   "ratio": 0.3948,
-   "compress_mbps": 35.52,
-   "decompress_mbps": 47.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 3,
-   "out_size": 3823540,
-   "ratio": 0.3835,
-   "compress_mbps": 27.78,
-   "decompress_mbps": 51.72
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 4,
-   "out_size": 3799601,
-   "ratio": 0.3811,
-   "compress_mbps": 33.02,
-   "decompress_mbps": 63.69
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 5,
-   "out_size": 3830938,
-   "ratio": 0.3842,
-   "compress_mbps": 22.58,
-   "decompress_mbps": 58.61
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 6,
-   "out_size": 3808303,
-   "ratio": 0.382,
-   "compress_mbps": 14.79,
-   "decompress_mbps": 57.61
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 7,
-   "out_size": 3802814,
-   "ratio": 0.3814,
-   "compress_mbps": 12.14,
-   "decompress_mbps": 57.87
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 8,
-   "out_size": 3800355,
-   "ratio": 0.3812,
-   "compress_mbps": 6.76,
-   "decompress_mbps": 59.01
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 9,
-   "out_size": 3799676,
-   "ratio": 0.3811,
-   "compress_mbps": 6.05,
-   "decompress_mbps": 59.07
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 1,
-   "out_size": 4899547,
-   "ratio": 0.146,
-   "compress_mbps": 95.3,
-   "decompress_mbps": 131.63
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 2,
-   "out_size": 4587004,
-   "ratio": 0.1367,
-   "compress_mbps": 94.92,
-   "decompress_mbps": 142.96
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 3,
-   "out_size": 4229035,
-   "ratio": 0.126,
-   "compress_mbps": 90.43,
-   "decompress_mbps": 152.33
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 4,
-   "out_size": 3791322,
-   "ratio": 0.113,
-   "compress_mbps": 81.61,
-   "decompress_mbps": 160.66
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 5,
-   "out_size": 3449193,
-   "ratio": 0.1028,
-   "compress_mbps": 72.81,
-   "decompress_mbps": 168.1
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 6,
-   "out_size": 3269452,
-   "ratio": 0.0974,
-   "compress_mbps": 58.66,
-   "decompress_mbps": 173.37
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 7,
-   "out_size": 3211286,
-   "ratio": 0.0957,
-   "compress_mbps": 50.59,
-   "decompress_mbps": 173.62
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 8,
-   "out_size": 3101534,
-   "ratio": 0.0924,
-   "compress_mbps": 27.5,
-   "decompress_mbps": 174.42
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 9,
-   "out_size": 3058177,
-   "ratio": 0.0911,
-   "compress_mbps": 16.6,
-   "decompress_mbps": 177.54
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 1,
-   "out_size": 4024327,
-   "ratio": 0.6541,
-   "compress_mbps": 22.81,
-   "decompress_mbps": 29.95
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 2,
-   "out_size": 3953722,
-   "ratio": 0.6427,
-   "compress_mbps": 21.66,
-   "decompress_mbps": 30.5
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 3,
-   "out_size": 3887921,
-   "ratio": 0.632,
-   "compress_mbps": 18.47,
-   "decompress_mbps": 31.15
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 4,
-   "out_size": 3320440,
-   "ratio": 0.5397,
-   "compress_mbps": 21.3,
-   "decompress_mbps": 37.41
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 5,
-   "out_size": 3279338,
-   "ratio": 0.533,
-   "compress_mbps": 17.83,
-   "decompress_mbps": 38.07
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 6,
-   "out_size": 3254309,
-   "ratio": 0.529,
-   "compress_mbps": 14.0,
-   "decompress_mbps": 37.9
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 7,
-   "out_size": 3250139,
-   "ratio": 0.5283,
-   "compress_mbps": 12.22,
-   "decompress_mbps": 38.09
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 8,
-   "out_size": 3247018,
-   "ratio": 0.5278,
-   "compress_mbps": 10.17,
-   "decompress_mbps": 38.03
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 9,
-   "out_size": 3246865,
-   "ratio": 0.5278,
-   "compress_mbps": 9.51,
-   "decompress_mbps": 38.0
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 1,
-   "out_size": 4471091,
-   "ratio": 0.4433,
-   "compress_mbps": 34.91,
-   "decompress_mbps": 69.94
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 2,
-   "out_size": 4372105,
-   "ratio": 0.4335,
-   "compress_mbps": 33.82,
-   "decompress_mbps": 71.85
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 3,
-   "out_size": 4305270,
-   "ratio": 0.4269,
-   "compress_mbps": 30.7,
-   "decompress_mbps": 73.16
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 4,
-   "out_size": 3920495,
-   "ratio": 0.3887,
-   "compress_mbps": 30.3,
-   "decompress_mbps": 64.84
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 5,
-   "out_size": 3853177,
-   "ratio": 0.382,
-   "compress_mbps": 26.63,
-   "decompress_mbps": 63.95
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 6,
-   "out_size": 3780878,
-   "ratio": 0.3749,
-   "compress_mbps": 23.38,
-   "decompress_mbps": 64.31
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 7,
-   "out_size": 3763880,
-   "ratio": 0.3732,
-   "compress_mbps": 20.2,
-   "decompress_mbps": 72.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 8,
-   "out_size": 3757719,
-   "ratio": 0.3726,
-   "compress_mbps": 18.3,
-   "decompress_mbps": 73.42
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 9,
-   "out_size": 3757719,
-   "ratio": 0.3726,
-   "compress_mbps": 18.25,
-   "decompress_mbps": 72.55
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 1,
-   "out_size": 2722387,
-   "ratio": 0.4108,
-   "compress_mbps": 38.01,
-   "decompress_mbps": 64.73
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 2,
-   "out_size": 2572544,
-   "ratio": 0.3882,
-   "compress_mbps": 36.87,
-   "decompress_mbps": 70.55
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 3,
-   "out_size": 2384328,
-   "ratio": 0.3598,
-   "compress_mbps": 29.15,
-   "decompress_mbps": 78.64
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 4,
-   "out_size": 2112060,
-   "ratio": 0.3187,
-   "compress_mbps": 36.42,
-   "decompress_mbps": 85.62
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 5,
-   "out_size": 1991581,
-   "ratio": 0.3005,
-   "compress_mbps": 25.34,
-   "decompress_mbps": 91.01
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 6,
-   "out_size": 1917866,
-   "ratio": 0.2894,
-   "compress_mbps": 15.03,
-   "decompress_mbps": 90.85
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 7,
-   "out_size": 1895353,
-   "ratio": 0.286,
-   "compress_mbps": 11.08,
-   "decompress_mbps": 90.48
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 8,
-   "out_size": 1880740,
-   "ratio": 0.2838,
-   "compress_mbps": 5.59,
-   "decompress_mbps": 90.95
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 9,
-   "out_size": 1880711,
-   "ratio": 0.2838,
-   "compress_mbps": 5.56,
-   "decompress_mbps": 92.3
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 1,
-   "out_size": 7441483,
-   "ratio": 0.3444,
-   "compress_mbps": 43.78,
-   "decompress_mbps": 66.88
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 2,
-   "out_size": 7229248,
-   "ratio": 0.3346,
-   "compress_mbps": 43.14,
-   "decompress_mbps": 69.03
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 3,
-   "out_size": 7083451,
-   "ratio": 0.3278,
-   "compress_mbps": 38.92,
-   "decompress_mbps": 71.31
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 4,
-   "out_size": 6189639,
-   "ratio": 0.2865,
-   "compress_mbps": 42.2,
-   "decompress_mbps": 92.76
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 5,
-   "out_size": 6053058,
-   "ratio": 0.2802,
-   "compress_mbps": 35.08,
-   "decompress_mbps": 96.18
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 6,
-   "out_size": 5988137,
-   "ratio": 0.2771,
-   "compress_mbps": 28.51,
-   "decompress_mbps": 101.1
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 7,
-   "out_size": 5949908,
-   "ratio": 0.2754,
-   "compress_mbps": 25.19,
-   "decompress_mbps": 103.3
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 8,
-   "out_size": 5936656,
-   "ratio": 0.2748,
-   "compress_mbps": 19.22,
-   "decompress_mbps": 106.46
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 9,
-   "out_size": 5934701,
-   "ratio": 0.2747,
-   "compress_mbps": 17.98,
-   "decompress_mbps": 105.25
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 1,
-   "out_size": 6335542,
-   "ratio": 0.8736,
-   "compress_mbps": 18.44,
-   "decompress_mbps": 31.75
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 2,
-   "out_size": 6247260,
-   "ratio": 0.8615,
-   "compress_mbps": 17.59,
-   "decompress_mbps": 48.2
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 3,
-   "out_size": 6064713,
-   "ratio": 0.8363,
-   "compress_mbps": 15.15,
-   "decompress_mbps": 56.49
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 4,
-   "out_size": 5568111,
-   "ratio": 0.7678,
-   "compress_mbps": 17.55,
-   "decompress_mbps": 58.99
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 5,
-   "out_size": 5544524,
-   "ratio": 0.7646,
-   "compress_mbps": 14.42,
-   "decompress_mbps": 64.88
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 6,
-   "out_size": 5513056,
-   "ratio": 0.7602,
-   "compress_mbps": 11.94,
-   "decompress_mbps": 62.87
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 7,
-   "out_size": 5508915,
-   "ratio": 0.7596,
-   "compress_mbps": 11.32,
-   "decompress_mbps": 64.42
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 8,
-   "out_size": 5508365,
-   "ratio": 0.7596,
-   "compress_mbps": 10.52,
-   "decompress_mbps": 65.26
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 9,
-   "out_size": 5508365,
-   "ratio": 0.7596,
-   "compress_mbps": 10.57,
-   "decompress_mbps": 64.3
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 1,
-   "out_size": 16776095,
-   "ratio": 0.4046,
-   "compress_mbps": 37.73,
-   "decompress_mbps": 50.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 2,
-   "out_size": 16032651,
-   "ratio": 0.3867,
-   "compress_mbps": 36.24,
-   "decompress_mbps": 54.65
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 3,
-   "out_size": 15180334,
-   "ratio": 0.3662,
-   "compress_mbps": 31.28,
-   "decompress_mbps": 51.85
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 4,
-   "out_size": 13261924,
-   "ratio": 0.3199,
-   "compress_mbps": 35.24,
-   "decompress_mbps": 68.67
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 5,
-   "out_size": 12706028,
-   "ratio": 0.3065,
-   "compress_mbps": 27.63,
-   "decompress_mbps": 70.4
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 6,
-   "out_size": 12464158,
-   "ratio": 0.3006,
-   "compress_mbps": 21.0,
-   "decompress_mbps": 70.64
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 7,
-   "out_size": 12375954,
-   "ratio": 0.2985,
-   "compress_mbps": 18.31,
-   "decompress_mbps": 73.55
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 8,
-   "out_size": 12321552,
-   "ratio": 0.2972,
-   "compress_mbps": 14.45,
-   "decompress_mbps": 70.76
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 9,
-   "out_size": 12320276,
-   "ratio": 0.2972,
-   "compress_mbps": 14.41,
-   "decompress_mbps": 70.34
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 1,
-   "out_size": 6799201,
-   "ratio": 0.8023,
-   "compress_mbps": 18.34,
-   "decompress_mbps": 18.29
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 2,
-   "out_size": 6800500,
-   "ratio": 0.8025,
-   "compress_mbps": 16.95,
-   "decompress_mbps": 18.49
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 3,
-   "out_size": 6803212,
-   "ratio": 0.8028,
-   "compress_mbps": 14.91,
-   "decompress_mbps": 18.44
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 4,
-   "out_size": 6264611,
-   "ratio": 0.7393,
-   "compress_mbps": 17.32,
-   "decompress_mbps": 24.91
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 5,
-   "out_size": 6217901,
-   "ratio": 0.7337,
-   "compress_mbps": 15.76,
-   "decompress_mbps": 25.36
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 6,
-   "out_size": 6201999,
-   "ratio": 0.7319,
-   "compress_mbps": 15.32,
-   "decompress_mbps": 25.35
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 7,
-   "out_size": 6201883,
-   "ratio": 0.7319,
-   "compress_mbps": 15.24,
-   "decompress_mbps": 25.06
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 8,
-   "out_size": 6201887,
-   "ratio": 0.7319,
-   "compress_mbps": 15.22,
-   "decompress_mbps": 24.94
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 9,
-   "out_size": 6201887,
-   "ratio": 0.7319,
-   "compress_mbps": 15.3,
-   "decompress_mbps": 24.93
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 1,
-   "out_size": 1081679,
-   "ratio": 0.2024,
-   "compress_mbps": 74.26,
-   "decompress_mbps": 106.26
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 2,
-   "out_size": 1001890,
-   "ratio": 0.1874,
-   "compress_mbps": 74.05,
-   "decompress_mbps": 118.21
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 3,
-   "out_size": 921722,
-   "ratio": 0.1724,
-   "compress_mbps": 67.22,
-   "decompress_mbps": 127.75
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 4,
-   "out_size": 849263,
-   "ratio": 0.1589,
-   "compress_mbps": 64.23,
-   "decompress_mbps": 142.53
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 5,
-   "out_size": 771964,
-   "ratio": 0.1444,
-   "compress_mbps": 54.81,
-   "decompress_mbps": 144.22
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 6,
-   "out_size": 728098,
-   "ratio": 0.1362,
-   "compress_mbps": 43.49,
-   "decompress_mbps": 150.41
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 7,
-   "out_size": 713635,
-   "ratio": 0.1335,
-   "compress_mbps": 37.23,
-   "decompress_mbps": 154.84
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 8,
-   "out_size": 699093,
-   "ratio": 0.1308,
-   "compress_mbps": 27.08,
-   "decompress_mbps": 146.56
-  },
-  {
-   "compressor": "ocaml",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 9,
-   "out_size": 698459,
-   "ratio": 0.1307,
-   "compress_mbps": 25.17,
-   "decompress_mbps": 148.81
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 10,
-   "out_size": 51721,
-   "ratio": 0.3401,
-   "compress_mbps": 12.25,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 11,
-   "out_size": 51662,
-   "ratio": 0.3397,
-   "compress_mbps": 8.43,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 12,
-   "out_size": 51662,
-   "ratio": 0.3397,
-   "compress_mbps": 5.17,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 10,
-   "out_size": 46657,
-   "ratio": 0.3727,
-   "compress_mbps": 13.72,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 11,
-   "out_size": 46515,
-   "ratio": 0.3716,
-   "compress_mbps": 9.35,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 12,
-   "out_size": 46469,
-   "ratio": 0.3712,
-   "compress_mbps": 7.14,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 10,
-   "out_size": 7725,
-   "ratio": 0.314,
-   "compress_mbps": 15.97,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 11,
-   "out_size": 7727,
-   "ratio": 0.3141,
-   "compress_mbps": 10.79,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 12,
-   "out_size": 7723,
-   "ratio": 0.3139,
-   "compress_mbps": 7.17,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 10,
-   "out_size": 3026,
-   "ratio": 0.2714,
-   "compress_mbps": 17.74,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 11,
-   "out_size": 3024,
-   "ratio": 0.2712,
-   "compress_mbps": 14.13,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 12,
-   "out_size": 3024,
-   "ratio": 0.2712,
-   "compress_mbps": 10.64,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 10,
-   "out_size": 1186,
-   "ratio": 0.3187,
-   "compress_mbps": 41.49,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 11,
-   "out_size": 1186,
-   "ratio": 0.3187,
-   "compress_mbps": 33.55,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 12,
-   "out_size": 1186,
-   "ratio": 0.3187,
-   "compress_mbps": 24.35,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 10,
-   "out_size": 179347,
-   "ratio": 0.1742,
-   "compress_mbps": 30.91,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 11,
-   "out_size": 179096,
-   "ratio": 0.1739,
-   "compress_mbps": 20.04,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 12,
-   "out_size": 179049,
-   "ratio": 0.1739,
-   "compress_mbps": 15.47,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 10,
-   "out_size": 138116,
-   "ratio": 0.3236,
-   "compress_mbps": 12.77,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 11,
-   "out_size": 137923,
-   "ratio": 0.3232,
-   "compress_mbps": 8.78,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 12,
-   "out_size": 137921,
-   "ratio": 0.3232,
-   "compress_mbps": 7.43,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 10,
-   "out_size": 185328,
-   "ratio": 0.3846,
-   "compress_mbps": 12.88,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 11,
-   "out_size": 184440,
-   "ratio": 0.3828,
-   "compress_mbps": 9.1,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 12,
-   "out_size": 184371,
-   "ratio": 0.3826,
-   "compress_mbps": 5.56,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 10,
-   "out_size": 51319,
-   "ratio": 0.1,
-   "compress_mbps": 12.87,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 11,
-   "out_size": 49675,
-   "ratio": 0.0968,
-   "compress_mbps": 6.13,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 12,
-   "out_size": 49194,
-   "ratio": 0.0959,
-   "compress_mbps": 3.65,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 10,
-   "out_size": 11975,
-   "ratio": 0.3132,
-   "compress_mbps": 20.05,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 11,
-   "out_size": 11966,
-   "ratio": 0.3129,
-   "compress_mbps": 13.4,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 12,
-   "out_size": 11965,
-   "ratio": 0.3129,
-   "compress_mbps": 10.77,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 10,
-   "out_size": 1692,
-   "ratio": 0.4003,
-   "compress_mbps": 54.22,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 11,
-   "out_size": 1690,
-   "ratio": 0.3998,
-   "compress_mbps": 45.3,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 12,
-   "out_size": 1690,
-   "ratio": 0.3998,
-   "compress_mbps": 29.74,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 10,
-   "out_size": 3681797,
-   "ratio": 0.3612,
-   "compress_mbps": 12.62,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 11,
-   "out_size": 3679289,
-   "ratio": 0.361,
-   "compress_mbps": 9.26,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 12,
-   "out_size": 3679105,
-   "ratio": 0.361,
-   "compress_mbps": 7.67,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 10,
-   "out_size": 18268811,
-   "ratio": 0.3567,
-   "compress_mbps": 16.35,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 11,
-   "out_size": 18245674,
-   "ratio": 0.3562,
-   "compress_mbps": 11.71,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 12,
-   "out_size": 18241312,
-   "ratio": 0.3561,
-   "compress_mbps": 9.35,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 10,
-   "out_size": 3461494,
-   "ratio": 0.3472,
-   "compress_mbps": 18.28,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 11,
-   "out_size": 3446053,
-   "ratio": 0.3456,
-   "compress_mbps": 10.54,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 12,
-   "out_size": 3447985,
-   "ratio": 0.3458,
-   "compress_mbps": 5.38,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 10,
-   "out_size": 2782465,
-   "ratio": 0.0829,
-   "compress_mbps": 8.49,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 11,
-   "out_size": 2751857,
-   "ratio": 0.082,
-   "compress_mbps": 5.54,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 12,
-   "out_size": 2748273,
-   "ratio": 0.0819,
-   "compress_mbps": 4.07,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 10,
-   "out_size": 2995902,
-   "ratio": 0.487,
-   "compress_mbps": 19.22,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 11,
-   "out_size": 2994386,
-   "ratio": 0.4867,
-   "compress_mbps": 14.58,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 12,
-   "out_size": 2994086,
-   "ratio": 0.4867,
-   "compress_mbps": 12.48,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 10,
-   "out_size": 3608746,
-   "ratio": 0.3578,
-   "compress_mbps": 19.08,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 11,
-   "out_size": 3608161,
-   "ratio": 0.3578,
-   "compress_mbps": 14.81,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 12,
-   "out_size": 3608138,
-   "ratio": 0.3577,
-   "compress_mbps": 13.22,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 10,
-   "out_size": 1697693,
-   "ratio": 0.2562,
-   "compress_mbps": 8.9,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 11,
-   "out_size": 1696742,
-   "ratio": 0.256,
-   "compress_mbps": 6.68,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 12,
-   "out_size": 1696488,
-   "ratio": 0.256,
-   "compress_mbps": 5.74,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 10,
-   "out_size": 5137640,
-   "ratio": 0.2378,
-   "compress_mbps": 16.05,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 11,
-   "out_size": 5122694,
-   "ratio": 0.2371,
-   "compress_mbps": 9.68,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 12,
-   "out_size": 5118130,
-   "ratio": 0.2369,
-   "compress_mbps": 7.0,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 10,
-   "out_size": 5250862,
-   "ratio": 0.7241,
-   "compress_mbps": 25.53,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 11,
-   "out_size": 5250747,
-   "ratio": 0.724,
-   "compress_mbps": 20.83,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 12,
-   "out_size": 5250745,
-   "ratio": 0.724,
-   "compress_mbps": 19.39,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 10,
-   "out_size": 11526846,
-   "ratio": 0.278,
-   "compress_mbps": 10.51,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 11,
-   "out_size": 11520969,
-   "ratio": 0.2779,
-   "compress_mbps": 7.08,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 12,
-   "out_size": 11520871,
-   "ratio": 0.2779,
-   "compress_mbps": 6.12,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 10,
-   "out_size": 5748096,
-   "ratio": 0.6783,
-   "compress_mbps": 38.25,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 11,
-   "out_size": 5747172,
-   "ratio": 0.6782,
-   "compress_mbps": 29.45,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 12,
-   "out_size": 5747146,
-   "ratio": 0.6782,
-   "compress_mbps": 26.58,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 10,
-   "out_size": 637425,
-   "ratio": 0.1193,
-   "compress_mbps": 12.15,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 11,
-   "out_size": 630827,
-   "ratio": 0.118,
-   "compress_mbps": 7.32,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "libdeflate",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 12,
-   "out_size": 629349,
-   "ratio": 0.1177,
-   "compress_mbps": 4.73,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/alice29.txt",
-   "size": 152089,
-   "level": 10,
-   "out_size": 52078,
-   "ratio": 0.3424,
-   "compress_mbps": 2.25,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/asyoulik.txt",
-   "size": 125179,
-   "level": 10,
-   "out_size": 46865,
-   "ratio": 0.3744,
-   "compress_mbps": 2.63,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/cp.html",
-   "size": 24603,
-   "level": 10,
-   "out_size": 7737,
-   "ratio": 0.3145,
-   "compress_mbps": 2.63,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/fields.c",
-   "size": 11150,
-   "level": 10,
-   "out_size": 3032,
-   "ratio": 0.2719,
-   "compress_mbps": 2.58,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/grammar.lsp",
-   "size": 3721,
-   "level": 10,
-   "out_size": 1191,
-   "ratio": 0.3201,
-   "compress_mbps": 2.16,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/kennedy.xls",
-   "size": 1029744,
-   "level": 10,
-   "out_size": 178067,
-   "ratio": 0.1729,
-   "compress_mbps": 1.31,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/lcet10.txt",
-   "size": 426754,
-   "level": 10,
-   "out_size": 138830,
-   "ratio": 0.3253,
-   "compress_mbps": 2.36,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/plrabn12.txt",
-   "size": 481861,
-   "level": 10,
-   "out_size": 186147,
-   "ratio": 0.3863,
-   "compress_mbps": 2.3,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/ptt5",
-   "size": 513216,
-   "level": 10,
-   "out_size": 52234,
-   "ratio": 0.1018,
-   "compress_mbps": 3.33,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/sum",
-   "size": 38240,
-   "level": 10,
-   "out_size": 12274,
-   "ratio": 0.321,
-   "compress_mbps": 2.53,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "canterbury/xargs.1",
-   "size": 4227,
-   "level": 10,
-   "out_size": 1693,
-   "ratio": 0.4005,
-   "compress_mbps": 2.47,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/dickens",
-   "size": 10192446,
-   "level": 10,
-   "out_size": 3711172,
-   "ratio": 0.3641,
-   "compress_mbps": 2.32,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mozilla",
-   "size": 51220480,
-   "level": 10,
-   "out_size": 18539905,
-   "ratio": 0.362,
-   "compress_mbps": 2.09,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/mr",
-   "size": 9970564,
-   "level": 10,
-   "out_size": 3512886,
-   "ratio": 0.3523,
-   "compress_mbps": 2.62,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/nci",
-   "size": 33553445,
-   "level": 10,
-   "out_size": 2902186,
-   "ratio": 0.0865,
-   "compress_mbps": 1.84,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/ooffice",
-   "size": 6152192,
-   "level": 10,
-   "out_size": 3021986,
-   "ratio": 0.4912,
-   "compress_mbps": 2.86,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/osdb",
-   "size": 10085684,
-   "level": 10,
-   "out_size": 3647321,
-   "ratio": 0.3616,
-   "compress_mbps": 3.07,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/reymont",
-   "size": 6627202,
-   "level": 10,
-   "out_size": 1718500,
-   "ratio": 0.2593,
-   "compress_mbps": 1.49,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/samba",
-   "size": 21606400,
-   "level": 10,
-   "out_size": 5177560,
-   "ratio": 0.2396,
-   "compress_mbps": 2.4,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/sao",
-   "size": 7251944,
-   "level": 10,
-   "out_size": 5262319,
-   "ratio": 0.7256,
-   "compress_mbps": 3.14,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/webster",
-   "size": 41458703,
-   "level": 10,
-   "out_size": 11636727,
-   "ratio": 0.2807,
-   "compress_mbps": 1.92,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/x-ray",
-   "size": 8474240,
-   "level": 10,
-   "out_size": 5848663,
-   "ratio": 0.6902,
-   "compress_mbps": 3.77,
-   "decompress_mbps": null
-  },
-  {
-   "compressor": "native",
-   "pattern": "silesia/xml",
-   "size": 5345280,
-   "level": 10,
-   "out_size": 643093,
-   "ratio": 0.1203,
-   "compress_mbps": 2.84,
-   "decompress_mbps": null
-  }
- ]
+"meta": {
+"date": "2026-07-05T22:33:53Z",
+"machine": "Linux chungus2 x86_64",
+"git_commit": "9c93b270",
+"toolchain": "leanprover/lean4:v4.30.0-rc2",
+"note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
+},
+"results": [
+{
+"compressor": "native",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 1,
+"out_size": 60455,
+"ratio": 0.3975,
+"compress_mbps": 63.67,
+"decompress_mbps": 112.38
+},
+{
+"compressor": "native",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 2,
+"out_size": 56316,
+"ratio": 0.3703,
+"compress_mbps": 46.82,
+"decompress_mbps": 124.69
+},
+{
+"compressor": "native",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 3,
+"out_size": 55646,
+"ratio": 0.3659,
+"compress_mbps": 41.97,
+"decompress_mbps": 135.62
+},
+{
+"compressor": "native",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 4,
+"out_size": 54681,
+"ratio": 0.3595,
+"compress_mbps": 31.2,
+"decompress_mbps": 138.97
+},
+{
+"compressor": "native",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 5,
+"out_size": 54437,
+"ratio": 0.3579,
+"compress_mbps": 24.77,
+"decompress_mbps": 146.05
+},
+{
+"compressor": "native",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 6,
+"out_size": 54348,
+"ratio": 0.3573,
+"compress_mbps": 21.99,
+"decompress_mbps": 150.55
+},
+{
+"compressor": "native",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 7,
+"out_size": 54140,
+"ratio": 0.356,
+"compress_mbps": 19.14,
+"decompress_mbps": 151.01
+},
+{
+"compressor": "native",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 8,
+"out_size": 54127,
+"ratio": 0.3559,
+"compress_mbps": 18.6,
+"decompress_mbps": 152.26
+},
+{
+"compressor": "native",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 9,
+"out_size": 52732,
+"ratio": 0.3467,
+"compress_mbps": 4.05,
+"decompress_mbps": 152.01
+},
+{
+"compressor": "native",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 10,
+"out_size": 52078,
+"ratio": 0.3424,
+"compress_mbps": 2.27,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 1,
+"out_size": 53135,
+"ratio": 0.4245,
+"compress_mbps": 57.42,
+"decompress_mbps": 106.1
+},
+{
+"compressor": "native",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 2,
+"out_size": 50187,
+"ratio": 0.4009,
+"compress_mbps": 43.34,
+"decompress_mbps": 113.72
+},
+{
+"compressor": "native",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 3,
+"out_size": 49810,
+"ratio": 0.3979,
+"compress_mbps": 39.39,
+"decompress_mbps": 122.12
+},
+{
+"compressor": "native",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 4,
+"out_size": 48992,
+"ratio": 0.3914,
+"compress_mbps": 29.15,
+"decompress_mbps": 126.22
+},
+{
+"compressor": "native",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 5,
+"out_size": 48891,
+"ratio": 0.3906,
+"compress_mbps": 25.19,
+"decompress_mbps": 131.56
+},
+{
+"compressor": "native",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 6,
+"out_size": 48715,
+"ratio": 0.3892,
+"compress_mbps": 20.89,
+"decompress_mbps": 135.46
+},
+{
+"compressor": "native",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 7,
+"out_size": 48634,
+"ratio": 0.3885,
+"compress_mbps": 19.59,
+"decompress_mbps": 137.08
+},
+{
+"compressor": "native",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 8,
+"out_size": 48634,
+"ratio": 0.3885,
+"compress_mbps": 19.61,
+"decompress_mbps": 137.01
+},
+{
+"compressor": "native",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 9,
+"out_size": 47430,
+"ratio": 0.3789,
+"compress_mbps": 4.33,
+"decompress_mbps": 137.25
+},
+{
+"compressor": "native",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 10,
+"out_size": 46865,
+"ratio": 0.3744,
+"compress_mbps": 2.63,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 1,
+"out_size": 8476,
+"ratio": 0.3445,
+"compress_mbps": 42.87,
+"decompress_mbps": 125.49
+},
+{
+"compressor": "native",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 2,
+"out_size": 8271,
+"ratio": 0.3362,
+"compress_mbps": 37.58,
+"decompress_mbps": 129.87
+},
+{
+"compressor": "native",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 3,
+"out_size": 8158,
+"ratio": 0.3316,
+"compress_mbps": 36.88,
+"decompress_mbps": 132.48
+},
+{
+"compressor": "native",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 4,
+"out_size": 7961,
+"ratio": 0.3236,
+"compress_mbps": 32.91,
+"decompress_mbps": 138.56
+},
+{
+"compressor": "native",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 5,
+"out_size": 7932,
+"ratio": 0.3224,
+"compress_mbps": 28.44,
+"decompress_mbps": 142.6
+},
+{
+"compressor": "native",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 6,
+"out_size": 7938,
+"ratio": 0.3226,
+"compress_mbps": 24.51,
+"decompress_mbps": 144.23
+},
+{
+"compressor": "native",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 7,
+"out_size": 7929,
+"ratio": 0.3223,
+"compress_mbps": 23.44,
+"decompress_mbps": 146.19
+},
+{
+"compressor": "native",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 8,
+"out_size": 7929,
+"ratio": 0.3223,
+"compress_mbps": 23.44,
+"decompress_mbps": 146.05
+},
+{
+"compressor": "native",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 9,
+"out_size": 7803,
+"ratio": 0.3172,
+"compress_mbps": 4.42,
+"decompress_mbps": 146.11
+},
+{
+"compressor": "native",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 10,
+"out_size": 7737,
+"ratio": 0.3145,
+"compress_mbps": 2.66,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 1,
+"out_size": 3509,
+"ratio": 0.3147,
+"compress_mbps": 27.46,
+"decompress_mbps": 100.21
+},
+{
+"compressor": "native",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 2,
+"out_size": 3269,
+"ratio": 0.2932,
+"compress_mbps": 25.4,
+"decompress_mbps": 103.22
+},
+{
+"compressor": "native",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 3,
+"out_size": 3208,
+"ratio": 0.2877,
+"compress_mbps": 24.76,
+"decompress_mbps": 106.62
+},
+{
+"compressor": "native",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 4,
+"out_size": 3141,
+"ratio": 0.2817,
+"compress_mbps": 23.23,
+"decompress_mbps": 108.88
+},
+{
+"compressor": "native",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 5,
+"out_size": 3128,
+"ratio": 0.2805,
+"compress_mbps": 21.3,
+"decompress_mbps": 110.97
+},
+{
+"compressor": "native",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 6,
+"out_size": 3135,
+"ratio": 0.2812,
+"compress_mbps": 19.33,
+"decompress_mbps": 111.89
+},
+{
+"compressor": "native",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 7,
+"out_size": 3128,
+"ratio": 0.2805,
+"compress_mbps": 18.73,
+"decompress_mbps": 111.97
+},
+{
+"compressor": "native",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 8,
+"out_size": 3128,
+"ratio": 0.2805,
+"compress_mbps": 18.68,
+"decompress_mbps": 111.89
+},
+{
+"compressor": "native",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 9,
+"out_size": 3056,
+"ratio": 0.2741,
+"compress_mbps": 4.48,
+"decompress_mbps": 111.93
+},
+{
+"compressor": "native",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 10,
+"out_size": 3032,
+"ratio": 0.2719,
+"compress_mbps": 2.59,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 1,
+"out_size": 1282,
+"ratio": 0.3445,
+"compress_mbps": 12.81,
+"decompress_mbps": 56.78
+},
+{
+"compressor": "native",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 2,
+"out_size": 1225,
+"ratio": 0.3292,
+"compress_mbps": 12.43,
+"decompress_mbps": 57.55
+},
+{
+"compressor": "native",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 3,
+"out_size": 1220,
+"ratio": 0.3279,
+"compress_mbps": 12.3,
+"decompress_mbps": 57.59
+},
+{
+"compressor": "native",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 4,
+"out_size": 1213,
+"ratio": 0.326,
+"compress_mbps": 12.16,
+"decompress_mbps": 58.63
+},
+{
+"compressor": "native",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 5,
+"out_size": 1209,
+"ratio": 0.3249,
+"compress_mbps": 11.8,
+"decompress_mbps": 59.12
+},
+{
+"compressor": "native",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 6,
+"out_size": 1209,
+"ratio": 0.3249,
+"compress_mbps": 10.69,
+"decompress_mbps": 59.14
+},
+{
+"compressor": "native",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 7,
+"out_size": 1209,
+"ratio": 0.3249,
+"compress_mbps": 10.67,
+"decompress_mbps": 58.9
+},
+{
+"compressor": "native",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 8,
+"out_size": 1209,
+"ratio": 0.3249,
+"compress_mbps": 10.65,
+"decompress_mbps": 59.05
+},
+{
+"compressor": "native",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 9,
+"out_size": 1205,
+"ratio": 0.3238,
+"compress_mbps": 3.5,
+"decompress_mbps": 59.28
+},
+{
+"compressor": "native",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 10,
+"out_size": 1191,
+"ratio": 0.3201,
+"compress_mbps": 2.15,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 1,
+"out_size": 251793,
+"ratio": 0.2445,
+"compress_mbps": 123.04,
+"decompress_mbps": 209.63
+},
+{
+"compressor": "native",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 2,
+"out_size": 242565,
+"ratio": 0.2356,
+"compress_mbps": 87.16,
+"decompress_mbps": 223.82
+},
+{
+"compressor": "native",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 3,
+"out_size": 242532,
+"ratio": 0.2355,
+"compress_mbps": 74.73,
+"decompress_mbps": 233.6
+},
+{
+"compressor": "native",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 4,
+"out_size": 239804,
+"ratio": 0.2329,
+"compress_mbps": 69.36,
+"decompress_mbps": 240.04
+},
+{
+"compressor": "native",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 5,
+"out_size": 215530,
+"ratio": 0.2093,
+"compress_mbps": 39.5,
+"decompress_mbps": 236.55
+},
+{
+"compressor": "native",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 6,
+"out_size": 201414,
+"ratio": 0.1956,
+"compress_mbps": 22.6,
+"decompress_mbps": 242.79
+},
+{
+"compressor": "native",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 7,
+"out_size": 200711,
+"ratio": 0.1949,
+"compress_mbps": 16.19,
+"decompress_mbps": 245.92
+},
+{
+"compressor": "native",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 8,
+"out_size": 200719,
+"ratio": 0.1949,
+"compress_mbps": 12.13,
+"decompress_mbps": 248.68
+},
+{
+"compressor": "native",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 9,
+"out_size": 182508,
+"ratio": 0.1772,
+"compress_mbps": 2.9,
+"decompress_mbps": 250.04
+},
+{
+"compressor": "native",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 10,
+"out_size": 178067,
+"ratio": 0.1729,
+"compress_mbps": 1.32,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 1,
+"out_size": 160674,
+"ratio": 0.3765,
+"compress_mbps": 71.7,
+"decompress_mbps": 120.26
+},
+{
+"compressor": "native",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 2,
+"out_size": 149787,
+"ratio": 0.351,
+"compress_mbps": 51.4,
+"decompress_mbps": 129.5
+},
+{
+"compressor": "native",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 3,
+"out_size": 148055,
+"ratio": 0.3469,
+"compress_mbps": 45.78,
+"decompress_mbps": 142.25
+},
+{
+"compressor": "native",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 4,
+"out_size": 145631,
+"ratio": 0.3413,
+"compress_mbps": 34.03,
+"decompress_mbps": 147.4
+},
+{
+"compressor": "native",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 5,
+"out_size": 145321,
+"ratio": 0.3405,
+"compress_mbps": 27.66,
+"decompress_mbps": 154.44
+},
+{
+"compressor": "native",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 6,
+"out_size": 145046,
+"ratio": 0.3399,
+"compress_mbps": 23.76,
+"decompress_mbps": 158.09
+},
+{
+"compressor": "native",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 7,
+"out_size": 144554,
+"ratio": 0.3387,
+"compress_mbps": 21.1,
+"decompress_mbps": 158.84
+},
+{
+"compressor": "native",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 8,
+"out_size": 144540,
+"ratio": 0.3387,
+"compress_mbps": 20.66,
+"decompress_mbps": 159.22
+},
+{
+"compressor": "native",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 9,
+"out_size": 140322,
+"ratio": 0.3288,
+"compress_mbps": 4.0,
+"decompress_mbps": 159.35
+},
+{
+"compressor": "native",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 10,
+"out_size": 138830,
+"ratio": 0.3253,
+"compress_mbps": 2.36,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 1,
+"out_size": 212588,
+"ratio": 0.4412,
+"compress_mbps": 61.23,
+"decompress_mbps": 100.12
+},
+{
+"compressor": "native",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 2,
+"out_size": 199981,
+"ratio": 0.415,
+"compress_mbps": 44.09,
+"decompress_mbps": 109.01
+},
+{
+"compressor": "native",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 3,
+"out_size": 198551,
+"ratio": 0.4121,
+"compress_mbps": 39.06,
+"decompress_mbps": 119.07
+},
+{
+"compressor": "native",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 4,
+"out_size": 195460,
+"ratio": 0.4056,
+"compress_mbps": 26.52,
+"decompress_mbps": 122.98
+},
+{
+"compressor": "native",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 5,
+"out_size": 194902,
+"ratio": 0.4045,
+"compress_mbps": 22.31,
+"decompress_mbps": 129.17
+},
+{
+"compressor": "native",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 6,
+"out_size": 195177,
+"ratio": 0.405,
+"compress_mbps": 20.64,
+"decompress_mbps": 132.65
+},
+{
+"compressor": "native",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 7,
+"out_size": 194385,
+"ratio": 0.4034,
+"compress_mbps": 18.19,
+"decompress_mbps": 133.19
+},
+{
+"compressor": "native",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 8,
+"out_size": 194380,
+"ratio": 0.4034,
+"compress_mbps": 18.07,
+"decompress_mbps": 133.44
+},
+{
+"compressor": "native",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 9,
+"out_size": 189365,
+"ratio": 0.393,
+"compress_mbps": 3.87,
+"decompress_mbps": 134.0
+},
+{
+"compressor": "native",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 10,
+"out_size": 186147,
+"ratio": 0.3863,
+"compress_mbps": 2.32,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 1,
+"out_size": 60161,
+"ratio": 0.1172,
+"compress_mbps": 181.49,
+"decompress_mbps": 344.42
+},
+{
+"compressor": "native",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 2,
+"out_size": 58873,
+"ratio": 0.1147,
+"compress_mbps": 138.62,
+"decompress_mbps": 358.66
+},
+{
+"compressor": "native",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 3,
+"out_size": 58327,
+"ratio": 0.1137,
+"compress_mbps": 120.91,
+"decompress_mbps": 383.77
+},
+{
+"compressor": "native",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 4,
+"out_size": 55673,
+"ratio": 0.1085,
+"compress_mbps": 83.15,
+"decompress_mbps": 356.0
+},
+{
+"compressor": "native",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 5,
+"out_size": 54950,
+"ratio": 0.1071,
+"compress_mbps": 57.89,
+"decompress_mbps": 378.91
+},
+{
+"compressor": "native",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 6,
+"out_size": 55259,
+"ratio": 0.1077,
+"compress_mbps": 39.05,
+"decompress_mbps": 408.03
+},
+{
+"compressor": "native",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 7,
+"out_size": 53713,
+"ratio": 0.1047,
+"compress_mbps": 29.64,
+"decompress_mbps": 430.78
+},
+{
+"compressor": "native",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 8,
+"out_size": 52897,
+"ratio": 0.1031,
+"compress_mbps": 25.45,
+"decompress_mbps": 461.18
+},
+{
+"compressor": "native",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 9,
+"out_size": 52729,
+"ratio": 0.1027,
+"compress_mbps": 5.0,
+"decompress_mbps": 474.03
+},
+{
+"compressor": "native",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 10,
+"out_size": 52234,
+"ratio": 0.1018,
+"compress_mbps": 3.33,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 1,
+"out_size": 14249,
+"ratio": 0.3726,
+"compress_mbps": 31.42,
+"decompress_mbps": 114.62
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 2,
+"out_size": 13825,
+"ratio": 0.3615,
+"compress_mbps": 28.82,
+"decompress_mbps": 117.1
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 3,
+"out_size": 13751,
+"ratio": 0.3596,
+"compress_mbps": 28.14,
+"decompress_mbps": 118.31
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 4,
+"out_size": 13366,
+"ratio": 0.3495,
+"compress_mbps": 25.37,
+"decompress_mbps": 125.33
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 5,
+"out_size": 13346,
+"ratio": 0.349,
+"compress_mbps": 22.55,
+"decompress_mbps": 131.07
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 6,
+"out_size": 13040,
+"ratio": 0.341,
+"compress_mbps": 9.92,
+"decompress_mbps": 133.5
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 7,
+"out_size": 13035,
+"ratio": 0.3409,
+"compress_mbps": 9.29,
+"decompress_mbps": 133.61
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 8,
+"out_size": 13028,
+"ratio": 0.3407,
+"compress_mbps": 8.63,
+"decompress_mbps": 135.85
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 9,
+"out_size": 12427,
+"ratio": 0.325,
+"compress_mbps": 4.2,
+"decompress_mbps": 137.28
+},
+{
+"compressor": "native",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 10,
+"out_size": 12274,
+"ratio": 0.321,
+"compress_mbps": 2.53,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 1,
+"out_size": 1800,
+"ratio": 0.4258,
+"compress_mbps": 14.48,
+"decompress_mbps": 58.16
+},
+{
+"compressor": "native",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 2,
+"out_size": 1750,
+"ratio": 0.414,
+"compress_mbps": 13.8,
+"decompress_mbps": 58.62
+},
+{
+"compressor": "native",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 3,
+"out_size": 1742,
+"ratio": 0.4121,
+"compress_mbps": 13.72,
+"decompress_mbps": 58.69
+},
+{
+"compressor": "native",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 4,
+"out_size": 1732,
+"ratio": 0.4097,
+"compress_mbps": 13.48,
+"decompress_mbps": 60.15
+},
+{
+"compressor": "native",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 5,
+"out_size": 1729,
+"ratio": 0.409,
+"compress_mbps": 13.37,
+"decompress_mbps": 60.39
+},
+{
+"compressor": "native",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 6,
+"out_size": 1729,
+"ratio": 0.409,
+"compress_mbps": 11.61,
+"decompress_mbps": 60.43
+},
+{
+"compressor": "native",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 7,
+"out_size": 1729,
+"ratio": 0.409,
+"compress_mbps": 11.58,
+"decompress_mbps": 60.32
+},
+{
+"compressor": "native",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 8,
+"out_size": 1729,
+"ratio": 0.409,
+"compress_mbps": 11.61,
+"decompress_mbps": 60.45
+},
+{
+"compressor": "native",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 9,
+"out_size": 1708,
+"ratio": 0.4041,
+"compress_mbps": 3.95,
+"decompress_mbps": 60.51
+},
+{
+"compressor": "native",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 10,
+"out_size": 1693,
+"ratio": 0.4005,
+"compress_mbps": 2.45,
+"decompress_mbps": null
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 1,
+"out_size": 65130,
+"ratio": 0.4282,
+"compress_mbps": 119.16,
+"decompress_mbps": 393.49
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 2,
+"out_size": 62270,
+"ratio": 0.4094,
+"compress_mbps": 102.04,
+"decompress_mbps": 412.56
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 3,
+"out_size": 59488,
+"ratio": 0.3911,
+"compress_mbps": 67.18,
+"decompress_mbps": 427.67
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 4,
+"out_size": 57679,
+"ratio": 0.3792,
+"compress_mbps": 71.84,
+"decompress_mbps": 406.6
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 5,
+"out_size": 55616,
+"ratio": 0.3657,
+"compress_mbps": 41.94,
+"decompress_mbps": 399.81
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 6,
+"out_size": 54398,
+"ratio": 0.3577,
+"compress_mbps": 25.54,
+"decompress_mbps": 412.45
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 7,
+"out_size": 54253,
+"ratio": 0.3567,
+"compress_mbps": 21.44,
+"decompress_mbps": 414.47
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 8,
+"out_size": 54164,
+"ratio": 0.3561,
+"compress_mbps": 17.0,
+"decompress_mbps": 415.54
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 9,
+"out_size": 54164,
+"ratio": 0.3561,
+"compress_mbps": 16.98,
+"decompress_mbps": 416.37
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 1,
+"out_size": 56791,
+"ratio": 0.4537,
+"compress_mbps": 115.48,
+"decompress_mbps": 386.4
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 2,
+"out_size": 54652,
+"ratio": 0.4366,
+"compress_mbps": 97.99,
+"decompress_mbps": 401.9
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 3,
+"out_size": 52663,
+"ratio": 0.4207,
+"compress_mbps": 62.55,
+"decompress_mbps": 432.53
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 4,
+"out_size": 51266,
+"ratio": 0.4095,
+"compress_mbps": 67.6,
+"decompress_mbps": 400.76
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 5,
+"out_size": 49622,
+"ratio": 0.3964,
+"compress_mbps": 37.32,
+"decompress_mbps": 387.54
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 6,
+"out_size": 48891,
+"ratio": 0.3906,
+"compress_mbps": 22.79,
+"decompress_mbps": 395.44
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 7,
+"out_size": 48801,
+"ratio": 0.3898,
+"compress_mbps": 20.01,
+"decompress_mbps": 395.17
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 8,
+"out_size": 48772,
+"ratio": 0.3896,
+"compress_mbps": 18.12,
+"decompress_mbps": 395.78
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 9,
+"out_size": 48772,
+"ratio": 0.3896,
+"compress_mbps": 18.11,
+"decompress_mbps": 395.81
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 1,
+"out_size": 9028,
+"ratio": 0.3669,
+"compress_mbps": 413.16,
+"decompress_mbps": 1048.54
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 2,
+"out_size": 8811,
+"ratio": 0.3581,
+"compress_mbps": 216.27,
+"decompress_mbps": 1072.51
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 3,
+"out_size": 8616,
+"ratio": 0.3502,
+"compress_mbps": 155.32,
+"decompress_mbps": 1108.48
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 4,
+"out_size": 8219,
+"ratio": 0.3341,
+"compress_mbps": 115.91,
+"decompress_mbps": 1125.93
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 5,
+"out_size": 8001,
+"ratio": 0.3252,
+"compress_mbps": 85.05,
+"decompress_mbps": 1145.5
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 6,
+"out_size": 7955,
+"ratio": 0.3233,
+"compress_mbps": 68.88,
+"decompress_mbps": 1156.57
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 7,
+"out_size": 7933,
+"ratio": 0.3224,
+"compress_mbps": 63.0,
+"decompress_mbps": 1160.28
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 8,
+"out_size": 7934,
+"ratio": 0.3225,
+"compress_mbps": 58.11,
+"decompress_mbps": 1157.25
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 9,
+"out_size": 7934,
+"ratio": 0.3225,
+"compress_mbps": 57.98,
+"decompress_mbps": 1156.91
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 1,
+"out_size": 3647,
+"ratio": 0.3271,
+"compress_mbps": 426.88,
+"decompress_mbps": 1068.91
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 2,
+"out_size": 3501,
+"ratio": 0.314,
+"compress_mbps": 408.45,
+"decompress_mbps": 1109.39
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 3,
+"out_size": 3393,
+"ratio": 0.3043,
+"compress_mbps": 338.89,
+"decompress_mbps": 1135.33
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 4,
+"out_size": 3215,
+"ratio": 0.2883,
+"compress_mbps": 274.69,
+"decompress_mbps": 1169.54
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 5,
+"out_size": 3140,
+"ratio": 0.2816,
+"compress_mbps": 206.54,
+"decompress_mbps": 1204.24
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 6,
+"out_size": 3116,
+"ratio": 0.2795,
+"compress_mbps": 154.05,
+"decompress_mbps": 1215.11
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 7,
+"out_size": 3112,
+"ratio": 0.2791,
+"compress_mbps": 132.02,
+"decompress_mbps": 1220.83
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 8,
+"out_size": 3109,
+"ratio": 0.2788,
+"compress_mbps": 111.36,
+"decompress_mbps": 1211.79
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 9,
+"out_size": 3109,
+"ratio": 0.2788,
+"compress_mbps": 111.17,
+"decompress_mbps": 1221.54
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 1,
+"out_size": 1326,
+"ratio": 0.3564,
+"compress_mbps": 316.62,
+"decompress_mbps": 784.92
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 2,
+"out_size": 1306,
+"ratio": 0.351,
+"compress_mbps": 310.47,
+"decompress_mbps": 775.49
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 3,
+"out_size": 1301,
+"ratio": 0.3496,
+"compress_mbps": 291.4,
+"decompress_mbps": 783.71
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 4,
+"out_size": 1228,
+"ratio": 0.33,
+"compress_mbps": 233.74,
+"decompress_mbps": 819.16
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 5,
+"out_size": 1216,
+"ratio": 0.3268,
+"compress_mbps": 199.28,
+"decompress_mbps": 811.67
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 6,
+"out_size": 1216,
+"ratio": 0.3268,
+"compress_mbps": 178.18,
+"decompress_mbps": 810.93
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 7,
+"out_size": 1216,
+"ratio": 0.3268,
+"compress_mbps": 170.94,
+"decompress_mbps": 816.34
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 8,
+"out_size": 1216,
+"ratio": 0.3268,
+"compress_mbps": 168.09,
+"decompress_mbps": 815.03
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 9,
+"out_size": 1216,
+"ratio": 0.3268,
+"compress_mbps": 167.98,
+"decompress_mbps": 812.97
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 1,
+"out_size": 242293,
+"ratio": 0.2353,
+"compress_mbps": 262.08,
+"decompress_mbps": 830.92
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 2,
+"out_size": 233553,
+"ratio": 0.2268,
+"compress_mbps": 247.77,
+"decompress_mbps": 981.42
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 3,
+"out_size": 228222,
+"ratio": 0.2216,
+"compress_mbps": 195.24,
+"decompress_mbps": 1038.02
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 4,
+"out_size": 223668,
+"ratio": 0.2172,
+"compress_mbps": 177.62,
+"decompress_mbps": 1069.05
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 5,
+"out_size": 205994,
+"ratio": 0.2,
+"compress_mbps": 110.2,
+"decompress_mbps": 1028.7
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 6,
+"out_size": 203986,
+"ratio": 0.1981,
+"compress_mbps": 49.93,
+"decompress_mbps": 1032.63
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 7,
+"out_size": 207681,
+"ratio": 0.2017,
+"compress_mbps": 37.01,
+"decompress_mbps": 1024.77
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 8,
+"out_size": 206827,
+"ratio": 0.2009,
+"compress_mbps": 7.3,
+"decompress_mbps": 996.72
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 9,
+"out_size": 207023,
+"ratio": 0.201,
+"compress_mbps": 3.43,
+"decompress_mbps": 994.12
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 1,
+"out_size": 174124,
+"ratio": 0.408,
+"compress_mbps": 123.62,
+"decompress_mbps": 391.8
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 2,
+"out_size": 166150,
+"ratio": 0.3893,
+"compress_mbps": 104.81,
+"decompress_mbps": 401.7
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 3,
+"out_size": 158784,
+"ratio": 0.3721,
+"compress_mbps": 70.23,
+"decompress_mbps": 419.82
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 4,
+"out_size": 152782,
+"ratio": 0.358,
+"compress_mbps": 73.72,
+"decompress_mbps": 407.18
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 5,
+"out_size": 147196,
+"ratio": 0.3449,
+"compress_mbps": 43.35,
+"decompress_mbps": 401.98
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 6,
+"out_size": 144898,
+"ratio": 0.3395,
+"compress_mbps": 26.3,
+"decompress_mbps": 412.86
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 7,
+"out_size": 144589,
+"ratio": 0.3388,
+"compress_mbps": 22.81,
+"decompress_mbps": 413.61
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 8,
+"out_size": 144436,
+"ratio": 0.3385,
+"compress_mbps": 19.6,
+"decompress_mbps": 413.12
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 9,
+"out_size": 144433,
+"ratio": 0.3384,
+"compress_mbps": 19.54,
+"decompress_mbps": 413.31
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 1,
+"out_size": 228883,
+"ratio": 0.475,
+"compress_mbps": 107.83,
+"decompress_mbps": 367.64
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 2,
+"out_size": 219047,
+"ratio": 0.4546,
+"compress_mbps": 90.66,
+"decompress_mbps": 385.82
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 3,
+"out_size": 209408,
+"ratio": 0.4346,
+"compress_mbps": 55.28,
+"decompress_mbps": 400.37
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 4,
+"out_size": 205916,
+"ratio": 0.4273,
+"compress_mbps": 62.18,
+"decompress_mbps": 375.5
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 5,
+"out_size": 199188,
+"ratio": 0.4134,
+"compress_mbps": 32.87,
+"decompress_mbps": 358.02
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 6,
+"out_size": 195255,
+"ratio": 0.4052,
+"compress_mbps": 19.31,
+"decompress_mbps": 359.99
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 7,
+"out_size": 194657,
+"ratio": 0.404,
+"compress_mbps": 16.33,
+"decompress_mbps": 360.28
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 8,
+"out_size": 194326,
+"ratio": 0.4033,
+"compress_mbps": 12.9,
+"decompress_mbps": 366.37
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 9,
+"out_size": 194326,
+"ratio": 0.4033,
+"compress_mbps": 12.9,
+"decompress_mbps": 362.41
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 1,
+"out_size": 65553,
+"ratio": 0.1277,
+"compress_mbps": 273.36,
+"decompress_mbps": 876.91
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 2,
+"out_size": 63891,
+"ratio": 0.1245,
+"compress_mbps": 247.13,
+"decompress_mbps": 903.46
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 3,
+"out_size": 62515,
+"ratio": 0.1218,
+"compress_mbps": 193.01,
+"decompress_mbps": 962.2
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 4,
+"out_size": 58451,
+"ratio": 0.1139,
+"compress_mbps": 168.63,
+"decompress_mbps": 693.08
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 5,
+"out_size": 57410,
+"ratio": 0.1119,
+"compress_mbps": 130.05,
+"decompress_mbps": 721.34
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 6,
+"out_size": 56459,
+"ratio": 0.11,
+"compress_mbps": 76.97,
+"decompress_mbps": 771.47
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 7,
+"out_size": 55358,
+"ratio": 0.1079,
+"compress_mbps": 60.1,
+"decompress_mbps": 803.98
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 8,
+"out_size": 52991,
+"ratio": 0.1033,
+"compress_mbps": 27.44,
+"decompress_mbps": 859.31
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 9,
+"out_size": 52215,
+"ratio": 0.1017,
+"compress_mbps": 9.79,
+"decompress_mbps": 872.15
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 1,
+"out_size": 14112,
+"ratio": 0.369,
+"compress_mbps": 128.53,
+"decompress_mbps": 939.3
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 2,
+"out_size": 13815,
+"ratio": 0.3613,
+"compress_mbps": 109.01,
+"decompress_mbps": 977.63
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 3,
+"out_size": 13795,
+"ratio": 0.3607,
+"compress_mbps": 78.92,
+"decompress_mbps": 1019.56
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 4,
+"out_size": 13375,
+"ratio": 0.3498,
+"compress_mbps": 80.43,
+"decompress_mbps": 996.76
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 5,
+"out_size": 13062,
+"ratio": 0.3416,
+"compress_mbps": 55.68,
+"decompress_mbps": 1020.16
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 6,
+"out_size": 12984,
+"ratio": 0.3395,
+"compress_mbps": 33.03,
+"decompress_mbps": 1058.22
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 7,
+"out_size": 12949,
+"ratio": 0.3386,
+"compress_mbps": 25.4,
+"decompress_mbps": 1066.55
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 8,
+"out_size": 12894,
+"ratio": 0.3372,
+"compress_mbps": 11.05,
+"decompress_mbps": 1073.99
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 9,
+"out_size": 12832,
+"ratio": 0.3356,
+"compress_mbps": 5.08,
+"decompress_mbps": 1078.09
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 1,
+"out_size": 1846,
+"ratio": 0.4367,
+"compress_mbps": 291.54,
+"decompress_mbps": 710.22
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 2,
+"out_size": 1820,
+"ratio": 0.4306,
+"compress_mbps": 285.68,
+"decompress_mbps": 721.53
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 3,
+"out_size": 1808,
+"ratio": 0.4277,
+"compress_mbps": 273.13,
+"decompress_mbps": 722.95
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 4,
+"out_size": 1749,
+"ratio": 0.4138,
+"compress_mbps": 226.8,
+"decompress_mbps": 747.21
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 5,
+"out_size": 1730,
+"ratio": 0.4093,
+"compress_mbps": 202.13,
+"decompress_mbps": 753.35
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 6,
+"out_size": 1730,
+"ratio": 0.4093,
+"compress_mbps": 199.33,
+"decompress_mbps": 752.79
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 7,
+"out_size": 1730,
+"ratio": 0.4093,
+"compress_mbps": 196.97,
+"decompress_mbps": 754.48
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 8,
+"out_size": 1730,
+"ratio": 0.4093,
+"compress_mbps": 197.03,
+"decompress_mbps": 752.65
+},
+{
+"compressor": "zlib",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 9,
+"out_size": 1730,
+"ratio": 0.4093,
+"compress_mbps": 197.14,
+"decompress_mbps": 753.21
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 1,
+"out_size": 76470,
+"ratio": 0.5028,
+"compress_mbps": 157.78,
+"decompress_mbps": 442.94
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 2,
+"out_size": 62765,
+"ratio": 0.4127,
+"compress_mbps": 132.14,
+"decompress_mbps": 490.51
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 3,
+"out_size": 57162,
+"ratio": 0.3758,
+"compress_mbps": 72.22,
+"decompress_mbps": 551.62
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 4,
+"out_size": 56826,
+"ratio": 0.3736,
+"compress_mbps": 64.16,
+"decompress_mbps": 535.92
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 5,
+"out_size": 55696,
+"ratio": 0.3662,
+"compress_mbps": 46.86,
+"decompress_mbps": 525.1
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 6,
+"out_size": 54440,
+"ratio": 0.3579,
+"compress_mbps": 26.56,
+"decompress_mbps": 542.84
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 7,
+"out_size": 54283,
+"ratio": 0.3569,
+"compress_mbps": 22.4,
+"decompress_mbps": 543.39
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 8,
+"out_size": 54221,
+"ratio": 0.3565,
+"compress_mbps": 19.71,
+"decompress_mbps": 544.04
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 9,
+"out_size": 54217,
+"ratio": 0.3565,
+"compress_mbps": 19.49,
+"decompress_mbps": 546.52
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 1,
+"out_size": 64926,
+"ratio": 0.5187,
+"compress_mbps": 151.42,
+"decompress_mbps": 421.18
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 2,
+"out_size": 54985,
+"ratio": 0.4393,
+"compress_mbps": 123.65,
+"decompress_mbps": 467.93
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 3,
+"out_size": 51148,
+"ratio": 0.4086,
+"compress_mbps": 67.07,
+"decompress_mbps": 534.82
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 4,
+"out_size": 50599,
+"ratio": 0.4042,
+"compress_mbps": 58.95,
+"decompress_mbps": 519.63
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 5,
+"out_size": 49775,
+"ratio": 0.3976,
+"compress_mbps": 42.66,
+"decompress_mbps": 506.03
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 6,
+"out_size": 48967,
+"ratio": 0.3912,
+"compress_mbps": 24.99,
+"decompress_mbps": 519.13
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 7,
+"out_size": 48870,
+"ratio": 0.3904,
+"compress_mbps": 22.17,
+"decompress_mbps": 525.91
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 8,
+"out_size": 48845,
+"ratio": 0.3902,
+"compress_mbps": 20.89,
+"decompress_mbps": 523.43
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 9,
+"out_size": 48845,
+"ratio": 0.3902,
+"compress_mbps": 20.9,
+"decompress_mbps": 518.44
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 1,
+"out_size": 10024,
+"ratio": 0.4074,
+"compress_mbps": 531.61,
+"decompress_mbps": 900.15
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 2,
+"out_size": 8577,
+"ratio": 0.3486,
+"compress_mbps": 261.38,
+"decompress_mbps": 926.45
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 3,
+"out_size": 8168,
+"ratio": 0.332,
+"compress_mbps": 156.0,
+"decompress_mbps": 944.92
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 4,
+"out_size": 8069,
+"ratio": 0.328,
+"compress_mbps": 114.85,
+"decompress_mbps": 969.72
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 5,
+"out_size": 7997,
+"ratio": 0.325,
+"compress_mbps": 100.16,
+"decompress_mbps": 998.61
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 6,
+"out_size": 7952,
+"ratio": 0.3232,
+"compress_mbps": 74.97,
+"decompress_mbps": 1005.75
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 7,
+"out_size": 7947,
+"ratio": 0.323,
+"compress_mbps": 72.58,
+"decompress_mbps": 1011.17
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 8,
+"out_size": 7947,
+"ratio": 0.323,
+"compress_mbps": 71.43,
+"decompress_mbps": 1011.35
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 9,
+"out_size": 7947,
+"ratio": 0.323,
+"compress_mbps": 71.29,
+"decompress_mbps": 1010.78
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 1,
+"out_size": 4061,
+"ratio": 0.3642,
+"compress_mbps": 489.84,
+"decompress_mbps": 854.64
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 2,
+"out_size": 3446,
+"ratio": 0.3091,
+"compress_mbps": 305.95,
+"decompress_mbps": 893.64
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 3,
+"out_size": 3201,
+"ratio": 0.2871,
+"compress_mbps": 233.51,
+"decompress_mbps": 927.8
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 4,
+"out_size": 3168,
+"ratio": 0.2841,
+"compress_mbps": 193.82,
+"decompress_mbps": 956.16
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 5,
+"out_size": 3139,
+"ratio": 0.2815,
+"compress_mbps": 162.46,
+"decompress_mbps": 972.16
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 6,
+"out_size": 3115,
+"ratio": 0.2794,
+"compress_mbps": 116.38,
+"decompress_mbps": 985.86
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 7,
+"out_size": 3112,
+"ratio": 0.2791,
+"compress_mbps": 106.48,
+"decompress_mbps": 989.34
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 8,
+"out_size": 3112,
+"ratio": 0.2791,
+"compress_mbps": 103.65,
+"decompress_mbps": 993.13
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 9,
+"out_size": 3112,
+"ratio": 0.2791,
+"compress_mbps": 103.26,
+"decompress_mbps": 992.76
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 1,
+"out_size": 1410,
+"ratio": 0.3789,
+"compress_mbps": 366.9,
+"decompress_mbps": 596.01
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 2,
+"out_size": 1262,
+"ratio": 0.3392,
+"compress_mbps": 234.45,
+"decompress_mbps": 604.74
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 3,
+"out_size": 1238,
+"ratio": 0.3327,
+"compress_mbps": 203.34,
+"decompress_mbps": 605.36
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 4,
+"out_size": 1219,
+"ratio": 0.3276,
+"compress_mbps": 174.55,
+"decompress_mbps": 620.28
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 5,
+"out_size": 1216,
+"ratio": 0.3268,
+"compress_mbps": 160.35,
+"decompress_mbps": 629.75
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 6,
+"out_size": 1216,
+"ratio": 0.3268,
+"compress_mbps": 146.33,
+"decompress_mbps": 631.65
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 7,
+"out_size": 1216,
+"ratio": 0.3268,
+"compress_mbps": 145.11,
+"decompress_mbps": 634.93
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 8,
+"out_size": 1216,
+"ratio": 0.3268,
+"compress_mbps": 145.24,
+"decompress_mbps": 633.23
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 9,
+"out_size": 1216,
+"ratio": 0.3268,
+"compress_mbps": 144.99,
+"decompress_mbps": 630.75
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 1,
+"out_size": 274412,
+"ratio": 0.2665,
+"compress_mbps": 449.9,
+"decompress_mbps": 793.96
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 2,
+"out_size": 213239,
+"ratio": 0.2071,
+"compress_mbps": 272.27,
+"decompress_mbps": 896.17
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 3,
+"out_size": 232107,
+"ratio": 0.2254,
+"compress_mbps": 136.67,
+"decompress_mbps": 941.49
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 4,
+"out_size": 202733,
+"ratio": 0.1969,
+"compress_mbps": 129.64,
+"decompress_mbps": 941.54
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 5,
+"out_size": 207803,
+"ratio": 0.2018,
+"compress_mbps": 84.14,
+"decompress_mbps": 955.89
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 6,
+"out_size": 205270,
+"ratio": 0.1993,
+"compress_mbps": 27.3,
+"decompress_mbps": 979.27
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 7,
+"out_size": 209951,
+"ratio": 0.2039,
+"compress_mbps": 19.31,
+"decompress_mbps": 995.45
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 8,
+"out_size": 209656,
+"ratio": 0.2036,
+"compress_mbps": 12.24,
+"decompress_mbps": 1009.18
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 9,
+"out_size": 209189,
+"ratio": 0.2031,
+"compress_mbps": 8.96,
+"decompress_mbps": 1011.13
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 1,
+"out_size": 208640,
+"ratio": 0.4889,
+"compress_mbps": 157.45,
+"decompress_mbps": 423.89
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 2,
+"out_size": 167329,
+"ratio": 0.3921,
+"compress_mbps": 137.6,
+"decompress_mbps": 464.74
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 3,
+"out_size": 151097,
+"ratio": 0.3541,
+"compress_mbps": 73.65,
+"decompress_mbps": 512.52
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 4,
+"out_size": 150035,
+"ratio": 0.3516,
+"compress_mbps": 66.13,
+"decompress_mbps": 509.05
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 5,
+"out_size": 147375,
+"ratio": 0.3453,
+"compress_mbps": 48.14,
+"decompress_mbps": 506.78
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 6,
+"out_size": 144908,
+"ratio": 0.3396,
+"compress_mbps": 28.05,
+"decompress_mbps": 518.33
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 7,
+"out_size": 144562,
+"ratio": 0.3387,
+"compress_mbps": 24.64,
+"decompress_mbps": 518.63
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 8,
+"out_size": 144449,
+"ratio": 0.3385,
+"compress_mbps": 22.4,
+"decompress_mbps": 516.33
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 9,
+"out_size": 144438,
+"ratio": 0.3385,
+"compress_mbps": 22.34,
+"decompress_mbps": 517.74
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 1,
+"out_size": 264549,
+"ratio": 0.549,
+"compress_mbps": 136.07,
+"decompress_mbps": 376.66
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 2,
+"out_size": 223724,
+"ratio": 0.4643,
+"compress_mbps": 118.11,
+"decompress_mbps": 422.07
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 3,
+"out_size": 204825,
+"ratio": 0.4251,
+"compress_mbps": 60.64,
+"decompress_mbps": 477.68
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 4,
+"out_size": 203945,
+"ratio": 0.4232,
+"compress_mbps": 53.78,
+"decompress_mbps": 471.87
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 5,
+"out_size": 199780,
+"ratio": 0.4146,
+"compress_mbps": 37.88,
+"decompress_mbps": 455.85
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 6,
+"out_size": 195417,
+"ratio": 0.4055,
+"compress_mbps": 21.15,
+"decompress_mbps": 465.48
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 7,
+"out_size": 194796,
+"ratio": 0.4043,
+"compress_mbps": 17.87,
+"decompress_mbps": 466.91
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 8,
+"out_size": 194543,
+"ratio": 0.4037,
+"compress_mbps": 15.68,
+"decompress_mbps": 465.89
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 9,
+"out_size": 194460,
+"ratio": 0.4036,
+"compress_mbps": 15.02,
+"decompress_mbps": 465.94
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 1,
+"out_size": 67436,
+"ratio": 0.1314,
+"compress_mbps": 626.36,
+"decompress_mbps": 1001.38
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 2,
+"out_size": 59257,
+"ratio": 0.1155,
+"compress_mbps": 276.28,
+"decompress_mbps": 1056.51
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 3,
+"out_size": 58316,
+"ratio": 0.1136,
+"compress_mbps": 180.05,
+"decompress_mbps": 1135.86
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 4,
+"out_size": 56291,
+"ratio": 0.1097,
+"compress_mbps": 183.07,
+"decompress_mbps": 1151.41
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 5,
+"out_size": 56220,
+"ratio": 0.1095,
+"compress_mbps": 144.89,
+"decompress_mbps": 1205.93
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 6,
+"out_size": 55972,
+"ratio": 0.1091,
+"compress_mbps": 74.28,
+"decompress_mbps": 1269.6
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 7,
+"out_size": 55121,
+"ratio": 0.1074,
+"compress_mbps": 51.98,
+"decompress_mbps": 1309.93
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 8,
+"out_size": 54124,
+"ratio": 0.1055,
+"compress_mbps": 36.61,
+"decompress_mbps": 1367.67
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 9,
+"out_size": 53699,
+"ratio": 0.1046,
+"compress_mbps": 28.61,
+"decompress_mbps": 1404.21
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 1,
+"out_size": 15612,
+"ratio": 0.4083,
+"compress_mbps": 513.43,
+"decompress_mbps": 865.99
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 2,
+"out_size": 14133,
+"ratio": 0.3696,
+"compress_mbps": 144.5,
+"decompress_mbps": 895.42
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 3,
+"out_size": 13341,
+"ratio": 0.3489,
+"compress_mbps": 87.64,
+"decompress_mbps": 919.3
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 4,
+"out_size": 13289,
+"ratio": 0.3475,
+"compress_mbps": 82.82,
+"decompress_mbps": 945.1
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 5,
+"out_size": 13052,
+"ratio": 0.3413,
+"compress_mbps": 66.19,
+"decompress_mbps": 984.73
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 6,
+"out_size": 12996,
+"ratio": 0.3399,
+"compress_mbps": 37.0,
+"decompress_mbps": 1002.74
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 7,
+"out_size": 12972,
+"ratio": 0.3392,
+"compress_mbps": 27.16,
+"decompress_mbps": 1006.0
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 8,
+"out_size": 12951,
+"ratio": 0.3387,
+"compress_mbps": 19.0,
+"decompress_mbps": 1014.42
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 9,
+"out_size": 12933,
+"ratio": 0.3382,
+"compress_mbps": 14.84,
+"decompress_mbps": 1016.18
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 1,
+"out_size": 1988,
+"ratio": 0.4703,
+"compress_mbps": 352.16,
+"decompress_mbps": 550.26
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 2,
+"out_size": 1802,
+"ratio": 0.4263,
+"compress_mbps": 218.43,
+"decompress_mbps": 554.34
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 3,
+"out_size": 1760,
+"ratio": 0.4164,
+"compress_mbps": 205.02,
+"decompress_mbps": 556.18
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 4,
+"out_size": 1732,
+"ratio": 0.4097,
+"compress_mbps": 169.87,
+"decompress_mbps": 571.64
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 5,
+"out_size": 1730,
+"ratio": 0.4093,
+"compress_mbps": 166.82,
+"decompress_mbps": 581.2
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 6,
+"out_size": 1730,
+"ratio": 0.4093,
+"compress_mbps": 165.11,
+"decompress_mbps": 580.19
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 7,
+"out_size": 1730,
+"ratio": 0.4093,
+"compress_mbps": 165.65,
+"decompress_mbps": 581.36
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 8,
+"out_size": 1730,
+"ratio": 0.4093,
+"compress_mbps": 164.8,
+"decompress_mbps": 583.89
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 9,
+"out_size": 1730,
+"ratio": 0.4093,
+"compress_mbps": 165.0,
+"decompress_mbps": 583.21
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 1,
+"out_size": 59790,
+"ratio": 0.3931,
+"compress_mbps": 259.33,
+"decompress_mbps": 996.52
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 2,
+"out_size": 57173,
+"ratio": 0.3759,
+"compress_mbps": 180.49,
+"decompress_mbps": 1070.19
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 3,
+"out_size": 56189,
+"ratio": 0.3694,
+"compress_mbps": 150.33,
+"decompress_mbps": 1145.58
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 4,
+"out_size": 55816,
+"ratio": 0.367,
+"compress_mbps": 137.81,
+"decompress_mbps": 1185.99
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 5,
+"out_size": 54758,
+"ratio": 0.36,
+"compress_mbps": 108.84,
+"decompress_mbps": 1238.7
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 6,
+"out_size": 54220,
+"ratio": 0.3565,
+"compress_mbps": 84.22,
+"decompress_mbps": 1278.06
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 7,
+"out_size": 53801,
+"ratio": 0.3537,
+"compress_mbps": 60.73,
+"decompress_mbps": 1281.4
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 8,
+"out_size": 53573,
+"ratio": 0.3522,
+"compress_mbps": 39.0,
+"decompress_mbps": 1280.04
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 9,
+"out_size": 53546,
+"ratio": 0.3521,
+"compress_mbps": 34.45,
+"decompress_mbps": 1277.72
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 10,
+"out_size": 51721,
+"ratio": 0.3401,
+"compress_mbps": 12.18,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 11,
+"out_size": 51662,
+"ratio": 0.3397,
+"compress_mbps": 8.34,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 12,
+"out_size": 51662,
+"ratio": 0.3397,
+"compress_mbps": 5.1,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 1,
+"out_size": 52276,
+"ratio": 0.4176,
+"compress_mbps": 241.61,
+"decompress_mbps": 939.42
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 2,
+"out_size": 50534,
+"ratio": 0.4037,
+"compress_mbps": 168.24,
+"decompress_mbps": 989.01
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 3,
+"out_size": 49919,
+"ratio": 0.3988,
+"compress_mbps": 141.33,
+"decompress_mbps": 1053.86
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 4,
+"out_size": 49715,
+"ratio": 0.3972,
+"compress_mbps": 130.46,
+"decompress_mbps": 1090.5
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 5,
+"out_size": 48735,
+"ratio": 0.3893,
+"compress_mbps": 100.2,
+"decompress_mbps": 1139.61
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 6,
+"out_size": 48422,
+"ratio": 0.3868,
+"compress_mbps": 79.3,
+"decompress_mbps": 1156.59
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 7,
+"out_size": 48249,
+"ratio": 0.3854,
+"compress_mbps": 60.96,
+"decompress_mbps": 1163.41
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 8,
+"out_size": 47977,
+"ratio": 0.3833,
+"compress_mbps": 43.03,
+"decompress_mbps": 1166.29
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 9,
+"out_size": 47971,
+"ratio": 0.3832,
+"compress_mbps": 41.09,
+"decompress_mbps": 1165.4
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 10,
+"out_size": 46657,
+"ratio": 0.3727,
+"compress_mbps": 13.62,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 11,
+"out_size": 46515,
+"ratio": 0.3716,
+"compress_mbps": 9.25,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 12,
+"out_size": 46469,
+"ratio": 0.3712,
+"compress_mbps": 7.05,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 1,
+"out_size": 8385,
+"ratio": 0.3408,
+"compress_mbps": 695.0,
+"decompress_mbps": 957.8
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 2,
+"out_size": 8380,
+"ratio": 0.3406,
+"compress_mbps": 441.98,
+"decompress_mbps": 969.0
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 3,
+"out_size": 8286,
+"ratio": 0.3368,
+"compress_mbps": 405.77,
+"decompress_mbps": 985.48
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 4,
+"out_size": 8163,
+"ratio": 0.3318,
+"compress_mbps": 377.87,
+"decompress_mbps": 999.24
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 5,
+"out_size": 8053,
+"ratio": 0.3273,
+"compress_mbps": 337.25,
+"decompress_mbps": 1015.86
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 6,
+"out_size": 7986,
+"ratio": 0.3246,
+"compress_mbps": 276.49,
+"decompress_mbps": 1030.31
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 7,
+"out_size": 7954,
+"ratio": 0.3233,
+"compress_mbps": 190.41,
+"decompress_mbps": 1032.9
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 8,
+"out_size": 7916,
+"ratio": 0.3217,
+"compress_mbps": 126.18,
+"decompress_mbps": 1029.63
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 9,
+"out_size": 7916,
+"ratio": 0.3217,
+"compress_mbps": 125.1,
+"decompress_mbps": 1031.53
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 10,
+"out_size": 7725,
+"ratio": 0.314,
+"compress_mbps": 15.79,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 11,
+"out_size": 7727,
+"ratio": 0.3141,
+"compress_mbps": 10.77,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 12,
+"out_size": 7723,
+"ratio": 0.3139,
+"compress_mbps": 7.18,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 1,
+"out_size": 3401,
+"ratio": 0.305,
+"compress_mbps": 586.51,
+"decompress_mbps": 768.31
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 2,
+"out_size": 3307,
+"ratio": 0.2966,
+"compress_mbps": 399.66,
+"decompress_mbps": 789.24
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 3,
+"out_size": 3242,
+"ratio": 0.2908,
+"compress_mbps": 367.93,
+"decompress_mbps": 807.71
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 4,
+"out_size": 3205,
+"ratio": 0.2874,
+"compress_mbps": 351.44,
+"decompress_mbps": 815.58
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 5,
+"out_size": 3150,
+"ratio": 0.2825,
+"compress_mbps": 313.88,
+"decompress_mbps": 830.35
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 6,
+"out_size": 3126,
+"ratio": 0.2804,
+"compress_mbps": 266.83,
+"decompress_mbps": 840.06
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 7,
+"out_size": 3106,
+"ratio": 0.2786,
+"compress_mbps": 206.86,
+"decompress_mbps": 839.2
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 8,
+"out_size": 3102,
+"ratio": 0.2782,
+"compress_mbps": 147.64,
+"decompress_mbps": 843.66
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 9,
+"out_size": 3102,
+"ratio": 0.2782,
+"compress_mbps": 140.31,
+"decompress_mbps": 843.26
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 10,
+"out_size": 3026,
+"ratio": 0.2714,
+"compress_mbps": 17.51,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 11,
+"out_size": 3024,
+"ratio": 0.2712,
+"compress_mbps": 13.82,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 12,
+"out_size": 3024,
+"ratio": 0.2712,
+"compress_mbps": 10.64,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 1,
+"out_size": 1251,
+"ratio": 0.3362,
+"compress_mbps": 382.39,
+"decompress_mbps": 436.06
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 2,
+"out_size": 1228,
+"ratio": 0.33,
+"compress_mbps": 271.65,
+"decompress_mbps": 441.1
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 3,
+"out_size": 1219,
+"ratio": 0.3276,
+"compress_mbps": 261.74,
+"decompress_mbps": 439.73
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 4,
+"out_size": 1220,
+"ratio": 0.3279,
+"compress_mbps": 256.64,
+"decompress_mbps": 442.14
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 5,
+"out_size": 1207,
+"ratio": 0.3244,
+"compress_mbps": 240.91,
+"decompress_mbps": 448.68
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 6,
+"out_size": 1207,
+"ratio": 0.3244,
+"compress_mbps": 224.04,
+"decompress_mbps": 450.45
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 7,
+"out_size": 1207,
+"ratio": 0.3244,
+"compress_mbps": 203.76,
+"decompress_mbps": 450.96
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 8,
+"out_size": 1204,
+"ratio": 0.3236,
+"compress_mbps": 169.34,
+"decompress_mbps": 451.48
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 9,
+"out_size": 1204,
+"ratio": 0.3236,
+"compress_mbps": 168.85,
+"decompress_mbps": 450.56
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 10,
+"out_size": 1186,
+"ratio": 0.3187,
+"compress_mbps": 41.99,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 11,
+"out_size": 1186,
+"ratio": 0.3187,
+"compress_mbps": 32.99,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 12,
+"out_size": 1186,
+"ratio": 0.3187,
+"compress_mbps": 24.38,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 1,
+"out_size": 221813,
+"ratio": 0.2154,
+"compress_mbps": 595.78,
+"decompress_mbps": 1009.43
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 2,
+"out_size": 199825,
+"ratio": 0.1941,
+"compress_mbps": 410.21,
+"decompress_mbps": 1465.65
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 3,
+"out_size": 195675,
+"ratio": 0.19,
+"compress_mbps": 283.21,
+"decompress_mbps": 1533.25
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 4,
+"out_size": 195664,
+"ratio": 0.19,
+"compress_mbps": 280.07,
+"decompress_mbps": 1537.01
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 5,
+"out_size": 198900,
+"ratio": 0.1932,
+"compress_mbps": 239.61,
+"decompress_mbps": 1128.92
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 6,
+"out_size": 199347,
+"ratio": 0.1936,
+"compress_mbps": 204.37,
+"decompress_mbps": 1127.33
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 7,
+"out_size": 199777,
+"ratio": 0.194,
+"compress_mbps": 123.58,
+"decompress_mbps": 1186.64
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 8,
+"out_size": 182094,
+"ratio": 0.1768,
+"compress_mbps": 25.62,
+"decompress_mbps": 1170.25
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 9,
+"out_size": 181451,
+"ratio": 0.1762,
+"compress_mbps": 13.6,
+"decompress_mbps": 1174.11
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 10,
+"out_size": 179347,
+"ratio": 0.1742,
+"compress_mbps": 30.78,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 11,
+"out_size": 179096,
+"ratio": 0.1739,
+"compress_mbps": 19.99,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 12,
+"out_size": 179049,
+"ratio": 0.1739,
+"compress_mbps": 15.46,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 1,
+"out_size": 159063,
+"ratio": 0.3727,
+"compress_mbps": 263.79,
+"decompress_mbps": 1021.8
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 2,
+"out_size": 152115,
+"ratio": 0.3564,
+"compress_mbps": 186.84,
+"decompress_mbps": 1101.82
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 3,
+"out_size": 149162,
+"ratio": 0.3495,
+"compress_mbps": 156.34,
+"decompress_mbps": 1190.05
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 4,
+"out_size": 148359,
+"ratio": 0.3476,
+"compress_mbps": 142.52,
+"decompress_mbps": 1028.42
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 5,
+"out_size": 145353,
+"ratio": 0.3406,
+"compress_mbps": 112.89,
+"decompress_mbps": 996.54
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 6,
+"out_size": 144209,
+"ratio": 0.3379,
+"compress_mbps": 87.51,
+"decompress_mbps": 1031.7
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 7,
+"out_size": 143604,
+"ratio": 0.3365,
+"compress_mbps": 66.73,
+"decompress_mbps": 1039.91
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 8,
+"out_size": 142086,
+"ratio": 0.3329,
+"compress_mbps": 44.23,
+"decompress_mbps": 1037.6
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 9,
+"out_size": 142027,
+"ratio": 0.3328,
+"compress_mbps": 40.4,
+"decompress_mbps": 1036.5
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 10,
+"out_size": 138116,
+"ratio": 0.3236,
+"compress_mbps": 12.68,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 11,
+"out_size": 137923,
+"ratio": 0.3232,
+"compress_mbps": 8.69,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 12,
+"out_size": 137921,
+"ratio": 0.3232,
+"compress_mbps": 7.36,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 1,
+"out_size": 210662,
+"ratio": 0.4372,
+"compress_mbps": 228.42,
+"decompress_mbps": 865.39
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 2,
+"out_size": 202881,
+"ratio": 0.421,
+"compress_mbps": 158.66,
+"decompress_mbps": 938.79
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 3,
+"out_size": 200409,
+"ratio": 0.4159,
+"compress_mbps": 133.13,
+"decompress_mbps": 1016.29
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 4,
+"out_size": 199678,
+"ratio": 0.4144,
+"compress_mbps": 122.65,
+"decompress_mbps": 841.37
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 5,
+"out_size": 195798,
+"ratio": 0.4063,
+"compress_mbps": 93.06,
+"decompress_mbps": 790.98
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 6,
+"out_size": 194029,
+"ratio": 0.4027,
+"compress_mbps": 71.77,
+"decompress_mbps": 811.6
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 7,
+"out_size": 192773,
+"ratio": 0.4001,
+"compress_mbps": 50.51,
+"decompress_mbps": 815.68
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 8,
+"out_size": 191739,
+"ratio": 0.3979,
+"compress_mbps": 33.65,
+"decompress_mbps": 821.06
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 9,
+"out_size": 191676,
+"ratio": 0.3978,
+"compress_mbps": 31.02,
+"decompress_mbps": 821.03
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 10,
+"out_size": 185328,
+"ratio": 0.3846,
+"compress_mbps": 12.74,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 11,
+"out_size": 184440,
+"ratio": 0.3828,
+"compress_mbps": 8.96,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 12,
+"out_size": 184371,
+"ratio": 0.3826,
+"compress_mbps": 5.45,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 1,
+"out_size": 58079,
+"ratio": 0.1132,
+"compress_mbps": 371.33,
+"decompress_mbps": 1662.96
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 2,
+"out_size": 57838,
+"ratio": 0.1127,
+"compress_mbps": 410.38,
+"decompress_mbps": 1764.85
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 3,
+"out_size": 57554,
+"ratio": 0.1121,
+"compress_mbps": 390.9,
+"decompress_mbps": 1862.82
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 4,
+"out_size": 57064,
+"ratio": 0.1112,
+"compress_mbps": 371.73,
+"decompress_mbps": 1695.93
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 5,
+"out_size": 55743,
+"ratio": 0.1086,
+"compress_mbps": 341.58,
+"decompress_mbps": 1774.61
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 6,
+"out_size": 55102,
+"ratio": 0.1074,
+"compress_mbps": 278.3,
+"decompress_mbps": 1856.38
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 7,
+"out_size": 54742,
+"ratio": 0.1067,
+"compress_mbps": 192.18,
+"decompress_mbps": 1914.68
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 8,
+"out_size": 53133,
+"ratio": 0.1035,
+"compress_mbps": 102.47,
+"decompress_mbps": 1969.76
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 9,
+"out_size": 52186,
+"ratio": 0.1017,
+"compress_mbps": 72.13,
+"decompress_mbps": 2001.32
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 10,
+"out_size": 51319,
+"ratio": 0.1,
+"compress_mbps": 12.76,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 11,
+"out_size": 49675,
+"ratio": 0.0968,
+"compress_mbps": 6.04,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 12,
+"out_size": 49194,
+"ratio": 0.0959,
+"compress_mbps": 3.5,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 1,
+"out_size": 14122,
+"ratio": 0.3693,
+"compress_mbps": 651.19,
+"decompress_mbps": 823.09
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 2,
+"out_size": 13374,
+"ratio": 0.3497,
+"compress_mbps": 345.74,
+"decompress_mbps": 878.53
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 3,
+"out_size": 13293,
+"ratio": 0.3476,
+"compress_mbps": 286.57,
+"decompress_mbps": 952.93
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 4,
+"out_size": 13259,
+"ratio": 0.3467,
+"compress_mbps": 265.38,
+"decompress_mbps": 948.93
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 5,
+"out_size": 12641,
+"ratio": 0.3306,
+"compress_mbps": 189.13,
+"decompress_mbps": 989.89
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 6,
+"out_size": 12432,
+"ratio": 0.3251,
+"compress_mbps": 164.09,
+"decompress_mbps": 1011.41
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 7,
+"out_size": 12439,
+"ratio": 0.3253,
+"compress_mbps": 122.75,
+"decompress_mbps": 1008.2
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 8,
+"out_size": 12579,
+"ratio": 0.3289,
+"compress_mbps": 67.84,
+"decompress_mbps": 1015.44
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 9,
+"out_size": 12574,
+"ratio": 0.3288,
+"compress_mbps": 47.51,
+"decompress_mbps": 1027.14
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 10,
+"out_size": 11975,
+"ratio": 0.3132,
+"compress_mbps": 19.93,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 11,
+"out_size": 11966,
+"ratio": 0.3129,
+"compress_mbps": 13.28,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 12,
+"out_size": 11965,
+"ratio": 0.3129,
+"compress_mbps": 10.53,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 1,
+"out_size": 1777,
+"ratio": 0.4204,
+"compress_mbps": 383.89,
+"decompress_mbps": 399.96
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 2,
+"out_size": 1756,
+"ratio": 0.4154,
+"compress_mbps": 258.74,
+"decompress_mbps": 401.83
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 3,
+"out_size": 1746,
+"ratio": 0.4131,
+"compress_mbps": 256.81,
+"decompress_mbps": 403.4
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 4,
+"out_size": 1740,
+"ratio": 0.4116,
+"compress_mbps": 254.22,
+"decompress_mbps": 409.76
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 5,
+"out_size": 1722,
+"ratio": 0.4074,
+"compress_mbps": 239.57,
+"decompress_mbps": 415.67
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 6,
+"out_size": 1721,
+"ratio": 0.4071,
+"compress_mbps": 234.6,
+"decompress_mbps": 415.71
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 7,
+"out_size": 1720,
+"ratio": 0.4069,
+"compress_mbps": 233.37,
+"decompress_mbps": 414.43
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 8,
+"out_size": 1717,
+"ratio": 0.4062,
+"compress_mbps": 216.54,
+"decompress_mbps": 413.37
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 9,
+"out_size": 1717,
+"ratio": 0.4062,
+"compress_mbps": 216.39,
+"decompress_mbps": 413.88
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 10,
+"out_size": 1692,
+"ratio": 0.4003,
+"compress_mbps": 54.8,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 11,
+"out_size": 1690,
+"ratio": 0.3998,
+"compress_mbps": 45.13,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 12,
+"out_size": 1690,
+"ratio": 0.3998,
+"compress_mbps": 29.88,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4259644,
+"ratio": 0.4179,
+"compress_mbps": 65.86,
+"decompress_mbps": 105.55
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 2,
+"out_size": 3977395,
+"ratio": 0.3902,
+"compress_mbps": 47.37,
+"decompress_mbps": 114.1
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3945296,
+"ratio": 0.3871,
+"compress_mbps": 41.44,
+"decompress_mbps": 125.54
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 4,
+"out_size": 3882303,
+"ratio": 0.3809,
+"compress_mbps": 29.15,
+"decompress_mbps": 128.05
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 5,
+"out_size": 3870984,
+"ratio": 0.3798,
+"compress_mbps": 24.26,
+"decompress_mbps": 133.95
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3878499,
+"ratio": 0.3805,
+"compress_mbps": 22.99,
+"decompress_mbps": 137.77
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 7,
+"out_size": 3865234,
+"ratio": 0.3792,
+"compress_mbps": 19.95,
+"decompress_mbps": 138.22
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 8,
+"out_size": 3864805,
+"ratio": 0.3792,
+"compress_mbps": 19.45,
+"decompress_mbps": 138.39
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3766584,
+"ratio": 0.3695,
+"compress_mbps": 3.92,
+"decompress_mbps": 142.27
+},
+{
+"compressor": "native",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 10,
+"out_size": 3711172,
+"ratio": 0.3641,
+"compress_mbps": 2.32,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 21267086,
+"ratio": 0.4152,
+"compress_mbps": 79.55,
+"decompress_mbps": 134.07
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 2,
+"out_size": 20802983,
+"ratio": 0.4061,
+"compress_mbps": 63.79,
+"decompress_mbps": 140.56
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 20665485,
+"ratio": 0.4035,
+"compress_mbps": 58.91,
+"decompress_mbps": 144.94
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 4,
+"out_size": 20393572,
+"ratio": 0.3982,
+"compress_mbps": 44.93,
+"decompress_mbps": 152.03
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 5,
+"out_size": 20264932,
+"ratio": 0.3956,
+"compress_mbps": 33.04,
+"decompress_mbps": 160.26
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 19208910,
+"ratio": 0.375,
+"compress_mbps": 17.28,
+"decompress_mbps": 164.29
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 7,
+"out_size": 19177573,
+"ratio": 0.3744,
+"compress_mbps": 14.3,
+"decompress_mbps": 164.74
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 8,
+"out_size": 19172591,
+"ratio": 0.3743,
+"compress_mbps": 12.52,
+"decompress_mbps": 162.27
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18686872,
+"ratio": 0.3648,
+"compress_mbps": 3.76,
+"decompress_mbps": 164.35
+},
+{
+"compressor": "native",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 10,
+"out_size": 18539905,
+"ratio": 0.362,
+"compress_mbps": 2.09,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3864163,
+"ratio": 0.3876,
+"compress_mbps": 80.07,
+"decompress_mbps": 117.92
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 2,
+"out_size": 3734957,
+"ratio": 0.3746,
+"compress_mbps": 60.7,
+"decompress_mbps": 128.07
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3708443,
+"ratio": 0.3719,
+"compress_mbps": 52.31,
+"decompress_mbps": 136.92
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 4,
+"out_size": 3707604,
+"ratio": 0.3719,
+"compress_mbps": 34.04,
+"decompress_mbps": 133.34
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 5,
+"out_size": 3705174,
+"ratio": 0.3716,
+"compress_mbps": 27.09,
+"decompress_mbps": 139.01
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3612809,
+"ratio": 0.3623,
+"compress_mbps": 20.92,
+"decompress_mbps": 143.87
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 7,
+"out_size": 3608980,
+"ratio": 0.362,
+"compress_mbps": 18.09,
+"decompress_mbps": 145.25
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 8,
+"out_size": 3609490,
+"ratio": 0.362,
+"compress_mbps": 16.61,
+"decompress_mbps": 148.42
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3581441,
+"ratio": 0.3592,
+"compress_mbps": 4.2,
+"decompress_mbps": 152.41
+},
+{
+"compressor": "native",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 10,
+"out_size": 3512886,
+"ratio": 0.3523,
+"compress_mbps": 2.62,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3785443,
+"ratio": 0.1128,
+"compress_mbps": 232.74,
+"decompress_mbps": 364.56
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 2,
+"out_size": 3761560,
+"ratio": 0.1121,
+"compress_mbps": 145.7,
+"decompress_mbps": 411.17
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3606997,
+"ratio": 0.1075,
+"compress_mbps": 124.89,
+"decompress_mbps": 458.24
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 4,
+"out_size": 3225450,
+"ratio": 0.0961,
+"compress_mbps": 92.12,
+"decompress_mbps": 468.85
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 5,
+"out_size": 3145121,
+"ratio": 0.0937,
+"compress_mbps": 63.08,
+"decompress_mbps": 533.8
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3158854,
+"ratio": 0.0941,
+"compress_mbps": 59.78,
+"decompress_mbps": 573.38
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 7,
+"out_size": 3124878,
+"ratio": 0.0931,
+"compress_mbps": 42.13,
+"decompress_mbps": 588.15
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 8,
+"out_size": 3112207,
+"ratio": 0.0928,
+"compress_mbps": 34.57,
+"decompress_mbps": 604.7
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 3034875,
+"ratio": 0.0904,
+"compress_mbps": 3.12,
+"decompress_mbps": 588.57
+},
+{
+"compressor": "native",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 10,
+"out_size": 2902186,
+"ratio": 0.0865,
+"compress_mbps": 1.83,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3357083,
+"ratio": 0.5457,
+"compress_mbps": 56.31,
+"decompress_mbps": 92.77
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 2,
+"out_size": 3285077,
+"ratio": 0.534,
+"compress_mbps": 46.39,
+"decompress_mbps": 96.56
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3272746,
+"ratio": 0.532,
+"compress_mbps": 44.65,
+"decompress_mbps": 97.16
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 4,
+"out_size": 3237094,
+"ratio": 0.5262,
+"compress_mbps": 35.72,
+"decompress_mbps": 104.92
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 5,
+"out_size": 3233792,
+"ratio": 0.5256,
+"compress_mbps": 31.99,
+"decompress_mbps": 109.12
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3168386,
+"ratio": 0.515,
+"compress_mbps": 17.83,
+"decompress_mbps": 110.97
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 7,
+"out_size": 3165783,
+"ratio": 0.5146,
+"compress_mbps": 16.79,
+"decompress_mbps": 112.05
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 8,
+"out_size": 3165909,
+"ratio": 0.5146,
+"compress_mbps": 16.07,
+"decompress_mbps": 112.63
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3048772,
+"ratio": 0.4956,
+"compress_mbps": 4.4,
+"decompress_mbps": 114.06
+},
+{
+"compressor": "native",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 10,
+"out_size": 3021986,
+"ratio": 0.4912,
+"compress_mbps": 2.84,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3838828,
+"ratio": 0.3806,
+"compress_mbps": 90.02,
+"decompress_mbps": 159.08
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 2,
+"out_size": 3792520,
+"ratio": 0.376,
+"compress_mbps": 66.94,
+"decompress_mbps": 164.47
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3783171,
+"ratio": 0.3751,
+"compress_mbps": 64.0,
+"decompress_mbps": 162.67
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 4,
+"out_size": 3706928,
+"ratio": 0.3675,
+"compress_mbps": 55.82,
+"decompress_mbps": 173.82
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 5,
+"out_size": 3707010,
+"ratio": 0.3676,
+"compress_mbps": 52.61,
+"decompress_mbps": 178.92
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3707065,
+"ratio": 0.3676,
+"compress_mbps": 38.29,
+"decompress_mbps": 187.64
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 7,
+"out_size": 3706769,
+"ratio": 0.3675,
+"compress_mbps": 38.13,
+"decompress_mbps": 189.46
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 8,
+"out_size": 3706769,
+"ratio": 0.3675,
+"compress_mbps": 38.38,
+"decompress_mbps": 190.47
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3665069,
+"ratio": 0.3634,
+"compress_mbps": 5.19,
+"decompress_mbps": 195.86
+},
+{
+"compressor": "native",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 10,
+"out_size": 3647321,
+"ratio": 0.3616,
+"compress_mbps": 3.07,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2254442,
+"ratio": 0.3402,
+"compress_mbps": 83.54,
+"decompress_mbps": 126.2
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 2,
+"out_size": 2044843,
+"ratio": 0.3086,
+"compress_mbps": 56.06,
+"decompress_mbps": 142.3
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 1992105,
+"ratio": 0.3006,
+"compress_mbps": 45.26,
+"decompress_mbps": 156.6
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 4,
+"out_size": 1901081,
+"ratio": 0.2869,
+"compress_mbps": 27.96,
+"decompress_mbps": 160.98
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 5,
+"out_size": 1874829,
+"ratio": 0.2829,
+"compress_mbps": 17.0,
+"decompress_mbps": 170.98
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1867098,
+"ratio": 0.2817,
+"compress_mbps": 19.93,
+"decompress_mbps": 180.53
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 7,
+"out_size": 1843421,
+"ratio": 0.2782,
+"compress_mbps": 13.07,
+"decompress_mbps": 180.83
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 8,
+"out_size": 1841388,
+"ratio": 0.2779,
+"compress_mbps": 10.89,
+"decompress_mbps": 187.16
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1773447,
+"ratio": 0.2676,
+"compress_mbps": 2.7,
+"decompress_mbps": 191.59
+},
+{
+"compressor": "native",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 10,
+"out_size": 1718500,
+"ratio": 0.2593,
+"compress_mbps": 1.49,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 6406301,
+"ratio": 0.2965,
+"compress_mbps": 109.58,
+"decompress_mbps": 197.79
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 2,
+"out_size": 6102377,
+"ratio": 0.2824,
+"compress_mbps": 81.1,
+"decompress_mbps": 209.1
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 6022184,
+"ratio": 0.2787,
+"compress_mbps": 73.79,
+"decompress_mbps": 218.95
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 4,
+"out_size": 5880979,
+"ratio": 0.2722,
+"compress_mbps": 54.12,
+"decompress_mbps": 227.73
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 5,
+"out_size": 5839944,
+"ratio": 0.2703,
+"compress_mbps": 41.81,
+"decompress_mbps": 240.36
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5425813,
+"ratio": 0.2511,
+"compress_mbps": 29.2,
+"decompress_mbps": 244.92
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 7,
+"out_size": 5409983,
+"ratio": 0.2504,
+"compress_mbps": 25.86,
+"decompress_mbps": 247.57
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 8,
+"out_size": 5407066,
+"ratio": 0.2503,
+"compress_mbps": 24.17,
+"decompress_mbps": 249.21
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5235865,
+"ratio": 0.2423,
+"compress_mbps": 3.88,
+"decompress_mbps": 245.07
+},
+{
+"compressor": "native",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 10,
+"out_size": 5177560,
+"ratio": 0.2396,
+"compress_mbps": 2.29,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5612204,
+"ratio": 0.7739,
+"compress_mbps": 44.94,
+"decompress_mbps": 90.15
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 2,
+"out_size": 5533875,
+"ratio": 0.7631,
+"compress_mbps": 38.92,
+"decompress_mbps": 88.31
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5522436,
+"ratio": 0.7615,
+"compress_mbps": 36.25,
+"decompress_mbps": 95.47
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 4,
+"out_size": 5498823,
+"ratio": 0.7583,
+"compress_mbps": 28.94,
+"decompress_mbps": 97.25
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 5,
+"out_size": 5496802,
+"ratio": 0.758,
+"compress_mbps": 27.76,
+"decompress_mbps": 99.62
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5478405,
+"ratio": 0.7554,
+"compress_mbps": 20.04,
+"decompress_mbps": 105.13
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 7,
+"out_size": 5474648,
+"ratio": 0.7549,
+"compress_mbps": 19.37,
+"decompress_mbps": 106.41
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 8,
+"out_size": 5474139,
+"ratio": 0.7549,
+"compress_mbps": 19.29,
+"decompress_mbps": 104.39
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5284536,
+"ratio": 0.7287,
+"compress_mbps": 3.99,
+"decompress_mbps": 98.8
+},
+{
+"compressor": "native",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 10,
+"out_size": 5262319,
+"ratio": 0.7256,
+"compress_mbps": 3.03,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13727247,
+"ratio": 0.3311,
+"compress_mbps": 82.89,
+"decompress_mbps": 137.04
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 2,
+"out_size": 12940398,
+"ratio": 0.3121,
+"compress_mbps": 60.03,
+"decompress_mbps": 147.95
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12703756,
+"ratio": 0.3064,
+"compress_mbps": 55.24,
+"decompress_mbps": 159.59
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 4,
+"out_size": 12229398,
+"ratio": 0.295,
+"compress_mbps": 37.8,
+"decompress_mbps": 156.27
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 5,
+"out_size": 12123671,
+"ratio": 0.2924,
+"compress_mbps": 29.29,
+"decompress_mbps": 167.85
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12167341,
+"ratio": 0.2935,
+"compress_mbps": 28.55,
+"decompress_mbps": 165.43
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 7,
+"out_size": 12109369,
+"ratio": 0.2921,
+"compress_mbps": 24.01,
+"decompress_mbps": 182.62
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 8,
+"out_size": 12106058,
+"ratio": 0.292,
+"compress_mbps": 21.77,
+"decompress_mbps": 177.07
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11806466,
+"ratio": 0.2848,
+"compress_mbps": 3.59,
+"decompress_mbps": 184.45
+},
+{
+"compressor": "native",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 10,
+"out_size": 11636727,
+"ratio": 0.2807,
+"compress_mbps": 1.92,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6438176,
+"ratio": 0.7597,
+"compress_mbps": 42.9,
+"decompress_mbps": 78.68
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 2,
+"out_size": 6392101,
+"ratio": 0.7543,
+"compress_mbps": 41.08,
+"decompress_mbps": 79.19
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6392124,
+"ratio": 0.7543,
+"compress_mbps": 41.28,
+"decompress_mbps": 80.76
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 4,
+"out_size": 6368719,
+"ratio": 0.7515,
+"compress_mbps": 38.87,
+"decompress_mbps": 80.9
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 5,
+"out_size": 6368717,
+"ratio": 0.7515,
+"compress_mbps": 38.89,
+"decompress_mbps": 82.91
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 6278507,
+"ratio": 0.7409,
+"compress_mbps": 9.86,
+"decompress_mbps": 82.94
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 7,
+"out_size": 6278507,
+"ratio": 0.7409,
+"compress_mbps": 10.01,
+"decompress_mbps": 82.88
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 8,
+"out_size": 6278507,
+"ratio": 0.7409,
+"compress_mbps": 9.77,
+"decompress_mbps": 83.32
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5952505,
+"ratio": 0.7024,
+"compress_mbps": 4.98,
+"decompress_mbps": 84.24
+},
+{
+"compressor": "native",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 10,
+"out_size": 5848663,
+"ratio": 0.6902,
+"compress_mbps": 3.78,
+"decompress_mbps": null
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 858525,
+"ratio": 0.1606,
+"compress_mbps": 177.29,
+"decompress_mbps": 270.55
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 2,
+"out_size": 846807,
+"ratio": 0.1584,
+"compress_mbps": 112.57,
+"decompress_mbps": 301.81
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 806798,
+"ratio": 0.1509,
+"compress_mbps": 102.84,
+"decompress_mbps": 338.17
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 4,
+"out_size": 721655,
+"ratio": 0.135,
+"compress_mbps": 73.68,
+"decompress_mbps": 333.13
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 5,
+"out_size": 710636,
+"ratio": 0.1329,
+"compress_mbps": 53.59,
+"decompress_mbps": 365.86
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 688375,
+"ratio": 0.1288,
+"compress_mbps": 47.38,
+"decompress_mbps": 403.0
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 7,
+"out_size": 676544,
+"ratio": 0.1266,
+"compress_mbps": 38.07,
+"decompress_mbps": 413.62
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 8,
+"out_size": 674362,
+"ratio": 0.1262,
+"compress_mbps": 33.09,
+"decompress_mbps": 424.31
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 659417,
+"ratio": 0.1234,
+"compress_mbps": 4.19,
+"decompress_mbps": 449.48
+},
+{
+"compressor": "native",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 10,
+"out_size": 643093,
+"ratio": 0.1203,
+"compress_mbps": 2.84,
+"decompress_mbps": null
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4585612,
+"ratio": 0.4499,
+"compress_mbps": 112.9,
+"decompress_mbps": 344.92
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 2,
+"out_size": 4389474,
+"ratio": 0.4307,
+"compress_mbps": 95.43,
+"decompress_mbps": 367.17
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 4192079,
+"ratio": 0.4113,
+"compress_mbps": 59.17,
+"decompress_mbps": 398.26
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 4,
+"out_size": 4095021,
+"ratio": 0.4018,
+"compress_mbps": 65.65,
+"decompress_mbps": 380.09
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 5,
+"out_size": 3949169,
+"ratio": 0.3875,
+"compress_mbps": 35.62,
+"decompress_mbps": 367.61
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3871628,
+"ratio": 0.3799,
+"compress_mbps": 21.17,
+"decompress_mbps": 377.77
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 7,
+"out_size": 3858876,
+"ratio": 0.3786,
+"compress_mbps": 17.65,
+"decompress_mbps": 379.94
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 8,
+"out_size": 3854729,
+"ratio": 0.3782,
+"compress_mbps": 15.03,
+"decompress_mbps": 379.97
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3854729,
+"ratio": 0.3782,
+"compress_mbps": 15.0,
+"decompress_mbps": 380.17
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20577220,
+"ratio": 0.4017,
+"compress_mbps": 112.07,
+"decompress_mbps": 353.52
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 2,
+"out_size": 20247697,
+"ratio": 0.3953,
+"compress_mbps": 100.19,
+"decompress_mbps": 366.17
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19987880,
+"ratio": 0.3902,
+"compress_mbps": 76.03,
+"decompress_mbps": 373.04
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 4,
+"out_size": 19512665,
+"ratio": 0.381,
+"compress_mbps": 75.24,
+"decompress_mbps": 363.97
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 5,
+"out_size": 19213507,
+"ratio": 0.3751,
+"compress_mbps": 53.09,
+"decompress_mbps": 369.34
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 19089118,
+"ratio": 0.3727,
+"compress_mbps": 34.33,
+"decompress_mbps": 373.69
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 7,
+"out_size": 19061204,
+"ratio": 0.3721,
+"compress_mbps": 27.3,
+"decompress_mbps": 376.83
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 8,
+"out_size": 19040998,
+"ratio": 0.3717,
+"compress_mbps": 15.4,
+"decompress_mbps": 376.27
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 19044390,
+"ratio": 0.3718,
+"compress_mbps": 9.51,
+"decompress_mbps": 377.24
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3828360,
+"ratio": 0.384,
+"compress_mbps": 143.06,
+"decompress_mbps": 466.9
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 2,
+"out_size": 3798539,
+"ratio": 0.381,
+"compress_mbps": 126.34,
+"decompress_mbps": 481.52
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3674568,
+"ratio": 0.3685,
+"compress_mbps": 79.25,
+"decompress_mbps": 499.48
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 4,
+"out_size": 3680923,
+"ratio": 0.3692,
+"compress_mbps": 87.5,
+"decompress_mbps": 443.81
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 5,
+"out_size": 3698707,
+"ratio": 0.371,
+"compress_mbps": 47.33,
+"decompress_mbps": 415.52
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3675935,
+"ratio": 0.3687,
+"compress_mbps": 26.24,
+"decompress_mbps": 432.27
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 7,
+"out_size": 3670281,
+"ratio": 0.3681,
+"compress_mbps": 20.75,
+"decompress_mbps": 438.0
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 8,
+"out_size": 3661103,
+"ratio": 0.3672,
+"compress_mbps": 10.99,
+"decompress_mbps": 447.92
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3660788,
+"ratio": 0.3672,
+"compress_mbps": 9.51,
+"decompress_mbps": 448.66
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 4624591,
+"ratio": 0.1378,
+"compress_mbps": 334.74,
+"decompress_mbps": 810.57
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 2,
+"out_size": 4303176,
+"ratio": 0.1282,
+"compress_mbps": 309.81,
+"decompress_mbps": 840.23
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 4010156,
+"ratio": 0.1195,
+"compress_mbps": 258.23,
+"decompress_mbps": 922.43
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 4,
+"out_size": 3713866,
+"ratio": 0.1107,
+"compress_mbps": 212.43,
+"decompress_mbps": 899.61
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 5,
+"out_size": 3378136,
+"ratio": 0.1007,
+"compress_mbps": 165.59,
+"decompress_mbps": 955.5
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3200182,
+"ratio": 0.0954,
+"compress_mbps": 114.19,
+"decompress_mbps": 1003.83
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 7,
+"out_size": 3141278,
+"ratio": 0.0936,
+"compress_mbps": 90.27,
+"decompress_mbps": 1014.87
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 8,
+"out_size": 3031199,
+"ratio": 0.0903,
+"compress_mbps": 39.33,
+"decompress_mbps": 1003.59
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2987995,
+"ratio": 0.0891,
+"compress_mbps": 21.46,
+"decompress_mbps": 1030.56
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3290526,
+"ratio": 0.5349,
+"compress_mbps": 78.63,
+"decompress_mbps": 253.04
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 2,
+"out_size": 3238282,
+"ratio": 0.5264,
+"compress_mbps": 71.42,
+"decompress_mbps": 258.74
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3193366,
+"ratio": 0.5191,
+"compress_mbps": 56.57,
+"decompress_mbps": 265.13
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 4,
+"out_size": 3158012,
+"ratio": 0.5133,
+"compress_mbps": 55.17,
+"decompress_mbps": 266.79
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 5,
+"out_size": 3115309,
+"ratio": 0.5064,
+"compress_mbps": 39.03,
+"decompress_mbps": 270.19
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3097288,
+"ratio": 0.5034,
+"compress_mbps": 26.4,
+"decompress_mbps": 273.25
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 7,
+"out_size": 3094363,
+"ratio": 0.503,
+"compress_mbps": 21.97,
+"decompress_mbps": 273.42
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 8,
+"out_size": 3093026,
+"ratio": 0.5028,
+"compress_mbps": 17.15,
+"decompress_mbps": 274.45
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3092920,
+"ratio": 0.5027,
+"compress_mbps": 15.57,
+"decompress_mbps": 273.36
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 4076385,
+"ratio": 0.4042,
+"compress_mbps": 126.52,
+"decompress_mbps": 451.69
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 2,
+"out_size": 3991014,
+"ratio": 0.3957,
+"compress_mbps": 117.71,
+"decompress_mbps": 492.11
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3934055,
+"ratio": 0.3901,
+"compress_mbps": 93.9,
+"decompress_mbps": 511.69
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 4,
+"out_size": 3825092,
+"ratio": 0.3793,
+"compress_mbps": 85.01,
+"decompress_mbps": 505.76
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 5,
+"out_size": 3752932,
+"ratio": 0.3721,
+"compress_mbps": 64.85,
+"decompress_mbps": 500.03
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3695164,
+"ratio": 0.3664,
+"compress_mbps": 49.58,
+"decompress_mbps": 511.28
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 7,
+"out_size": 3676881,
+"ratio": 0.3646,
+"compress_mbps": 38.18,
+"decompress_mbps": 520.25
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 8,
+"out_size": 3673171,
+"ratio": 0.3642,
+"compress_mbps": 32.02,
+"decompress_mbps": 524.7
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3673171,
+"ratio": 0.3642,
+"compress_mbps": 31.98,
+"decompress_mbps": 523.22
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2376424,
+"ratio": 0.3586,
+"compress_mbps": 130.75,
+"decompress_mbps": 395.81
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 2,
+"out_size": 2259060,
+"ratio": 0.3409,
+"compress_mbps": 112.16,
+"decompress_mbps": 412.15
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2135664,
+"ratio": 0.3223,
+"compress_mbps": 72.65,
+"decompress_mbps": 434.27
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 4,
+"out_size": 2052793,
+"ratio": 0.3098,
+"compress_mbps": 82.15,
+"decompress_mbps": 431.28
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 5,
+"out_size": 1932127,
+"ratio": 0.2915,
+"compress_mbps": 45.47,
+"decompress_mbps": 432.58
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1860865,
+"ratio": 0.2808,
+"compress_mbps": 22.86,
+"decompress_mbps": 430.09
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 7,
+"out_size": 1838671,
+"ratio": 0.2774,
+"compress_mbps": 15.9,
+"decompress_mbps": 431.27
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 8,
+"out_size": 1823235,
+"ratio": 0.2751,
+"compress_mbps": 8.11,
+"decompress_mbps": 430.78
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1823190,
+"ratio": 0.2751,
+"compress_mbps": 8.07,
+"decompress_mbps": 436.02
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 6329449,
+"ratio": 0.2929,
+"compress_mbps": 168.35,
+"decompress_mbps": 457.14
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 2,
+"out_size": 6128866,
+"ratio": 0.2837,
+"compress_mbps": 155.31,
+"decompress_mbps": 544.24
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5982546,
+"ratio": 0.2769,
+"compress_mbps": 124.88,
+"decompress_mbps": 568.18
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 4,
+"out_size": 5656400,
+"ratio": 0.2618,
+"compress_mbps": 116.79,
+"decompress_mbps": 567.03
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 5,
+"out_size": 5511352,
+"ratio": 0.2551,
+"compress_mbps": 82.16,
+"decompress_mbps": 575.02
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5451399,
+"ratio": 0.2523,
+"compress_mbps": 56.58,
+"decompress_mbps": 558.24
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 7,
+"out_size": 5417123,
+"ratio": 0.2507,
+"compress_mbps": 46.62,
+"decompress_mbps": 589.12
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 8,
+"out_size": 5404364,
+"ratio": 0.2501,
+"compress_mbps": 32.68,
+"decompress_mbps": 594.94
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5402704,
+"ratio": 0.2501,
+"compress_mbps": 29.8,
+"decompress_mbps": 596.17
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5567768,
+"ratio": 0.7678,
+"compress_mbps": 64.24,
+"decompress_mbps": 313.33
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 2,
+"out_size": 5504009,
+"ratio": 0.759,
+"compress_mbps": 58.26,
+"decompress_mbps": 324.49
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5439339,
+"ratio": 0.7501,
+"compress_mbps": 46.28,
+"decompress_mbps": 333.53
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 4,
+"out_size": 5394604,
+"ratio": 0.7439,
+"compress_mbps": 47.91,
+"decompress_mbps": 343.92
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 5,
+"out_size": 5370116,
+"ratio": 0.7405,
+"compress_mbps": 33.04,
+"decompress_mbps": 337.26
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5331793,
+"ratio": 0.7352,
+"compress_mbps": 23.02,
+"decompress_mbps": 342.64
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 7,
+"out_size": 5327677,
+"ratio": 0.7347,
+"compress_mbps": 21.09,
+"decompress_mbps": 340.24
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 8,
+"out_size": 5325914,
+"ratio": 0.7344,
+"compress_mbps": 18.88,
+"decompress_mbps": 343.38
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5325914,
+"ratio": 0.7344,
+"compress_mbps": 18.86,
+"decompress_mbps": 340.76
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 14991236,
+"ratio": 0.3616,
+"compress_mbps": 136.57,
+"decompress_mbps": 360.93
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 2,
+"out_size": 14249692,
+"ratio": 0.3437,
+"compress_mbps": 120.26,
+"decompress_mbps": 393.57
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 13627761,
+"ratio": 0.3287,
+"compress_mbps": 87.43,
+"decompress_mbps": 409.97
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 4,
+"out_size": 13001990,
+"ratio": 0.3136,
+"compress_mbps": 84.92,
+"decompress_mbps": 390.84
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 5,
+"out_size": 12445991,
+"ratio": 0.3002,
+"compress_mbps": 54.7,
+"decompress_mbps": 387.48
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12213941,
+"ratio": 0.2946,
+"compress_mbps": 36.36,
+"decompress_mbps": 394.08
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 7,
+"out_size": 12130416,
+"ratio": 0.2926,
+"compress_mbps": 29.55,
+"decompress_mbps": 396.12
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 8,
+"out_size": 12073697,
+"ratio": 0.2912,
+"compress_mbps": 21.38,
+"decompress_mbps": 398.65
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 12073469,
+"ratio": 0.2912,
+"compress_mbps": 21.24,
+"decompress_mbps": 400.02
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6033926,
+"ratio": 0.712,
+"compress_mbps": 74.72,
+"decompress_mbps": 290.16
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 2,
+"out_size": 5997474,
+"ratio": 0.7077,
+"compress_mbps": 68.17,
+"decompress_mbps": 298.3
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 5966621,
+"ratio": 0.7041,
+"compress_mbps": 55.2,
+"decompress_mbps": 305.36
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 4,
+"out_size": 6091108,
+"ratio": 0.7188,
+"compress_mbps": 45.51,
+"decompress_mbps": 262.1
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 5,
+"out_size": 6053566,
+"ratio": 0.7143,
+"compress_mbps": 36.91,
+"decompress_mbps": 270.38
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 6045111,
+"ratio": 0.7134,
+"compress_mbps": 34.75,
+"decompress_mbps": 275.14
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 7,
+"out_size": 6045034,
+"ratio": 0.7133,
+"compress_mbps": 34.64,
+"decompress_mbps": 275.6
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 8,
+"out_size": 6045032,
+"ratio": 0.7133,
+"compress_mbps": 34.69,
+"decompress_mbps": 275.05
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 6045032,
+"ratio": 0.7133,
+"compress_mbps": 34.64,
+"decompress_mbps": 274.34
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 965242,
+"ratio": 0.1806,
+"compress_mbps": 262.6,
+"decompress_mbps": 674.71
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 2,
+"out_size": 887265,
+"ratio": 0.166,
+"compress_mbps": 245.29,
+"decompress_mbps": 734.01
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 822167,
+"ratio": 0.1538,
+"compress_mbps": 190.93,
+"decompress_mbps": 787.19
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 4,
+"out_size": 807518,
+"ratio": 0.1511,
+"compress_mbps": 168.99,
+"decompress_mbps": 754.09
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 5,
+"out_size": 730574,
+"ratio": 0.1367,
+"compress_mbps": 121.67,
+"decompress_mbps": 801.04
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 687991,
+"ratio": 0.1287,
+"compress_mbps": 79.4,
+"decompress_mbps": 858.56
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 7,
+"out_size": 673933,
+"ratio": 0.1261,
+"compress_mbps": 65.06,
+"decompress_mbps": 870.44
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 8,
+"out_size": 659518,
+"ratio": 0.1234,
+"compress_mbps": 43.03,
+"decompress_mbps": 886.73
+},
+{
+"compressor": "zlib",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 658899,
+"ratio": 0.1233,
+"compress_mbps": 39.76,
+"decompress_mbps": 889.25
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 5363862,
+"ratio": 0.5263,
+"compress_mbps": 142.13,
+"decompress_mbps": 367.89
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 2,
+"out_size": 4438205,
+"ratio": 0.4354,
+"compress_mbps": 127.41,
+"decompress_mbps": 418.03
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 4054333,
+"ratio": 0.3978,
+"compress_mbps": 63.93,
+"decompress_mbps": 465.47
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 4,
+"out_size": 4038550,
+"ratio": 0.3962,
+"compress_mbps": 57.58,
+"decompress_mbps": 461.6
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 5,
+"out_size": 3954920,
+"ratio": 0.388,
+"compress_mbps": 40.28,
+"decompress_mbps": 451.82
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3872874,
+"ratio": 0.38,
+"compress_mbps": 22.59,
+"decompress_mbps": 463.35
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 7,
+"out_size": 3859937,
+"ratio": 0.3787,
+"compress_mbps": 18.86,
+"decompress_mbps": 464.51
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 8,
+"out_size": 3855935,
+"ratio": 0.3783,
+"compress_mbps": 17.01,
+"decompress_mbps": 462.2
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3855791,
+"ratio": 0.3783,
+"compress_mbps": 17.01,
+"decompress_mbps": 464.34
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 22334882,
+"ratio": 0.4361,
+"compress_mbps": 237.47,
+"decompress_mbps": 359.97
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 2,
+"out_size": 20150366,
+"ratio": 0.3934,
+"compress_mbps": 119.56,
+"decompress_mbps": 371.65
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19495014,
+"ratio": 0.3806,
+"compress_mbps": 70.05,
+"decompress_mbps": 380.8
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 4,
+"out_size": 19424978,
+"ratio": 0.3792,
+"compress_mbps": 71.25,
+"decompress_mbps": 394.95
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 5,
+"out_size": 19298736,
+"ratio": 0.3768,
+"compress_mbps": 54.15,
+"decompress_mbps": 408.78
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 19179167,
+"ratio": 0.3744,
+"compress_mbps": 29.73,
+"decompress_mbps": 415.74
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 7,
+"out_size": 19151324,
+"ratio": 0.3739,
+"compress_mbps": 21.93,
+"decompress_mbps": 416.25
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 8,
+"out_size": 19144373,
+"ratio": 0.3738,
+"compress_mbps": 16.58,
+"decompress_mbps": 419.75
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 19141383,
+"ratio": 0.3737,
+"compress_mbps": 14.19,
+"decompress_mbps": 404.15
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 4249731,
+"ratio": 0.4262,
+"compress_mbps": 311.43,
+"decompress_mbps": 518.78
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 2,
+"out_size": 3775479,
+"ratio": 0.3787,
+"compress_mbps": 156.55,
+"decompress_mbps": 540.67
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3656966,
+"ratio": 0.3668,
+"compress_mbps": 79.24,
+"decompress_mbps": 565.82
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 4,
+"out_size": 3740378,
+"ratio": 0.3751,
+"compress_mbps": 67.15,
+"decompress_mbps": 526.93
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 5,
+"out_size": 3713604,
+"ratio": 0.3725,
+"compress_mbps": 48.3,
+"decompress_mbps": 488.73
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3683556,
+"ratio": 0.3694,
+"compress_mbps": 24.9,
+"decompress_mbps": 510.52
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 7,
+"out_size": 3683797,
+"ratio": 0.3695,
+"compress_mbps": 18.88,
+"decompress_mbps": 500.66
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 8,
+"out_size": 3684477,
+"ratio": 0.3695,
+"compress_mbps": 14.29,
+"decompress_mbps": 526.33
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3679414,
+"ratio": 0.369,
+"compress_mbps": 12.32,
+"decompress_mbps": 528.49
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 5594622,
+"ratio": 0.1667,
+"compress_mbps": 433.14,
+"decompress_mbps": 839.24
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 2,
+"out_size": 4179532,
+"ratio": 0.1246,
+"compress_mbps": 326.71,
+"decompress_mbps": 924.08
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3542329,
+"ratio": 0.1056,
+"compress_mbps": 211.96,
+"decompress_mbps": 841.08
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 4,
+"out_size": 3323363,
+"ratio": 0.099,
+"compress_mbps": 198.1,
+"decompress_mbps": 871.39
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 5,
+"out_size": 3230343,
+"ratio": 0.0963,
+"compress_mbps": 162.32,
+"decompress_mbps": 955.61
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3123421,
+"ratio": 0.0931,
+"compress_mbps": 96.23,
+"decompress_mbps": 1013.27
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 7,
+"out_size": 3093778,
+"ratio": 0.0922,
+"compress_mbps": 70.75,
+"decompress_mbps": 977.54
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 8,
+"out_size": 3067318,
+"ratio": 0.0914,
+"compress_mbps": 50.12,
+"decompress_mbps": 1016.81
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 3050695,
+"ratio": 0.0909,
+"compress_mbps": 42.12,
+"decompress_mbps": 1024.82
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3543611,
+"ratio": 0.576,
+"compress_mbps": 167.45,
+"decompress_mbps": 270.34
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 2,
+"out_size": 3226818,
+"ratio": 0.5245,
+"compress_mbps": 85.72,
+"decompress_mbps": 286.81
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3144140,
+"ratio": 0.5111,
+"compress_mbps": 52.56,
+"decompress_mbps": 297.2
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 4,
+"out_size": 3129833,
+"ratio": 0.5087,
+"compress_mbps": 51.44,
+"decompress_mbps": 326.1
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 5,
+"out_size": 3114809,
+"ratio": 0.5063,
+"compress_mbps": 40.37,
+"decompress_mbps": 338.6
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3095705,
+"ratio": 0.5032,
+"compress_mbps": 25.15,
+"decompress_mbps": 345.2
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 7,
+"out_size": 3090055,
+"ratio": 0.5023,
+"compress_mbps": 20.49,
+"decompress_mbps": 346.01
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 8,
+"out_size": 3087665,
+"ratio": 0.5019,
+"compress_mbps": 17.42,
+"decompress_mbps": 347.62
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3087158,
+"ratio": 0.5018,
+"compress_mbps": 16.34,
+"decompress_mbps": 347.62
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 5419510,
+"ratio": 0.5373,
+"compress_mbps": 240.9,
+"decompress_mbps": 518.99
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 2,
+"out_size": 3982547,
+"ratio": 0.3949,
+"compress_mbps": 122.69,
+"decompress_mbps": 541.32
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3806102,
+"ratio": 0.3774,
+"compress_mbps": 81.9,
+"decompress_mbps": 559.37
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 4,
+"out_size": 3761477,
+"ratio": 0.373,
+"compress_mbps": 78.54,
+"decompress_mbps": 591.74
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 5,
+"out_size": 3740298,
+"ratio": 0.3709,
+"compress_mbps": 67.47,
+"decompress_mbps": 592.01
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3686116,
+"ratio": 0.3655,
+"compress_mbps": 49.5,
+"decompress_mbps": 626.28
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 7,
+"out_size": 3668442,
+"ratio": 0.3637,
+"compress_mbps": 38.83,
+"decompress_mbps": 638.73
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 8,
+"out_size": 3665072,
+"ratio": 0.3634,
+"compress_mbps": 33.19,
+"decompress_mbps": 636.26
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3665057,
+"ratio": 0.3634,
+"compress_mbps": 33.07,
+"decompress_mbps": 636.34
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2842321,
+"ratio": 0.4289,
+"compress_mbps": 190.94,
+"decompress_mbps": 438.05
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 2,
+"out_size": 2232180,
+"ratio": 0.3368,
+"compress_mbps": 151.11,
+"decompress_mbps": 509.32
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2003056,
+"ratio": 0.3022,
+"compress_mbps": 82.05,
+"decompress_mbps": 549.56
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 4,
+"out_size": 1985375,
+"ratio": 0.2996,
+"compress_mbps": 73.94,
+"decompress_mbps": 556.86
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 5,
+"out_size": 1933775,
+"ratio": 0.2918,
+"compress_mbps": 51.93,
+"decompress_mbps": 532.62
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1858103,
+"ratio": 0.2804,
+"compress_mbps": 22.01,
+"decompress_mbps": 538.05
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 7,
+"out_size": 1840414,
+"ratio": 0.2777,
+"compress_mbps": 15.12,
+"decompress_mbps": 544.33
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 8,
+"out_size": 1831679,
+"ratio": 0.2764,
+"compress_mbps": 11.71,
+"decompress_mbps": 532.34
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1827137,
+"ratio": 0.2757,
+"compress_mbps": 10.14,
+"decompress_mbps": 539.04
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 7089759,
+"ratio": 0.3281,
+"compress_mbps": 290.39,
+"decompress_mbps": 563.58
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 2,
+"out_size": 5966231,
+"ratio": 0.2761,
+"compress_mbps": 173.09,
+"decompress_mbps": 612.26
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5611838,
+"ratio": 0.2597,
+"compress_mbps": 111.24,
+"decompress_mbps": 638.04
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 4,
+"out_size": 5535436,
+"ratio": 0.2562,
+"compress_mbps": 105.15,
+"decompress_mbps": 662.01
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 5,
+"out_size": 5480971,
+"ratio": 0.2537,
+"compress_mbps": 81.26,
+"decompress_mbps": 670.81
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5437556,
+"ratio": 0.2517,
+"compress_mbps": 49.58,
+"decompress_mbps": 684.55
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 7,
+"out_size": 5432108,
+"ratio": 0.2514,
+"compress_mbps": 40.49,
+"decompress_mbps": 626.85
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 8,
+"out_size": 5428571,
+"ratio": 0.2512,
+"compress_mbps": 33.69,
+"decompress_mbps": 690.55
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5425526,
+"ratio": 0.2511,
+"compress_mbps": 30.52,
+"decompress_mbps": 688.43
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5900800,
+"ratio": 0.8137,
+"compress_mbps": 187.81,
+"decompress_mbps": 312.3
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 2,
+"out_size": 5523611,
+"ratio": 0.7617,
+"compress_mbps": 68.34,
+"decompress_mbps": 337.84
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5393086,
+"ratio": 0.7437,
+"compress_mbps": 40.05,
+"decompress_mbps": 349.72
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 4,
+"out_size": 5401582,
+"ratio": 0.7448,
+"compress_mbps": 40.5,
+"decompress_mbps": 365.18
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 5,
+"out_size": 5371274,
+"ratio": 0.7407,
+"compress_mbps": 31.19,
+"decompress_mbps": 358.17
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5330096,
+"ratio": 0.735,
+"compress_mbps": 20.78,
+"decompress_mbps": 364.67
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 7,
+"out_size": 5325437,
+"ratio": 0.7343,
+"compress_mbps": 18.99,
+"decompress_mbps": 366.29
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 8,
+"out_size": 5323934,
+"ratio": 0.7341,
+"compress_mbps": 18.04,
+"decompress_mbps": 358.83
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323621,
+"ratio": 0.7341,
+"compress_mbps": 17.73,
+"decompress_mbps": 364.14
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 17587173,
+"ratio": 0.4242,
+"compress_mbps": 184.15,
+"decompress_mbps": 360.59
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 2,
+"out_size": 14171707,
+"ratio": 0.3418,
+"compress_mbps": 147.7,
+"decompress_mbps": 408.57
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12774851,
+"ratio": 0.3081,
+"compress_mbps": 85.53,
+"decompress_mbps": 439.04
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 4,
+"out_size": 12612554,
+"ratio": 0.3042,
+"compress_mbps": 75.97,
+"decompress_mbps": 437.95
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 5,
+"out_size": 12392339,
+"ratio": 0.2989,
+"compress_mbps": 57.99,
+"decompress_mbps": 450.61
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12158314,
+"ratio": 0.2933,
+"compress_mbps": 34.34,
+"decompress_mbps": 456.5
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 7,
+"out_size": 12107840,
+"ratio": 0.292,
+"compress_mbps": 27.58,
+"decompress_mbps": 459.59
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 8,
+"out_size": 12081311,
+"ratio": 0.2914,
+"compress_mbps": 22.87,
+"decompress_mbps": 460.8
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 12081011,
+"ratio": 0.2914,
+"compress_mbps": 22.77,
+"decompress_mbps": 460.43
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6527324,
+"ratio": 0.7703,
+"compress_mbps": 238.01,
+"decompress_mbps": 325.92
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 2,
+"out_size": 6051483,
+"ratio": 0.7141,
+"compress_mbps": 75.23,
+"decompress_mbps": 327.25
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6010123,
+"ratio": 0.7092,
+"compress_mbps": 51.94,
+"decompress_mbps": 330.03
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 4,
+"out_size": 6024815,
+"ratio": 0.711,
+"compress_mbps": 44.37,
+"decompress_mbps": 279.89
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 5,
+"out_size": 6005181,
+"ratio": 0.7086,
+"compress_mbps": 40.25,
+"decompress_mbps": 285.12
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5997508,
+"ratio": 0.7077,
+"compress_mbps": 37.74,
+"decompress_mbps": 289.09
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 7,
+"out_size": 5997403,
+"ratio": 0.7077,
+"compress_mbps": 37.64,
+"decompress_mbps": 290.49
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 8,
+"out_size": 5997403,
+"ratio": 0.7077,
+"compress_mbps": 37.67,
+"decompress_mbps": 289.81
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5997403,
+"ratio": 0.7077,
+"compress_mbps": 37.67,
+"decompress_mbps": 289.76
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 1147652,
+"ratio": 0.2147,
+"compress_mbps": 387.25,
+"decompress_mbps": 750.94
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 2,
+"out_size": 919639,
+"ratio": 0.172,
+"compress_mbps": 261.15,
+"decompress_mbps": 942.03
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 752341,
+"ratio": 0.1407,
+"compress_mbps": 166.75,
+"decompress_mbps": 1050.82
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 4,
+"out_size": 735537,
+"ratio": 0.1376,
+"compress_mbps": 161.05,
+"decompress_mbps": 1025.31
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 5,
+"out_size": 706789,
+"ratio": 0.1322,
+"compress_mbps": 123.6,
+"decompress_mbps": 1117.4
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 676279,
+"ratio": 0.1265,
+"compress_mbps": 69.65,
+"decompress_mbps": 1201.48
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 7,
+"out_size": 668772,
+"ratio": 0.1251,
+"compress_mbps": 56.08,
+"decompress_mbps": 1218.43
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 8,
+"out_size": 665340,
+"ratio": 0.1245,
+"compress_mbps": 47.65,
+"decompress_mbps": 1208.96
+},
+{
+"compressor": "miniz_oxide",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 664273,
+"ratio": 0.1243,
+"compress_mbps": 45.88,
+"decompress_mbps": 1215.47
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4217525,
+"ratio": 0.4138,
+"compress_mbps": 239.71,
+"decompress_mbps": 790.0
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 2,
+"out_size": 4053259,
+"ratio": 0.3977,
+"compress_mbps": 168.86,
+"decompress_mbps": 853.57
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3989875,
+"ratio": 0.3915,
+"compress_mbps": 139.03,
+"decompress_mbps": 927.64
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 4,
+"out_size": 3972869,
+"ratio": 0.3898,
+"compress_mbps": 127.1,
+"decompress_mbps": 821.17
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 5,
+"out_size": 3894026,
+"ratio": 0.3821,
+"compress_mbps": 98.79,
+"decompress_mbps": 797.62
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3859436,
+"ratio": 0.3787,
+"compress_mbps": 75.36,
+"decompress_mbps": 823.04
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 7,
+"out_size": 3837515,
+"ratio": 0.3765,
+"compress_mbps": 55.56,
+"decompress_mbps": 819.25
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 8,
+"out_size": 3811467,
+"ratio": 0.374,
+"compress_mbps": 36.02,
+"decompress_mbps": 820.77
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3810354,
+"ratio": 0.3738,
+"compress_mbps": 32.7,
+"decompress_mbps": 826.03
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 10,
+"out_size": 3681797,
+"ratio": 0.3612,
+"compress_mbps": 12.47,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 11,
+"out_size": 3679289,
+"ratio": 0.361,
+"compress_mbps": 9.08,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 12,
+"out_size": 3679105,
+"ratio": 0.361,
+"compress_mbps": 7.51,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20192961,
+"ratio": 0.3942,
+"compress_mbps": 242.73,
+"decompress_mbps": 677.88
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 2,
+"out_size": 19374226,
+"ratio": 0.3783,
+"compress_mbps": 185.59,
+"decompress_mbps": 715.55
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19234937,
+"ratio": 0.3755,
+"compress_mbps": 173.02,
+"decompress_mbps": 729.95
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 4,
+"out_size": 19145385,
+"ratio": 0.3738,
+"compress_mbps": 162.19,
+"decompress_mbps": 727.78
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 5,
+"out_size": 18878875,
+"ratio": 0.3686,
+"compress_mbps": 142.6,
+"decompress_mbps": 748.14
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 18805391,
+"ratio": 0.3671,
+"compress_mbps": 120.03,
+"decompress_mbps": 759.24
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 7,
+"out_size": 18749947,
+"ratio": 0.3661,
+"compress_mbps": 87.47,
+"decompress_mbps": 759.27
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 8,
+"out_size": 18718540,
+"ratio": 0.3655,
+"compress_mbps": 47.44,
+"decompress_mbps": 760.16
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 18713659,
+"ratio": 0.3654,
+"compress_mbps": 33.55,
+"decompress_mbps": 756.4
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 10,
+"out_size": 18268811,
+"ratio": 0.3567,
+"compress_mbps": 16.29,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 11,
+"out_size": 18245674,
+"ratio": 0.3562,
+"compress_mbps": 11.63,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 12,
+"out_size": 18241312,
+"ratio": 0.3561,
+"compress_mbps": 9.25,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3740775,
+"ratio": 0.3752,
+"compress_mbps": 292.32,
+"decompress_mbps": 717.67
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 2,
+"out_size": 3707407,
+"ratio": 0.3718,
+"compress_mbps": 215.91,
+"decompress_mbps": 749.51
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3672389,
+"ratio": 0.3683,
+"compress_mbps": 184.12,
+"decompress_mbps": 784.61
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 4,
+"out_size": 3660011,
+"ratio": 0.3671,
+"compress_mbps": 170.1,
+"decompress_mbps": 717.47
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 5,
+"out_size": 3664245,
+"ratio": 0.3675,
+"compress_mbps": 140.41,
+"decompress_mbps": 675.48
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3648644,
+"ratio": 0.3659,
+"compress_mbps": 105.4,
+"decompress_mbps": 708.33
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 7,
+"out_size": 3635323,
+"ratio": 0.3646,
+"compress_mbps": 67.54,
+"decompress_mbps": 729.2
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 8,
+"out_size": 3624778,
+"ratio": 0.3635,
+"compress_mbps": 42.96,
+"decompress_mbps": 774.95
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3625176,
+"ratio": 0.3636,
+"compress_mbps": 38.8,
+"decompress_mbps": 752.82
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 10,
+"out_size": 3461494,
+"ratio": 0.3472,
+"compress_mbps": 18.25,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 11,
+"out_size": 3446053,
+"ratio": 0.3456,
+"compress_mbps": 10.54,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 12,
+"out_size": 3447985,
+"ratio": 0.3458,
+"compress_mbps": 5.38,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3837577,
+"ratio": 0.1144,
+"compress_mbps": 605.16,
+"decompress_mbps": 1502.39
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 2,
+"out_size": 3714632,
+"ratio": 0.1107,
+"compress_mbps": 460.38,
+"decompress_mbps": 1712.18
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3599455,
+"ratio": 0.1073,
+"compress_mbps": 424.4,
+"decompress_mbps": 1819.21
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 4,
+"out_size": 3431843,
+"ratio": 0.1023,
+"compress_mbps": 387.62,
+"decompress_mbps": 1807.25
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 5,
+"out_size": 3268188,
+"ratio": 0.0974,
+"compress_mbps": 347.18,
+"decompress_mbps": 1824.98
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3091741,
+"ratio": 0.0921,
+"compress_mbps": 263.43,
+"decompress_mbps": 1809.93
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 7,
+"out_size": 3032499,
+"ratio": 0.0904,
+"compress_mbps": 185.26,
+"decompress_mbps": 1828.9
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 8,
+"out_size": 2949097,
+"ratio": 0.0879,
+"compress_mbps": 97.29,
+"decompress_mbps": 1755.09
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2925243,
+"ratio": 0.0872,
+"compress_mbps": 69.11,
+"decompress_mbps": 1716.66
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 10,
+"out_size": 2782465,
+"ratio": 0.0829,
+"compress_mbps": 8.4,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 11,
+"out_size": 2751857,
+"ratio": 0.082,
+"compress_mbps": 5.49,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 12,
+"out_size": 2748273,
+"ratio": 0.0819,
+"compress_mbps": 4.05,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3275124,
+"ratio": 0.5324,
+"compress_mbps": 166.4,
+"decompress_mbps": 432.93
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 2,
+"out_size": 3150806,
+"ratio": 0.5121,
+"compress_mbps": 126.88,
+"decompress_mbps": 498.99
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3137061,
+"ratio": 0.5099,
+"compress_mbps": 119.44,
+"decompress_mbps": 523.59
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 4,
+"out_size": 3129676,
+"ratio": 0.5087,
+"compress_mbps": 115.62,
+"decompress_mbps": 542.62
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 5,
+"out_size": 3079277,
+"ratio": 0.5005,
+"compress_mbps": 98.82,
+"decompress_mbps": 561.4
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3072378,
+"ratio": 0.4994,
+"compress_mbps": 87.08,
+"decompress_mbps": 570.61
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 7,
+"out_size": 3068123,
+"ratio": 0.4987,
+"compress_mbps": 74.7,
+"decompress_mbps": 573.32
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 8,
+"out_size": 3067299,
+"ratio": 0.4986,
+"compress_mbps": 55.04,
+"decompress_mbps": 575.17
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3066968,
+"ratio": 0.4985,
+"compress_mbps": 49.77,
+"decompress_mbps": 573.4
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 10,
+"out_size": 2995902,
+"ratio": 0.487,
+"compress_mbps": 18.97,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 11,
+"out_size": 2994386,
+"ratio": 0.4867,
+"compress_mbps": 14.38,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 12,
+"out_size": 2994086,
+"ratio": 0.4867,
+"compress_mbps": 12.27,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3868663,
+"ratio": 0.3836,
+"compress_mbps": 278.48,
+"decompress_mbps": 739.01
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 2,
+"out_size": 3839158,
+"ratio": 0.3807,
+"compress_mbps": 207.66,
+"decompress_mbps": 860.45
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3818964,
+"ratio": 0.3787,
+"compress_mbps": 193.08,
+"decompress_mbps": 890.83
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 4,
+"out_size": 3789325,
+"ratio": 0.3757,
+"compress_mbps": 176.73,
+"decompress_mbps": 926.5
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 5,
+"out_size": 3666476,
+"ratio": 0.3635,
+"compress_mbps": 155.97,
+"decompress_mbps": 937.62
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3660266,
+"ratio": 0.3629,
+"compress_mbps": 140.77,
+"decompress_mbps": 974.05
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 7,
+"out_size": 3659491,
+"ratio": 0.3628,
+"compress_mbps": 133.11,
+"decompress_mbps": 952.39
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 8,
+"out_size": 3654863,
+"ratio": 0.3624,
+"compress_mbps": 114.1,
+"decompress_mbps": 972.29
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3654860,
+"ratio": 0.3624,
+"compress_mbps": 114.29,
+"decompress_mbps": 945.42
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 10,
+"out_size": 3608746,
+"ratio": 0.3578,
+"compress_mbps": 18.87,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 11,
+"out_size": 3608161,
+"ratio": 0.3578,
+"compress_mbps": 14.63,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 12,
+"out_size": 3608138,
+"ratio": 0.3577,
+"compress_mbps": 13.05,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2197055,
+"ratio": 0.3315,
+"compress_mbps": 298.73,
+"decompress_mbps": 852.56
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 2,
+"out_size": 2082309,
+"ratio": 0.3142,
+"compress_mbps": 214.22,
+"decompress_mbps": 934.45
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2021047,
+"ratio": 0.305,
+"compress_mbps": 178.25,
+"decompress_mbps": 1068.04
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 4,
+"out_size": 1990952,
+"ratio": 0.3004,
+"compress_mbps": 158.42,
+"decompress_mbps": 1003.76
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 5,
+"out_size": 1921113,
+"ratio": 0.2899,
+"compress_mbps": 127.07,
+"decompress_mbps": 952.93
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1876257,
+"ratio": 0.2831,
+"compress_mbps": 86.95,
+"decompress_mbps": 960.2
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 7,
+"out_size": 1832695,
+"ratio": 0.2765,
+"compress_mbps": 46.57,
+"decompress_mbps": 907.88
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 8,
+"out_size": 1809967,
+"ratio": 0.2731,
+"compress_mbps": 24.25,
+"decompress_mbps": 844.4
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1806374,
+"ratio": 0.2726,
+"compress_mbps": 19.88,
+"decompress_mbps": 905.95
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 10,
+"out_size": 1697693,
+"ratio": 0.2562,
+"compress_mbps": 8.75,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 11,
+"out_size": 1696742,
+"ratio": 0.256,
+"compress_mbps": 6.54,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 12,
+"out_size": 1696488,
+"ratio": 0.256,
+"compress_mbps": 5.61,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5866517,
+"ratio": 0.2715,
+"compress_mbps": 340.26,
+"decompress_mbps": 952.81
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 2,
+"out_size": 5695942,
+"ratio": 0.2636,
+"compress_mbps": 255.24,
+"decompress_mbps": 1038.53
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5605878,
+"ratio": 0.2595,
+"compress_mbps": 231.7,
+"decompress_mbps": 1069.2
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 4,
+"out_size": 5553432,
+"ratio": 0.257,
+"compress_mbps": 215.99,
+"decompress_mbps": 1047.1
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 5,
+"out_size": 5416713,
+"ratio": 0.2507,
+"compress_mbps": 186.63,
+"decompress_mbps": 1059.1
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5337149,
+"ratio": 0.247,
+"compress_mbps": 143.25,
+"decompress_mbps": 1056.25
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 7,
+"out_size": 5310181,
+"ratio": 0.2458,
+"compress_mbps": 100.19,
+"decompress_mbps": 1049.35
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 8,
+"out_size": 5272761,
+"ratio": 0.244,
+"compress_mbps": 62.34,
+"decompress_mbps": 1056.09
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5270405,
+"ratio": 0.2439,
+"compress_mbps": 50.09,
+"decompress_mbps": 1037.46
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 10,
+"out_size": 5137640,
+"ratio": 0.2378,
+"compress_mbps": 15.84,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 11,
+"out_size": 5122694,
+"ratio": 0.2371,
+"compress_mbps": 9.54,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 12,
+"out_size": 5118130,
+"ratio": 0.2369,
+"compress_mbps": 6.89,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5575128,
+"ratio": 0.7688,
+"compress_mbps": 163.85,
+"decompress_mbps": 458.98
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 2,
+"out_size": 5417142,
+"ratio": 0.747,
+"compress_mbps": 116.56,
+"decompress_mbps": 504.35
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5397999,
+"ratio": 0.7444,
+"compress_mbps": 103.93,
+"decompress_mbps": 508.38
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 4,
+"out_size": 5391125,
+"ratio": 0.7434,
+"compress_mbps": 98.9,
+"decompress_mbps": 517.7
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 5,
+"out_size": 5352212,
+"ratio": 0.738,
+"compress_mbps": 86.65,
+"decompress_mbps": 504.77
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5335405,
+"ratio": 0.7357,
+"compress_mbps": 72.7,
+"decompress_mbps": 509.45
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 7,
+"out_size": 5325697,
+"ratio": 0.7344,
+"compress_mbps": 62.93,
+"decompress_mbps": 516.26
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 8,
+"out_size": 5324004,
+"ratio": 0.7341,
+"compress_mbps": 52.25,
+"decompress_mbps": 513.7
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5323197,
+"ratio": 0.734,
+"compress_mbps": 50.74,
+"decompress_mbps": 504.37
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 10,
+"out_size": 5250862,
+"ratio": 0.7241,
+"compress_mbps": 25.48,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 11,
+"out_size": 5250747,
+"ratio": 0.724,
+"compress_mbps": 20.78,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 12,
+"out_size": 5250745,
+"ratio": 0.724,
+"compress_mbps": 19.39,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 13550569,
+"ratio": 0.3268,
+"compress_mbps": 270.14,
+"decompress_mbps": 883.43
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 2,
+"out_size": 13130705,
+"ratio": 0.3167,
+"compress_mbps": 201.99,
+"decompress_mbps": 989.91
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12839361,
+"ratio": 0.3097,
+"compress_mbps": 178.64,
+"decompress_mbps": 1030.28
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 4,
+"out_size": 12601933,
+"ratio": 0.304,
+"compress_mbps": 163.2,
+"decompress_mbps": 905.55
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 5,
+"out_size": 12310776,
+"ratio": 0.2969,
+"compress_mbps": 132.49,
+"decompress_mbps": 607.45
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12140474,
+"ratio": 0.2928,
+"compress_mbps": 105.68,
+"decompress_mbps": 896.67
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 7,
+"out_size": 12025296,
+"ratio": 0.2901,
+"compress_mbps": 75.3,
+"decompress_mbps": 900.54
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 8,
+"out_size": 11893824,
+"ratio": 0.2869,
+"compress_mbps": 46.13,
+"decompress_mbps": 806.33
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11882496,
+"ratio": 0.2866,
+"compress_mbps": 37.39,
+"decompress_mbps": 815.43
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 10,
+"out_size": 11526846,
+"ratio": 0.278,
+"compress_mbps": 10.06,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 11,
+"out_size": 11520969,
+"ratio": 0.2779,
+"compress_mbps": 6.91,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 12,
+"out_size": 11520871,
+"ratio": 0.2779,
+"compress_mbps": 5.85,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6293390,
+"ratio": 0.7426,
+"compress_mbps": 147.98,
+"decompress_mbps": 465.49
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 2,
+"out_size": 6058412,
+"ratio": 0.7149,
+"compress_mbps": 119.79,
+"decompress_mbps": 506.86
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6058381,
+"ratio": 0.7149,
+"compress_mbps": 119.2,
+"decompress_mbps": 514.84
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 4,
+"out_size": 6058363,
+"ratio": 0.7149,
+"compress_mbps": 119.3,
+"decompress_mbps": 415.52
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 5,
+"out_size": 5998400,
+"ratio": 0.7078,
+"compress_mbps": 105.57,
+"decompress_mbps": 432.18
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5998438,
+"ratio": 0.7078,
+"compress_mbps": 105.97,
+"decompress_mbps": 440.63
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 7,
+"out_size": 5998439,
+"ratio": 0.7078,
+"compress_mbps": 106.47,
+"decompress_mbps": 438.91
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 8,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": 88.92,
+"decompress_mbps": 434.5
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5986859,
+"ratio": 0.7065,
+"compress_mbps": 87.71,
+"decompress_mbps": 416.28
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 10,
+"out_size": 5748096,
+"ratio": 0.6783,
+"compress_mbps": 37.77,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 11,
+"out_size": 5747172,
+"ratio": 0.6782,
+"compress_mbps": 28.72,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 12,
+"out_size": 5747146,
+"ratio": 0.6782,
+"compress_mbps": 26.57,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 887708,
+"ratio": 0.1661,
+"compress_mbps": 487.74,
+"decompress_mbps": 1232.1
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 2,
+"out_size": 843475,
+"ratio": 0.1578,
+"compress_mbps": 361.41,
+"decompress_mbps": 1500.87
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 793388,
+"ratio": 0.1484,
+"compress_mbps": 333.76,
+"decompress_mbps": 1649.87
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 4,
+"out_size": 747602,
+"ratio": 0.1399,
+"compress_mbps": 302.22,
+"decompress_mbps": 1613.69
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 5,
+"out_size": 718615,
+"ratio": 0.1344,
+"compress_mbps": 260.88,
+"decompress_mbps": 1656.06
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 684405,
+"ratio": 0.128,
+"compress_mbps": 204.65,
+"decompress_mbps": 1603.35
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 7,
+"out_size": 664859,
+"ratio": 0.1244,
+"compress_mbps": 141.51,
+"decompress_mbps": 1662.71
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 8,
+"out_size": 650835,
+"ratio": 0.1218,
+"compress_mbps": 84.48,
+"decompress_mbps": 1415.83
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 649494,
+"ratio": 0.1215,
+"compress_mbps": 68.12,
+"decompress_mbps": 1568.14
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 10,
+"out_size": 637425,
+"ratio": 0.1193,
+"compress_mbps": 11.89,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 11,
+"out_size": 630827,
+"ratio": 0.118,
+"compress_mbps": 7.0,
+"decompress_mbps": null
+},
+{
+"compressor": "libdeflate",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 12,
+"out_size": 629349,
+"ratio": 0.1177,
+"compress_mbps": 4.54,
+"decompress_mbps": null
+},
+{
+"compressor": "go",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 1,
+"out_size": 65708,
+"ratio": 0.432,
+"compress_mbps": 109.44,
+"decompress_mbps": 192.48
+},
+{
+"compressor": "go",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 2,
+"out_size": 60259,
+"ratio": 0.3962,
+"compress_mbps": 79.44,
+"decompress_mbps": 219.13
+},
+{
+"compressor": "go",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 3,
+"out_size": 58544,
+"ratio": 0.3849,
+"compress_mbps": 66.36,
+"decompress_mbps": 226.05
+},
+{
+"compressor": "go",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 4,
+"out_size": 56238,
+"ratio": 0.3698,
+"compress_mbps": 65.73,
+"decompress_mbps": 231.45
+},
+{
+"compressor": "go",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 5,
+"out_size": 54764,
+"ratio": 0.3601,
+"compress_mbps": 39.45,
+"decompress_mbps": 234.66
+},
+{
+"compressor": "go",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 6,
+"out_size": 54311,
+"ratio": 0.3571,
+"compress_mbps": 30.43,
+"decompress_mbps": 235.25
+},
+{
+"compressor": "go",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 7,
+"out_size": 54262,
+"ratio": 0.3568,
+"compress_mbps": 27.11,
+"decompress_mbps": 235.47
+},
+{
+"compressor": "go",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 8,
+"out_size": 54247,
+"ratio": 0.3567,
+"compress_mbps": 25.8,
+"decompress_mbps": 238.36
+},
+{
+"compressor": "go",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 9,
+"out_size": 54247,
+"ratio": 0.3567,
+"compress_mbps": 25.76,
+"decompress_mbps": 236.1
+},
+{
+"compressor": "go",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 1,
+"out_size": 56882,
+"ratio": 0.4544,
+"compress_mbps": 104.58,
+"decompress_mbps": 183.83
+},
+{
+"compressor": "go",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 2,
+"out_size": 52826,
+"ratio": 0.422,
+"compress_mbps": 73.05,
+"decompress_mbps": 205.6
+},
+{
+"compressor": "go",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 3,
+"out_size": 51625,
+"ratio": 0.4124,
+"compress_mbps": 61.78,
+"decompress_mbps": 211.24
+},
+{
+"compressor": "go",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 4,
+"out_size": 50034,
+"ratio": 0.3997,
+"compress_mbps": 61.66,
+"decompress_mbps": 217.96
+},
+{
+"compressor": "go",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 5,
+"out_size": 48912,
+"ratio": 0.3907,
+"compress_mbps": 37.33,
+"decompress_mbps": 217.44
+},
+{
+"compressor": "go",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 6,
+"out_size": 48738,
+"ratio": 0.3893,
+"compress_mbps": 31.17,
+"decompress_mbps": 219.56
+},
+{
+"compressor": "go",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 7,
+"out_size": 48719,
+"ratio": 0.3892,
+"compress_mbps": 29.9,
+"decompress_mbps": 220.02
+},
+{
+"compressor": "go",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 8,
+"out_size": 48716,
+"ratio": 0.3892,
+"compress_mbps": 29.7,
+"decompress_mbps": 219.36
+},
+{
+"compressor": "go",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 9,
+"out_size": 48716,
+"ratio": 0.3892,
+"compress_mbps": 30.07,
+"decompress_mbps": 219.72
+},
+{
+"compressor": "go",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 1,
+"out_size": 8988,
+"ratio": 0.3653,
+"compress_mbps": 195.21,
+"decompress_mbps": 289.47
+},
+{
+"compressor": "go",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 2,
+"out_size": 8564,
+"ratio": 0.3481,
+"compress_mbps": 143.69,
+"decompress_mbps": 317.83
+},
+{
+"compressor": "go",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 3,
+"out_size": 8390,
+"ratio": 0.341,
+"compress_mbps": 129.4,
+"decompress_mbps": 337.5
+},
+{
+"compressor": "go",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 4,
+"out_size": 8167,
+"ratio": 0.332,
+"compress_mbps": 115.12,
+"decompress_mbps": 328.64
+},
+{
+"compressor": "go",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 5,
+"out_size": 7965,
+"ratio": 0.3237,
+"compress_mbps": 81.76,
+"decompress_mbps": 356.34
+},
+{
+"compressor": "go",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 6,
+"out_size": 7916,
+"ratio": 0.3217,
+"compress_mbps": 62.46,
+"decompress_mbps": 356.77
+},
+{
+"compressor": "go",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 7,
+"out_size": 7900,
+"ratio": 0.3211,
+"compress_mbps": 59.77,
+"decompress_mbps": 329.36
+},
+{
+"compressor": "go",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 8,
+"out_size": 7900,
+"ratio": 0.3211,
+"compress_mbps": 56.57,
+"decompress_mbps": 357.23
+},
+{
+"compressor": "go",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 9,
+"out_size": 7900,
+"ratio": 0.3211,
+"compress_mbps": 56.39,
+"decompress_mbps": 355
+},
+{
+"compressor": "go",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 1,
+"out_size": 3731,
+"ratio": 0.3346,
+"compress_mbps": 160.08,
+"decompress_mbps": 347.11
+},
+{
+"compressor": "go",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 2,
+"out_size": 3491,
+"ratio": 0.3131,
+"compress_mbps": 156.38,
+"decompress_mbps": 385.2
+},
+{
+"compressor": "go",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 3,
+"out_size": 3384,
+"ratio": 0.3035,
+"compress_mbps": 156.98,
+"decompress_mbps": 389.78
+},
+{
+"compressor": "go",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 4,
+"out_size": 3220,
+"ratio": 0.2888,
+"compress_mbps": 135.13,
+"decompress_mbps": 416.97
+},
+{
+"compressor": "go",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 5,
+"out_size": 3138,
+"ratio": 0.2814,
+"compress_mbps": 113.25,
+"decompress_mbps": 431.73
+},
+{
+"compressor": "go",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 6,
+"out_size": 3118,
+"ratio": 0.2796,
+"compress_mbps": 92.3,
+"decompress_mbps": 425.1
+},
+{
+"compressor": "go",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 7,
+"out_size": 3116,
+"ratio": 0.2795,
+"compress_mbps": 82.76,
+"decompress_mbps": 423.91
+},
+{
+"compressor": "go",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 8,
+"out_size": 3116,
+"ratio": 0.2795,
+"compress_mbps": 80.39,
+"decompress_mbps": 436.84
+},
+{
+"compressor": "go",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 9,
+"out_size": 3116,
+"ratio": 0.2795,
+"compress_mbps": 79.5,
+"decompress_mbps": 428.65
+},
+{
+"compressor": "go",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 1,
+"out_size": 1352,
+"ratio": 0.3633,
+"compress_mbps": 79.19,
+"decompress_mbps": 292.96
+},
+{
+"compressor": "go",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 2,
+"out_size": 1287,
+"ratio": 0.3459,
+"compress_mbps": 91.56,
+"decompress_mbps": 299.79
+},
+{
+"compressor": "go",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 3,
+"out_size": 1284,
+"ratio": 0.3451,
+"compress_mbps": 87.27,
+"decompress_mbps": 297.35
+},
+{
+"compressor": "go",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 4,
+"out_size": 1226,
+"ratio": 0.3295,
+"compress_mbps": 81.6,
+"decompress_mbps": 307.4
+},
+{
+"compressor": "go",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 5,
+"out_size": 1211,
+"ratio": 0.3255,
+"compress_mbps": 75.85,
+"decompress_mbps": 311.15
+},
+{
+"compressor": "go",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 6,
+"out_size": 1211,
+"ratio": 0.3255,
+"compress_mbps": 74.64,
+"decompress_mbps": 316.22
+},
+{
+"compressor": "go",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 7,
+"out_size": 1211,
+"ratio": 0.3255,
+"compress_mbps": 70.12,
+"decompress_mbps": 326.4
+},
+{
+"compressor": "go",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 8,
+"out_size": 1211,
+"ratio": 0.3255,
+"compress_mbps": 68.19,
+"decompress_mbps": 326.31
+},
+{
+"compressor": "go",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 9,
+"out_size": 1211,
+"ratio": 0.3255,
+"compress_mbps": 71.6,
+"decompress_mbps": 319.55
+},
+{
+"compressor": "go",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 1,
+"out_size": 245423,
+"ratio": 0.2383,
+"compress_mbps": 247.5,
+"decompress_mbps": 426.86
+},
+{
+"compressor": "go",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 2,
+"out_size": 229642,
+"ratio": 0.223,
+"compress_mbps": 222.09,
+"decompress_mbps": 492.5
+},
+{
+"compressor": "go",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 3,
+"out_size": 225678,
+"ratio": 0.2192,
+"compress_mbps": 184.98,
+"decompress_mbps": 499.76
+},
+{
+"compressor": "go",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 4,
+"out_size": 218218,
+"ratio": 0.2119,
+"compress_mbps": 172.54,
+"decompress_mbps": 531.98
+},
+{
+"compressor": "go",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 5,
+"out_size": 210550,
+"ratio": 0.2045,
+"compress_mbps": 98.16,
+"decompress_mbps": 510.74
+},
+{
+"compressor": "go",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 6,
+"out_size": 207949,
+"ratio": 0.2019,
+"compress_mbps": 41.8,
+"decompress_mbps": 512.45
+},
+{
+"compressor": "go",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 7,
+"out_size": 207413,
+"ratio": 0.2014,
+"compress_mbps": 24.36,
+"decompress_mbps": 505.8
+},
+{
+"compressor": "go",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 8,
+"out_size": 207478,
+"ratio": 0.2015,
+"compress_mbps": 7.43,
+"decompress_mbps": 502.84
+},
+{
+"compressor": "go",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 9,
+"out_size": 207482,
+"ratio": 0.2015,
+"compress_mbps": 3.6,
+"decompress_mbps": 504.79
+},
+{
+"compressor": "go",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 1,
+"out_size": 175980,
+"ratio": 0.4124,
+"compress_mbps": 114.75,
+"decompress_mbps": 196.92
+},
+{
+"compressor": "go",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 2,
+"out_size": 160455,
+"ratio": 0.376,
+"compress_mbps": 84.36,
+"decompress_mbps": 222.57
+},
+{
+"compressor": "go",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 3,
+"out_size": 156690,
+"ratio": 0.3672,
+"compress_mbps": 70.92,
+"decompress_mbps": 227.01
+},
+{
+"compressor": "go",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 4,
+"out_size": 149064,
+"ratio": 0.3493,
+"compress_mbps": 69.92,
+"decompress_mbps": 237.82
+},
+{
+"compressor": "go",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 5,
+"out_size": 145616,
+"ratio": 0.3412,
+"compress_mbps": 42.26,
+"decompress_mbps": 237.6
+},
+{
+"compressor": "go",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 6,
+"out_size": 144773,
+"ratio": 0.3392,
+"compress_mbps": 33.93,
+"decompress_mbps": 241.57
+},
+{
+"compressor": "go",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 7,
+"out_size": 144603,
+"ratio": 0.3388,
+"compress_mbps": 30.55,
+"decompress_mbps": 240.64
+},
+{
+"compressor": "go",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 8,
+"out_size": 144573,
+"ratio": 0.3388,
+"compress_mbps": 29.22,
+"decompress_mbps": 239.94
+},
+{
+"compressor": "go",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 9,
+"out_size": 144570,
+"ratio": 0.3388,
+"compress_mbps": 29.23,
+"decompress_mbps": 236.89
+},
+{
+"compressor": "go",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 1,
+"out_size": 228837,
+"ratio": 0.4749,
+"compress_mbps": 101.53,
+"decompress_mbps": 170.49
+},
+{
+"compressor": "go",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 2,
+"out_size": 211248,
+"ratio": 0.4384,
+"compress_mbps": 69.11,
+"decompress_mbps": 193.03
+},
+{
+"compressor": "go",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 3,
+"out_size": 205619,
+"ratio": 0.4267,
+"compress_mbps": 56.87,
+"decompress_mbps": 198.04
+},
+{
+"compressor": "go",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 4,
+"out_size": 200595,
+"ratio": 0.4163,
+"compress_mbps": 57.72,
+"decompress_mbps": 203.39
+},
+{
+"compressor": "go",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 5,
+"out_size": 195418,
+"ratio": 0.4055,
+"compress_mbps": 33.47,
+"decompress_mbps": 204.8
+},
+{
+"compressor": "go",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 6,
+"out_size": 194148,
+"ratio": 0.4029,
+"compress_mbps": 25.84,
+"decompress_mbps": 204.61
+},
+{
+"compressor": "go",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 7,
+"out_size": 193994,
+"ratio": 0.4026,
+"compress_mbps": 23.88,
+"decompress_mbps": 204.82
+},
+{
+"compressor": "go",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 8,
+"out_size": 193991,
+"ratio": 0.4026,
+"compress_mbps": 23.63,
+"decompress_mbps": 205.49
+},
+{
+"compressor": "go",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 9,
+"out_size": 193991,
+"ratio": 0.4026,
+"compress_mbps": 23.71,
+"decompress_mbps": 204.38
+},
+{
+"compressor": "go",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 1,
+"out_size": 60990,
+"ratio": 0.1188,
+"compress_mbps": 318.56,
+"decompress_mbps": 589.73
+},
+{
+"compressor": "go",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 2,
+"out_size": 61650,
+"ratio": 0.1201,
+"compress_mbps": 306.96,
+"decompress_mbps": 659.53
+},
+{
+"compressor": "go",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 3,
+"out_size": 60035,
+"ratio": 0.117,
+"compress_mbps": 269.08,
+"decompress_mbps": 683.91
+},
+{
+"compressor": "go",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 4,
+"out_size": 57005,
+"ratio": 0.1111,
+"compress_mbps": 223.63,
+"decompress_mbps": 691.14
+},
+{
+"compressor": "go",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 5,
+"out_size": 55779,
+"ratio": 0.1087,
+"compress_mbps": 171.39,
+"decompress_mbps": 699.37
+},
+{
+"compressor": "go",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 6,
+"out_size": 54970,
+"ratio": 0.1071,
+"compress_mbps": 114,
+"decompress_mbps": 721.14
+},
+{
+"compressor": "go",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 7,
+"out_size": 53922,
+"ratio": 0.1051,
+"compress_mbps": 83.73,
+"decompress_mbps": 760.74
+},
+{
+"compressor": "go",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 8,
+"out_size": 51977,
+"ratio": 0.1013,
+"compress_mbps": 29.04,
+"decompress_mbps": 793.55
+},
+{
+"compressor": "go",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 9,
+"out_size": 51474,
+"ratio": 0.1003,
+"compress_mbps": 7.47,
+"decompress_mbps": 773.32
+},
+{
+"compressor": "go",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 1,
+"out_size": 14783,
+"ratio": 0.3866,
+"compress_mbps": 113.64,
+"decompress_mbps": 269.04
+},
+{
+"compressor": "go",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 2,
+"out_size": 14101,
+"ratio": 0.3688,
+"compress_mbps": 107.75,
+"decompress_mbps": 299.25
+},
+{
+"compressor": "go",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 3,
+"out_size": 13975,
+"ratio": 0.3655,
+"compress_mbps": 100.63,
+"decompress_mbps": 306.25
+},
+{
+"compressor": "go",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 4,
+"out_size": 13632,
+"ratio": 0.3565,
+"compress_mbps": 91.77,
+"decompress_mbps": 310.62
+},
+{
+"compressor": "go",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 5,
+"out_size": 13302,
+"ratio": 0.3479,
+"compress_mbps": 69.51,
+"decompress_mbps": 325.89
+},
+{
+"compressor": "go",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 6,
+"out_size": 13279,
+"ratio": 0.3473,
+"compress_mbps": 52.22,
+"decompress_mbps": 324.3
+},
+{
+"compressor": "go",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 7,
+"out_size": 13274,
+"ratio": 0.3471,
+"compress_mbps": 41.96,
+"decompress_mbps": 325.59
+},
+{
+"compressor": "go",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 8,
+"out_size": 13260,
+"ratio": 0.3468,
+"compress_mbps": 22,
+"decompress_mbps": 332.6
+},
+{
+"compressor": "go",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 9,
+"out_size": 13260,
+"ratio": 0.3468,
+"compress_mbps": 13.89,
+"decompress_mbps": 332.15
+},
+{
+"compressor": "go",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 1,
+"out_size": 1862,
+"ratio": 0.4405,
+"compress_mbps": 88.73,
+"decompress_mbps": 262.09
+},
+{
+"compressor": "go",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 2,
+"out_size": 1803,
+"ratio": 0.4265,
+"compress_mbps": 91.48,
+"decompress_mbps": 272.93
+},
+{
+"compressor": "go",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 3,
+"out_size": 1791,
+"ratio": 0.4237,
+"compress_mbps": 90.92,
+"decompress_mbps": 277.92
+},
+{
+"compressor": "go",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 4,
+"out_size": 1746,
+"ratio": 0.4131,
+"compress_mbps": 85.18,
+"decompress_mbps": 279.61
+},
+{
+"compressor": "go",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 5,
+"out_size": 1725,
+"ratio": 0.4081,
+"compress_mbps": 81.24,
+"decompress_mbps": 274.79
+},
+{
+"compressor": "go",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 6,
+"out_size": 1725,
+"ratio": 0.4081,
+"compress_mbps": 80.27,
+"decompress_mbps": 275.17
+},
+{
+"compressor": "go",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 7,
+"out_size": 1725,
+"ratio": 0.4081,
+"compress_mbps": 80.46,
+"decompress_mbps": 279.25
+},
+{
+"compressor": "go",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 8,
+"out_size": 1725,
+"ratio": 0.4081,
+"compress_mbps": 82.41,
+"decompress_mbps": 285.9
+},
+{
+"compressor": "go",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 9,
+"out_size": 1725,
+"ratio": 0.4081,
+"compress_mbps": 79.5,
+"decompress_mbps": 277.76
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4623589,
+"ratio": 0.4536,
+"compress_mbps": 106.98,
+"decompress_mbps": 176.02
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 2,
+"out_size": 4241525,
+"ratio": 0.4161,
+"compress_mbps": 74.17,
+"decompress_mbps": 194.53
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 4123202,
+"ratio": 0.4045,
+"compress_mbps": 61.3,
+"decompress_mbps": 203.94
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 4,
+"out_size": 3985937,
+"ratio": 0.3911,
+"compress_mbps": 61.86,
+"decompress_mbps": 202.71
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 5,
+"out_size": 3883839,
+"ratio": 0.3811,
+"compress_mbps": 35.88,
+"decompress_mbps": 207.24
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3860437,
+"ratio": 0.3788,
+"compress_mbps": 27.91,
+"decompress_mbps": 211.1
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 7,
+"out_size": 3857076,
+"ratio": 0.3784,
+"compress_mbps": 25.28,
+"decompress_mbps": 210.73
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 8,
+"out_size": 3856651,
+"ratio": 0.3784,
+"compress_mbps": 24.89,
+"decompress_mbps": 210.33
+},
+{
+"compressor": "go",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3856651,
+"ratio": 0.3784,
+"compress_mbps": 24.92,
+"decompress_mbps": 207.99
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 21508211,
+"ratio": 0.4199,
+"compress_mbps": 140.53,
+"decompress_mbps": 236.89
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 2,
+"out_size": 20538783,
+"ratio": 0.401,
+"compress_mbps": 109.51,
+"decompress_mbps": 239
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 20334352,
+"ratio": 0.397,
+"compress_mbps": 95.46,
+"decompress_mbps": 239.62
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 4,
+"out_size": 19886937,
+"ratio": 0.3883,
+"compress_mbps": 92.08,
+"decompress_mbps": 243.19
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 5,
+"out_size": 19582363,
+"ratio": 0.3823,
+"compress_mbps": 66.13,
+"decompress_mbps": 255.01
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 19512479,
+"ratio": 0.381,
+"compress_mbps": 44.92,
+"decompress_mbps": 263.81
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 7,
+"out_size": 19489160,
+"ratio": 0.3805,
+"compress_mbps": 32.8,
+"decompress_mbps": 264.43
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 8,
+"out_size": 19475109,
+"ratio": 0.3802,
+"compress_mbps": 18.46,
+"decompress_mbps": 257.16
+},
+{
+"compressor": "go",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 19476276,
+"ratio": 0.3802,
+"compress_mbps": 10.54,
+"decompress_mbps": 253.25
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3967718,
+"ratio": 0.3979,
+"compress_mbps": 149.74,
+"decompress_mbps": 229.45
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 2,
+"out_size": 3773274,
+"ratio": 0.3784,
+"compress_mbps": 107.04,
+"decompress_mbps": 231
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3670460,
+"ratio": 0.3681,
+"compress_mbps": 78.33,
+"decompress_mbps": 243.29
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 4,
+"out_size": 3655100,
+"ratio": 0.3666,
+"compress_mbps": 88.4,
+"decompress_mbps": 240.27
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 5,
+"out_size": 3620881,
+"ratio": 0.3632,
+"compress_mbps": 51.48,
+"decompress_mbps": 252.04
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3606626,
+"ratio": 0.3617,
+"compress_mbps": 33.56,
+"decompress_mbps": 245.58
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 7,
+"out_size": 3605405,
+"ratio": 0.3616,
+"compress_mbps": 30.67,
+"decompress_mbps": 251.27
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 8,
+"out_size": 3601635,
+"ratio": 0.3612,
+"compress_mbps": 26.32,
+"decompress_mbps": 248.46
+},
+{
+"compressor": "go",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3601151,
+"ratio": 0.3612,
+"compress_mbps": 19.54,
+"decompress_mbps": 245.27
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 4501482,
+"ratio": 0.1342,
+"compress_mbps": 336.67,
+"decompress_mbps": 474.09
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 2,
+"out_size": 3875891,
+"ratio": 0.1155,
+"compress_mbps": 318.06,
+"decompress_mbps": 611.55
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3731525,
+"ratio": 0.1112,
+"compress_mbps": 286.8,
+"decompress_mbps": 640.47
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 4,
+"out_size": 3542242,
+"ratio": 0.1056,
+"compress_mbps": 238.32,
+"decompress_mbps": 645.82
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 5,
+"out_size": 3239184,
+"ratio": 0.0965,
+"compress_mbps": 174.47,
+"decompress_mbps": 710.22
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3113927,
+"ratio": 0.0928,
+"compress_mbps": 122.16,
+"decompress_mbps": 697.72
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 7,
+"out_size": 3063520,
+"ratio": 0.0913,
+"compress_mbps": 84.42,
+"decompress_mbps": 735.89
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 8,
+"out_size": 2961320,
+"ratio": 0.0883,
+"compress_mbps": 29.4,
+"decompress_mbps": 787.56
+},
+{
+"compressor": "go",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2940087,
+"ratio": 0.0876,
+"compress_mbps": 20.47,
+"decompress_mbps": 776.18
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3462708,
+"ratio": 0.5628,
+"compress_mbps": 101.43,
+"decompress_mbps": 165.18
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 2,
+"out_size": 3327399,
+"ratio": 0.5408,
+"compress_mbps": 74.25,
+"decompress_mbps": 175.32
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3297422,
+"ratio": 0.536,
+"compress_mbps": 67.06,
+"decompress_mbps": 175.22
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 4,
+"out_size": 3249485,
+"ratio": 0.5282,
+"compress_mbps": 64.75,
+"decompress_mbps": 173.73
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 5,
+"out_size": 3220046,
+"ratio": 0.5234,
+"compress_mbps": 50.21,
+"decompress_mbps": 178.36
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3213239,
+"ratio": 0.5223,
+"compress_mbps": 43.5,
+"decompress_mbps": 179.43
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 7,
+"out_size": 3212009,
+"ratio": 0.5221,
+"compress_mbps": 39.47,
+"decompress_mbps": 177.9
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 8,
+"out_size": 3211575,
+"ratio": 0.522,
+"compress_mbps": 33.8,
+"decompress_mbps": 180.66
+},
+{
+"compressor": "go",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3211561,
+"ratio": 0.522,
+"compress_mbps": 30.3,
+"decompress_mbps": 180.52
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 4334497,
+"ratio": 0.4298,
+"compress_mbps": 144.58,
+"decompress_mbps": 232.26
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 2,
+"out_size": 3900156,
+"ratio": 0.3867,
+"compress_mbps": 133.61,
+"decompress_mbps": 260.56
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3876099,
+"ratio": 0.3843,
+"compress_mbps": 124.07,
+"decompress_mbps": 258.01
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 4,
+"out_size": 3782364,
+"ratio": 0.375,
+"compress_mbps": 111.89,
+"decompress_mbps": 261.88
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 5,
+"out_size": 3679310,
+"ratio": 0.3648,
+"compress_mbps": 90.33,
+"decompress_mbps": 279.39
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3679424,
+"ratio": 0.3648,
+"compress_mbps": 88.7,
+"decompress_mbps": 275.79
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 7,
+"out_size": 3679163,
+"ratio": 0.3648,
+"compress_mbps": 83.3,
+"decompress_mbps": 267.69
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 8,
+"out_size": 3679169,
+"ratio": 0.3648,
+"compress_mbps": 82.19,
+"decompress_mbps": 271.3
+},
+{
+"compressor": "go",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3679169,
+"ratio": 0.3648,
+"compress_mbps": 82.74,
+"decompress_mbps": 267.98
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2496363,
+"ratio": 0.3767,
+"compress_mbps": 130.19,
+"decompress_mbps": 209.65
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 2,
+"out_size": 2202601,
+"ratio": 0.3324,
+"compress_mbps": 94.83,
+"decompress_mbps": 244.49
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2103089,
+"ratio": 0.3173,
+"compress_mbps": 67.59,
+"decompress_mbps": 252.42
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 4,
+"out_size": 1999697,
+"ratio": 0.3017,
+"compress_mbps": 75.73,
+"decompress_mbps": 258.61
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 5,
+"out_size": 1892143,
+"ratio": 0.2855,
+"compress_mbps": 37.51,
+"decompress_mbps": 255.03
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1838372,
+"ratio": 0.2774,
+"compress_mbps": 20.39,
+"decompress_mbps": 264.23
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 7,
+"out_size": 1828850,
+"ratio": 0.276,
+"compress_mbps": 15.79,
+"decompress_mbps": 269.79
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 8,
+"out_size": 1823159,
+"ratio": 0.2751,
+"compress_mbps": 12.51,
+"decompress_mbps": 260.94
+},
+{
+"compressor": "go",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1823159,
+"ratio": 0.2751,
+"compress_mbps": 12.44,
+"decompress_mbps": 259.47
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 6447290,
+"ratio": 0.2984,
+"compress_mbps": 192.72,
+"decompress_mbps": 292.27
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 2,
+"out_size": 6030257,
+"ratio": 0.2791,
+"compress_mbps": 149.93,
+"decompress_mbps": 306.13
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5928121,
+"ratio": 0.2744,
+"compress_mbps": 130.08,
+"decompress_mbps": 317.1
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 4,
+"out_size": 5615804,
+"ratio": 0.2599,
+"compress_mbps": 123.41,
+"decompress_mbps": 335.76
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 5,
+"out_size": 5496738,
+"ratio": 0.2544,
+"compress_mbps": 82.03,
+"decompress_mbps": 343.64
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5464184,
+"ratio": 0.2529,
+"compress_mbps": 62.81,
+"decompress_mbps": 342.49
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 7,
+"out_size": 5429645,
+"ratio": 0.2513,
+"compress_mbps": 49.23,
+"decompress_mbps": 339.67
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 8,
+"out_size": 5418135,
+"ratio": 0.2508,
+"compress_mbps": 37.69,
+"decompress_mbps": 335.21
+},
+{
+"compressor": "go",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5416628,
+"ratio": 0.2507,
+"compress_mbps": 34.16,
+"decompress_mbps": 341.22
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5759187,
+"ratio": 0.7942,
+"compress_mbps": 100.78,
+"decompress_mbps": 175.91
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 2,
+"out_size": 5619390,
+"ratio": 0.7749,
+"compress_mbps": 65.71,
+"decompress_mbps": 177.71
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5560914,
+"ratio": 0.7668,
+"compress_mbps": 56.9,
+"decompress_mbps": 188.82
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 4,
+"out_size": 5544069,
+"ratio": 0.7645,
+"compress_mbps": 58.81,
+"decompress_mbps": 183.49
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 5,
+"out_size": 5518257,
+"ratio": 0.7609,
+"compress_mbps": 45.01,
+"decompress_mbps": 179.45
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5508662,
+"ratio": 0.7596,
+"compress_mbps": 39.88,
+"decompress_mbps": 181.4
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 7,
+"out_size": 5507534,
+"ratio": 0.7595,
+"compress_mbps": 38.81,
+"decompress_mbps": 185.25
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 8,
+"out_size": 5507183,
+"ratio": 0.7594,
+"compress_mbps": 38.34,
+"decompress_mbps": 181
+},
+{
+"compressor": "go",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5507183,
+"ratio": 0.7594,
+"compress_mbps": 38.39,
+"decompress_mbps": 179.46
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 15230651,
+"ratio": 0.3674,
+"compress_mbps": 124.61,
+"decompress_mbps": 206.2
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 2,
+"out_size": 13822040,
+"ratio": 0.3334,
+"compress_mbps": 97.4,
+"decompress_mbps": 219.05
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 13397592,
+"ratio": 0.3232,
+"compress_mbps": 84.32,
+"decompress_mbps": 233.41
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 4,
+"out_size": 12759940,
+"ratio": 0.3078,
+"compress_mbps": 82.61,
+"decompress_mbps": 238.83
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 5,
+"out_size": 12274278,
+"ratio": 0.2961,
+"compress_mbps": 54.59,
+"decompress_mbps": 253.03
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12131738,
+"ratio": 0.2926,
+"compress_mbps": 40.48,
+"decompress_mbps": 247.18
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 7,
+"out_size": 12060450,
+"ratio": 0.2909,
+"compress_mbps": 33.75,
+"decompress_mbps": 253.63
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 8,
+"out_size": 12036900,
+"ratio": 0.2903,
+"compress_mbps": 30.14,
+"decompress_mbps": 251.44
+},
+{
+"compressor": "go",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 12036900,
+"ratio": 0.2903,
+"compress_mbps": 30.19,
+"decompress_mbps": 249.33
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6653052,
+"ratio": 0.7851,
+"compress_mbps": 172.49,
+"decompress_mbps": 182.77
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 2,
+"out_size": 6305035,
+"ratio": 0.744,
+"compress_mbps": 69.43,
+"decompress_mbps": 165.29
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6302730,
+"ratio": 0.7438,
+"compress_mbps": 68.88,
+"decompress_mbps": 168.25
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 4,
+"out_size": 6299134,
+"ratio": 0.7433,
+"compress_mbps": 68.45,
+"decompress_mbps": 166.89
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 5,
+"out_size": 6289022,
+"ratio": 0.7421,
+"compress_mbps": 65.16,
+"decompress_mbps": 169.15
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 6289013,
+"ratio": 0.7421,
+"compress_mbps": 65.19,
+"decompress_mbps": 167.45
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 7,
+"out_size": 6289013,
+"ratio": 0.7421,
+"compress_mbps": 65.58,
+"decompress_mbps": 165.62
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 8,
+"out_size": 6289012,
+"ratio": 0.7421,
+"compress_mbps": 65.58,
+"decompress_mbps": 165.13
+},
+{
+"compressor": "go",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 6289012,
+"ratio": 0.7421,
+"compress_mbps": 65.51,
+"decompress_mbps": 167.6
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 989456,
+"ratio": 0.1851,
+"compress_mbps": 255.45,
+"decompress_mbps": 390.55
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 2,
+"out_size": 839766,
+"ratio": 0.1571,
+"compress_mbps": 233.42,
+"decompress_mbps": 504.86
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 800619,
+"ratio": 0.1498,
+"compress_mbps": 201.28,
+"decompress_mbps": 494.08
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 4,
+"out_size": 776397,
+"ratio": 0.1452,
+"compress_mbps": 178.01,
+"decompress_mbps": 508.96
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 5,
+"out_size": 712679,
+"ratio": 0.1333,
+"compress_mbps": 126.49,
+"decompress_mbps": 592.48
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 683707,
+"ratio": 0.1279,
+"compress_mbps": 95.75,
+"decompress_mbps": 571.97
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 7,
+"out_size": 668601,
+"ratio": 0.1251,
+"compress_mbps": 71.72,
+"decompress_mbps": 590.26
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 8,
+"out_size": 659106,
+"ratio": 0.1233,
+"compress_mbps": 48.43,
+"decompress_mbps": 582.15
+},
+{
+"compressor": "go",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 658920,
+"ratio": 0.1233,
+"compress_mbps": 47.23,
+"decompress_mbps": 637.82
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 1,
+"out_size": 56099,
+"ratio": 0.3689,
+"compress_mbps": 87.23,
+"decompress_mbps": 313.92
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 2,
+"out_size": 56099,
+"ratio": 0.3689,
+"compress_mbps": 87.82,
+"decompress_mbps": 313.53
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 3,
+"out_size": 56099,
+"ratio": 0.3689,
+"compress_mbps": 84.18,
+"decompress_mbps": 314.84
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 4,
+"out_size": 56099,
+"ratio": 0.3689,
+"compress_mbps": 88.33,
+"decompress_mbps": 311.1
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 5,
+"out_size": 54531,
+"ratio": 0.3585,
+"compress_mbps": 54.91,
+"decompress_mbps": 307.09
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 6,
+"out_size": 54068,
+"ratio": 0.3555,
+"compress_mbps": 42.11,
+"decompress_mbps": 310.58
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 7,
+"out_size": 54003,
+"ratio": 0.3551,
+"compress_mbps": 37.17,
+"decompress_mbps": 312.05
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 8,
+"out_size": 53974,
+"ratio": 0.3549,
+"compress_mbps": 32.72,
+"decompress_mbps": 307.61
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 9,
+"out_size": 53974,
+"ratio": 0.3549,
+"compress_mbps": 32.8,
+"decompress_mbps": 305.54
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 1,
+"out_size": 50031,
+"ratio": 0.3997,
+"compress_mbps": 83.09,
+"decompress_mbps": 278.48
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 2,
+"out_size": 50031,
+"ratio": 0.3997,
+"compress_mbps": 83.15,
+"decompress_mbps": 279.32
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 3,
+"out_size": 50031,
+"ratio": 0.3997,
+"compress_mbps": 82.26,
+"decompress_mbps": 275.94
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 4,
+"out_size": 50031,
+"ratio": 0.3997,
+"compress_mbps": 83.53,
+"decompress_mbps": 277.74
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 5,
+"out_size": 48753,
+"ratio": 0.3895,
+"compress_mbps": 50.56,
+"decompress_mbps": 275.32
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 6,
+"out_size": 48557,
+"ratio": 0.3879,
+"compress_mbps": 40.4,
+"decompress_mbps": 278.51
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 7,
+"out_size": 48523,
+"ratio": 0.3876,
+"compress_mbps": 38.25,
+"decompress_mbps": 278.64
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 8,
+"out_size": 48522,
+"ratio": 0.3876,
+"compress_mbps": 37.36,
+"decompress_mbps": 279.9
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 9,
+"out_size": 48522,
+"ratio": 0.3876,
+"compress_mbps": 37.5,
+"decompress_mbps": 279.58
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 1,
+"out_size": 8182,
+"ratio": 0.3326,
+"compress_mbps": 156.38,
+"decompress_mbps": 280.51
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 2,
+"out_size": 8182,
+"ratio": 0.3326,
+"compress_mbps": 173.35,
+"decompress_mbps": 279.44
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 3,
+"out_size": 8182,
+"ratio": 0.3326,
+"compress_mbps": 163.42,
+"decompress_mbps": 281.7
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 4,
+"out_size": 8182,
+"ratio": 0.3326,
+"compress_mbps": 174.83,
+"decompress_mbps": 284.38
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 5,
+"out_size": 7965,
+"ratio": 0.3237,
+"compress_mbps": 108.3,
+"decompress_mbps": 287.18
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 6,
+"out_size": 7914,
+"ratio": 0.3217,
+"compress_mbps": 86.29,
+"decompress_mbps": 291.13
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 7,
+"out_size": 7895,
+"ratio": 0.3209,
+"compress_mbps": 76.54,
+"decompress_mbps": 289.34
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 8,
+"out_size": 7896,
+"ratio": 0.3209,
+"compress_mbps": 69.93,
+"decompress_mbps": 292.05
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 9,
+"out_size": 7896,
+"ratio": 0.3209,
+"compress_mbps": 72.79,
+"decompress_mbps": 289.49
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 1,
+"out_size": 3218,
+"ratio": 0.2886,
+"compress_mbps": 170.42,
+"decompress_mbps": 257.79
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 2,
+"out_size": 3218,
+"ratio": 0.2886,
+"compress_mbps": 173.96,
+"decompress_mbps": 255.07
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 3,
+"out_size": 3218,
+"ratio": 0.2886,
+"compress_mbps": 171.38,
+"decompress_mbps": 255.39
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 4,
+"out_size": 3218,
+"ratio": 0.2886,
+"compress_mbps": 163.6,
+"decompress_mbps": 259.71
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 5,
+"out_size": 3136,
+"ratio": 0.2813,
+"compress_mbps": 141.53,
+"decompress_mbps": 263.78
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 6,
+"out_size": 3115,
+"ratio": 0.2794,
+"compress_mbps": 124.88,
+"decompress_mbps": 262.73
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 7,
+"out_size": 3112,
+"ratio": 0.2791,
+"compress_mbps": 98.74,
+"decompress_mbps": 265.35
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 8,
+"out_size": 3112,
+"ratio": 0.2791,
+"compress_mbps": 105.25,
+"decompress_mbps": 265.25
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 9,
+"out_size": 3112,
+"ratio": 0.2791,
+"compress_mbps": 106.7,
+"decompress_mbps": 266.44
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 1,
+"out_size": 1221,
+"ratio": 0.3281,
+"compress_mbps": 120.04,
+"decompress_mbps": 121.08
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 2,
+"out_size": 1221,
+"ratio": 0.3281,
+"compress_mbps": 117.35,
+"decompress_mbps": 118.87
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 3,
+"out_size": 1221,
+"ratio": 0.3281,
+"compress_mbps": 118.61,
+"decompress_mbps": 118.91
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 4,
+"out_size": 1221,
+"ratio": 0.3281,
+"compress_mbps": 117.29,
+"decompress_mbps": 117.83
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 5,
+"out_size": 1207,
+"ratio": 0.3244,
+"compress_mbps": 108.92,
+"decompress_mbps": 118.49
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 6,
+"out_size": 1207,
+"ratio": 0.3244,
+"compress_mbps": 105.41,
+"decompress_mbps": 121.54
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 7,
+"out_size": 1207,
+"ratio": 0.3244,
+"compress_mbps": 100.51,
+"decompress_mbps": 119.96
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 8,
+"out_size": 1207,
+"ratio": 0.3244,
+"compress_mbps": 100.99,
+"decompress_mbps": 119.54
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 9,
+"out_size": 1207,
+"ratio": 0.3244,
+"compress_mbps": 100.76,
+"decompress_mbps": 117.12
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 1,
+"out_size": 227063,
+"ratio": 0.2205,
+"compress_mbps": 224.07,
+"decompress_mbps": 458.01
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 2,
+"out_size": 227063,
+"ratio": 0.2205,
+"compress_mbps": 227.75,
+"decompress_mbps": 460.41
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 3,
+"out_size": 227063,
+"ratio": 0.2205,
+"compress_mbps": 229.45,
+"decompress_mbps": 459.42
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 4,
+"out_size": 227063,
+"ratio": 0.2205,
+"compress_mbps": 230.58,
+"decompress_mbps": 459.38
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 5,
+"out_size": 218313,
+"ratio": 0.212,
+"compress_mbps": 156.12,
+"decompress_mbps": 444.95
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 6,
+"out_size": 215095,
+"ratio": 0.2089,
+"compress_mbps": 106.5,
+"decompress_mbps": 447.33
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 7,
+"out_size": 213213,
+"ratio": 0.2071,
+"compress_mbps": 71.16,
+"decompress_mbps": 445.04
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 8,
+"out_size": 210955,
+"ratio": 0.2049,
+"compress_mbps": 9.25,
+"decompress_mbps": 447.09
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 9,
+"out_size": 210981,
+"ratio": 0.2049,
+"compress_mbps": 4.62,
+"decompress_mbps": 451.19
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 1,
+"out_size": 148927,
+"ratio": 0.349,
+"compress_mbps": 92.3,
+"decompress_mbps": 307.48
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 2,
+"out_size": 148927,
+"ratio": 0.349,
+"compress_mbps": 92.07,
+"decompress_mbps": 310.96
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 3,
+"out_size": 148927,
+"ratio": 0.349,
+"compress_mbps": 91.88,
+"decompress_mbps": 308.43
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 4,
+"out_size": 148927,
+"ratio": 0.349,
+"compress_mbps": 92.46,
+"decompress_mbps": 309.65
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 5,
+"out_size": 145024,
+"ratio": 0.3398,
+"compress_mbps": 57.59,
+"decompress_mbps": 307.15
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 6,
+"out_size": 144159,
+"ratio": 0.3378,
+"compress_mbps": 44.47,
+"decompress_mbps": 308.17
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 7,
+"out_size": 143991,
+"ratio": 0.3374,
+"compress_mbps": 40.14,
+"decompress_mbps": 307.36
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 8,
+"out_size": 143941,
+"ratio": 0.3373,
+"compress_mbps": 36.91,
+"decompress_mbps": 307.68
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 9,
+"out_size": 143939,
+"ratio": 0.3373,
+"compress_mbps": 36.73,
+"decompress_mbps": 293.8
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 1,
+"out_size": 200074,
+"ratio": 0.4152,
+"compress_mbps": 80.64,
+"decompress_mbps": 252.66
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 2,
+"out_size": 200074,
+"ratio": 0.4152,
+"compress_mbps": 80.21,
+"decompress_mbps": 249.45
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 3,
+"out_size": 200074,
+"ratio": 0.4152,
+"compress_mbps": 79.98,
+"decompress_mbps": 242.83
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 4,
+"out_size": 200074,
+"ratio": 0.4152,
+"compress_mbps": 79.52,
+"decompress_mbps": 245.99
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 5,
+"out_size": 194496,
+"ratio": 0.4036,
+"compress_mbps": 45.02,
+"decompress_mbps": 245.25
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 6,
+"out_size": 193176,
+"ratio": 0.4009,
+"compress_mbps": 33.8,
+"decompress_mbps": 249.91
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 7,
+"out_size": 192991,
+"ratio": 0.4005,
+"compress_mbps": 30.68,
+"decompress_mbps": 248.71
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 8,
+"out_size": 192980,
+"ratio": 0.4005,
+"compress_mbps": 29.06,
+"decompress_mbps": 244.39
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 9,
+"out_size": 192980,
+"ratio": 0.4005,
+"compress_mbps": 29.11,
+"decompress_mbps": 248.52
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 1,
+"out_size": 57484,
+"ratio": 0.112,
+"compress_mbps": 290.93,
+"decompress_mbps": 708.69
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 2,
+"out_size": 57484,
+"ratio": 0.112,
+"compress_mbps": 288.71,
+"decompress_mbps": 722.23
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 3,
+"out_size": 57484,
+"ratio": 0.112,
+"compress_mbps": 288.41,
+"decompress_mbps": 730.83
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 4,
+"out_size": 57484,
+"ratio": 0.112,
+"compress_mbps": 287.22,
+"decompress_mbps": 733.87
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 5,
+"out_size": 56050,
+"ratio": 0.1092,
+"compress_mbps": 227.48,
+"decompress_mbps": 754.71
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 6,
+"out_size": 55292,
+"ratio": 0.1077,
+"compress_mbps": 151.11,
+"decompress_mbps": 780.26
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 7,
+"out_size": 54651,
+"ratio": 0.1065,
+"compress_mbps": 122.76,
+"decompress_mbps": 798.56
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 8,
+"out_size": 52583,
+"ratio": 0.1025,
+"compress_mbps": 46.44,
+"decompress_mbps": 818.39
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 9,
+"out_size": 51816,
+"ratio": 0.101,
+"compress_mbps": 15.56,
+"decompress_mbps": 803.12
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 1,
+"out_size": 13765,
+"ratio": 0.36,
+"compress_mbps": 116.13,
+"decompress_mbps": 300.55
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 2,
+"out_size": 13765,
+"ratio": 0.36,
+"compress_mbps": 115.93,
+"decompress_mbps": 300.55
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 3,
+"out_size": 13765,
+"ratio": 0.36,
+"compress_mbps": 110.39,
+"decompress_mbps": 299.85
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 4,
+"out_size": 13765,
+"ratio": 0.36,
+"compress_mbps": 115.14,
+"decompress_mbps": 300.62
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 5,
+"out_size": 13290,
+"ratio": 0.3475,
+"compress_mbps": 85.87,
+"decompress_mbps": 314.77
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 6,
+"out_size": 13258,
+"ratio": 0.3467,
+"compress_mbps": 67.57,
+"decompress_mbps": 315.93
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 7,
+"out_size": 13246,
+"ratio": 0.3464,
+"compress_mbps": 56.2,
+"decompress_mbps": 308.85
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 8,
+"out_size": 13236,
+"ratio": 0.3461,
+"compress_mbps": 24.96,
+"decompress_mbps": 318.92
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 9,
+"out_size": 13233,
+"ratio": 0.3461,
+"compress_mbps": 15.95,
+"decompress_mbps": 318.71
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 1,
+"out_size": 1742,
+"ratio": 0.4121,
+"compress_mbps": 96.54,
+"decompress_mbps": 131.88
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 2,
+"out_size": 1742,
+"ratio": 0.4121,
+"compress_mbps": 93.5,
+"decompress_mbps": 132.47
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 3,
+"out_size": 1742,
+"ratio": 0.4121,
+"compress_mbps": 98.07,
+"decompress_mbps": 132.39
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 4,
+"out_size": 1742,
+"ratio": 0.4121,
+"compress_mbps": 98.56,
+"decompress_mbps": 132.91
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 5,
+"out_size": 1720,
+"ratio": 0.4069,
+"compress_mbps": 94.01,
+"decompress_mbps": 133.38
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 6,
+"out_size": 1720,
+"ratio": 0.4069,
+"compress_mbps": 93.93,
+"decompress_mbps": 134.14
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 7,
+"out_size": 1720,
+"ratio": 0.4069,
+"compress_mbps": 92.87,
+"decompress_mbps": 133.66
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 8,
+"out_size": 1720,
+"ratio": 0.4069,
+"compress_mbps": 93.28,
+"decompress_mbps": 133.46
+},
+{
+"compressor": "zig",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 9,
+"out_size": 1720,
+"ratio": 0.4069,
+"compress_mbps": 95.85,
+"decompress_mbps": 133.7
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 3974126,
+"ratio": 0.3899,
+"compress_mbps": 82.59,
+"decompress_mbps": 270.19
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 2,
+"out_size": 3974126,
+"ratio": 0.3899,
+"compress_mbps": 83.3,
+"decompress_mbps": 274.91
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 3974126,
+"ratio": 0.3899,
+"compress_mbps": 83.66,
+"decompress_mbps": 275.15
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 4,
+"out_size": 3974126,
+"ratio": 0.3899,
+"compress_mbps": 83.47,
+"decompress_mbps": 271.41
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 5,
+"out_size": 3863846,
+"ratio": 0.3791,
+"compress_mbps": 48.19,
+"decompress_mbps": 269.37
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3838854,
+"ratio": 0.3766,
+"compress_mbps": 36.71,
+"decompress_mbps": 269.3
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 7,
+"out_size": 3835182,
+"ratio": 0.3763,
+"compress_mbps": 33.02,
+"decompress_mbps": 269.03
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 8,
+"out_size": 3834518,
+"ratio": 0.3762,
+"compress_mbps": 31.03,
+"decompress_mbps": 274.07
+},
+{
+"compressor": "zig",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3834518,
+"ratio": 0.3762,
+"compress_mbps": 31.2,
+"decompress_mbps": 274.73
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 19877952,
+"ratio": 0.3881,
+"compress_mbps": 103.35,
+"decompress_mbps": 251.68
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 2,
+"out_size": 19877952,
+"ratio": 0.3881,
+"compress_mbps": 102.55,
+"decompress_mbps": 253.17
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19877952,
+"ratio": 0.3881,
+"compress_mbps": 101.76,
+"decompress_mbps": 250.34
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 4,
+"out_size": 19877952,
+"ratio": 0.3881,
+"compress_mbps": 102.91,
+"decompress_mbps": 252.16
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 5,
+"out_size": 19578840,
+"ratio": 0.3822,
+"compress_mbps": 77.43,
+"decompress_mbps": 261.3
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 19492445,
+"ratio": 0.3806,
+"compress_mbps": 57.57,
+"decompress_mbps": 264.67
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 7,
+"out_size": 19463481,
+"ratio": 0.38,
+"compress_mbps": 45.88,
+"decompress_mbps": 263.63
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 8,
+"out_size": 19444704,
+"ratio": 0.3796,
+"compress_mbps": 22.74,
+"decompress_mbps": 262.77
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 19440748,
+"ratio": 0.3796,
+"compress_mbps": 13.03,
+"decompress_mbps": 265.43
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3662279,
+"ratio": 0.3673,
+"compress_mbps": 112.81,
+"decompress_mbps": 262.84
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 2,
+"out_size": 3662279,
+"ratio": 0.3673,
+"compress_mbps": 112.15,
+"decompress_mbps": 262.41
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3662279,
+"ratio": 0.3673,
+"compress_mbps": 112.47,
+"decompress_mbps": 260.84
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 4,
+"out_size": 3662279,
+"ratio": 0.3673,
+"compress_mbps": 112.42,
+"decompress_mbps": 262.7
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 5,
+"out_size": 3637736,
+"ratio": 0.3648,
+"compress_mbps": 65.76,
+"decompress_mbps": 270.06
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3621530,
+"ratio": 0.3632,
+"compress_mbps": 46.28,
+"decompress_mbps": 271.66
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 7,
+"out_size": 3623924,
+"ratio": 0.3635,
+"compress_mbps": 41.81,
+"decompress_mbps": 272.81
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 8,
+"out_size": 3623112,
+"ratio": 0.3634,
+"compress_mbps": 32.5,
+"decompress_mbps": 272.72
+},
+{
+"compressor": "zig",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3623382,
+"ratio": 0.3634,
+"compress_mbps": 24.71,
+"decompress_mbps": 272.05
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 3580057,
+"ratio": 0.1067,
+"compress_mbps": 309.13,
+"decompress_mbps": 892.04
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 2,
+"out_size": 3580057,
+"ratio": 0.1067,
+"compress_mbps": 308.95,
+"decompress_mbps": 885.83
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3580057,
+"ratio": 0.1067,
+"compress_mbps": 306.9,
+"decompress_mbps": 881.55
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 4,
+"out_size": 3580057,
+"ratio": 0.1067,
+"compress_mbps": 308.3,
+"decompress_mbps": 884.17
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 5,
+"out_size": 3268887,
+"ratio": 0.0974,
+"compress_mbps": 225.83,
+"decompress_mbps": 931.27
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3131445,
+"ratio": 0.0933,
+"compress_mbps": 161.25,
+"decompress_mbps": 965.09
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 7,
+"out_size": 3080217,
+"ratio": 0.0918,
+"compress_mbps": 126.08,
+"decompress_mbps": 961.7
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 8,
+"out_size": 2978354,
+"ratio": 0.0888,
+"compress_mbps": 54.64,
+"decompress_mbps": 984.8
+},
+{
+"compressor": "zig",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 2947971,
+"ratio": 0.0879,
+"compress_mbps": 33.84,
+"decompress_mbps": 989.96
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3221973,
+"ratio": 0.5237,
+"compress_mbps": 71.81,
+"decompress_mbps": 184.61
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 2,
+"out_size": 3221973,
+"ratio": 0.5237,
+"compress_mbps": 72.12,
+"decompress_mbps": 184.24
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3221973,
+"ratio": 0.5237,
+"compress_mbps": 71.93,
+"decompress_mbps": 184.96
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 4,
+"out_size": 3221973,
+"ratio": 0.5237,
+"compress_mbps": 72.26,
+"decompress_mbps": 184.78
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 5,
+"out_size": 3178914,
+"ratio": 0.5167,
+"compress_mbps": 55.7,
+"decompress_mbps": 191.91
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3174170,
+"ratio": 0.5159,
+"compress_mbps": 48.64,
+"decompress_mbps": 193.0
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 7,
+"out_size": 3172734,
+"ratio": 0.5157,
+"compress_mbps": 45.8,
+"decompress_mbps": 193.57
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 8,
+"out_size": 3171353,
+"ratio": 0.5155,
+"compress_mbps": 38.57,
+"decompress_mbps": 193.32
+},
+{
+"compressor": "zig",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3171299,
+"ratio": 0.5155,
+"compress_mbps": 34.71,
+"decompress_mbps": 193.42
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 3791952,
+"ratio": 0.376,
+"compress_mbps": 123.53,
+"decompress_mbps": 272.88
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 2,
+"out_size": 3791952,
+"ratio": 0.376,
+"compress_mbps": 123.96,
+"decompress_mbps": 275.8
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3791952,
+"ratio": 0.376,
+"compress_mbps": 123.58,
+"decompress_mbps": 276.01
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 4,
+"out_size": 3791952,
+"ratio": 0.376,
+"compress_mbps": 123.38,
+"decompress_mbps": 273.95
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 5,
+"out_size": 3654027,
+"ratio": 0.3623,
+"compress_mbps": 96.18,
+"decompress_mbps": 277.93
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3652732,
+"ratio": 0.3622,
+"compress_mbps": 93.36,
+"decompress_mbps": 277.41
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 7,
+"out_size": 3652496,
+"ratio": 0.3621,
+"compress_mbps": 87.38,
+"decompress_mbps": 277.61
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 8,
+"out_size": 3652505,
+"ratio": 0.3621,
+"compress_mbps": 87.25,
+"decompress_mbps": 277.42
+},
+{
+"compressor": "zig",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3652505,
+"ratio": 0.3621,
+"compress_mbps": 87.18,
+"decompress_mbps": 274.43
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2009824,
+"ratio": 0.3033,
+"compress_mbps": 99.53,
+"decompress_mbps": 359.02
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 2,
+"out_size": 2009824,
+"ratio": 0.3033,
+"compress_mbps": 99.54,
+"decompress_mbps": 357.84
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2009824,
+"ratio": 0.3033,
+"compress_mbps": 98.86,
+"decompress_mbps": 358.42
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 4,
+"out_size": 2009824,
+"ratio": 0.3033,
+"compress_mbps": 99.12,
+"decompress_mbps": 358.87
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 5,
+"out_size": 1892183,
+"ratio": 0.2855,
+"compress_mbps": 52.27,
+"decompress_mbps": 357.11
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1837957,
+"ratio": 0.2773,
+"compress_mbps": 30.32,
+"decompress_mbps": 366.73
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 7,
+"out_size": 1826603,
+"ratio": 0.2756,
+"compress_mbps": 24.27,
+"decompress_mbps": 366.65
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 8,
+"out_size": 1818702,
+"ratio": 0.2744,
+"compress_mbps": 15.83,
+"decompress_mbps": 365.68
+},
+{
+"compressor": "zig",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1818702,
+"ratio": 0.2744,
+"compress_mbps": 15.8,
+"decompress_mbps": 366.33
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 5633558,
+"ratio": 0.2607,
+"compress_mbps": 144.08,
+"decompress_mbps": 400.86
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 2,
+"out_size": 5633558,
+"ratio": 0.2607,
+"compress_mbps": 144.61,
+"decompress_mbps": 403.43
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5633558,
+"ratio": 0.2607,
+"compress_mbps": 144.91,
+"decompress_mbps": 404.3
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 4,
+"out_size": 5633558,
+"ratio": 0.2607,
+"compress_mbps": 144.99,
+"decompress_mbps": 403.33
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 5,
+"out_size": 5501344,
+"ratio": 0.2546,
+"compress_mbps": 103.0,
+"decompress_mbps": 408.49
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5464646,
+"ratio": 0.2529,
+"compress_mbps": 78.95,
+"decompress_mbps": 412.0
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 7,
+"out_size": 5429975,
+"ratio": 0.2513,
+"compress_mbps": 66.89,
+"decompress_mbps": 413.55
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 8,
+"out_size": 5419566,
+"ratio": 0.2508,
+"compress_mbps": 49.42,
+"decompress_mbps": 412.12
+},
+{
+"compressor": "zig",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5417952,
+"ratio": 0.2508,
+"compress_mbps": 45.42,
+"decompress_mbps": 413.22
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5481930,
+"ratio": 0.7559,
+"compress_mbps": 60.25,
+"decompress_mbps": 162.57
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 2,
+"out_size": 5481930,
+"ratio": 0.7559,
+"compress_mbps": 60.57,
+"decompress_mbps": 162.43
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5481930,
+"ratio": 0.7559,
+"compress_mbps": 60.38,
+"decompress_mbps": 162.61
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 4,
+"out_size": 5481930,
+"ratio": 0.7559,
+"compress_mbps": 60.32,
+"decompress_mbps": 162.77
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 5,
+"out_size": 5450496,
+"ratio": 0.7516,
+"compress_mbps": 46.65,
+"decompress_mbps": 165.07
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5440281,
+"ratio": 0.7502,
+"compress_mbps": 40.78,
+"decompress_mbps": 152.94
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 7,
+"out_size": 5439077,
+"ratio": 0.75,
+"compress_mbps": 40.35,
+"decompress_mbps": 157.42
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 8,
+"out_size": 5438787,
+"ratio": 0.75,
+"compress_mbps": 38.69,
+"decompress_mbps": 161.6
+},
+{
+"compressor": "zig",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5438787,
+"ratio": 0.75,
+"compress_mbps": 39.68,
+"decompress_mbps": 164.63
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 12756531,
+"ratio": 0.3077,
+"compress_mbps": 106.97,
+"decompress_mbps": 315.78
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 2,
+"out_size": 12756531,
+"ratio": 0.3077,
+"compress_mbps": 108.82,
+"decompress_mbps": 316.45
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 12756531,
+"ratio": 0.3077,
+"compress_mbps": 108.42,
+"decompress_mbps": 319.83
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 4,
+"out_size": 12756531,
+"ratio": 0.3077,
+"compress_mbps": 108.71,
+"decompress_mbps": 320.21
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 5,
+"out_size": 12238874,
+"ratio": 0.2952,
+"compress_mbps": 72.07,
+"decompress_mbps": 324.63
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12086531,
+"ratio": 0.2915,
+"compress_mbps": 53.46,
+"decompress_mbps": 327.48
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 7,
+"out_size": 12020742,
+"ratio": 0.2899,
+"compress_mbps": 46.3,
+"decompress_mbps": 327.39
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 8,
+"out_size": 11987253,
+"ratio": 0.2891,
+"compress_mbps": 37.94,
+"decompress_mbps": 328.74
+},
+{
+"compressor": "zig",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 11987245,
+"ratio": 0.2891,
+"compress_mbps": 37.78,
+"decompress_mbps": 324.52
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6273039,
+"ratio": 0.7402,
+"compress_mbps": 61.03,
+"decompress_mbps": 147.69
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 2,
+"out_size": 6273039,
+"ratio": 0.7402,
+"compress_mbps": 61.28,
+"decompress_mbps": 147.25
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6273039,
+"ratio": 0.7402,
+"compress_mbps": 61.19,
+"decompress_mbps": 147.99
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 4,
+"out_size": 6273039,
+"ratio": 0.7402,
+"compress_mbps": 61.15,
+"decompress_mbps": 147.99
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 5,
+"out_size": 6244483,
+"ratio": 0.7369,
+"compress_mbps": 55.89,
+"decompress_mbps": 149.62
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 6244482,
+"ratio": 0.7369,
+"compress_mbps": 55.73,
+"decompress_mbps": 149.73
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 7,
+"out_size": 6244482,
+"ratio": 0.7369,
+"compress_mbps": 55.89,
+"decompress_mbps": 149.78
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 8,
+"out_size": 6244480,
+"ratio": 0.7369,
+"compress_mbps": 56.03,
+"decompress_mbps": 149.93
+},
+{
+"compressor": "zig",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 6244480,
+"ratio": 0.7369,
+"compress_mbps": 55.95,
+"decompress_mbps": 149.77
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 785041,
+"ratio": 0.1469,
+"compress_mbps": 230.99,
+"decompress_mbps": 681.22
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 2,
+"out_size": 785041,
+"ratio": 0.1469,
+"compress_mbps": 231.6,
+"decompress_mbps": 669.32
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 785041,
+"ratio": 0.1469,
+"compress_mbps": 231.88,
+"decompress_mbps": 680.3
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 4,
+"out_size": 785041,
+"ratio": 0.1469,
+"compress_mbps": 231.73,
+"decompress_mbps": 679.52
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 5,
+"out_size": 716461,
+"ratio": 0.134,
+"compress_mbps": 165.89,
+"decompress_mbps": 714.55
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 687053,
+"ratio": 0.1285,
+"compress_mbps": 124.71,
+"decompress_mbps": 741.63
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 7,
+"out_size": 673597,
+"ratio": 0.126,
+"compress_mbps": 101.0,
+"decompress_mbps": 757.21
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 8,
+"out_size": 662156,
+"ratio": 0.1239,
+"compress_mbps": 65.42,
+"decompress_mbps": 760.55
+},
+{
+"compressor": "zig",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 661610,
+"ratio": 0.1238,
+"compress_mbps": 61.08,
+"decompress_mbps": 762.12
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 1,
+"out_size": 73589,
+"ratio": 0.4839,
+"compress_mbps": 34.53,
+"decompress_mbps": 57.57
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 2,
+"out_size": 69878,
+"ratio": 0.4595,
+"compress_mbps": 32.9,
+"decompress_mbps": 58.57
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 3,
+"out_size": 66917,
+"ratio": 0.44,
+"compress_mbps": 27.28,
+"decompress_mbps": 66.6
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 4,
+"out_size": 59388,
+"ratio": 0.3905,
+"compress_mbps": 31.75,
+"decompress_mbps": 80.7
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 5,
+"out_size": 57062,
+"ratio": 0.3752,
+"compress_mbps": 22.74,
+"decompress_mbps": 80.55
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 6,
+"out_size": 55472,
+"ratio": 0.3647,
+"compress_mbps": 16.38,
+"decompress_mbps": 79.73
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 7,
+"out_size": 55265,
+"ratio": 0.3634,
+"compress_mbps": 14.32,
+"decompress_mbps": 80.11
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 8,
+"out_size": 55168,
+"ratio": 0.3627,
+"compress_mbps": 11.95,
+"decompress_mbps": 79.65
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 9,
+"out_size": 55168,
+"ratio": 0.3627,
+"compress_mbps": 11.97,
+"decompress_mbps": 80.09
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 1,
+"out_size": 64551,
+"ratio": 0.5157,
+"compress_mbps": 32.72,
+"decompress_mbps": 54.58
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 2,
+"out_size": 62089,
+"ratio": 0.496,
+"compress_mbps": 31.02,
+"decompress_mbps": 58.34
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 3,
+"out_size": 58690,
+"ratio": 0.4688,
+"compress_mbps": 24.8,
+"decompress_mbps": 59.71
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 4,
+"out_size": 53521,
+"ratio": 0.4276,
+"compress_mbps": 30.17,
+"decompress_mbps": 80.38
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 5,
+"out_size": 51677,
+"ratio": 0.4128,
+"compress_mbps": 20.96,
+"decompress_mbps": 78.86
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 6,
+"out_size": 50638,
+"ratio": 0.4045,
+"compress_mbps": 14.99,
+"decompress_mbps": 84.28
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 7,
+"out_size": 50501,
+"ratio": 0.4034,
+"compress_mbps": 13.57,
+"decompress_mbps": 80.06
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 8,
+"out_size": 50452,
+"ratio": 0.403,
+"compress_mbps": 12.62,
+"decompress_mbps": 83.56
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 9,
+"out_size": 50452,
+"ratio": 0.403,
+"compress_mbps": 12.61,
+"decompress_mbps": 83.29
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 1,
+"out_size": 9859,
+"ratio": 0.4007,
+"compress_mbps": 44.32,
+"decompress_mbps": 113.78
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 2,
+"out_size": 10473,
+"ratio": 0.4257,
+"compress_mbps": 48.22,
+"decompress_mbps": 149.83
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 3,
+"out_size": 10172,
+"ratio": 0.4134,
+"compress_mbps": 43.3,
+"decompress_mbps": 152.25
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 4,
+"out_size": 8692,
+"ratio": 0.3533,
+"compress_mbps": 41.91,
+"decompress_mbps": 152.55
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 5,
+"out_size": 8440,
+"ratio": 0.343,
+"compress_mbps": 36.02,
+"decompress_mbps": 156.73
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 6,
+"out_size": 8385,
+"ratio": 0.3408,
+"compress_mbps": 32.13,
+"decompress_mbps": 157.13
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 7,
+"out_size": 8366,
+"ratio": 0.34,
+"compress_mbps": 30.34,
+"decompress_mbps": 151.47
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 8,
+"out_size": 8367,
+"ratio": 0.3401,
+"compress_mbps": 29.21,
+"decompress_mbps": 158.02
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 9,
+"out_size": 8367,
+"ratio": 0.3401,
+"compress_mbps": 29.15,
+"decompress_mbps": 155.98
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 1,
+"out_size": 4822,
+"ratio": 0.4325,
+"compress_mbps": 54.52,
+"decompress_mbps": 188.53
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 2,
+"out_size": 4593,
+"ratio": 0.4119,
+"compress_mbps": 54.24,
+"decompress_mbps": 193.47
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 3,
+"out_size": 4381,
+"ratio": 0.3929,
+"compress_mbps": 52.66,
+"decompress_mbps": 199.66
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 4,
+"out_size": 3725,
+"ratio": 0.3341,
+"compress_mbps": 52.59,
+"decompress_mbps": 202.76
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 5,
+"out_size": 3614,
+"ratio": 0.3241,
+"compress_mbps": 44.28,
+"decompress_mbps": 208.75
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 6,
+"out_size": 3578,
+"ratio": 0.3209,
+"compress_mbps": 39.76,
+"decompress_mbps": 210.48
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 7,
+"out_size": 3572,
+"ratio": 0.3204,
+"compress_mbps": 37.2,
+"decompress_mbps": 210.06
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 8,
+"out_size": 3568,
+"ratio": 0.32,
+"compress_mbps": 33.64,
+"decompress_mbps": 209.49
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 9,
+"out_size": 3568,
+"ratio": 0.32,
+"compress_mbps": 34.12,
+"decompress_mbps": 210.14
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 1,
+"out_size": 1738,
+"ratio": 0.4671,
+"compress_mbps": 30.63,
+"decompress_mbps": 178.86
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 2,
+"out_size": 1709,
+"ratio": 0.4593,
+"compress_mbps": 32.07,
+"decompress_mbps": 179.56
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 3,
+"out_size": 1694,
+"ratio": 0.4553,
+"compress_mbps": 31.49,
+"decompress_mbps": 180.49
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 4,
+"out_size": 1458,
+"ratio": 0.3918,
+"compress_mbps": 30.44,
+"decompress_mbps": 188.96
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 5,
+"out_size": 1441,
+"ratio": 0.3873,
+"compress_mbps": 29.17,
+"decompress_mbps": 190.78
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 6,
+"out_size": 1440,
+"ratio": 0.387,
+"compress_mbps": 27.19,
+"decompress_mbps": 192.85
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 7,
+"out_size": 1440,
+"ratio": 0.387,
+"compress_mbps": 27.94,
+"decompress_mbps": 190.99
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 8,
+"out_size": 1440,
+"ratio": 0.387,
+"compress_mbps": 27.47,
+"decompress_mbps": 192.63
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 9,
+"out_size": 1440,
+"ratio": 0.387,
+"compress_mbps": 27.85,
+"decompress_mbps": 192.42
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 1,
+"out_size": 260073,
+"ratio": 0.2526,
+"compress_mbps": 53.47,
+"decompress_mbps": 57.67
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 2,
+"out_size": 296764,
+"ratio": 0.2882,
+"compress_mbps": 49.71,
+"decompress_mbps": 76.91
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 3,
+"out_size": 288989,
+"ratio": 0.2806,
+"compress_mbps": 38.04,
+"decompress_mbps": 78.61
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 4,
+"out_size": 246442,
+"ratio": 0.2393,
+"compress_mbps": 54.21,
+"decompress_mbps": 83.24
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 5,
+"out_size": 218888,
+"ratio": 0.2126,
+"compress_mbps": 40.33,
+"decompress_mbps": 77.32
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 6,
+"out_size": 217830,
+"ratio": 0.2115,
+"compress_mbps": 24.23,
+"decompress_mbps": 88.27
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 7,
+"out_size": 221437,
+"ratio": 0.215,
+"compress_mbps": 19.37,
+"decompress_mbps": 87.65
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 8,
+"out_size": 219666,
+"ratio": 0.2133,
+"compress_mbps": 5.51,
+"decompress_mbps": 85.96
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 9,
+"out_size": 219921,
+"ratio": 0.2136,
+"compress_mbps": 2.78,
+"decompress_mbps": 87.37
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 1,
+"out_size": 194588,
+"ratio": 0.456,
+"compress_mbps": 34.89,
+"decompress_mbps": 52.3
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 2,
+"out_size": 185757,
+"ratio": 0.4353,
+"compress_mbps": 33.46,
+"decompress_mbps": 49.8
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 3,
+"out_size": 175850,
+"ratio": 0.4121,
+"compress_mbps": 27.59,
+"decompress_mbps": 59.35
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 4,
+"out_size": 155951,
+"ratio": 0.3654,
+"compress_mbps": 32.39,
+"decompress_mbps": 73.44
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 5,
+"out_size": 150274,
+"ratio": 0.3521,
+"compress_mbps": 23.26,
+"decompress_mbps": 72.52
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 6,
+"out_size": 147958,
+"ratio": 0.3467,
+"compress_mbps": 16.81,
+"decompress_mbps": 73.51
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 7,
+"out_size": 147522,
+"ratio": 0.3457,
+"compress_mbps": 15.18,
+"decompress_mbps": 71.72
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 8,
+"out_size": 147331,
+"ratio": 0.3452,
+"compress_mbps": 13.61,
+"decompress_mbps": 71.04
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 9,
+"out_size": 147328,
+"ratio": 0.3452,
+"compress_mbps": 13.61,
+"decompress_mbps": 72.61
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 1,
+"out_size": 256904,
+"ratio": 0.5331,
+"compress_mbps": 30.48,
+"decompress_mbps": 46.92
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 2,
+"out_size": 245675,
+"ratio": 0.5098,
+"compress_mbps": 29.14,
+"decompress_mbps": 50.06
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 3,
+"out_size": 231519,
+"ratio": 0.4805,
+"compress_mbps": 23.07,
+"decompress_mbps": 57.17
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 4,
+"out_size": 210028,
+"ratio": 0.4359,
+"compress_mbps": 27.9,
+"decompress_mbps": 65.64
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 5,
+"out_size": 203312,
+"ratio": 0.4219,
+"compress_mbps": 18.75,
+"decompress_mbps": 62.62
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 6,
+"out_size": 199287,
+"ratio": 0.4136,
+"compress_mbps": 12.87,
+"decompress_mbps": 66.39
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 7,
+"out_size": 198474,
+"ratio": 0.4119,
+"compress_mbps": 11.21,
+"decompress_mbps": 66.15
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 8,
+"out_size": 198080,
+"ratio": 0.4111,
+"compress_mbps": 8.86,
+"decompress_mbps": 65.49
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 9,
+"out_size": 198080,
+"ratio": 0.4111,
+"compress_mbps": 8.91,
+"decompress_mbps": 65.86
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 1,
+"out_size": 71229,
+"ratio": 0.1388,
+"compress_mbps": 83.77,
+"decompress_mbps": 131.58
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 2,
+"out_size": 69946,
+"ratio": 0.1363,
+"compress_mbps": 80.79,
+"decompress_mbps": 137.1
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 3,
+"out_size": 68538,
+"ratio": 0.1335,
+"compress_mbps": 71.18,
+"decompress_mbps": 151.28
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 4,
+"out_size": 61320,
+"ratio": 0.1195,
+"compress_mbps": 66.7,
+"decompress_mbps": 167.14
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 5,
+"out_size": 59993,
+"ratio": 0.1169,
+"compress_mbps": 57.62,
+"decompress_mbps": 167.58
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 6,
+"out_size": 58637,
+"ratio": 0.1143,
+"compress_mbps": 41.62,
+"decompress_mbps": 167.55
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 7,
+"out_size": 58209,
+"ratio": 0.1134,
+"compress_mbps": 35.62,
+"decompress_mbps": 175.53
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 8,
+"out_size": 55749,
+"ratio": 0.1086,
+"compress_mbps": 19.34,
+"decompress_mbps": 178.8
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 9,
+"out_size": 54927,
+"ratio": 0.107,
+"compress_mbps": 7.47,
+"decompress_mbps": 178.91
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 1,
+"out_size": 16399,
+"ratio": 0.4288,
+"compress_mbps": 37.32,
+"decompress_mbps": 88.99
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 2,
+"out_size": 15933,
+"ratio": 0.4167,
+"compress_mbps": 34.65,
+"decompress_mbps": 90.16
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 3,
+"out_size": 15739,
+"ratio": 0.4116,
+"compress_mbps": 28.77,
+"decompress_mbps": 87.25
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 4,
+"out_size": 13834,
+"ratio": 0.3618,
+"compress_mbps": 32.3,
+"decompress_mbps": 107.86
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 5,
+"out_size": 13463,
+"ratio": 0.3521,
+"compress_mbps": 26.29,
+"decompress_mbps": 110.38
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 6,
+"out_size": 13353,
+"ratio": 0.3492,
+"compress_mbps": 19.08,
+"decompress_mbps": 111.13
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 7,
+"out_size": 13317,
+"ratio": 0.3482,
+"compress_mbps": 15.86,
+"decompress_mbps": 111.35
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 8,
+"out_size": 13255,
+"ratio": 0.3466,
+"compress_mbps": 8.41,
+"decompress_mbps": 111.28
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 9,
+"out_size": 13171,
+"ratio": 0.3444,
+"compress_mbps": 4.15,
+"decompress_mbps": 113.75
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 1,
+"out_size": 2512,
+"ratio": 0.5943,
+"compress_mbps": 28.93,
+"decompress_mbps": 159.45
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 2,
+"out_size": 2477,
+"ratio": 0.586,
+"compress_mbps": 29.81,
+"decompress_mbps": 161.01
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 3,
+"out_size": 2452,
+"ratio": 0.5801,
+"compress_mbps": 30.92,
+"decompress_mbps": 161.34
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 4,
+"out_size": 2110,
+"ratio": 0.4992,
+"compress_mbps": 29.19,
+"decompress_mbps": 160.49
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 5,
+"out_size": 2086,
+"ratio": 0.4935,
+"compress_mbps": 28.88,
+"decompress_mbps": 169.94
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 6,
+"out_size": 2086,
+"ratio": 0.4935,
+"compress_mbps": 29.34,
+"decompress_mbps": 170.83
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 7,
+"out_size": 2086,
+"ratio": 0.4935,
+"compress_mbps": 28.91,
+"decompress_mbps": 169.65
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 8,
+"out_size": 2086,
+"ratio": 0.4935,
+"compress_mbps": 29.08,
+"decompress_mbps": 170.68
+},
+{
+"compressor": "ocaml",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 9,
+"out_size": 2086,
+"ratio": 0.4935,
+"compress_mbps": 28.76,
+"decompress_mbps": 162.67
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 5183792,
+"ratio": 0.5086,
+"compress_mbps": 31.94,
+"decompress_mbps": 39.96
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 2,
+"out_size": 4956750,
+"ratio": 0.4863,
+"compress_mbps": 30.27,
+"decompress_mbps": 43.07
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 4644095,
+"ratio": 0.4556,
+"compress_mbps": 24.33,
+"decompress_mbps": 47.82
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 4,
+"out_size": 4178564,
+"ratio": 0.41,
+"compress_mbps": 29.19,
+"decompress_mbps": 60.15
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 5,
+"out_size": 4034632,
+"ratio": 0.3958,
+"compress_mbps": 20.02,
+"decompress_mbps": 61.14
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3952244,
+"ratio": 0.3878,
+"compress_mbps": 14.05,
+"decompress_mbps": 61.12
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 7,
+"out_size": 3938822,
+"ratio": 0.3864,
+"compress_mbps": 12.28,
+"decompress_mbps": 61.54
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 8,
+"out_size": 3935171,
+"ratio": 0.3861,
+"compress_mbps": 10.81,
+"decompress_mbps": 61.85
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3935171,
+"ratio": 0.3861,
+"compress_mbps": 10.75,
+"decompress_mbps": 61.78
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 25320013,
+"ratio": 0.4943,
+"compress_mbps": 32.7,
+"decompress_mbps": 34.95
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 2,
+"out_size": 24804084,
+"ratio": 0.4843,
+"compress_mbps": 31.11,
+"decompress_mbps": 36.42
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 24241121,
+"ratio": 0.4733,
+"compress_mbps": 26.19,
+"decompress_mbps": 37.28
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 4,
+"out_size": 20950547,
+"ratio": 0.409,
+"compress_mbps": 29.54,
+"decompress_mbps": 44.04
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 5,
+"out_size": 20592289,
+"ratio": 0.402,
+"compress_mbps": 24.65,
+"decompress_mbps": 45.47
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 20445232,
+"ratio": 0.3992,
+"compress_mbps": 18.85,
+"decompress_mbps": 46.45
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 7,
+"out_size": 20407676,
+"ratio": 0.3984,
+"compress_mbps": 16.11,
+"decompress_mbps": 46.66
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 8,
+"out_size": 20389473,
+"ratio": 0.3981,
+"compress_mbps": 10.25,
+"decompress_mbps": 45.88
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 20386824,
+"ratio": 0.398,
+"compress_mbps": 6.88,
+"decompress_mbps": 45.39
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3964698,
+"ratio": 0.3976,
+"compress_mbps": 38.8,
+"decompress_mbps": 48.48
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 2,
+"out_size": 3936391,
+"ratio": 0.3948,
+"compress_mbps": 36.31,
+"decompress_mbps": 49.1
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3823540,
+"ratio": 0.3835,
+"compress_mbps": 28.05,
+"decompress_mbps": 52.45
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 4,
+"out_size": 3799601,
+"ratio": 0.3811,
+"compress_mbps": 33.08,
+"decompress_mbps": 62.74
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 5,
+"out_size": 3830938,
+"ratio": 0.3842,
+"compress_mbps": 22.72,
+"decompress_mbps": 57.8
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3808303,
+"ratio": 0.382,
+"compress_mbps": 14.84,
+"decompress_mbps": 58.01
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 7,
+"out_size": 3802814,
+"ratio": 0.3814,
+"compress_mbps": 12.15,
+"decompress_mbps": 57.78
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 8,
+"out_size": 3800355,
+"ratio": 0.3812,
+"compress_mbps": 6.76,
+"decompress_mbps": 57.86
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3799676,
+"ratio": 0.3811,
+"compress_mbps": 6.07,
+"decompress_mbps": 58.42
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 4899547,
+"ratio": 0.146,
+"compress_mbps": 96.81,
+"decompress_mbps": 130.32
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 2,
+"out_size": 4587004,
+"ratio": 0.1367,
+"compress_mbps": 96.43,
+"decompress_mbps": 139.86
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 4229035,
+"ratio": 0.126,
+"compress_mbps": 90.78,
+"decompress_mbps": 152.03
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 4,
+"out_size": 3791322,
+"ratio": 0.113,
+"compress_mbps": 82.31,
+"decompress_mbps": 162.11
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 5,
+"out_size": 3449193,
+"ratio": 0.1028,
+"compress_mbps": 72.86,
+"decompress_mbps": 166.93
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3269452,
+"ratio": 0.0974,
+"compress_mbps": 58.61,
+"decompress_mbps": 171.28
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 7,
+"out_size": 3211286,
+"ratio": 0.0957,
+"compress_mbps": 50.41,
+"decompress_mbps": 168.5
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 8,
+"out_size": 3101534,
+"ratio": 0.0924,
+"compress_mbps": 27.51,
+"decompress_mbps": 171.08
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 3058177,
+"ratio": 0.0911,
+"compress_mbps": 16.54,
+"decompress_mbps": 179.25
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 4024327,
+"ratio": 0.6541,
+"compress_mbps": 23.3,
+"decompress_mbps": 29.55
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 2,
+"out_size": 3953722,
+"ratio": 0.6427,
+"compress_mbps": 22.26,
+"decompress_mbps": 30.51
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3887921,
+"ratio": 0.632,
+"compress_mbps": 18.93,
+"decompress_mbps": 30.66
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 4,
+"out_size": 3320440,
+"ratio": 0.5397,
+"compress_mbps": 21.59,
+"decompress_mbps": 37.26
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 5,
+"out_size": 3279338,
+"ratio": 0.533,
+"compress_mbps": 18.04,
+"decompress_mbps": 38.33
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3254309,
+"ratio": 0.529,
+"compress_mbps": 14.03,
+"decompress_mbps": 38.11
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 7,
+"out_size": 3250139,
+"ratio": 0.5283,
+"compress_mbps": 12.36,
+"decompress_mbps": 37.71
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 8,
+"out_size": 3247018,
+"ratio": 0.5278,
+"compress_mbps": 10.17,
+"decompress_mbps": 37.99
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3246865,
+"ratio": 0.5278,
+"compress_mbps": 9.55,
+"decompress_mbps": 38.02
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 4471091,
+"ratio": 0.4433,
+"compress_mbps": 35.74,
+"decompress_mbps": 69.37
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 2,
+"out_size": 4372105,
+"ratio": 0.4335,
+"compress_mbps": 34.44,
+"decompress_mbps": 73.11
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 4305270,
+"ratio": 0.4269,
+"compress_mbps": 30.84,
+"decompress_mbps": 74.76
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 4,
+"out_size": 3920495,
+"ratio": 0.3887,
+"compress_mbps": 30.64,
+"decompress_mbps": 66.2
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 5,
+"out_size": 3853177,
+"ratio": 0.382,
+"compress_mbps": 26.77,
+"decompress_mbps": 65.04
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3780878,
+"ratio": 0.3749,
+"compress_mbps": 23.5,
+"decompress_mbps": 63.8
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 7,
+"out_size": 3763880,
+"ratio": 0.3732,
+"compress_mbps": 20.18,
+"decompress_mbps": 72.63
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 8,
+"out_size": 3757719,
+"ratio": 0.3726,
+"compress_mbps": 18.28,
+"decompress_mbps": 71.63
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3757719,
+"ratio": 0.3726,
+"compress_mbps": 18.37,
+"decompress_mbps": 72.35
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2722387,
+"ratio": 0.4108,
+"compress_mbps": 38.5,
+"decompress_mbps": 66.16
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 2,
+"out_size": 2572544,
+"ratio": 0.3882,
+"compress_mbps": 37.5,
+"decompress_mbps": 70.7
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2384328,
+"ratio": 0.3598,
+"compress_mbps": 29.7,
+"decompress_mbps": 80.12
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 4,
+"out_size": 2112060,
+"ratio": 0.3187,
+"compress_mbps": 36.54,
+"decompress_mbps": 85.21
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 5,
+"out_size": 1991581,
+"ratio": 0.3005,
+"compress_mbps": 25.62,
+"decompress_mbps": 88.33
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1917866,
+"ratio": 0.2894,
+"compress_mbps": 15.14,
+"decompress_mbps": 93.59
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 7,
+"out_size": 1895353,
+"ratio": 0.286,
+"compress_mbps": 11.09,
+"decompress_mbps": 90.12
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 8,
+"out_size": 1880740,
+"ratio": 0.2838,
+"compress_mbps": 5.6,
+"decompress_mbps": 91.25
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1880711,
+"ratio": 0.2838,
+"compress_mbps": 5.58,
+"decompress_mbps": 91.25
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 7441483,
+"ratio": 0.3444,
+"compress_mbps": 45.31,
+"decompress_mbps": 67.23
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 2,
+"out_size": 7229248,
+"ratio": 0.3346,
+"compress_mbps": 44.23,
+"decompress_mbps": 69.05
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 7083451,
+"ratio": 0.3278,
+"compress_mbps": 39.55,
+"decompress_mbps": 71.01
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 4,
+"out_size": 6189639,
+"ratio": 0.2865,
+"compress_mbps": 42.58,
+"decompress_mbps": 92.48
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 5,
+"out_size": 6053058,
+"ratio": 0.2802,
+"compress_mbps": 35.44,
+"decompress_mbps": 96.9
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5988137,
+"ratio": 0.2771,
+"compress_mbps": 28.74,
+"decompress_mbps": 102.79
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 7,
+"out_size": 5949908,
+"ratio": 0.2754,
+"compress_mbps": 25.39,
+"decompress_mbps": 103.55
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 8,
+"out_size": 5936656,
+"ratio": 0.2748,
+"compress_mbps": 19.35,
+"decompress_mbps": 106.16
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5934701,
+"ratio": 0.2747,
+"compress_mbps": 18.09,
+"decompress_mbps": 106.06
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 6335542,
+"ratio": 0.8736,
+"compress_mbps": 19.02,
+"decompress_mbps": 31.37
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 2,
+"out_size": 6247260,
+"ratio": 0.8615,
+"compress_mbps": 17.95,
+"decompress_mbps": 49.12
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 6064713,
+"ratio": 0.8363,
+"compress_mbps": 15.55,
+"decompress_mbps": 56.91
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 4,
+"out_size": 5568111,
+"ratio": 0.7678,
+"compress_mbps": 17.78,
+"decompress_mbps": 60.28
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 5,
+"out_size": 5544524,
+"ratio": 0.7646,
+"compress_mbps": 14.67,
+"decompress_mbps": 65.44
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5513056,
+"ratio": 0.7602,
+"compress_mbps": 12.16,
+"decompress_mbps": 62.98
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 7,
+"out_size": 5508915,
+"ratio": 0.7596,
+"compress_mbps": 11.43,
+"decompress_mbps": 64.41
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 8,
+"out_size": 5508365,
+"ratio": 0.7596,
+"compress_mbps": 10.71,
+"decompress_mbps": 64.32
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5508365,
+"ratio": 0.7596,
+"compress_mbps": 10.65,
+"decompress_mbps": 64.32
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 16776095,
+"ratio": 0.4046,
+"compress_mbps": 38.53,
+"decompress_mbps": 51.03
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 2,
+"out_size": 16032651,
+"ratio": 0.3867,
+"compress_mbps": 36.77,
+"decompress_mbps": 55.83
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 15180334,
+"ratio": 0.3662,
+"compress_mbps": 31.71,
+"decompress_mbps": 52.1
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 4,
+"out_size": 13261924,
+"ratio": 0.3199,
+"compress_mbps": 36.14,
+"decompress_mbps": 67.86
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 5,
+"out_size": 12706028,
+"ratio": 0.3065,
+"compress_mbps": 27.77,
+"decompress_mbps": 72.16
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12464158,
+"ratio": 0.3006,
+"compress_mbps": 21.22,
+"decompress_mbps": 72.21
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 7,
+"out_size": 12375954,
+"ratio": 0.2985,
+"compress_mbps": 18.25,
+"decompress_mbps": 70.48
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 8,
+"out_size": 12321552,
+"ratio": 0.2972,
+"compress_mbps": 14.41,
+"decompress_mbps": 70.54
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 12320276,
+"ratio": 0.2972,
+"compress_mbps": 13.86,
+"decompress_mbps": 70.47
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6799201,
+"ratio": 0.8023,
+"compress_mbps": 18.93,
+"decompress_mbps": 18.26
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 2,
+"out_size": 6800500,
+"ratio": 0.8025,
+"compress_mbps": 17.48,
+"decompress_mbps": 18.29
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 6803212,
+"ratio": 0.8028,
+"compress_mbps": 15.35,
+"decompress_mbps": 18.41
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 4,
+"out_size": 6264611,
+"ratio": 0.7393,
+"compress_mbps": 17.68,
+"decompress_mbps": 25.16
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 5,
+"out_size": 6217901,
+"ratio": 0.7337,
+"compress_mbps": 16.03,
+"decompress_mbps": 24.76
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 6201999,
+"ratio": 0.7319,
+"compress_mbps": 15.62,
+"decompress_mbps": 24.92
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 7,
+"out_size": 6201883,
+"ratio": 0.7319,
+"compress_mbps": 15.57,
+"decompress_mbps": 24.84
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 8,
+"out_size": 6201887,
+"ratio": 0.7319,
+"compress_mbps": 15.53,
+"decompress_mbps": 25.08
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 6201887,
+"ratio": 0.7319,
+"compress_mbps": 15.5,
+"decompress_mbps": 25.13
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 1081679,
+"ratio": 0.2024,
+"compress_mbps": 75.64,
+"decompress_mbps": 107.31
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 2,
+"out_size": 1001890,
+"ratio": 0.1874,
+"compress_mbps": 74.66,
+"decompress_mbps": 116.68
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 921722,
+"ratio": 0.1724,
+"compress_mbps": 67.17,
+"decompress_mbps": 127.42
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 4,
+"out_size": 849263,
+"ratio": 0.1589,
+"compress_mbps": 65.29,
+"decompress_mbps": 141.45
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 5,
+"out_size": 771964,
+"ratio": 0.1444,
+"compress_mbps": 55.0,
+"decompress_mbps": 142.5
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 728098,
+"ratio": 0.1362,
+"compress_mbps": 42.74,
+"decompress_mbps": 149.94
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 7,
+"out_size": 713635,
+"ratio": 0.1335,
+"compress_mbps": 37.31,
+"decompress_mbps": 149.43
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 8,
+"out_size": 699093,
+"ratio": 0.1308,
+"compress_mbps": 27.08,
+"decompress_mbps": 145.77
+},
+{
+"compressor": "ocaml",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 698459,
+"ratio": 0.1307,
+"compress_mbps": 25.24,
+"decompress_mbps": 150.48
+},
+{
+"compressor": "js",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 1,
+"out_size": 62797,
+"ratio": 0.4129,
+"compress_mbps": 68.56,
+"decompress_mbps": 158.42
+},
+{
+"compressor": "js",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 2,
+"out_size": 59605,
+"ratio": 0.3919,
+"compress_mbps": 57.55,
+"decompress_mbps": 183.76
+},
+{
+"compressor": "js",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 3,
+"out_size": 57675,
+"ratio": 0.3792,
+"compress_mbps": 49.31,
+"decompress_mbps": 171.74
+},
+{
+"compressor": "js",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 4,
+"out_size": 56500,
+"ratio": 0.3715,
+"compress_mbps": 42.67,
+"decompress_mbps": 133.64
+},
+{
+"compressor": "js",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 5,
+"out_size": 56440,
+"ratio": 0.3711,
+"compress_mbps": 42.15,
+"decompress_mbps": 142.06
+},
+{
+"compressor": "js",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 6,
+"out_size": 55443,
+"ratio": 0.3645,
+"compress_mbps": 35.41,
+"decompress_mbps": 138.32
+},
+{
+"compressor": "js",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 7,
+"out_size": 55373,
+"ratio": 0.3641,
+"compress_mbps": 34.36,
+"decompress_mbps": 137
+},
+{
+"compressor": "js",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 8,
+"out_size": 55352,
+"ratio": 0.3639,
+"compress_mbps": 33.41,
+"decompress_mbps": 182.41
+},
+{
+"compressor": "js",
+"pattern": "canterbury/alice29.txt",
+"size": 152089,
+"level": 9,
+"out_size": 55352,
+"ratio": 0.3639,
+"compress_mbps": 33.5,
+"decompress_mbps": 129.92
+},
+{
+"compressor": "js",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 1,
+"out_size": 55063,
+"ratio": 0.4399,
+"compress_mbps": 63.55,
+"decompress_mbps": 163.9
+},
+{
+"compressor": "js",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 2,
+"out_size": 52932,
+"ratio": 0.4229,
+"compress_mbps": 54.4,
+"decompress_mbps": 120.17
+},
+{
+"compressor": "js",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 3,
+"out_size": 51597,
+"ratio": 0.4122,
+"compress_mbps": 46.63,
+"decompress_mbps": 93.11
+},
+{
+"compressor": "js",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 4,
+"out_size": 50780,
+"ratio": 0.4057,
+"compress_mbps": 37.77,
+"decompress_mbps": 86.8
+},
+{
+"compressor": "js",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 5,
+"out_size": 50767,
+"ratio": 0.4056,
+"compress_mbps": 39.45,
+"decompress_mbps": 88.09
+},
+{
+"compressor": "js",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 6,
+"out_size": 50160,
+"ratio": 0.4007,
+"compress_mbps": 32.07,
+"decompress_mbps": 118.41
+},
+{
+"compressor": "js",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 7,
+"out_size": 50138,
+"ratio": 0.4005,
+"compress_mbps": 33.01,
+"decompress_mbps": 92.32
+},
+{
+"compressor": "js",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 8,
+"out_size": 50138,
+"ratio": 0.4005,
+"compress_mbps": 31.73,
+"decompress_mbps": 86.87
+},
+{
+"compressor": "js",
+"pattern": "canterbury/asyoulik.txt",
+"size": 125179,
+"level": 9,
+"out_size": 50138,
+"ratio": 0.4005,
+"compress_mbps": 31.75,
+"decompress_mbps": 124.96
+},
+{
+"compressor": "js",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 1,
+"out_size": 8730,
+"ratio": 0.3548,
+"compress_mbps": 43,
+"decompress_mbps": 35.73
+},
+{
+"compressor": "js",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 2,
+"out_size": 8457,
+"ratio": 0.3437,
+"compress_mbps": 74.58,
+"decompress_mbps": 53.62
+},
+{
+"compressor": "js",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 3,
+"out_size": 8353,
+"ratio": 0.3395,
+"compress_mbps": 39.6,
+"decompress_mbps": 45.98
+},
+{
+"compressor": "js",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 4,
+"out_size": 8301,
+"ratio": 0.3374,
+"compress_mbps": 71.04,
+"decompress_mbps": 49.17
+},
+{
+"compressor": "js",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 5,
+"out_size": 8212,
+"ratio": 0.3338,
+"compress_mbps": 36.39,
+"decompress_mbps": 43.68
+},
+{
+"compressor": "js",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 6,
+"out_size": 8172,
+"ratio": 0.3322,
+"compress_mbps": 58.86,
+"decompress_mbps": 47.79
+},
+{
+"compressor": "js",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 7,
+"out_size": 8171,
+"ratio": 0.3321,
+"compress_mbps": 53.96,
+"decompress_mbps": 46.46
+},
+{
+"compressor": "js",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 8,
+"out_size": 8171,
+"ratio": 0.3321,
+"compress_mbps": 59.01,
+"decompress_mbps": 46.76
+},
+{
+"compressor": "js",
+"pattern": "canterbury/cp.html",
+"size": 24603,
+"level": 9,
+"out_size": 8171,
+"ratio": 0.3321,
+"compress_mbps": 54.5,
+"decompress_mbps": 49.29
+},
+{
+"compressor": "js",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 1,
+"out_size": 3475,
+"ratio": 0.3117,
+"compress_mbps": 77.94,
+"decompress_mbps": 58.2
+},
+{
+"compressor": "js",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 2,
+"out_size": 3305,
+"ratio": 0.2964,
+"compress_mbps": 63.71,
+"decompress_mbps": 51.69
+},
+{
+"compressor": "js",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 3,
+"out_size": 3225,
+"ratio": 0.2892,
+"compress_mbps": 72.96,
+"decompress_mbps": 67.52
+},
+{
+"compressor": "js",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 4,
+"out_size": 3192,
+"ratio": 0.2863,
+"compress_mbps": 71.43,
+"decompress_mbps": 66.05
+},
+{
+"compressor": "js",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 5,
+"out_size": 3180,
+"ratio": 0.2852,
+"compress_mbps": 71.91,
+"decompress_mbps": 61.67
+},
+{
+"compressor": "js",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 6,
+"out_size": 3168,
+"ratio": 0.2841,
+"compress_mbps": 62.79,
+"decompress_mbps": 60.69
+},
+{
+"compressor": "js",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 7,
+"out_size": 3168,
+"ratio": 0.2841,
+"compress_mbps": 52.9,
+"decompress_mbps": 64.49
+},
+{
+"compressor": "js",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 8,
+"out_size": 3168,
+"ratio": 0.2841,
+"compress_mbps": 69.05,
+"decompress_mbps": 64.73
+},
+{
+"compressor": "js",
+"pattern": "canterbury/fields.c",
+"size": 11150,
+"level": 9,
+"out_size": 3168,
+"ratio": 0.2841,
+"compress_mbps": 67.52,
+"decompress_mbps": 60.86
+},
+{
+"compressor": "js",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 1,
+"out_size": 1275,
+"ratio": 0.3426,
+"compress_mbps": 30.33,
+"decompress_mbps": 25.75
+},
+{
+"compressor": "js",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 2,
+"out_size": 1247,
+"ratio": 0.3351,
+"compress_mbps": 26.62,
+"decompress_mbps": 26.26
+},
+{
+"compressor": "js",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 3,
+"out_size": 1239,
+"ratio": 0.333,
+"compress_mbps": 28.08,
+"decompress_mbps": 24.32
+},
+{
+"compressor": "js",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 4,
+"out_size": 1238,
+"ratio": 0.3327,
+"compress_mbps": 27.91,
+"decompress_mbps": 26.5
+},
+{
+"compressor": "js",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 5,
+"out_size": 1239,
+"ratio": 0.333,
+"compress_mbps": 23.23,
+"decompress_mbps": 26.4
+},
+{
+"compressor": "js",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 6,
+"out_size": 1237,
+"ratio": 0.3324,
+"compress_mbps": 33.51,
+"decompress_mbps": 26.22
+},
+{
+"compressor": "js",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 7,
+"out_size": 1237,
+"ratio": 0.3324,
+"compress_mbps": 26.3,
+"decompress_mbps": 26.34
+},
+{
+"compressor": "js",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 8,
+"out_size": 1237,
+"ratio": 0.3324,
+"compress_mbps": 24.78,
+"decompress_mbps": 26.52
+},
+{
+"compressor": "js",
+"pattern": "canterbury/grammar.lsp",
+"size": 3721,
+"level": 9,
+"out_size": 1237,
+"ratio": 0.3324,
+"compress_mbps": 21.78,
+"decompress_mbps": 28.52
+},
+{
+"compressor": "js",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 1,
+"out_size": 226284,
+"ratio": 0.2197,
+"compress_mbps": 134.49,
+"decompress_mbps": 255.27
+},
+{
+"compressor": "js",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 2,
+"out_size": 221369,
+"ratio": 0.215,
+"compress_mbps": 99.6,
+"decompress_mbps": 268.5
+},
+{
+"compressor": "js",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 3,
+"out_size": 218607,
+"ratio": 0.2123,
+"compress_mbps": 89,
+"decompress_mbps": 272.02
+},
+{
+"compressor": "js",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 4,
+"out_size": 217919,
+"ratio": 0.2116,
+"compress_mbps": 80.85,
+"decompress_mbps": 276.89
+},
+{
+"compressor": "js",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 5,
+"out_size": 217919,
+"ratio": 0.2116,
+"compress_mbps": 81.27,
+"decompress_mbps": 277.27
+},
+{
+"compressor": "js",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 6,
+"out_size": 217312,
+"ratio": 0.211,
+"compress_mbps": 54.76,
+"decompress_mbps": 270.88
+},
+{
+"compressor": "js",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 7,
+"out_size": 215966,
+"ratio": 0.2097,
+"compress_mbps": 40.6,
+"decompress_mbps": 269.26
+},
+{
+"compressor": "js",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 8,
+"out_size": 215930,
+"ratio": 0.2097,
+"compress_mbps": 19.55,
+"decompress_mbps": 274.47
+},
+{
+"compressor": "js",
+"pattern": "canterbury/kennedy.xls",
+"size": 1029744,
+"level": 9,
+"out_size": 215912,
+"ratio": 0.2097,
+"compress_mbps": 15.7,
+"decompress_mbps": 308.1
+},
+{
+"compressor": "js",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 1,
+"out_size": 167622,
+"ratio": 0.3928,
+"compress_mbps": 62.33,
+"decompress_mbps": 106.11
+},
+{
+"compressor": "js",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 2,
+"out_size": 158003,
+"ratio": 0.3702,
+"compress_mbps": 49.14,
+"decompress_mbps": 88.59
+},
+{
+"compressor": "js",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 3,
+"out_size": 152928,
+"ratio": 0.3584,
+"compress_mbps": 49.6,
+"decompress_mbps": 96.98
+},
+{
+"compressor": "js",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 4,
+"out_size": 149886,
+"ratio": 0.3512,
+"compress_mbps": 38.56,
+"decompress_mbps": 119.38
+},
+{
+"compressor": "js",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 5,
+"out_size": 149767,
+"ratio": 0.3509,
+"compress_mbps": 40.53,
+"decompress_mbps": 85.64
+},
+{
+"compressor": "js",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 6,
+"out_size": 147818,
+"ratio": 0.3464,
+"compress_mbps": 34.71,
+"decompress_mbps": 94.25
+},
+{
+"compressor": "js",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 7,
+"out_size": 147733,
+"ratio": 0.3462,
+"compress_mbps": 32.03,
+"decompress_mbps": 99.55
+},
+{
+"compressor": "js",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 8,
+"out_size": 147709,
+"ratio": 0.3461,
+"compress_mbps": 31.41,
+"decompress_mbps": 99.42
+},
+{
+"compressor": "js",
+"pattern": "canterbury/lcet10.txt",
+"size": 426754,
+"level": 9,
+"out_size": 147705,
+"ratio": 0.3461,
+"compress_mbps": 33.45,
+"decompress_mbps": 89.22
+},
+{
+"compressor": "js",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 1,
+"out_size": 222866,
+"ratio": 0.4625,
+"compress_mbps": 71.4,
+"decompress_mbps": 143.74
+},
+{
+"compressor": "js",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 2,
+"out_size": 212925,
+"ratio": 0.4419,
+"compress_mbps": 58.24,
+"decompress_mbps": 157.21
+},
+{
+"compressor": "js",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 3,
+"out_size": 206913,
+"ratio": 0.4294,
+"compress_mbps": 40.37,
+"decompress_mbps": 119.73
+},
+{
+"compressor": "js",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 4,
+"out_size": 202875,
+"ratio": 0.421,
+"compress_mbps": 35.81,
+"decompress_mbps": 112.43
+},
+{
+"compressor": "js",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 5,
+"out_size": 202867,
+"ratio": 0.421,
+"compress_mbps": 35.22,
+"decompress_mbps": 176.5
+},
+{
+"compressor": "js",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 6,
+"out_size": 199818,
+"ratio": 0.4147,
+"compress_mbps": 29.94,
+"decompress_mbps": 122.03
+},
+{
+"compressor": "js",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 7,
+"out_size": 199664,
+"ratio": 0.4144,
+"compress_mbps": 29.08,
+"decompress_mbps": 164.03
+},
+{
+"compressor": "js",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 8,
+"out_size": 199634,
+"ratio": 0.4143,
+"compress_mbps": 28.55,
+"decompress_mbps": 113.85
+},
+{
+"compressor": "js",
+"pattern": "canterbury/plrabn12.txt",
+"size": 481861,
+"level": 9,
+"out_size": 199634,
+"ratio": 0.4143,
+"compress_mbps": 28.96,
+"decompress_mbps": 160.17
+},
+{
+"compressor": "js",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 1,
+"out_size": 60580,
+"ratio": 0.118,
+"compress_mbps": 135.13,
+"decompress_mbps": 168.22
+},
+{
+"compressor": "js",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 2,
+"out_size": 59663,
+"ratio": 0.1163,
+"compress_mbps": 125.37,
+"decompress_mbps": 145.52
+},
+{
+"compressor": "js",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 3,
+"out_size": 59465,
+"ratio": 0.1159,
+"compress_mbps": 117.64,
+"decompress_mbps": 329.46
+},
+{
+"compressor": "js",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 4,
+"out_size": 59353,
+"ratio": 0.1156,
+"compress_mbps": 112.4,
+"decompress_mbps": 158.61
+},
+{
+"compressor": "js",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 5,
+"out_size": 58830,
+"ratio": 0.1146,
+"compress_mbps": 106.94,
+"decompress_mbps": 138.94
+},
+{
+"compressor": "js",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 6,
+"out_size": 57884,
+"ratio": 0.1128,
+"compress_mbps": 71.04,
+"decompress_mbps": 140.49
+},
+{
+"compressor": "js",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 7,
+"out_size": 57206,
+"ratio": 0.1115,
+"compress_mbps": 57.86,
+"decompress_mbps": 137.88
+},
+{
+"compressor": "js",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 8,
+"out_size": 56545,
+"ratio": 0.1102,
+"compress_mbps": 30.93,
+"decompress_mbps": 137.12
+},
+{
+"compressor": "js",
+"pattern": "canterbury/ptt5",
+"size": 513216,
+"level": 9,
+"out_size": 56454,
+"ratio": 0.11,
+"compress_mbps": 12.82,
+"decompress_mbps": 137.07
+},
+{
+"compressor": "js",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 1,
+"out_size": 14194,
+"ratio": 0.3712,
+"compress_mbps": 62.96,
+"decompress_mbps": 62.62
+},
+{
+"compressor": "js",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 2,
+"out_size": 13770,
+"ratio": 0.3601,
+"compress_mbps": 44.68,
+"decompress_mbps": 52.53
+},
+{
+"compressor": "js",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 3,
+"out_size": 13611,
+"ratio": 0.3559,
+"compress_mbps": 60.61,
+"decompress_mbps": 48.72
+},
+{
+"compressor": "js",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 4,
+"out_size": 13534,
+"ratio": 0.3539,
+"compress_mbps": 57.34,
+"decompress_mbps": 60.12
+},
+{
+"compressor": "js",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 5,
+"out_size": 13527,
+"ratio": 0.3537,
+"compress_mbps": 57.3,
+"decompress_mbps": 55.11
+},
+{
+"compressor": "js",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 6,
+"out_size": 13438,
+"ratio": 0.3514,
+"compress_mbps": 37.2,
+"decompress_mbps": 58.23
+},
+{
+"compressor": "js",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 7,
+"out_size": 13419,
+"ratio": 0.3509,
+"compress_mbps": 50.17,
+"decompress_mbps": 60.53
+},
+{
+"compressor": "js",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 8,
+"out_size": 13404,
+"ratio": 0.3505,
+"compress_mbps": 41.25,
+"decompress_mbps": 60.63
+},
+{
+"compressor": "js",
+"pattern": "canterbury/sum",
+"size": 38240,
+"level": 9,
+"out_size": 13390,
+"ratio": 0.3502,
+"compress_mbps": 24.99,
+"decompress_mbps": 60.66
+},
+{
+"compressor": "js",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 1,
+"out_size": 1832,
+"ratio": 0.4334,
+"compress_mbps": 33.47,
+"decompress_mbps": 24.8
+},
+{
+"compressor": "js",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 2,
+"out_size": 1776,
+"ratio": 0.4202,
+"compress_mbps": 28.92,
+"decompress_mbps": 28.77
+},
+{
+"compressor": "js",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 3,
+"out_size": 1764,
+"ratio": 0.4173,
+"compress_mbps": 29.3,
+"decompress_mbps": 25.73
+},
+{
+"compressor": "js",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 4,
+"out_size": 1763,
+"ratio": 0.4171,
+"compress_mbps": 37.31,
+"decompress_mbps": 29.49
+},
+{
+"compressor": "js",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 5,
+"out_size": 1760,
+"ratio": 0.4164,
+"compress_mbps": 27.55,
+"decompress_mbps": 29.7
+},
+{
+"compressor": "js",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 6,
+"out_size": 1760,
+"ratio": 0.4164,
+"compress_mbps": 28.12,
+"decompress_mbps": 27.83
+},
+{
+"compressor": "js",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 7,
+"out_size": 1760,
+"ratio": 0.4164,
+"compress_mbps": 26.98,
+"decompress_mbps": 27.73
+},
+{
+"compressor": "js",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 8,
+"out_size": 1760,
+"ratio": 0.4164,
+"compress_mbps": 23.43,
+"decompress_mbps": 29.45
+},
+{
+"compressor": "js",
+"pattern": "canterbury/xargs.1",
+"size": 4227,
+"level": 9,
+"out_size": 1760,
+"ratio": 0.4164,
+"compress_mbps": 21.87,
+"decompress_mbps": 28.32
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 1,
+"out_size": 4462632,
+"ratio": 0.4378,
+"compress_mbps": 57.87,
+"decompress_mbps": 125.17
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 2,
+"out_size": 4244833,
+"ratio": 0.4165,
+"compress_mbps": 48.15,
+"decompress_mbps": 147.15
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 3,
+"out_size": 4112285,
+"ratio": 0.4035,
+"compress_mbps": 40.82,
+"decompress_mbps": 139.91
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 4,
+"out_size": 4020435,
+"ratio": 0.3945,
+"compress_mbps": 36.37,
+"decompress_mbps": 142.4
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 5,
+"out_size": 4019177,
+"ratio": 0.3943,
+"compress_mbps": 36.45,
+"decompress_mbps": 142.97
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 6,
+"out_size": 3956464,
+"ratio": 0.3882,
+"compress_mbps": 30.24,
+"decompress_mbps": 159.85
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 7,
+"out_size": 3953310,
+"ratio": 0.3879,
+"compress_mbps": 29.41,
+"decompress_mbps": 146.27
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 8,
+"out_size": 3952872,
+"ratio": 0.3878,
+"compress_mbps": 29.15,
+"decompress_mbps": 161.1
+},
+{
+"compressor": "js",
+"pattern": "silesia/dickens",
+"size": 10192446,
+"level": 9,
+"out_size": 3952872,
+"ratio": 0.3878,
+"compress_mbps": 29.91,
+"decompress_mbps": 158.9
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 1,
+"out_size": 20177423,
+"ratio": 0.3939,
+"compress_mbps": 79.22,
+"decompress_mbps": 165.46
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 2,
+"out_size": 19759467,
+"ratio": 0.3858,
+"compress_mbps": 69.86,
+"decompress_mbps": 153.08
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 3,
+"out_size": 19583171,
+"ratio": 0.3823,
+"compress_mbps": 62.32,
+"decompress_mbps": 168.16
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 4,
+"out_size": 19479125,
+"ratio": 0.3803,
+"compress_mbps": 54.79,
+"decompress_mbps": 170.19
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 5,
+"out_size": 19423693,
+"ratio": 0.3792,
+"compress_mbps": 52.87,
+"decompress_mbps": 155.75
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 6,
+"out_size": 19337683,
+"ratio": 0.3775,
+"compress_mbps": 35.86,
+"decompress_mbps": 158.01
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 7,
+"out_size": 19323922,
+"ratio": 0.3773,
+"compress_mbps": 31.01,
+"decompress_mbps": 162.6
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 8,
+"out_size": 19314797,
+"ratio": 0.3771,
+"compress_mbps": 25.05,
+"decompress_mbps": 170.24
+},
+{
+"compressor": "js",
+"pattern": "silesia/mozilla",
+"size": 51220480,
+"level": 9,
+"out_size": 19312663,
+"ratio": 0.377,
+"compress_mbps": 10.78,
+"decompress_mbps": 170.64
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 1,
+"out_size": 3762978,
+"ratio": 0.3774,
+"compress_mbps": 73.55,
+"decompress_mbps": 158.73
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 2,
+"out_size": 3711615,
+"ratio": 0.3723,
+"compress_mbps": 61.61,
+"decompress_mbps": 156.01
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 3,
+"out_size": 3663131,
+"ratio": 0.3674,
+"compress_mbps": 54.17,
+"decompress_mbps": 162.95
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 4,
+"out_size": 3631512,
+"ratio": 0.3642,
+"compress_mbps": 47.67,
+"decompress_mbps": 162.23
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 5,
+"out_size": 3630867,
+"ratio": 0.3642,
+"compress_mbps": 47.3,
+"decompress_mbps": 136.29
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 6,
+"out_size": 3615953,
+"ratio": 0.3627,
+"compress_mbps": 36.72,
+"decompress_mbps": 183.9
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 7,
+"out_size": 3615518,
+"ratio": 0.3626,
+"compress_mbps": 34.5,
+"decompress_mbps": 166.79
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 8,
+"out_size": 3613845,
+"ratio": 0.3625,
+"compress_mbps": 29.37,
+"decompress_mbps": 167.22
+},
+{
+"compressor": "js",
+"pattern": "silesia/mr",
+"size": 9970564,
+"level": 9,
+"out_size": 3614283,
+"ratio": 0.3625,
+"compress_mbps": 25.49,
+"decompress_mbps": 152.16
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 1,
+"out_size": 4418800,
+"ratio": 0.1317,
+"compress_mbps": 147.78,
+"decompress_mbps": 255.76
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 2,
+"out_size": 4026774,
+"ratio": 0.12,
+"compress_mbps": 133.75,
+"decompress_mbps": 246.16
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 3,
+"out_size": 3837798,
+"ratio": 0.1144,
+"compress_mbps": 127.06,
+"decompress_mbps": 265.57
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 4,
+"out_size": 3751023,
+"ratio": 0.1118,
+"compress_mbps": 119.47,
+"decompress_mbps": 276.82
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 5,
+"out_size": 3643468,
+"ratio": 0.1086,
+"compress_mbps": 109.94,
+"decompress_mbps": 278.05
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 6,
+"out_size": 3379481,
+"ratio": 0.1007,
+"compress_mbps": 71.5,
+"decompress_mbps": 283.02
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 7,
+"out_size": 3354082,
+"ratio": 0.1,
+"compress_mbps": 63.54,
+"decompress_mbps": 278.98
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 8,
+"out_size": 3330028,
+"ratio": 0.0992,
+"compress_mbps": 48.52,
+"decompress_mbps": 294.14
+},
+{
+"compressor": "js",
+"pattern": "silesia/nci",
+"size": 33553445,
+"level": 9,
+"out_size": 3327482,
+"ratio": 0.0992,
+"compress_mbps": 38.14,
+"decompress_mbps": 281.8
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 1,
+"out_size": 3233790,
+"ratio": 0.5256,
+"compress_mbps": 49.01,
+"decompress_mbps": 104.92
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 2,
+"out_size": 3184644,
+"ratio": 0.5176,
+"compress_mbps": 43.61,
+"decompress_mbps": 93.6
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 3,
+"out_size": 3160521,
+"ratio": 0.5137,
+"compress_mbps": 39.95,
+"decompress_mbps": 118.96
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 4,
+"out_size": 3141929,
+"ratio": 0.5107,
+"compress_mbps": 36.7,
+"decompress_mbps": 111.6
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 5,
+"out_size": 3138514,
+"ratio": 0.5101,
+"compress_mbps": 36.34,
+"decompress_mbps": 96.01
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 6,
+"out_size": 3126843,
+"ratio": 0.5082,
+"compress_mbps": 31.55,
+"decompress_mbps": 95.28
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 7,
+"out_size": 3126796,
+"ratio": 0.5082,
+"compress_mbps": 29.22,
+"decompress_mbps": 93.53
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 8,
+"out_size": 3126322,
+"ratio": 0.5082,
+"compress_mbps": 25.65,
+"decompress_mbps": 95.56
+},
+{
+"compressor": "js",
+"pattern": "silesia/ooffice",
+"size": 6152192,
+"level": 9,
+"out_size": 3126286,
+"ratio": 0.5082,
+"compress_mbps": 22.12,
+"decompress_mbps": 94.53
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 1,
+"out_size": 4076349,
+"ratio": 0.4042,
+"compress_mbps": 70.62,
+"decompress_mbps": 128.6
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 2,
+"out_size": 3914739,
+"ratio": 0.3881,
+"compress_mbps": 65.68,
+"decompress_mbps": 162.69
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 3,
+"out_size": 3845160,
+"ratio": 0.3812,
+"compress_mbps": 62.94,
+"decompress_mbps": 190.14
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 4,
+"out_size": 3822047,
+"ratio": 0.379,
+"compress_mbps": 61.07,
+"decompress_mbps": 175.36
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 5,
+"out_size": 3799472,
+"ratio": 0.3767,
+"compress_mbps": 56.83,
+"decompress_mbps": 195.63
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 6,
+"out_size": 3783861,
+"ratio": 0.3752,
+"compress_mbps": 54.95,
+"decompress_mbps": 154.3
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 7,
+"out_size": 3783432,
+"ratio": 0.3751,
+"compress_mbps": 54.44,
+"decompress_mbps": 195.71
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 8,
+"out_size": 3783342,
+"ratio": 0.3751,
+"compress_mbps": 54.44,
+"decompress_mbps": 152.64
+},
+{
+"compressor": "js",
+"pattern": "silesia/osdb",
+"size": 10085684,
+"level": 9,
+"out_size": 3783342,
+"ratio": 0.3751,
+"compress_mbps": 54.41,
+"decompress_mbps": 153.36
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 1,
+"out_size": 2261112,
+"ratio": 0.3412,
+"compress_mbps": 63.14,
+"decompress_mbps": 144.01
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 2,
+"out_size": 2128691,
+"ratio": 0.3212,
+"compress_mbps": 51.99,
+"decompress_mbps": 119.21
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 3,
+"out_size": 2049023,
+"ratio": 0.3092,
+"compress_mbps": 42.59,
+"decompress_mbps": 136.54
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 4,
+"out_size": 1990249,
+"ratio": 0.3003,
+"compress_mbps": 36.52,
+"decompress_mbps": 119.84
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 5,
+"out_size": 1975224,
+"ratio": 0.298,
+"compress_mbps": 35.45,
+"decompress_mbps": 187.46
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 6,
+"out_size": 1910262,
+"ratio": 0.2882,
+"compress_mbps": 26.28,
+"decompress_mbps": 116.08
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 7,
+"out_size": 1902923,
+"ratio": 0.2871,
+"compress_mbps": 24,
+"decompress_mbps": 193.41
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 8,
+"out_size": 1900964,
+"ratio": 0.2868,
+"compress_mbps": 22.36,
+"decompress_mbps": 150.61
+},
+{
+"compressor": "js",
+"pattern": "silesia/reymont",
+"size": 6627202,
+"level": 9,
+"out_size": 1900958,
+"ratio": 0.2868,
+"compress_mbps": 22.83,
+"decompress_mbps": 141.37
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 1,
+"out_size": 6016919,
+"ratio": 0.2785,
+"compress_mbps": 102.33,
+"decompress_mbps": 220.56
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 2,
+"out_size": 5767272,
+"ratio": 0.2669,
+"compress_mbps": 90.9,
+"decompress_mbps": 177.16
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 3,
+"out_size": 5669548,
+"ratio": 0.2624,
+"compress_mbps": 81.47,
+"decompress_mbps": 209.95
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 4,
+"out_size": 5619947,
+"ratio": 0.2601,
+"compress_mbps": 73.58,
+"decompress_mbps": 212.53
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 5,
+"out_size": 5586034,
+"ratio": 0.2585,
+"compress_mbps": 69.19,
+"decompress_mbps": 216.46
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 6,
+"out_size": 5540130,
+"ratio": 0.2564,
+"compress_mbps": 59.45,
+"decompress_mbps": 218.47
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 7,
+"out_size": 5537271,
+"ratio": 0.2563,
+"compress_mbps": 50.37,
+"decompress_mbps": 215.76
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 8,
+"out_size": 5530686,
+"ratio": 0.256,
+"compress_mbps": 39.81,
+"decompress_mbps": 229.67
+},
+{
+"compressor": "js",
+"pattern": "silesia/samba",
+"size": 21606400,
+"level": 9,
+"out_size": 5529823,
+"ratio": 0.2559,
+"compress_mbps": 37.98,
+"decompress_mbps": 218.14
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 1,
+"out_size": 5602819,
+"ratio": 0.7726,
+"compress_mbps": 43.77,
+"decompress_mbps": 122.65
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 2,
+"out_size": 5504019,
+"ratio": 0.759,
+"compress_mbps": 39.83,
+"decompress_mbps": 116.35
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 3,
+"out_size": 5452816,
+"ratio": 0.7519,
+"compress_mbps": 36.31,
+"decompress_mbps": 101.11
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 4,
+"out_size": 5425752,
+"ratio": 0.7482,
+"compress_mbps": 33.34,
+"decompress_mbps": 111.95
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 5,
+"out_size": 5425752,
+"ratio": 0.7482,
+"compress_mbps": 33.33,
+"decompress_mbps": 134.03
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 6,
+"out_size": 5407602,
+"ratio": 0.7457,
+"compress_mbps": 29.93,
+"decompress_mbps": 117.04
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 7,
+"out_size": 5406417,
+"ratio": 0.7455,
+"compress_mbps": 28.96,
+"decompress_mbps": 101.72
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 8,
+"out_size": 5406380,
+"ratio": 0.7455,
+"compress_mbps": 29.09,
+"decompress_mbps": 101.95
+},
+{
+"compressor": "js",
+"pattern": "silesia/sao",
+"size": 7251944,
+"level": 9,
+"out_size": 5406380,
+"ratio": 0.7455,
+"compress_mbps": 29.06,
+"decompress_mbps": 122.69
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 1,
+"out_size": 14342407,
+"ratio": 0.3459,
+"compress_mbps": 80.69,
+"decompress_mbps": 148.42
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 2,
+"out_size": 13424966,
+"ratio": 0.3238,
+"compress_mbps": 69.28,
+"decompress_mbps": 152.62
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 3,
+"out_size": 13061399,
+"ratio": 0.315,
+"compress_mbps": 61.33,
+"decompress_mbps": 154.49
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 4,
+"out_size": 12877207,
+"ratio": 0.3106,
+"compress_mbps": 55.43,
+"decompress_mbps": 148.12
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 5,
+"out_size": 12671090,
+"ratio": 0.3056,
+"compress_mbps": 51.73,
+"decompress_mbps": 148.74
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 6,
+"out_size": 12511088,
+"ratio": 0.3018,
+"compress_mbps": 43.72,
+"decompress_mbps": 155.85
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 7,
+"out_size": 12503313,
+"ratio": 0.3016,
+"compress_mbps": 42.4,
+"decompress_mbps": 157.06
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 8,
+"out_size": 12502263,
+"ratio": 0.3016,
+"compress_mbps": 42.05,
+"decompress_mbps": 158.38
+},
+{
+"compressor": "js",
+"pattern": "silesia/webster",
+"size": 41458703,
+"level": 9,
+"out_size": 12502263,
+"ratio": 0.3016,
+"compress_mbps": 42.14,
+"decompress_mbps": 158.28
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 1,
+"out_size": 6022390,
+"ratio": 0.7107,
+"compress_mbps": 49.65,
+"decompress_mbps": 97.24
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 2,
+"out_size": 5997124,
+"ratio": 0.7077,
+"compress_mbps": 44.68,
+"decompress_mbps": 113.66
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 3,
+"out_size": 5979254,
+"ratio": 0.7056,
+"compress_mbps": 41.54,
+"decompress_mbps": 116.97
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 4,
+"out_size": 5967955,
+"ratio": 0.7042,
+"compress_mbps": 39.36,
+"decompress_mbps": 110.22
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 5,
+"out_size": 5967953,
+"ratio": 0.7042,
+"compress_mbps": 39.23,
+"decompress_mbps": 117.4
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 6,
+"out_size": 5965386,
+"ratio": 0.7039,
+"compress_mbps": 39.35,
+"decompress_mbps": 117.27
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 7,
+"out_size": 5965383,
+"ratio": 0.7039,
+"compress_mbps": 39.62,
+"decompress_mbps": 117.2
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 8,
+"out_size": 5965383,
+"ratio": 0.7039,
+"compress_mbps": 39.1,
+"decompress_mbps": 98.58
+},
+{
+"compressor": "js",
+"pattern": "silesia/x-ray",
+"size": 8474240,
+"level": 9,
+"out_size": 5965383,
+"ratio": 0.7039,
+"compress_mbps": 40.18,
+"decompress_mbps": 98.47
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 1,
+"out_size": 985606,
+"ratio": 0.1844,
+"compress_mbps": 93.37,
+"decompress_mbps": 141.78
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 2,
+"out_size": 852636,
+"ratio": 0.1595,
+"compress_mbps": 89.07,
+"decompress_mbps": 238.96
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 3,
+"out_size": 814293,
+"ratio": 0.1523,
+"compress_mbps": 81.69,
+"decompress_mbps": 223.79
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 4,
+"out_size": 788388,
+"ratio": 0.1475,
+"compress_mbps": 79.24,
+"decompress_mbps": 251.87
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 5,
+"out_size": 749390,
+"ratio": 0.1402,
+"compress_mbps": 74.77,
+"decompress_mbps": 224.33
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 6,
+"out_size": 706892,
+"ratio": 0.1322,
+"compress_mbps": 60.77,
+"decompress_mbps": 269.34
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 7,
+"out_size": 705695,
+"ratio": 0.132,
+"compress_mbps": 58.98,
+"decompress_mbps": 181.3
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 8,
+"out_size": 703904,
+"ratio": 0.1317,
+"compress_mbps": 56.3,
+"decompress_mbps": 170.78
+},
+{
+"compressor": "js",
+"pattern": "silesia/xml",
+"size": 5345280,
+"level": 9,
+"out_size": 703900,
+"ratio": 0.1317,
+"compress_mbps": 56.44,
+"decompress_mbps": 180.91
+}
+]
 }

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -75,7 +75,7 @@ in_project_shell "lake -d bench build bench-report \
 #    driver is pinned, so every comparator child inherits the single-core
 #    affinity and their rows are measured like the native ones.
 bash bench/comparators/build_all.sh
-nix-shell -p nodejs python3 --run \
+nix-shell -p nodejs_latest python3 --run \
   "$PIN python3 bench/comparators/run_external.py bench/payloads $OUT"
 
 # 3b. Decode-density experiment (the decompression analogue of the compress
@@ -87,7 +87,7 @@ nix-shell -p nodejs python3 --run \
 #    <corpus>_decode_density.svg.
 DD="bench/results/decode_density.json"
 in_project_shell "$PIN lake -d bench env bench/.lake/build/bin/bench-report --decode-density $DD bench/payloads-deflate"
-nix-shell -p nodejs python3 --run \
+nix-shell -p nodejs_latest python3 --run \
   "$PIN python3 bench/decode_density.py bench/payloads-deflate $DD"
 
 # 4. Render (project shell: python + matplotlib). plot.py auto-detects the


### PR DESCRIPTION
This PR moves the Track D dashboard from `chungus` to `chungus2` and re-records the full matrix — native plus all eight comparators plus the decode-density experiment — on the new machine, preserving the last `chungus` snapshot verbatim under `bench/results/archive/` rather than deleting it.

The move is sound. A new `bench/cross_machine.py` compares the two machines cell-by-cell (full write-up in [`bench/results/cross-machine-chungus-to-chungus2.md`](https://github.com/kim-em/lean-zip/blob/bench-migrate-chungus2/bench/results/cross-machine-chungus-to-chungus2.md)): the version-stable comparators — `native`, `libdeflate`, `miniz_oxide`, `zig`, `zlib`, `ocaml`, 1334 cells — agree to within 0.3% on throughput (geomean 1.0004× compress, 0.9967× decompress), and compression ratio is byte-identical across both machines and both commits (`max |Δratio| = 0.000000` for all eight compressors, 1748 cells). Historical numbers therefore stay directly comparable to fresh chungus2 numbers.

Be fair to `go` and `js`: each now runs on its best current release. `go` builds with `nix-shell -p go` (go 1.26.3, the newest — its `compress/flate` is much faster than the older Go the old snapshot used, hence +77%/+133%), and the JS comparator moves from the older default `nodejs` (v24) to `nodejs_latest` (v26, whose V8 is ~+22% on JS compress) in both `comparators/build_all.sh` and `run.sh`. The `go`/`js` rows thus track the compiler version across the move, not the machine; `js` additionally carries large V8 run-to-run variance, so its rows are a max-of-three clean sequential passes and are indicative only. Pinning `go`/`js` to a concrete version for strict reproducibility (the way `zig_0_14` is) is left as a possible follow-up — it would trade "best" for "frozen".

🤖 Prepared with Claude Code