### PR TITLE
perf: fuse split-heuristic passes and scalarize its counters (#2762)

### DIFF
--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -1133,6 +1133,71 @@ boxed reference via `deflateDynamicBlocksSharedAtP_eq`
   if w &&& ((1 : UInt32) <<< 31) = 0 then 1
   else ((w >>> 16) &&& 0x7FFF).toNat
 
+/-- The per-token core of `chooseSplitsHeuristicP`, threaded as a tail-recursive
+    loop over explicit scalar state so the hot accumulators compile to register
+    arithmetic instead of `Array Nat` `set!`/`getD` (#2762). The ten observation
+    counters live in the `n0..n9` (recent window) and `o0..o9` (block-so-far)
+    locals; `newTot`/`oldTot`/`blockBytes` are the window/block totals, and
+    `remaining` is the running byte suffix `totalBytes − doneBytes` (decremented
+    per token) that gates cuts against the min-block floor without a second
+    pass. The full ten-counter arrays are materialized only at a divergence
+    check (every `checkTokens` tokens, once the floors clear), where the shared
+    boxed `splitEndBlockCheck` reads them. -/
+def chooseSplitsHeuristicP.go (toks : Array UInt32)
+    (minBlockBytes softMaxBlockBytes checkTokens : Nat) (i : Nat)
+    (o0 o1 o2 o3 o4 o5 o6 o7 o8 o9 oldTot : Nat)
+    (n0 n1 n2 n3 n4 n5 n6 n7 n8 n9 newTot : Nat)
+    (blockBytes remaining : Nat) (cuts : Array Nat) : Array Nat :=
+  if h : i < toks.size then
+    let t := toks[i]
+    let c := splitTokenClassP t
+    let tb := splitTokenBytesP t
+    let (n0, n1, n2, n3, n4, n5, n6, n7, n8, n9) :=
+      match c with
+      | 0 => (n0 + 1, n1, n2, n3, n4, n5, n6, n7, n8, n9)
+      | 1 => (n0, n1 + 1, n2, n3, n4, n5, n6, n7, n8, n9)
+      | 2 => (n0, n1, n2 + 1, n3, n4, n5, n6, n7, n8, n9)
+      | 3 => (n0, n1, n2, n3 + 1, n4, n5, n6, n7, n8, n9)
+      | 4 => (n0, n1, n2, n3, n4 + 1, n5, n6, n7, n8, n9)
+      | 5 => (n0, n1, n2, n3, n4, n5 + 1, n6, n7, n8, n9)
+      | 6 => (n0, n1, n2, n3, n4, n5, n6 + 1, n7, n8, n9)
+      | 7 => (n0, n1, n2, n3, n4, n5, n6, n7 + 1, n8, n9)
+      | 8 => (n0, n1, n2, n3, n4, n5, n6, n7, n8 + 1, n9)
+      | _ => (n0, n1, n2, n3, n4, n5, n6, n7, n8, n9 + 1)
+    let newTot := newTot + 1
+    let blockBytes := blockBytes + tb
+    let remaining := remaining - tb
+    if blockBytes ≥ minBlockBytes && remaining ≥ minBlockBytes then
+      let cut :=
+        blockBytes ≥ softMaxBlockBytes ||
+        (newTot ≥ checkTokens && oldTot > 0 &&
+          splitEndBlockCheck #[o0, o1, o2, o3, o4, o5, o6, o7, o8, o9] oldTot
+            #[n0, n1, n2, n3, n4, n5, n6, n7, n8, n9] newTot blockBytes)
+      if cut then
+        chooseSplitsHeuristicP.go toks minBlockBytes softMaxBlockBytes checkTokens (i + 1)
+          0 0 0 0 0 0 0 0 0 0 0
+          0 0 0 0 0 0 0 0 0 0 0
+          0 remaining (cuts.push (i + 1))
+      else if newTot ≥ checkTokens then
+        chooseSplitsHeuristicP.go toks minBlockBytes softMaxBlockBytes checkTokens (i + 1)
+          (o0 + n0) (o1 + n1) (o2 + n2) (o3 + n3) (o4 + n4) (o5 + n5) (o6 + n6) (o7 + n7)
+          (o8 + n8) (o9 + n9) (oldTot + newTot)
+          0 0 0 0 0 0 0 0 0 0 0
+          blockBytes remaining cuts
+      else
+        chooseSplitsHeuristicP.go toks minBlockBytes softMaxBlockBytes checkTokens (i + 1)
+          o0 o1 o2 o3 o4 o5 o6 o7 o8 o9 oldTot
+          n0 n1 n2 n3 n4 n5 n6 n7 n8 n9 newTot
+          blockBytes remaining cuts
+    else
+      chooseSplitsHeuristicP.go toks minBlockBytes softMaxBlockBytes checkTokens (i + 1)
+        o0 o1 o2 o3 o4 o5 o6 o7 o8 o9 oldTot
+        n0 n1 n2 n3 n4 n5 n6 n7 n8 n9 newTot
+        blockBytes remaining cuts
+  else cuts
+termination_by toks.size - i
+decreasing_by all_goals omega
+
 /-- Packed twin of `chooseSplitsHeuristic`: entropy-divergence cut points
     computed directly from the packed token stream — same constants, same
     per-token floors/ceiling, same window-merge cadence, with
@@ -1141,47 +1206,23 @@ boxed reference via `deflateDynamicBlocksSharedAtP_eq`
     obligations; `ZipTest/PackedTokens.lean` pins it to the boxed heuristic
     over the `unpackTok` view. The block floor/ceiling and check cadence are
     defaulted parameters so the `mid-sweep` tuning tool can grid them without
-    touching the dispatch (which always calls with the tuned defaults). -/
-def chooseSplitsHeuristicP (toks : Array UInt32)
+    touching the dispatch (which always calls with the tuned defaults).
+
+    `totalBytes` is the whole-stream output byte count `Σ splitTokenBytesP t`.
+    The boxed reference computes it with a leading pass over `toks`; the packed
+    dispatch passes `data.size` instead (the token stream decodes to `data`, so
+    the two agree — pinned by the `chooseSplitsHeuristic` conformance test),
+    fusing that pass away (#2762). The main walk then tracks the running byte
+    suffix in `remaining` (start `totalBytes`, minus each token's bytes) rather
+    than a `doneBytes` prefix, and computes `splitTokenBytesP` once per token. -/
+def chooseSplitsHeuristicP (toks : Array UInt32) (totalBytes : Nat)
     (minBlockBytes : Nat := splitMinBlockBytes)
     (softMaxBlockBytes : Nat := splitSoftMaxBlockBytes)
-    (checkTokens : Nat := splitCheckTokens) : List Nat := Id.run do
-  let mut totalBytes := 0
-  for t in toks do
-    totalBytes := totalBytes + splitTokenBytesP t
-  let mut old : Array Nat := Array.replicate splitNumClasses 0
-  let mut oldTot := 0
-  let mut new : Array Nat := Array.replicate splitNumClasses 0
-  let mut newTot := 0
-  let mut blockBytes := 0
-  let mut doneBytes := 0
-  let mut cuts : Array Nat := #[]
-  for h : i in [0:toks.size] do
-    let t := toks[i]
-    let c := splitTokenClassP t
-    new := new.set! c (new.getD c 0 + 1)
-    newTot := newTot + 1
-    blockBytes := blockBytes + splitTokenBytesP t
-    doneBytes := doneBytes + splitTokenBytesP t
-    if blockBytes ≥ minBlockBytes && totalBytes - doneBytes ≥ minBlockBytes then
-      let cut :=
-        blockBytes ≥ softMaxBlockBytes ||
-        (newTot ≥ checkTokens && oldTot > 0 &&
-          splitEndBlockCheck old oldTot new newTot blockBytes)
-      if cut then
-        cuts := cuts.push (i + 1)
-        old := Array.replicate splitNumClasses 0
-        oldTot := 0
-        new := Array.replicate splitNumClasses 0
-        newTot := 0
-        blockBytes := 0
-      else if newTot ≥ checkTokens then
-        for j in [0:splitNumClasses] do
-          old := old.set! j (old.getD j 0 + new.getD j 0)
-        oldTot := oldTot + newTot
-        new := Array.replicate splitNumClasses 0
-        newTot := 0
-  return cuts.toList
+    (checkTokens : Nat := splitCheckTokens) : List Nat :=
+  (chooseSplitsHeuristicP.go toks minBlockBytes softMaxBlockBytes checkTokens 0
+    0 0 0 0 0 0 0 0 0 0 0
+    0 0 0 0 0 0 0 0 0 0 0
+    0 totalBytes #[]).toList
 
 /-- Packed twin of `emitDynBlock`: one dynamic Huffman block from a packed
     token group onto a running writer, with `emitTokensWithCodesP` in place of
@@ -1760,7 +1801,7 @@ def deflateRaw (data : ByteArray) (level : UInt8 := 6) : ByteArray :=
       -- would be a single dynamic block the base already sizes, so skip it
       -- entirely (every input under ~2·splitMinBlockBytes takes this path).
       let basePrep := deflateRawBasePPrep data ptokens
-      let cuts := chooseSplitsHeuristicP ptokens
+      let cuts := chooseSplitsHeuristicP ptokens data.size
       -- `withObs`: the base, or the size-arbitrated smaller of base and the
       -- obs-divergence split — selected *eagerly* (the winning prep pair, tie →
       -- the split, matching `pickSmaller`), so the loser's captured per-block

--- a/Zip/Spec/DeflateRoundtrip.lean
+++ b/Zip/Spec/DeflateRoundtrip.lean
@@ -154,11 +154,11 @@ theorem inflate_deflateRaw (data : ByteArray) (level : UInt8)
     exact inflate_deflateDynamicBlocksSharedAt data _ level _ hsize
   -- `withObs`: base, or the eagerly-selected smaller of base and the obs-split.
   have hwithObs : ∀ p : Nat × (Unit → ByteArray),
-      p = (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
+      p = (if (chooseSplitsHeuristicP (lzMatchP data level) data.size).isEmpty then
             deflateRawBasePPrep data (lzMatchP data level)
           else
             let obsPrep := deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level)
-              (chooseSplitsHeuristicP (lzMatchP data level))
+              (chooseSplitsHeuristicP (lzMatchP data level) data.size)
             if (deflateRawBasePPrep data (lzMatchP data level)).1 < obsPrep.1 then
               deflateRawBasePPrep data (lzMatchP data level) else obsPrep) →
       Zip.Native.Inflate.inflateReference (p.2 ()) maxOutputSize = .ok data := by
@@ -282,11 +282,11 @@ theorem deflateRaw_pad (data : ByteArray) (level : UInt8) :
     exact deflateDynamicBlocksSharedAt_pad data _ level
   -- `withObs`: base, or the eagerly-selected smaller of base and the obs-split.
   have hwithObs : ∀ p : Nat × (Unit → ByteArray),
-      p = (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
+      p = (if (chooseSplitsHeuristicP (lzMatchP data level) data.size).isEmpty then
             deflateRawBasePPrep data (lzMatchP data level)
           else
             let obsPrep := deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level)
-              (chooseSplitsHeuristicP (lzMatchP data level))
+              (chooseSplitsHeuristicP (lzMatchP data level) data.size)
             if (deflateRawBasePPrep data (lzMatchP data level)).1 < obsPrep.1 then
               deflateRawBasePPrep data (lzMatchP data level) else obsPrep) →
       ∃ (contentBits padding : List Bool),
@@ -489,11 +489,11 @@ theorem deflateRaw_goR_pad (data : ByteArray) (level : UInt8) :
     exact deflateDynamicBlocksSharedAt_goR_pad data _ level
   -- `withObs`: base, or the eagerly-selected smaller of base and the obs-split.
   have hwithObs : ∀ p : Nat × (Unit → ByteArray),
-      p = (if (chooseSplitsHeuristicP (lzMatchP data level)).isEmpty then
+      p = (if (chooseSplitsHeuristicP (lzMatchP data level) data.size).isEmpty then
             deflateRawBasePPrep data (lzMatchP data level)
           else
             let obsPrep := deflateDynamicBlocksSharedAtSizedP data (lzMatchP data level)
-              (chooseSplitsHeuristicP (lzMatchP data level))
+              (chooseSplitsHeuristicP (lzMatchP data level) data.size)
             if (deflateRawBasePPrep data (lzMatchP data level)).1 < obsPrep.1 then
               deflateRawBasePPrep data (lzMatchP data level) else obsPrep) →
       ∃ remaining,

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -500,7 +500,7 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
   -- both inflate implementations across the mid-band (4–5 single-block,
   -- 6–8 split).
   unless (Zip.Native.Deflate.chooseSplitsHeuristicP
-      (Zip.Native.Deflate.lzMatchP hetero 6)).length ≥ 1 do
+      (Zip.Native.Deflate.lzMatchP hetero 6) hetero.size).length ≥ 1 do
     throw (IO.userError "chooseSplitsHeuristicP found no cuts on heterogeneous input")
   for level in [4, 5, 6, 7, 8] do
     let out := Zip.Native.Deflate.deflateRaw hetero level.toUInt8

--- a/ZipTest/PackedTokens.lean
+++ b/ZipTest/PackedTokens.lean
@@ -87,7 +87,7 @@ private def checkSplitP (label : String) (data : ByteArray) : IO Unit := do
   for level in [(4 : UInt8), 6, 8] do
     let ptoks := lzMatchP data level
     let toks := ptoks.map unpackTok
-    let cutsP := chooseSplitsHeuristicP ptoks
+    let cutsP := chooseSplitsHeuristicP ptoks data.size
     let cutsB := chooseSplitsHeuristic toks
     unless cutsP == cutsB do
       throw (IO.userError
@@ -136,7 +136,7 @@ def tests : IO Unit := do
   -- conformance check then covers a real multi-block partition, not just
   -- the clamping edge cases).
   let hetero := mkTextData 65536 ++ mkPrngData 65536 ++ mkCyclicData 65536
-  unless (chooseSplitsHeuristicP (lzMatchP hetero 6)).length ≥ 1 do
+  unless (chooseSplitsHeuristicP (lzMatchP hetero 6) hetero.size).length ≥ 1 do
     throw (IO.userError "chooseSplitsHeuristicP found no cuts on heterogeneous input")
   checkSplitP "hetero192k" hetero
   checkSplitP "alice29" alice

--- a/ZipTest/SizeHelpers.lean
+++ b/ZipTest/SizeHelpers.lean
@@ -179,7 +179,7 @@ def tests : IO Unit := do
       -- diverse cut lists (the tree-reuse emit must match the recompute emit)
       if data.size > 0 then
         let cutsLists : List (String × List Nat) :=
-          [ ("heuristic", chooseSplitsHeuristicP ptokens),
+          [ ("heuristic", chooseSplitsHeuristicP ptokens data.size),
             ("fixed", fixedCadenceCuts sharedTokChunk ptokens.size),
             ("empty", []),
             ("nonmonotone", [5, 3, 7]),
@@ -197,7 +197,7 @@ def tests : IO Unit := do
       -- 7c. the size-arbitrated dispatch is byte-identical to the old
       -- emit-every-candidate one (`pickSmaller` over emitted blocks).
       let base := deflateRawBaseP data ptokens
-      let cuts := chooseSplitsHeuristicP ptokens
+      let cuts := chooseSplitsHeuristicP ptokens data.size
       let withObs := if cuts.isEmpty then base
         else pickSmaller base (deflateDynamicBlocksSharedAtP data ptokens cuts)
       let refOut := if 8 ≤ level then

--- a/bench/ZipMidSweep.lean
+++ b/bench/ZipMidSweep.lean
@@ -85,7 +85,7 @@ def runConfig (cfg : TimedConfig) (data : ByteArray) : Nat :=
   let base := deflateRawBaseP data ptoks
   if cfg.mode == 0 then base.size
   else
-    let cuts := chooseSplitsHeuristicP ptoks
+    let cuts := chooseSplitsHeuristicP ptoks data.size
     let obs := if cuts.isEmpty then base
       else pickSmaller base (deflateDynamicBlocksSharedAtP data ptoks cuts)
     if cfg.mode == 1 then obs.size
@@ -126,7 +126,7 @@ def main (args : List String) : IO Unit := do
         let cadSize := if cad.isEmpty then base
           else min base (deflateDynamicBlocksSharedAtP data ptoks cad).size
         for (minB, chk) in splitVariants do
-          let cuts := chooseSplitsHeuristicP ptoks minB splitSoftMaxBlockBytes chk
+          let cuts := chooseSplitsHeuristicP ptoks data.size minB splitSoftMaxBlockBytes chk
           let obs := if cuts.isEmpty then base
             else min base (deflateDynamicBlocksSharedAtP data ptoks cuts).size
           let obsCad := min obs cadSize

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pb6bae649af)">
+   <g clip-path="url(#pb65fad7f22)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJF0lEQVR4nO3YzYqk5R2H4aruanViK4PgBwqSkCwDrpKN7t17IB6BG4/BMwiB7EPARdZuXIqbhATCEAwxYdRRe3p66sNFIEdwP/y1uK4j+L08vG/d9WyP3/zhtOGn5fa76QXrPDnPZzvd3U5PWGb74ivTE9Z49mfTC9bZXkwvWOPp+b5n53pmp4f/nJ6wzHmeGADAIIEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABDbPdg+nN6wxN3hdnrCMq/d//n0hGWuj69MT1hi+/jR9IRlPnn8l+kJS7z+zMvTE5Y5HPfTE5b4dn8zPWGZ/ekwPWGJ37zwxvSEZdxgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGx3fXV/esMSx91xesIy15vnpies8/WD6QVLnB4/mp6wzG/ffHt6whI3+/M9s+/P9Nl+df3r6QnL3G330xOWOP3js+kJy7jBAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgJjAAgCICSwAgNju3uX19IYlbg830xPW2Z5xFz/34vSCJbZnfGZX+/30hCXO+cye353ne/bvuy+mJyyzP95NT1jijefvT09Y5ny/IAAAQwQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxLaHzz88TY+A/zsepxfA/1z4//mT4/vBj4gvCABATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMR27//nwfSGJR49OUxPWObTL76dnrDMn957Z3rCEq/ee3N6wjJv/e730xOWePeXL01PWObvXz2enrDEvd3l9IRl/vjxX6cnLHHz0QfTE5ZxgwUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx7f7459P0iBUOx/30hGUutufbxZe3N9MT1rjcTS9Y5/uH0wuWONx/bXrCMsfTcXrCElfb833Pnp7O8zftan+ez7XZuMECAMgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACAmMACAIgJLACA2O7icJzesMTF5TPTE9b58m/TC5Y53Xw9PWGNu6fTC5bZvvqL6QlLXJ7np3Gz2Ww2x+30gkW+++/0gmWuntxMT1ji9PBf0xOWcYMFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAMYEFABATWAAAsR8A3ECC0LzRZSAAAAAASUVORK5CYII=" id="image22da82dc48" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDElEQVR4nO3YvYpdVQCG4ZyZM5qYMQTBJBgIipaClTba23shXoGN1+AdiGAvgoW1jaXYKAgSYkDUUfMzM5mcHwvBK3gXy2ye5wq+zWLv85612v39+f4Sz5bzR7MXjPNkmc+2vzifPWGY1bUbsyeM8fwLsxeMszqYvWCMp8t9z5Z6ZvuTe7MnDLPMEwMAmEhgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE1ndXJ7M3DHGxPZ89YZhb11+dPWGY492N2ROGWJ09mD1hmG/Ofpg9YYhXnnt59oRhtrvN7AlDPNyczp4wzGa/nT1hiLdfvD17wjBusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2Pj66PnvDELv1bvaEYY4vXZ49YZy/7s5eMMT+7MHsCcO8c+fd2ROGON0s98weL/TZ3jh+c/aEYS5Wm9kThtj//N3sCcO4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY+srh8ewNQ5xvT2dPGGe14C6+fG32giFWCz6zo81m9oQhlnxmV9fLfM9+vbg/e8Iwm93F7AlD3L56ffaEYZb7BQEAmERgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGy1/f7j/ewR8J/dbvYC+NeB/5/PHN8P/kd8QQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/vC3u7M3DPHgyXb2hGG+vf9w9oRhvvzgvdkThrh55c7sCcO89elnsycM8f7rL82eMMxPf57NnjDElfXh7AnDfPHVj7MnDHH6yUezJwzjBgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiq83u6/3sESNsd5vZE4Y5WC23iw/PT2dPGONwPXvBOI9PZi8YYnv91uwJw+z2u9kThjhaLfc9e7pf5m/a0WaZz3XpkhssAICcwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiK0P9rMnDHKwnr1gmIOTe7MnjPPo99kLhthfPJ09YZjVzddmTxjicLXcb8h2fz57whiPT2YvGObo6TLPbP/HL7MnDOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL/AMJZgtdUCitGAAAAAElFTkSuQmCC" id="imageae30efa079" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mcd39e66306" d="M 0 0 
+       <path id="m0482965940" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcd39e66306" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mcd39e66306" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mcd39e66306" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mcd39e66306" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mcd39e66306" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mcd39e66306" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mcd39e66306" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mcd39e66306" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mcd39e66306" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mcd39e66306" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mcd39e66306" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0482965940" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m35331957b0" d="M 0 0 
+       <path id="md551c2000d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m35331957b0" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md551c2000d" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m35331957b0" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md551c2000d" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m35331957b0" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md551c2000d" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m35331957b0" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md551c2000d" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m35331957b0" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md551c2000d" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m35331957b0" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md551c2000d" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m35331957b0" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md551c2000d" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m35331957b0" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md551c2000d" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,8 +1303,66 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -8 -->
+    <!-- -5 -->
     <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- +4 -->
+    <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -49 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -80 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1348,53 +1406,19 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- -1 -->
-    <g transform="translate(151.312096 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -57 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -82 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -90 -->
-    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_24">
+    <!-- -88 -->
+    <g transform="translate(266.996679 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_25">
-    <!-- -38 -->
+    <!-- -34 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1432,121 +1456,51 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -6 -->
+    <!-- -1 -->
     <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +10 -->
+    <!-- +13 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-2b" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -35 -->
+    <!-- -33 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -50 -->
+    <!-- -45 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- -91 -->
+    <!-- -89 -->
     <g transform="translate(502.50147 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_31">
     <!-- +4 -->
     <g transform="translate(110.510438 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
     </g>
@@ -1593,6 +1547,18 @@ z
    <g id="text_37">
     <!-- +7 -->
     <g transform="translate(346.015229 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
@@ -1666,6 +1632,38 @@ z
    <g id="text_46">
     <!-- +26 -->
     <g transform="translate(265.44582 139.606222) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(147.412109 0)"/>
@@ -2180,18 +2178,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image77f2afe851" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image440c7b4646" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m085b58ea64" d="M 0 0 
+       <path id="m81963e1e02" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m085b58ea64" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81963e1e02" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2214,7 +2212,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m085b58ea64" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81963e1e02" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2228,7 +2226,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m085b58ea64" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81963e1e02" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2242,7 +2240,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m085b58ea64" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81963e1e02" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2255,7 +2253,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m085b58ea64" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81963e1e02" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2268,7 +2266,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m085b58ea64" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81963e1e02" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2281,7 +2279,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m085b58ea64" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m81963e1e02" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2942,8 +2940,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.380391 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.540625 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3013,13 +3011,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3059,109 +3057,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb6bae649af">
+  <clipPath id="pb65fad7f22">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m6eba45d44e" d="M 0 0 
+       <path id="m97f20478be" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6eba45d44e" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97f20478be" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m6eba45d44e" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97f20478be" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m6eba45d44e" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97f20478be" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m6eba45d44e" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97f20478be" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m6eba45d44e" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97f20478be" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m6eba45d44e" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97f20478be" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6eba45d44e" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m97f20478be" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m1727ca7e1d" d="M 0 0 
+       <path id="mb1d83d222f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1727ca7e1d" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb1d83d222f" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1727ca7e1d" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb1d83d222f" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m1727ca7e1d" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb1d83d222f" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mdb5e39ec65" d="M 0 0 
+       <path id="mae2b5af5bc" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mdb5e39ec65" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mae2b5af5bc" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 147.798199) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 147.424043) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 298.12969) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 297.6298) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="ma84a192c3d" d="M -2.5 2.5 
+     <path id="m5167237d69" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p95022286a9)">
-     <use xlink:href="#ma84a192c3d" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma84a192c3d" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma84a192c3d" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma84a192c3d" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma84a192c3d" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma84a192c3d" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma84a192c3d" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma84a192c3d" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma84a192c3d" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p80e98dc6c6)">
+     <use xlink:href="#m5167237d69" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5167237d69" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5167237d69" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5167237d69" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5167237d69" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5167237d69" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5167237d69" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5167237d69" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m5167237d69" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="ma5263759ec" d="M 0 -2.5 
+     <path id="m2986e0f99e" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p95022286a9)">
-     <use xlink:href="#ma5263759ec" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5263759ec" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5263759ec" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5263759ec" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5263759ec" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5263759ec" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5263759ec" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5263759ec" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#ma5263759ec" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p80e98dc6c6)">
+     <use xlink:href="#m2986e0f99e" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2986e0f99e" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2986e0f99e" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2986e0f99e" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2986e0f99e" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2986e0f99e" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2986e0f99e" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2986e0f99e" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2986e0f99e" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m4a937c07dc" d="M -0 3.535534 
+     <path id="mf1b6edff00" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p95022286a9)">
-     <use xlink:href="#m4a937c07dc" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4a937c07dc" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p80e98dc6c6)">
+     <use xlink:href="#mf1b6edff00" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1b6edff00" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m06b4eb8a2d" d="M -0 2.5 
+     <path id="m16974966b3" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p95022286a9)">
-     <use xlink:href="#m06b4eb8a2d" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p80e98dc6c6)">
+     <use xlink:href="#m16974966b3" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m35aab4875e" d="M -0.833333 2.5 
+     <path id="m3810016285" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p95022286a9)">
-     <use xlink:href="#m35aab4875e" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35aab4875e" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35aab4875e" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35aab4875e" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35aab4875e" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35aab4875e" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35aab4875e" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35aab4875e" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m35aab4875e" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p80e98dc6c6)">
+     <use xlink:href="#m3810016285" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3810016285" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3810016285" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3810016285" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3810016285" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3810016285" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3810016285" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3810016285" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m3810016285" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m85bac3a0ed" d="M -1.25 2.5 
+     <path id="maad1893cc0" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p95022286a9)">
-     <use xlink:href="#m85bac3a0ed" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m85bac3a0ed" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m85bac3a0ed" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m85bac3a0ed" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m85bac3a0ed" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m85bac3a0ed" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m85bac3a0ed" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m85bac3a0ed" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m85bac3a0ed" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p80e98dc6c6)">
+     <use xlink:href="#maad1893cc0" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maad1893cc0" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maad1893cc0" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maad1893cc0" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maad1893cc0" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maad1893cc0" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maad1893cc0" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maad1893cc0" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#maad1893cc0" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="mb2a95fcfdd" d="M 0 -2.5 
+     <path id="m998b140789" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p95022286a9)">
-     <use xlink:href="#mb2a95fcfdd" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb2a95fcfdd" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb2a95fcfdd" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb2a95fcfdd" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb2a95fcfdd" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb2a95fcfdd" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb2a95fcfdd" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb2a95fcfdd" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mb2a95fcfdd" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p80e98dc6c6)">
+     <use xlink:href="#m998b140789" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m998b140789" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m998b140789" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m998b140789" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m998b140789" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m998b140789" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m998b140789" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m998b140789" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m998b140789" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="maa52ccf2bd" d="M 0 -2.5 
+     <path id="m13fbd74be7" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p95022286a9)">
-     <use xlink:href="#maa52ccf2bd" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa52ccf2bd" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa52ccf2bd" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa52ccf2bd" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa52ccf2bd" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa52ccf2bd" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa52ccf2bd" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa52ccf2bd" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maa52ccf2bd" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p80e98dc6c6)">
+     <use xlink:href="#m13fbd74be7" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13fbd74be7" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13fbd74be7" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13fbd74be7" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13fbd74be7" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13fbd74be7" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13fbd74be7" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13fbd74be7" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m13fbd74be7" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m1cf56156c9" d="M 0 3.5 
+      <path id="ma4d61aa984" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m1cf56156c9" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#ma4d61aa984" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#ma84a192c3d" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m5167237d69" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#ma5263759ec" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2986e0f99e" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m4a937c07dc" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf1b6edff00" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m06b4eb8a2d" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m16974966b3" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m35aab4875e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m3810016285" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m85bac3a0ed" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#maad1893cc0" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#mb2a95fcfdd" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m998b140789" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#maa52ccf2bd" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m13fbd74be7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p95022286a9)">
-     <use xlink:href="#m1cf56156c9" x="289.669676" y="152.798199" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1cf56156c9" x="223.847406" y="163.663924" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1cf56156c9" x="212.215046" y="167.391399" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1cf56156c9" x="186.58897" y="177.108872" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1cf56156c9" x="169.057218" y="186.848851" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1cf56156c9" x="158.596848" y="196.294266" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1cf56156c9" x="152.867313" y="202.223877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1cf56156c9" x="150.950891" y="205.361615" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1cf56156c9" x="115.225692" y="277.324326" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1cf56156c9" x="99.852312" y="303.12969" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p80e98dc6c6)">
+     <use xlink:href="#ma4d61aa984" x="289.669676" y="152.424043" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4d61aa984" x="223.847406" y="163.470186" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4d61aa984" x="212.215046" y="167.327928" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4d61aa984" x="186.58897" y="177.24904" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4d61aa984" x="169.057218" y="186.931753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4d61aa984" x="158.596848" y="192.034656" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4d61aa984" x="152.867313" y="198.552958" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4d61aa984" x="150.950891" y="201.722371" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4d61aa984" x="115.225692" y="276.895357" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#ma4d61aa984" x="99.852312" y="302.6298" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 152.798199 
-L 288.298379 153.051936 
-L 286.927082 153.304322 
-L 285.555784 153.555371 
-L 284.184487 153.805097 
-L 282.81319 154.053515 
-L 281.441892 154.300637 
-L 280.070595 154.546478 
-L 278.699298 154.79105 
-L 277.328 155.034367 
-L 275.956703 155.276441 
-L 274.585406 155.517285 
-L 273.214109 155.756912 
-L 271.842811 155.995333 
-L 270.471514 156.232561 
-L 269.100217 156.468607 
-L 267.728919 156.703484 
-L 266.357622 156.937203 
-L 264.986325 157.169774 
-L 263.615028 157.401211 
-L 262.24373 157.631522 
-L 260.872433 157.86072 
-L 259.501136 158.088815 
-L 258.129838 158.315818 
-L 256.758541 158.541739 
-L 255.387244 158.766588 
-L 254.015947 158.990375 
-L 252.644649 159.213111 
-L 251.273352 159.434805 
-L 249.902055 159.655467 
-L 248.530757 159.875106 
-L 247.15946 160.093732 
-L 245.788163 160.311355 
-L 244.416866 160.527983 
-L 243.045568 160.743625 
-L 241.674271 160.958291 
-L 240.302974 161.171989 
-L 238.931676 161.384728 
-L 237.560379 161.596516 
-L 236.189082 161.807362 
-L 234.817784 162.017274 
-L 233.446487 162.226261 
-L 232.07519 162.434331 
-L 230.703893 162.641491 
-L 229.332595 162.847749 
-L 227.961298 163.053114 
-L 226.590001 163.257593 
-L 225.218703 163.461194 
-L 223.847406 163.663924 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 152.424043 
+L 288.298379 152.682491 
+L 286.927082 152.939537 
+L 285.555784 153.195197 
+L 284.184487 153.449485 
+L 282.81319 153.702416 
+L 281.441892 153.954004 
+L 280.070595 154.204264 
+L 278.699298 154.45321 
+L 277.328 154.700855 
+L 275.956703 154.947213 
+L 274.585406 155.192297 
+L 273.214109 155.436121 
+L 271.842811 155.678696 
+L 270.471514 155.920037 
+L 269.100217 156.160154 
+L 267.728919 156.399062 
+L 266.357622 156.636771 
+L 264.986325 156.873295 
+L 263.615028 157.108643 
+L 262.24373 157.342829 
+L 260.872433 157.575864 
+L 259.501136 157.807759 
+L 258.129838 158.038524 
+L 256.758541 158.268172 
+L 255.387244 158.496712 
+L 254.015947 158.724155 
+L 252.644649 158.950513 
+L 251.273352 159.175794 
+L 249.902055 159.40001 
+L 248.530757 159.62317 
+L 247.15946 159.845285 
+L 245.788163 160.066363 
+L 244.416866 160.286415 
+L 243.045568 160.505451 
+L 241.674271 160.723478 
+L 240.302974 160.940508 
+L 238.931676 161.156548 
+L 237.560379 161.371608 
+L 236.189082 161.585697 
+L 234.817784 161.798823 
+L 233.446487 162.010994 
+L 232.07519 162.222221 
+L 230.703893 162.43251 
+L 229.332595 162.641871 
+L 227.961298 162.85031 
+L 226.590001 163.057838 
+L 225.218703 163.26446 
+L 223.847406 163.470186 
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 163.663924 
-L 223.605065 163.744646 
-L 223.362724 163.82523 
-L 223.120384 163.905678 
-L 222.878043 163.98599 
-L 222.635702 164.066166 
-L 222.393361 164.146207 
-L 222.15102 164.226112 
-L 221.908679 164.305883 
-L 221.666339 164.38552 
-L 221.423998 164.465024 
-L 221.181657 164.544394 
-L 220.939316 164.623632 
-L 220.696975 164.702737 
-L 220.454635 164.781711 
-L 220.212294 164.860553 
-L 219.969953 164.939264 
-L 219.727612 165.017845 
-L 219.485271 165.096296 
-L 219.24293 165.174617 
-L 219.00059 165.252809 
-L 218.758249 165.330872 
-L 218.515908 165.408807 
-L 218.273567 165.486614 
-L 218.031226 165.564293 
-L 217.788885 165.641845 
-L 217.546545 165.719271 
-L 217.304204 165.79657 
-L 217.061863 165.873744 
-L 216.819522 165.950792 
-L 216.577181 166.027715 
-L 216.33484 166.104513 
-L 216.0925 166.181187 
-L 215.850159 166.257737 
-L 215.607818 166.334164 
-L 215.365477 166.410468 
-L 215.123136 166.486649 
-L 214.880795 166.562708 
-L 214.638455 166.638645 
-L 214.396114 166.714461 
-L 214.153773 166.790155 
-L 213.911432 166.865729 
-L 213.669091 166.941183 
-L 213.42675 167.016516 
-L 213.18441 167.09173 
-L 212.942069 167.166825 
-L 212.699728 167.241801 
-L 212.457387 167.316659 
-L 212.215046 167.391399 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 163.470186 
+L 223.605065 163.553843 
+L 223.362724 163.637352 
+L 223.120384 163.720715 
+L 222.878043 163.803931 
+L 222.635702 163.887002 
+L 222.393361 163.969927 
+L 222.15102 164.052707 
+L 221.908679 164.135343 
+L 221.666339 164.217835 
+L 221.423998 164.300184 
+L 221.181657 164.38239 
+L 220.939316 164.464454 
+L 220.696975 164.546376 
+L 220.454635 164.628156 
+L 220.212294 164.709796 
+L 219.969953 164.791295 
+L 219.727612 164.872654 
+L 219.485271 164.953874 
+L 219.24293 165.034955 
+L 219.00059 165.115898 
+L 218.758249 165.196703 
+L 218.515908 165.27737 
+L 218.273567 165.3579 
+L 218.031226 165.438293 
+L 217.788885 165.518551 
+L 217.546545 165.598672 
+L 217.304204 165.678659 
+L 217.061863 165.75851 
+L 216.819522 165.838228 
+L 216.577181 165.917811 
+L 216.33484 165.997261 
+L 216.0925 166.076579 
+L 215.850159 166.155763 
+L 215.607818 166.234816 
+L 215.365477 166.313737 
+L 215.123136 166.392527 
+L 214.880795 166.471186 
+L 214.638455 166.549714 
+L 214.396114 166.628113 
+L 214.153773 166.706383 
+L 213.911432 166.784523 
+L 213.669091 166.862535 
+L 213.42675 166.940418 
+L 213.18441 167.018174 
+L 212.942069 167.095803 
+L 212.699728 167.173304 
+L 212.457387 167.250679 
+L 212.215046 167.327928 
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 167.391399 
-L 211.68117 167.615561 
-L 211.147293 167.838669 
-L 210.613417 168.060731 
-L 210.07954 168.281758 
-L 209.545663 168.501759 
-L 209.011787 168.720744 
-L 208.47791 168.938721 
-L 207.944034 169.155701 
-L 207.410157 169.371692 
-L 206.87628 169.586703 
-L 206.342404 169.800743 
-L 205.808527 170.013821 
-L 205.274651 170.225945 
-L 204.740774 170.437125 
-L 204.206897 170.647367 
-L 203.673021 170.856681 
-L 203.139144 171.065075 
-L 202.605268 171.272557 
-L 202.071391 171.479134 
-L 201.537515 171.684815 
-L 201.003638 171.889608 
-L 200.469761 172.093519 
-L 199.935885 172.296557 
-L 199.402008 172.498728 
-L 198.868132 172.700042 
-L 198.334255 172.900503 
-L 197.800378 173.100121 
-L 197.266502 173.298901 
-L 196.732625 173.496851 
-L 196.198749 173.693978 
-L 195.664872 173.890289 
-L 195.130995 174.08579 
-L 194.597119 174.280487 
-L 194.063242 174.474389 
-L 193.529366 174.6675 
-L 192.995489 174.859828 
-L 192.461612 175.051378 
-L 191.927736 175.242157 
-L 191.393859 175.432172 
-L 190.859983 175.621428 
-L 190.326106 175.809931 
-L 189.79223 175.997688 
-L 189.258353 176.184704 
-L 188.724476 176.370985 
-L 188.1906 176.556536 
-L 187.656723 176.741364 
-L 187.122847 176.925474 
-L 186.58897 177.108872 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 167.327928 
+L 211.68117 167.557285 
+L 211.147293 167.785537 
+L 210.613417 168.012696 
+L 210.07954 168.238771 
+L 209.545663 168.463773 
+L 209.011787 168.687711 
+L 208.47791 168.910597 
+L 207.944034 169.13244 
+L 207.410157 169.353249 
+L 206.87628 169.573034 
+L 206.342404 169.791805 
+L 205.808527 170.009571 
+L 205.274651 170.22634 
+L 204.740774 170.442123 
+L 204.206897 170.656929 
+L 203.673021 170.870765 
+L 203.139144 171.08364 
+L 202.605268 171.295564 
+L 202.071391 171.506545 
+L 201.537515 171.71659 
+L 201.003638 171.925709 
+L 200.469761 172.133909 
+L 199.935885 172.341199 
+L 199.402008 172.547586 
+L 198.868132 172.753079 
+L 198.334255 172.957684 
+L 197.800378 173.16141 
+L 197.266502 173.364264 
+L 196.732625 173.566254 
+L 196.198749 173.767386 
+L 195.664872 173.967669 
+L 195.130995 174.167109 
+L 194.597119 174.365713 
+L 194.063242 174.563489 
+L 193.529366 174.760442 
+L 192.995489 174.956581 
+L 192.461612 175.151911 
+L 191.927736 175.34644 
+L 191.393859 175.540174 
+L 190.859983 175.733119 
+L 190.326106 175.925282 
+L 189.79223 176.116669 
+L 189.258353 176.307286 
+L 188.724476 176.49714 
+L 188.1906 176.686236 
+L 187.656723 176.874581 
+L 187.122847 177.06218 
+L 186.58897 177.24904 
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 186.58897 177.108872 
-L 186.223725 177.333608 
-L 185.85848 177.557283 
-L 185.493235 177.779908 
-L 185.127991 178.001492 
-L 184.762746 178.222044 
-L 184.397501 178.441576 
-L 184.032256 178.660095 
-L 183.667011 178.877611 
-L 183.301766 179.094134 
-L 182.936522 179.309672 
-L 182.571277 179.524235 
-L 182.206032 179.73783 
-L 181.840787 179.950468 
-L 181.475542 180.162156 
-L 181.110297 180.372902 
-L 180.745053 180.582716 
-L 180.379808 180.791605 
-L 180.014563 180.999577 
-L 179.649318 181.206641 
-L 179.284073 181.412804 
-L 178.918828 181.618075 
-L 178.553584 181.82246 
-L 178.188339 182.025968 
-L 177.823094 182.228606 
-L 177.457849 182.430381 
-L 177.092604 182.631301 
-L 176.727359 182.831372 
-L 176.362115 183.030603 
-L 175.99687 183.229 
-L 175.631625 183.42657 
-L 175.26638 183.62332 
-L 174.901135 183.819256 
-L 174.53589 184.014386 
-L 174.170645 184.208716 
-L 173.805401 184.402252 
-L 173.440156 184.595001 
-L 173.074911 184.78697 
-L 172.709666 184.978164 
-L 172.344421 185.168591 
-L 171.979176 185.358255 
-L 171.613932 185.547163 
-L 171.248687 185.735322 
-L 170.883442 185.922736 
-L 170.518197 186.109412 
-L 170.152952 186.295356 
-L 169.787707 186.480574 
-L 169.422463 186.66507 
-L 169.057218 186.848851 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.58897 177.24904 
+L 186.223725 177.472319 
+L 185.85848 177.69455 
+L 185.493235 177.915744 
+L 185.127991 178.135911 
+L 184.762746 178.35506 
+L 184.397501 178.573201 
+L 184.032256 178.790342 
+L 183.667011 179.006493 
+L 183.301766 179.221662 
+L 182.936522 179.435859 
+L 182.571277 179.649093 
+L 182.206032 179.861372 
+L 181.840787 180.072704 
+L 181.475542 180.283098 
+L 181.110297 180.492562 
+L 180.745053 180.701105 
+L 180.379808 180.908734 
+L 180.014563 181.115458 
+L 179.649318 181.321284 
+L 179.284073 181.52622 
+L 178.918828 181.730274 
+L 178.553584 181.933453 
+L 178.188339 182.135765 
+L 177.823094 182.337217 
+L 177.457849 182.537817 
+L 177.092604 182.737571 
+L 176.727359 182.936487 
+L 176.362115 183.134571 
+L 175.99687 183.331831 
+L 175.631625 183.528274 
+L 175.26638 183.723906 
+L 174.901135 183.918734 
+L 174.53589 184.112764 
+L 174.170645 184.306003 
+L 173.805401 184.498457 
+L 173.440156 184.690134 
+L 173.074911 184.881038 
+L 172.709666 185.071176 
+L 172.344421 185.260555 
+L 171.979176 185.44918 
+L 171.613932 185.637058 
+L 171.248687 185.824193 
+L 170.883442 186.010593 
+L 170.518197 186.196263 
+L 170.152952 186.381208 
+L 169.787707 186.565434 
+L 169.422463 186.748947 
+L 169.057218 186.931753 
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 169.057218 186.848851 
-L 168.839293 187.066109 
-L 168.621369 187.282375 
-L 168.403445 187.497658 
-L 168.18552 187.711969 
-L 167.967596 187.925315 
-L 167.749672 188.137704 
-L 167.531747 188.349147 
-L 167.313823 188.55965 
-L 167.095898 188.769223 
-L 166.877974 188.977873 
-L 166.66005 189.185608 
-L 166.442125 189.392437 
-L 166.224201 189.598368 
-L 166.006277 189.803407 
-L 165.788352 190.007564 
-L 165.570428 190.210845 
-L 165.352503 190.413258 
-L 165.134579 190.61481 
-L 164.916655 190.815509 
-L 164.69873 191.015361 
-L 164.480806 191.214374 
-L 164.262882 191.412556 
-L 164.044957 191.609912 
-L 163.827033 191.80645 
-L 163.609108 192.002176 
-L 163.391184 192.197097 
-L 163.17326 192.39122 
-L 162.955335 192.584551 
-L 162.737411 192.777097 
-L 162.519487 192.968864 
-L 162.301562 193.159858 
-L 162.083638 193.350086 
-L 161.865713 193.539553 
-L 161.647789 193.728266 
-L 161.429865 193.91623 
-L 161.21194 194.103452 
-L 160.994016 194.289938 
-L 160.776092 194.475692 
-L 160.558167 194.660722 
-L 160.340243 194.845032 
-L 160.122318 195.028628 
-L 159.904394 195.211516 
-L 159.68647 195.3937 
-L 159.468545 195.575188 
-L 159.250621 195.755983 
-L 159.032697 195.936091 
-L 158.814772 196.115517 
-L 158.596848 196.294266 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 169.057218 186.931753 
+L 168.839293 187.043864 
+L 168.621369 187.155711 
+L 168.403445 187.267294 
+L 168.18552 187.378616 
+L 167.967596 187.489677 
+L 167.749672 187.600478 
+L 167.531747 187.71102 
+L 167.313823 187.821306 
+L 167.095898 187.931335 
+L 166.877974 188.04111 
+L 166.66005 188.150631 
+L 166.442125 188.259899 
+L 166.224201 188.368916 
+L 166.006277 188.477683 
+L 165.788352 188.586201 
+L 165.570428 188.694471 
+L 165.352503 188.802495 
+L 165.134579 188.910272 
+L 164.916655 189.017806 
+L 164.69873 189.125095 
+L 164.480806 189.232143 
+L 164.262882 189.338949 
+L 164.044957 189.445515 
+L 163.827033 189.551842 
+L 163.609108 189.657932 
+L 163.391184 189.763784 
+L 163.17326 189.8694 
+L 162.955335 189.974782 
+L 162.737411 190.079929 
+L 162.519487 190.184844 
+L 162.301562 190.289528 
+L 162.083638 190.39398 
+L 161.865713 190.498203 
+L 161.647789 190.602197 
+L 161.429865 190.705964 
+L 161.21194 190.809504 
+L 160.994016 190.912818 
+L 160.776092 191.015908 
+L 160.558167 191.118773 
+L 160.340243 191.221416 
+L 160.122318 191.323838 
+L 159.904394 191.426038 
+L 159.68647 191.528019 
+L 159.468545 191.62978 
+L 159.250621 191.731324 
+L 159.032697 191.83265 
+L 158.814772 191.933761 
+L 158.596848 192.034656 
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 158.596848 196.294266 
-L 158.477483 196.425677 
-L 158.358117 196.556724 
-L 158.238752 196.687411 
-L 158.119387 196.817737 
-L 158.000021 196.947707 
-L 157.880656 197.077321 
-L 157.761291 197.206582 
-L 157.641925 197.335491 
-L 157.52256 197.46405 
-L 157.403195 197.592262 
-L 157.28383 197.720127 
-L 157.164464 197.847649 
-L 157.045099 197.974829 
-L 156.925734 198.101668 
-L 156.806368 198.228169 
-L 156.687003 198.354333 
-L 156.567638 198.480162 
-L 156.448272 198.605658 
-L 156.328907 198.730823 
-L 156.209542 198.855658 
-L 156.090177 198.980165 
-L 155.970811 199.104345 
-L 155.851446 199.228202 
-L 155.732081 199.351735 
-L 155.612715 199.474948 
-L 155.49335 199.597841 
-L 155.373985 199.720416 
-L 155.254619 199.842675 
-L 155.135254 199.964619 
-L 155.015889 200.086251 
-L 154.896524 200.207571 
-L 154.777158 200.328581 
-L 154.657793 200.449284 
-L 154.538428 200.569679 
-L 154.419062 200.68977 
-L 154.299697 200.809557 
-L 154.180332 200.929043 
-L 154.060966 201.048227 
-L 153.941601 201.167113 
-L 153.822236 201.285702 
-L 153.702871 201.403994 
-L 153.583505 201.521992 
-L 153.46414 201.639697 
-L 153.344775 201.75711 
-L 153.225409 201.874233 
-L 153.106044 201.991068 
-L 152.986679 202.107615 
-L 152.867313 202.223877 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.596848 192.034656 
+L 158.477483 192.180011 
+L 158.358117 192.324922 
+L 158.238752 192.469392 
+L 158.119387 192.613422 
+L 158.000021 192.757016 
+L 157.880656 192.900177 
+L 157.761291 193.042906 
+L 157.641925 193.185207 
+L 157.52256 193.327081 
+L 157.403195 193.468533 
+L 157.28383 193.609564 
+L 157.164464 193.750176 
+L 157.045099 193.890372 
+L 156.925734 194.030155 
+L 156.806368 194.169527 
+L 156.687003 194.30849 
+L 156.567638 194.447047 
+L 156.448272 194.5852 
+L 156.328907 194.722952 
+L 156.209542 194.860304 
+L 156.090177 194.99726 
+L 155.970811 195.133821 
+L 155.851446 195.26999 
+L 155.732081 195.405768 
+L 155.612715 195.541159 
+L 155.49335 195.676164 
+L 155.373985 195.810786 
+L 155.254619 195.945026 
+L 155.135254 196.078888 
+L 155.015889 196.212372 
+L 154.896524 196.345482 
+L 154.777158 196.478218 
+L 154.657793 196.610585 
+L 154.538428 196.742582 
+L 154.419062 196.874213 
+L 154.299697 197.005479 
+L 154.180332 197.136383 
+L 154.060966 197.266926 
+L 153.941601 197.397111 
+L 153.822236 197.526939 
+L 153.702871 197.656413 
+L 153.583505 197.785534 
+L 153.46414 197.914304 
+L 153.344775 198.042725 
+L 153.225409 198.170799 
+L 153.106044 198.298528 
+L 152.986679 198.425914 
+L 152.867313 198.552958 
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 152.867313 202.223877 
-L 152.827388 202.29141 
-L 152.787463 202.358848 
-L 152.747537 202.42619 
-L 152.707612 202.493436 
-L 152.667686 202.560587 
-L 152.627761 202.627643 
-L 152.587835 202.694604 
-L 152.54791 202.761471 
-L 152.507984 202.828243 
-L 152.468059 202.894922 
-L 152.428133 202.961507 
-L 152.388208 203.027998 
-L 152.348282 203.094397 
-L 152.308357 203.160702 
-L 152.268432 203.226915 
-L 152.228506 203.293036 
-L 152.188581 203.359064 
-L 152.148655 203.425001 
-L 152.10873 203.490846 
-L 152.068804 203.556599 
-L 152.028879 203.622262 
-L 151.988953 203.687834 
-L 151.949028 203.753315 
-L 151.909102 203.818705 
-L 151.869177 203.884006 
-L 151.829252 203.949217 
-L 151.789326 204.014338 
-L 151.749401 204.07937 
-L 151.709475 204.144313 
-L 151.66955 204.209167 
-L 151.629624 204.273932 
-L 151.589699 204.338609 
-L 151.549773 204.403198 
-L 151.509848 204.467699 
-L 151.469922 204.532112 
-L 151.429997 204.596438 
-L 151.390072 204.660677 
-L 151.350146 204.724829 
-L 151.310221 204.788894 
-L 151.270295 204.852872 
-L 151.23037 204.916765 
-L 151.190444 204.980571 
-L 151.150519 205.044291 
-L 151.110593 205.107926 
-L 151.070668 205.171476 
-L 151.030742 205.234941 
-L 150.990817 205.29832 
-L 150.950891 205.361615 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 152.867313 198.552958 
+L 152.827388 198.621196 
+L 152.787463 198.689336 
+L 152.747537 198.757378 
+L 152.707612 198.825322 
+L 152.667686 198.89317 
+L 152.627761 198.96092 
+L 152.587835 199.028573 
+L 152.54791 199.09613 
+L 152.507984 199.163591 
+L 152.468059 199.230956 
+L 152.428133 199.298226 
+L 152.388208 199.3654 
+L 152.348282 199.432479 
+L 152.308357 199.499463 
+L 152.268432 199.566353 
+L 152.228506 199.633149 
+L 152.188581 199.69985 
+L 152.148655 199.766458 
+L 152.10873 199.832972 
+L 152.068804 199.899393 
+L 152.028879 199.965721 
+L 151.988953 200.031957 
+L 151.949028 200.0981 
+L 151.909102 200.164151 
+L 151.869177 200.23011 
+L 151.829252 200.295977 
+L 151.789326 200.361753 
+L 151.749401 200.427438 
+L 151.709475 200.493031 
+L 151.66955 200.558535 
+L 151.629624 200.623947 
+L 151.589699 200.68927 
+L 151.549773 200.754503 
+L 151.509848 200.819646 
+L 151.469922 200.8847 
+L 151.429997 200.949664 
+L 151.390072 201.01454 
+L 151.350146 201.079327 
+L 151.310221 201.144025 
+L 151.270295 201.208635 
+L 151.23037 201.273158 
+L 151.190444 201.337592 
+L 151.150519 201.401939 
+L 151.110593 201.466199 
+L 151.070668 201.530372 
+L 151.030742 201.594458 
+L 150.990817 201.658458 
+L 150.950891 201.722371 
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 205.361615 
-L 150.206616 208.756605 
-L 149.462341 211.924594 
-L 148.718066 214.894046 
-L 147.973791 217.688384 
-L 147.229517 220.327116 
-L 146.485242 222.826663 
-L 145.740967 225.200975 
-L 144.996692 227.462005 
-L 144.252417 229.620071 
-L 143.508142 231.684145 
-L 142.763867 233.662074 
-L 142.019592 235.56076 
-L 141.275317 237.38631 
-L 140.531042 239.14415 
-L 139.786767 240.839123 
-L 139.042492 242.47557 
-L 138.298217 244.0574 
-L 137.553942 245.58814 
-L 136.809667 247.070988 
-L 136.065392 248.50885 
-L 135.321117 249.904375 
-L 134.576842 251.259985 
-L 133.832567 252.577901 
-L 133.088292 253.860161 
-L 132.344017 255.108644 
-L 131.599742 256.325085 
-L 130.855467 257.511087 
-L 130.111192 258.668136 
-L 129.366917 259.797612 
-L 128.622642 260.900799 
-L 127.878367 261.978892 
-L 127.134092 263.033009 
-L 126.389817 264.064192 
-L 125.645542 265.073418 
-L 124.901267 266.061603 
-L 124.156992 267.029605 
-L 123.412717 267.978234 
-L 122.668442 268.908249 
-L 121.924167 269.820367 
-L 121.179892 270.715264 
-L 120.435617 271.593577 
-L 119.691342 272.455911 
-L 118.947067 273.302836 
-L 118.202792 274.134894 
-L 117.458517 274.952596 
-L 116.714242 275.756432 
-L 115.969967 276.546862 
-L 115.225692 277.324326 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 150.950891 201.722371 
+L 150.206616 205.410452 
+L 149.462341 208.832166 
+L 148.718066 212.023412 
+L 147.973791 215.013286 
+L 147.229517 217.825701 
+L 146.485242 220.480547 
+L 145.740967 222.994547 
+L 144.996692 225.381897 
+L 144.252417 227.654746 
+L 143.508142 229.823577 
+L 142.763867 231.897497 
+L 142.019592 233.884464 
+L 141.275317 235.791478 
+L 140.531042 237.624724 
+L 139.786767 239.389699 
+L 139.042492 241.091305 
+L 138.298217 242.733935 
+L 137.553942 244.32154 
+L 136.809667 245.857688 
+L 136.065392 247.34561 
+L 135.321117 248.788242 
+L 134.576842 250.18826 
+L 133.832567 251.54811 
+L 133.088292 252.870031 
+L 132.344017 254.156084 
+L 131.599742 255.408162 
+L 130.855467 256.628015 
+L 130.111192 257.817261 
+L 129.366917 258.977396 
+L 128.622642 260.109814 
+L 127.878367 261.215807 
+L 127.134092 262.29658 
+L 126.389817 263.353258 
+L 125.645542 264.386892 
+L 124.901267 265.398466 
+L 124.156992 266.388901 
+L 123.412717 267.359064 
+L 122.668442 268.309766 
+L 121.924167 269.241775 
+L 121.179892 270.15581 
+L 120.435617 271.052552 
+L 119.691342 271.932643 
+L 118.947067 272.79669 
+L 118.202792 273.645268 
+L 117.458517 274.47892 
+L 116.714242 275.298164 
+L 115.969967 276.103488 
+L 115.225692 276.895357 
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.225692 277.324326 
-L 114.905413 278.033556 
-L 114.585134 278.732331 
-L 114.264856 279.420953 
-L 113.944577 280.099713 
-L 113.624298 280.768891 
-L 113.304019 281.428753 
-L 112.983741 282.079555 
-L 112.663462 282.721541 
-L 112.343183 283.354949 
-L 112.022904 283.980003 
-L 111.702626 284.596923 
-L 111.382347 285.205915 
-L 111.062068 285.807183 
-L 110.741789 286.400918 
-L 110.421511 286.987308 
-L 110.101232 287.566533 
-L 109.780953 288.138764 
-L 109.460674 288.704169 
-L 109.140396 289.26291 
-L 108.820117 289.81514 
-L 108.499838 290.361011 
-L 108.17956 290.900666 
-L 107.859281 291.434247 
-L 107.539002 291.961887 
-L 107.218723 292.483719 
-L 106.898445 292.999868 
-L 106.578166 293.510457 
-L 106.257887 294.015605 
-L 105.937608 294.515425 
-L 105.61733 295.01003 
-L 105.297051 295.499527 
-L 104.976772 295.984021 
-L 104.656493 296.463612 
-L 104.336215 296.9384 
-L 104.015936 297.408478 
-L 103.695657 297.87394 
-L 103.375378 298.334876 
-L 103.0551 298.791373 
-L 102.734821 299.243515 
-L 102.414542 299.691384 
-L 102.094264 300.135062 
-L 101.773985 300.574625 
-L 101.453706 301.010149 
-L 101.133427 301.441707 
-L 100.813149 301.869372 
-L 100.49287 302.293212 
-L 100.172591 302.713296 
-L 99.852312 303.12969 
-" clip-path="url(#p95022286a9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.225692 276.895357 
+L 114.905413 277.60208 
+L 114.585134 278.29842 
+L 114.264856 278.984679 
+L 113.944577 279.661143 
+L 113.624298 280.328089 
+L 113.304019 280.98578 
+L 112.983741 281.63447 
+L 112.663462 282.274401 
+L 112.343183 282.905809 
+L 112.022904 283.528915 
+L 111.702626 284.143936 
+L 111.382347 284.75108 
+L 111.062068 285.350544 
+L 110.741789 285.942522 
+L 110.421511 286.527197 
+L 110.101232 287.104748 
+L 109.780953 287.675346 
+L 109.460674 288.239157 
+L 109.140396 288.79634 
+L 108.820117 289.34705 
+L 108.499838 289.891434 
+L 108.17956 290.429637 
+L 107.859281 290.961797 
+L 107.539002 291.488049 
+L 107.218723 292.008522 
+L 106.898445 292.523342 
+L 106.578166 293.03263 
+L 106.257887 293.536505 
+L 105.937608 294.035079 
+L 105.61733 294.528463 
+L 105.297051 295.016765 
+L 104.976772 295.500087 
+L 104.656493 295.978531 
+L 104.336215 296.452193 
+L 104.015936 296.921169 
+L 103.695657 297.38555 
+L 103.375378 297.845426 
+L 103.0551 298.300883 
+L 102.734821 298.752004 
+L 102.414542 299.198873 
+L 102.094264 299.641568 
+L 101.773985 300.080166 
+L 101.453706 300.514744 
+L 101.133427 300.945373 
+L 100.813149 301.372124 
+L 100.49287 301.795068 
+L 100.172591 302.214272 
+L 99.852312 302.6298 
+" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.380391 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.540625 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6289,6 +6289,31 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6419,13 +6444,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6465,109 +6490,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p95022286a9">
+  <clipPath id="p80e98dc6c6">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p36856600c4)">
+   <g clip-path="url(#p4b78d9fec6)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="imagee04f5b8cf9" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="image4f6858b781" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m63b0fd2f7e" d="M 0 0 
+       <path id="maab05a0f5a" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m63b0fd2f7e" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maab05a0f5a" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="md119eec9e7" d="M 0 0 
+       <path id="m062ba063c9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md119eec9e7" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m062ba063c9" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#md119eec9e7" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m062ba063c9" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md119eec9e7" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m062ba063c9" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md119eec9e7" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m062ba063c9" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md119eec9e7" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m062ba063c9" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md119eec9e7" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m062ba063c9" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md119eec9e7" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m062ba063c9" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md119eec9e7" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m062ba063c9" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image8a61406706" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image24a004280d" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m059cf37bdf" d="M 0 0 
+       <path id="m78c517d08f" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m059cf37bdf" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78c517d08f" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m059cf37bdf" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78c517d08f" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m059cf37bdf" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78c517d08f" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m059cf37bdf" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78c517d08f" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m059cf37bdf" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78c517d08f" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m059cf37bdf" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78c517d08f" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m059cf37bdf" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78c517d08f" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m059cf37bdf" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78c517d08f" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m059cf37bdf" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m78c517d08f" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.380391 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.540625 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2953,13 +2953,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p36856600c4">
+  <clipPath id="p4b78d9fec6">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.639219pt" height="386.202469pt" viewBox="0 0 575.639219 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.31875pt" height="386.202469pt" viewBox="0 0 575.31875 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.639219 386.202469 
-L 575.639219 0 
+L 575.31875 386.202469 
+L 575.31875 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.944609 104.1264 
-L 294.569609 104.1264 
-L 294.569609 74.7432 
-L 189.944609 74.7432 
+    <path d="M 189.784375 104.1264 
+L 294.409375 104.1264 
+L 294.409375 74.7432 
+L 189.784375 74.7432 
 z
-" clip-path="url(#pbaae916470)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.569609 104.1264 
-L 399.194609 104.1264 
-L 399.194609 74.7432 
-L 294.569609 74.7432 
+    <path d="M 294.409375 104.1264 
+L 399.034375 104.1264 
+L 399.034375 74.7432 
+L 294.409375 74.7432 
 z
-" clip-path="url(#pbaae916470)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.194609 104.1264 
-L 503.819609 104.1264 
-L 503.819609 74.7432 
-L 399.194609 74.7432 
+    <path d="M 399.034375 104.1264 
+L 503.659375 104.1264 
+L 503.659375 74.7432 
+L 399.034375 74.7432 
 z
-" clip-path="url(#pbaae916470)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.944609 133.5096 
-L 294.569609 133.5096 
-L 294.569609 104.1264 
-L 189.944609 104.1264 
+    <path d="M 189.784375 133.5096 
+L 294.409375 133.5096 
+L 294.409375 104.1264 
+L 189.784375 104.1264 
 z
-" clip-path="url(#pbaae916470)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.569609 133.5096 
-L 399.194609 133.5096 
-L 399.194609 104.1264 
-L 294.569609 104.1264 
+    <path d="M 294.409375 133.5096 
+L 399.034375 133.5096 
+L 399.034375 104.1264 
+L 294.409375 104.1264 
 z
-" clip-path="url(#pbaae916470)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.194609 133.5096 
-L 503.819609 133.5096 
-L 503.819609 104.1264 
-L 399.194609 104.1264 
+    <path d="M 399.034375 133.5096 
+L 503.659375 133.5096 
+L 503.659375 104.1264 
+L 399.034375 104.1264 
 z
-" clip-path="url(#pbaae916470)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.944609 162.8928 
-L 294.569609 162.8928 
-L 294.569609 133.5096 
-L 189.944609 133.5096 
+    <path d="M 189.784375 162.8928 
+L 294.409375 162.8928 
+L 294.409375 133.5096 
+L 189.784375 133.5096 
 z
-" clip-path="url(#pbaae916470)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.569609 162.8928 
-L 399.194609 162.8928 
-L 399.194609 133.5096 
-L 294.569609 133.5096 
+    <path d="M 294.409375 162.8928 
+L 399.034375 162.8928 
+L 399.034375 133.5096 
+L 294.409375 133.5096 
 z
-" clip-path="url(#pbaae916470)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.194609 162.8928 
-L 503.819609 162.8928 
-L 503.819609 133.5096 
-L 399.194609 133.5096 
+    <path d="M 399.034375 162.8928 
+L 503.659375 162.8928 
+L 503.659375 133.5096 
+L 399.034375 133.5096 
 z
-" clip-path="url(#pbaae916470)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.944609 192.276 
-L 294.569609 192.276 
-L 294.569609 162.8928 
-L 189.944609 162.8928 
+    <path d="M 189.784375 192.276 
+L 294.409375 192.276 
+L 294.409375 162.8928 
+L 189.784375 162.8928 
 z
-" clip-path="url(#pbaae916470)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.569609 192.276 
-L 399.194609 192.276 
-L 399.194609 162.8928 
-L 294.569609 162.8928 
+    <path d="M 294.409375 192.276 
+L 399.034375 192.276 
+L 399.034375 162.8928 
+L 294.409375 162.8928 
 z
-" clip-path="url(#pbaae916470)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.194609 192.276 
-L 503.819609 192.276 
-L 503.819609 162.8928 
-L 399.194609 162.8928 
+    <path d="M 399.034375 192.276 
+L 503.659375 192.276 
+L 503.659375 162.8928 
+L 399.034375 162.8928 
 z
-" clip-path="url(#pbaae916470)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.944609 221.6592 
-L 294.569609 221.6592 
-L 294.569609 192.276 
-L 189.944609 192.276 
+    <path d="M 189.784375 221.6592 
+L 294.409375 221.6592 
+L 294.409375 192.276 
+L 189.784375 192.276 
 z
-" clip-path="url(#pbaae916470)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.569609 221.6592 
-L 399.194609 221.6592 
-L 399.194609 192.276 
-L 294.569609 192.276 
+    <path d="M 294.409375 221.6592 
+L 399.034375 221.6592 
+L 399.034375 192.276 
+L 294.409375 192.276 
 z
-" clip-path="url(#pbaae916470)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.194609 221.6592 
-L 503.819609 221.6592 
-L 503.819609 192.276 
-L 399.194609 192.276 
+    <path d="M 399.034375 221.6592 
+L 503.659375 221.6592 
+L 503.659375 192.276 
+L 399.034375 192.276 
 z
-" clip-path="url(#pbaae916470)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.944609 251.0424 
-L 294.569609 251.0424 
-L 294.569609 221.6592 
-L 189.944609 221.6592 
+    <path d="M 189.784375 251.0424 
+L 294.409375 251.0424 
+L 294.409375 221.6592 
+L 189.784375 221.6592 
 z
-" clip-path="url(#pbaae916470)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.569609 251.0424 
-L 399.194609 251.0424 
-L 399.194609 221.6592 
-L 294.569609 221.6592 
+    <path d="M 294.409375 251.0424 
+L 399.034375 251.0424 
+L 399.034375 221.6592 
+L 294.409375 221.6592 
 z
-" clip-path="url(#pbaae916470)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.194609 251.0424 
-L 503.819609 251.0424 
-L 503.819609 221.6592 
-L 399.194609 221.6592 
+    <path d="M 399.034375 251.0424 
+L 503.659375 251.0424 
+L 503.659375 221.6592 
+L 399.034375 221.6592 
 z
-" clip-path="url(#pbaae916470)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.944609 280.4256 
-L 294.569609 280.4256 
-L 294.569609 251.0424 
-L 189.944609 251.0424 
+    <path d="M 189.784375 280.4256 
+L 294.409375 280.4256 
+L 294.409375 251.0424 
+L 189.784375 251.0424 
 z
-" clip-path="url(#pbaae916470)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.569609 280.4256 
-L 399.194609 280.4256 
-L 399.194609 251.0424 
-L 294.569609 251.0424 
+    <path d="M 294.409375 280.4256 
+L 399.034375 280.4256 
+L 399.034375 251.0424 
+L 294.409375 251.0424 
 z
-" clip-path="url(#pbaae916470)" style="fill: #f99153; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.194609 280.4256 
-L 503.819609 280.4256 
-L 503.819609 251.0424 
-L 399.194609 251.0424 
+    <path d="M 399.034375 280.4256 
+L 503.659375 280.4256 
+L 503.659375 251.0424 
+L 399.034375 251.0424 
 z
-" clip-path="url(#pbaae916470)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.944609 309.8088 
-L 294.569609 309.8088 
-L 294.569609 280.4256 
-L 189.944609 280.4256 
+    <path d="M 189.784375 309.8088 
+L 294.409375 309.8088 
+L 294.409375 280.4256 
+L 189.784375 280.4256 
 z
-" clip-path="url(#pbaae916470)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.569609 309.8088 
-L 399.194609 309.8088 
-L 399.194609 280.4256 
-L 294.569609 280.4256 
+    <path d="M 294.409375 309.8088 
+L 399.034375 309.8088 
+L 399.034375 280.4256 
+L 294.409375 280.4256 
 z
-" clip-path="url(#pbaae916470)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.194609 309.8088 
-L 503.819609 309.8088 
-L 503.819609 280.4256 
-L 399.194609 280.4256 
+    <path d="M 399.034375 309.8088 
+L 503.659375 309.8088 
+L 503.659375 280.4256 
+L 399.034375 280.4256 
 z
-" clip-path="url(#pbaae916470)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.944609 339.192 
-L 294.569609 339.192 
-L 294.569609 309.8088 
-L 189.944609 309.8088 
+    <path d="M 189.784375 339.192 
+L 294.409375 339.192 
+L 294.409375 309.8088 
+L 189.784375 309.8088 
 z
-" clip-path="url(#pbaae916470)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.569609 339.192 
-L 399.194609 339.192 
-L 399.194609 309.8088 
-L 294.569609 309.8088 
+    <path d="M 294.409375 339.192 
+L 399.034375 339.192 
+L 399.034375 309.8088 
+L 294.409375 309.8088 
 z
-" clip-path="url(#pbaae916470)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.194609 339.192 
-L 503.819609 339.192 
-L 503.819609 309.8088 
-L 399.194609 309.8088 
+    <path d="M 399.034375 339.192 
+L 503.659375 339.192 
+L 503.659375 309.8088 
+L 399.034375 309.8088 
 z
-" clip-path="url(#pbaae916470)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p389273d815)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.931875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.771641 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.216094 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.055859 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.788203 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.627969 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(407.139922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.979688 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.869609 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.709375 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(230.805859 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(339.247109 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(339.086875 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(443.872109 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.507734 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.3475 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(230.805859 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(341.792109 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(443.872109 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(130.770859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(130.610625 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(230.805859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(341.792109 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(443.872109 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(101.200859 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(101.040625 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(230.805859 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(341.792109 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(443.872109 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(114.077109 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.916875 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(230.805859 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(341.792109 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(443.872109 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(122.233359 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(122.073125 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(230.805859 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(341.792109 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(446.417109 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(446.256875 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.578984 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.41875 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.298 -->
-    <g transform="translate(229.605234 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.445 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1883,36 +1883,27 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 24 -->
-    <g transform="translate(341.315859 267.9415) scale(0.08 -0.08)">
+    <!-- 27 -->
+    <g transform="translate(341.155625 267.9415) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- 136 -->
-    <g transform="translate(443.157734 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(442.9975 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1998,7 +1989,7 @@ z
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.693984 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.53375 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2063,7 +2054,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(230.805859 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2073,14 +2064,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(341.792109 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(443.872109 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2088,7 +2079,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.915234 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.755 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2099,7 +2090,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(230.805859 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2109,13 +2100,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(344.337109 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.176875 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.507109 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.346875 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2131,7 +2122,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(137.328359 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(137.168125 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2314,7 +2305,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2456,13 +2447,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2502,110 +2493,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pbaae916470">
-   <rect x="85.319609" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p389273d815">
+   <rect x="85.159375" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p1974a3c697)">
+   <g clip-path="url(#p36c68af620)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ7UlEQVR4nO3YwY6kVR2HYbqrpukZZcIAdhwzG90Q48JAQgy34XW4Yss1cAPuXHoBLty4YEECG5YkJJIAmgwYJ0KGseiu7vYiJuf9j1+e5wp+lVOnvre+k5t//+n2pS27fDa9YK2T0+kFa90cpxestfXzO15OL1jr3qvTC9b68en0Ap7H7mx6wVpb/37eOZ9esNTGn34AALxoBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn9p8evpjcsdXZnPz1hqcPxcnrCUg/v/2J6wlJffv/19ISljifX0xOW+vXd16YnLHV8+Xx6wlL/fPqP6QlLXdy9mJ6w1OHsOD1hqZOXnk1PWMobUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAILW/uHcxvWGphz/51fSEpb599tX0hKV+ftj2f6T7r/92esJSZ7vz6QlLXd8cpycstfXz2/znO93259ufPpqesNT54TA9YaltP90BAHjhCFAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFL7l3f3pjcs9eTweHrCUls/v+sHr01PWOrr/3w6PWGpp1eH6QlLvfPgnekJS13eHqcnLPXl919MT1jqN6+/PT1hqY8ffzQ9Yam3frbt8/MGFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACB1cv3he7fTI5a6uZlewPPY+vmd+g8IY7Z+//x+/n87HqcXLLXx0wMA4EUjQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASO0vPv5sesNSu7Pd9ISlvv3sX9MTlvrjH96anrDUB59s+/zefXR/esJSf/7bF9MTlnr/929OT1jqL3//bnrCUr989e70hKWe/PdqesJSv3t4b3rCUt6AAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAqZOr67/eTo9YaXd1OT1hrd3Z9IK1jofpBWvtz6cXrLXbTy9Y6/ZmesFaVxu/fycbfwdzuu37d3Wy7ft353icnrDUxm8fAAAvGgEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBqf3N7M71hqd0PT6YnrPXTN6YXrPXd4+kFa71yMb2A57E/m16w1tbv34NH0wvWOh6mFyx155vPpyestfHnuzegAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKn/AUineMpbWK/WAAAAAElFTkSuQmCC" id="image7be6dd23b1" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9klEQVR4nO3YP45kVx2G4emumnZPWxrGY9HyWE5wgpADZCQLsQ3WQUTKGtgAGSELIHDiwAGSSRw6wvI/pNEAFh6NxkV3dbcXYZ33N1w9zwq+0qlb961zcvufP9/d27Krl9ML1jo5nV6w1u1xesFaWz+/49X0grUuHk0vWOt/L6YX8GPszqYXrLX17+f98+kFS2387QcAwKtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNp/evxqesNSZ/f30xOWOhyvpics9eTh29MTlvry+dfTE5Y6ntxMT1jqFw8eT09Y6vja+fSEpf754pvpCUtdPricnrDU4ew4PWGpk3svpycs5QYUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7S8vLqc3LPXk9XenJyz17OVX0xOWeuuw7f9ID9/85fSEpc5259MTlrq5PU5PWGrr57f5z3e67c+3P31nesJS54fD9ISltv12BwDglSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7V/bXUxvWOrbw9PpCUtt/fxu3ng8PWGpr//76fSEpV5cH6YnLPXBGx9MT1jq6u44PWGpL59/Pj1hqffe/NX0hKU+efq36QlLvf/TbZ+fG1AAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1MnNx7+/mx6x1O3t9AJ+jK2f36n/gDBm68+f38//b8fj9IKlNn56AAC8agQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/eUnn01vWGp3tpuesNSzz/41PWGpP/3u/ekJS/3x79s+v9+883B6wlJ/+ejz6QlL/eG3P5+esNRf//Hd9ISlfvbowfSEpb79/np6wlK/fnIxPWEpN6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDq5Prmw7vpESvtrq+mJ6y1O5tesNbxML1grf359IK1dvvpBWvd3U4vWOt648/fycbvYE63/fxdn2z7+bt/PE5PWGrjTx8AAK8aAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGp/c3ec3rDU7vvn0xPWev3x9IK1vns6vWCtn7w1vWCtbf+83Lt3up9esNbzZ9ML1nr09vSCtY6H6QVL3f/3F9MT1rp4NL1gKTegAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKkfAKcSecnZ7ogIAAAAAElFTkSuQmCC" id="image12e1c1856d" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7edbed4d21" d="M 0 0 
+       <path id="m8c823a0aae" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7edbed4d21" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7edbed4d21" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7edbed4d21" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7edbed4d21" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7edbed4d21" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7edbed4d21" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7edbed4d21" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7edbed4d21" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7edbed4d21" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7edbed4d21" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7edbed4d21" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7edbed4d21" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c823a0aae" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m09565980af" d="M 0 0 
+       <path id="mb6efe2ef25" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m09565980af" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6efe2ef25" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m09565980af" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6efe2ef25" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m09565980af" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6efe2ef25" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m09565980af" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6efe2ef25" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m09565980af" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6efe2ef25" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m09565980af" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6efe2ef25" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m09565980af" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6efe2ef25" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m09565980af" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb6efe2ef25" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,8 +1138,8 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +9 -->
-    <g transform="translate(111.023738 69.553235) scale(0.065 -0.065)">
+    <!-- +11 -->
+    <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1156,43 +1156,28 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -33 -->
+    <!-- -31 -->
     <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
@@ -1230,89 +1215,12 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_23">
-    <!-- -12 -->
-    <g transform="translate(191.061582 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-31" d="M 794 531 
-L 1825 531 
-L 1825 4091 
-L 703 3866 
-L 703 4441 
-L 1819 4666 
-L 2450 4666 
-L 2450 531 
-L 3481 531 
-L 3481 0 
-L 794 0 
-L 794 531 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -44 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -18 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+    <!-- -8 -->
+    <g transform="translate(193.129395 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1355,44 +1263,76 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -44 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -15 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- -18 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_27">
-    <!-- -11 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_28">
-    <!-- -41 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -9 -->
-    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
     <!-- -16 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1430,9 +1370,9 @@ z
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_31">
-    <!-- -60 -->
-    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+   <g id="text_27">
+    <!-- -10 -->
+    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -1457,16 +1397,105 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
+   <g id="text_28">
+    <!-- -39 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_29">
+    <!-- -9 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
+    <!-- -15 -->
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_31">
+    <!-- -52 -->
+    <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
    <g id="text_32">
-    <!-- -36 -->
+    <!-- -35 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
@@ -1499,33 +1528,6 @@ z
    <g id="text_35">
     <!-- -5 -->
     <g transform="translate(193.129395 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
     </g>
@@ -2194,18 +2196,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image5b7cc89f80" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imageee5f537581" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="mcb2c8d09f2" d="M 0 0 
+       <path id="m72e69078bd" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72e69078bd" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2228,7 +2230,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72e69078bd" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2242,7 +2244,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72e69078bd" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2256,7 +2258,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72e69078bd" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2269,7 +2271,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72e69078bd" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2282,7 +2284,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72e69078bd" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2295,7 +2297,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mcb2c8d09f2" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m72e69078bd" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2911,8 +2913,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.380391 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.540625 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3004,13 +3006,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3050,109 +3052,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1974a3c697">
+  <clipPath id="p36c68af620">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m5b7f8f699a" d="M 0 0 
+       <path id="mb0320c9bc4" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5b7f8f699a" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0320c9bc4" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5b7f8f699a" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0320c9bc4" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m5b7f8f699a" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0320c9bc4" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m5b7f8f699a" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0320c9bc4" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m5b7f8f699a" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0320c9bc4" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m5b7f8f699a" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0320c9bc4" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m5b7f8f699a" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb0320c9bc4" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mc2ee42282c" d="M 0 0 
+       <path id="m7fc7328a31" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc2ee42282c" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fc7328a31" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mc2ee42282c" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fc7328a31" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mc2ee42282c" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fc7328a31" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mfea2ffb232" d="M 0 0 
+       <path id="mf29406200d" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mfea2ffb232" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf29406200d" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 123.22342) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 122.942665) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 312.538371) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 312.063858) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m1abd775f1e" d="M -2.5 2.5 
+     <path id="m6a980d8f59" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1264520be9)">
-     <use xlink:href="#m1abd775f1e" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1abd775f1e" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1abd775f1e" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1abd775f1e" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1abd775f1e" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1abd775f1e" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1abd775f1e" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1abd775f1e" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1abd775f1e" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p992d2108cc)">
+     <use xlink:href="#m6a980d8f59" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a980d8f59" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a980d8f59" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a980d8f59" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a980d8f59" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a980d8f59" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a980d8f59" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a980d8f59" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6a980d8f59" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m5169c26881" d="M 0 -2.5 
+     <path id="m7b5e28d8f0" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1264520be9)">
-     <use xlink:href="#m5169c26881" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5169c26881" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5169c26881" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5169c26881" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5169c26881" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5169c26881" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5169c26881" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5169c26881" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5169c26881" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p992d2108cc)">
+     <use xlink:href="#m7b5e28d8f0" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7b5e28d8f0" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7b5e28d8f0" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7b5e28d8f0" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7b5e28d8f0" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7b5e28d8f0" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7b5e28d8f0" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7b5e28d8f0" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7b5e28d8f0" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="me944f5d7e7" d="M -0 3.535534 
+     <path id="meb7478391e" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1264520be9)">
-     <use xlink:href="#me944f5d7e7" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me944f5d7e7" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p992d2108cc)">
+     <use xlink:href="#meb7478391e" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#meb7478391e" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="mccade9820f" d="M -0 2.5 
+     <path id="mb00d7d0063" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1264520be9)">
-     <use xlink:href="#mccade9820f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p992d2108cc)">
+     <use xlink:href="#mb00d7d0063" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m3d9c49e61e" d="M -0.833333 2.5 
+     <path id="m8bcfca8398" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1264520be9)">
-     <use xlink:href="#m3d9c49e61e" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d9c49e61e" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d9c49e61e" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d9c49e61e" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d9c49e61e" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d9c49e61e" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d9c49e61e" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d9c49e61e" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3d9c49e61e" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p992d2108cc)">
+     <use xlink:href="#m8bcfca8398" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bcfca8398" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bcfca8398" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bcfca8398" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bcfca8398" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bcfca8398" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bcfca8398" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bcfca8398" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8bcfca8398" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="mc1c42fe743" d="M -1.25 2.5 
+     <path id="m75bc00daba" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1264520be9)">
-     <use xlink:href="#mc1c42fe743" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc1c42fe743" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc1c42fe743" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc1c42fe743" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc1c42fe743" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc1c42fe743" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc1c42fe743" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc1c42fe743" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mc1c42fe743" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p992d2108cc)">
+     <use xlink:href="#m75bc00daba" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75bc00daba" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75bc00daba" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75bc00daba" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75bc00daba" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75bc00daba" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75bc00daba" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75bc00daba" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m75bc00daba" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mbe4ffeb296" d="M 0 -2.5 
+     <path id="m5d65e4db83" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p1264520be9)">
-     <use xlink:href="#mbe4ffeb296" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbe4ffeb296" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbe4ffeb296" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbe4ffeb296" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbe4ffeb296" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbe4ffeb296" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbe4ffeb296" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbe4ffeb296" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mbe4ffeb296" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p992d2108cc)">
+     <use xlink:href="#m5d65e4db83" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d65e4db83" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d65e4db83" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d65e4db83" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d65e4db83" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d65e4db83" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d65e4db83" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d65e4db83" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m5d65e4db83" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m259be2d04b" d="M 0 -2.5 
+     <path id="m33b92f56e7" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1264520be9)">
-     <use xlink:href="#m259be2d04b" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m259be2d04b" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m259be2d04b" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m259be2d04b" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m259be2d04b" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m259be2d04b" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m259be2d04b" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m259be2d04b" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m259be2d04b" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p992d2108cc)">
+     <use xlink:href="#m33b92f56e7" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33b92f56e7" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33b92f56e7" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33b92f56e7" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33b92f56e7" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33b92f56e7" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33b92f56e7" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33b92f56e7" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m33b92f56e7" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m36486bcaa9" d="M 0 3.5 
+      <path id="m53739538dd" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m36486bcaa9" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m53739538dd" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m1abd775f1e" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6a980d8f59" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m5169c26881" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7b5e28d8f0" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#me944f5d7e7" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#meb7478391e" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#mccade9820f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb00d7d0063" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m3d9c49e61e" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8bcfca8398" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#mc1c42fe743" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m75bc00daba" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mbe4ffeb296" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m5d65e4db83" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m259be2d04b" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m33b92f56e7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p1264520be9)">
-     <use xlink:href="#m36486bcaa9" x="319.643112" y="128.22342" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36486bcaa9" x="269.129958" y="143.747411" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36486bcaa9" x="247.452898" y="148.738527" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36486bcaa9" x="199.905291" y="164.022524" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36486bcaa9" x="190.316224" y="177.266549" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36486bcaa9" x="165.455859" y="188.087183" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36486bcaa9" x="159.141659" y="197.334556" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36486bcaa9" x="158.180344" y="201.58708" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36486bcaa9" x="120.106777" y="290.168877" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m36486bcaa9" x="97.799363" y="317.538371" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p992d2108cc)">
+     <use xlink:href="#m53739538dd" x="319.643112" y="127.942665" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m53739538dd" x="269.129958" y="143.706845" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m53739538dd" x="247.452898" y="148.721195" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m53739538dd" x="199.905291" y="164.114094" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m53739538dd" x="190.316224" y="176.561855" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m53739538dd" x="165.455859" y="186.277651" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m53739538dd" x="159.141659" y="195.694594" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m53739538dd" x="158.180344" y="200.062716" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m53739538dd" x="120.106777" y="289.878699" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m53739538dd" x="97.799363" y="317.063858" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 128.22342 
-L 318.590755 128.596692 
-L 317.538397 128.967408 
-L 316.48604 129.335602 
-L 315.433682 129.701309 
-L 314.381325 130.064561 
-L 313.328968 130.425392 
-L 312.27661 130.783834 
-L 311.224253 131.139918 
-L 310.171896 131.493675 
-L 309.119538 131.845135 
-L 308.067181 132.194328 
-L 307.014823 132.541283 
-L 305.962466 132.886028 
-L 304.910109 133.228591 
-L 303.857751 133.569 
-L 302.805394 133.907282 
-L 301.753037 134.243463 
-L 300.700679 134.577569 
-L 299.648322 134.909625 
-L 298.595965 135.239657 
-L 297.543607 135.567689 
-L 296.49125 135.893745 
-L 295.438892 136.217849 
-L 294.386535 136.540023 
-L 293.334178 136.860292 
-L 292.28182 137.178677 
-L 291.229463 137.4952 
-L 290.177106 137.809883 
-L 289.124748 138.122748 
-L 288.072391 138.433814 
-L 287.020033 138.743103 
-L 285.967676 139.050635 
-L 284.915319 139.35643 
-L 283.862961 139.660507 
-L 282.810604 139.962885 
-L 281.758247 140.263584 
-L 280.705889 140.562621 
-L 279.653532 140.860016 
-L 278.601175 141.155785 
-L 277.548817 141.449947 
-L 276.49646 141.74252 
-L 275.444102 142.033519 
-L 274.391745 142.322963 
-L 273.339388 142.610867 
-L 272.28703 142.897248 
-L 271.234673 143.182122 
-L 270.182316 143.465504 
-L 269.129958 143.747411 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 127.942665 
+L 318.590755 128.322571 
+L 317.538397 128.69983 
+L 316.48604 129.074478 
+L 315.433682 129.44655 
+L 314.381325 129.816083 
+L 313.328968 130.18311 
+L 312.27661 130.547665 
+L 311.224253 130.909782 
+L 310.171896 131.269492 
+L 309.119538 131.626828 
+L 308.067181 131.98182 
+L 307.014823 132.334499 
+L 305.962466 132.684896 
+L 304.910109 133.033039 
+L 303.857751 133.378957 
+L 302.805394 133.722678 
+L 301.753037 134.064231 
+L 300.700679 134.403642 
+L 299.648322 134.740939 
+L 298.595965 135.076146 
+L 297.543607 135.409291 
+L 296.49125 135.740398 
+L 295.438892 136.069491 
+L 294.386535 136.396597 
+L 293.334178 136.721737 
+L 292.28182 137.044936 
+L 291.229463 137.366217 
+L 290.177106 137.685602 
+L 289.124748 138.003114 
+L 288.072391 138.318774 
+L 287.020033 138.632604 
+L 285.967676 138.944626 
+L 284.915319 139.254859 
+L 283.862961 139.563324 
+L 282.810604 139.870041 
+L 281.758247 140.17503 
+L 280.705889 140.478311 
+L 279.653532 140.779901 
+L 278.601175 141.079821 
+L 277.548817 141.378088 
+L 276.49646 141.674721 
+L 275.444102 141.969737 
+L 274.391745 142.263154 
+L 273.339388 142.554988 
+L 272.28703 142.845259 
+L 271.234673 143.13398 
+L 270.182316 143.42117 
+L 269.129958 143.706845 
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 143.747411 
-L 268.678353 143.856228 
-L 268.226747 143.964826 
-L 267.775142 144.073207 
-L 267.323537 144.181372 
-L 266.871931 144.28932 
-L 266.420326 144.397054 
-L 265.96872 144.504574 
-L 265.517115 144.611881 
-L 265.065509 144.718975 
-L 264.613904 144.825858 
-L 264.162299 144.93253 
-L 263.710693 145.038993 
-L 263.259088 145.145246 
-L 262.807482 145.251292 
-L 262.355877 145.35713 
-L 261.904271 145.462761 
-L 261.452666 145.568187 
-L 261.001061 145.673408 
-L 260.549455 145.778425 
-L 260.09785 145.883238 
-L 259.646244 145.987849 
-L 259.194639 146.092258 
-L 258.743034 146.196466 
-L 258.291428 146.300474 
-L 257.839823 146.404282 
-L 257.388217 146.507892 
-L 256.936612 146.611303 
-L 256.485006 146.714518 
-L 256.033401 146.817536 
-L 255.581796 146.920359 
-L 255.13019 147.022986 
-L 254.678585 147.125419 
-L 254.226979 147.227659 
-L 253.775374 147.329706 
-L 253.323769 147.431561 
-L 252.872163 147.533225 
-L 252.420558 147.634698 
-L 251.968952 147.735982 
-L 251.517347 147.837076 
-L 251.065741 147.937982 
-L 250.614136 148.0387 
-L 250.162531 148.139231 
-L 249.710925 148.239575 
-L 249.25932 148.339734 
-L 248.807714 148.439708 
-L 248.356109 148.539498 
-L 247.904503 148.639104 
-L 247.452898 148.738527 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 143.706845 
+L 268.678353 143.816191 
+L 268.226747 143.925317 
+L 267.775142 144.034224 
+L 267.323537 144.142912 
+L 266.871931 144.251382 
+L 266.420326 144.359635 
+L 265.96872 144.467672 
+L 265.517115 144.575494 
+L 265.065509 144.683102 
+L 264.613904 144.790496 
+L 264.162299 144.897677 
+L 263.710693 145.004647 
+L 263.259088 145.111405 
+L 262.807482 145.217954 
+L 262.355877 145.324293 
+L 261.904271 145.430424 
+L 261.452666 145.536347 
+L 261.001061 145.642063 
+L 260.549455 145.747573 
+L 260.09785 145.852878 
+L 259.646244 145.957979 
+L 259.194639 146.062875 
+L 258.743034 146.167569 
+L 258.291428 146.272061 
+L 257.839823 146.376352 
+L 257.388217 146.480441 
+L 256.936612 146.584332 
+L 256.485006 146.688023 
+L 256.033401 146.791516 
+L 255.581796 146.894811 
+L 255.13019 146.99791 
+L 254.678585 147.100812 
+L 254.226979 147.20352 
+L 253.775374 147.306033 
+L 253.323769 147.408352 
+L 252.872163 147.510478 
+L 252.420558 147.612412 
+L 251.968952 147.714154 
+L 251.517347 147.815705 
+L 251.065741 147.917067 
+L 250.614136 148.018238 
+L 250.162531 148.119221 
+L 249.710925 148.220016 
+L 249.25932 148.320624 
+L 248.807714 148.421045 
+L 248.356109 148.52128 
+L 247.904503 148.62133 
+L 247.452898 148.721195 
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 148.738527 
-L 246.462323 149.105198 
-L 245.471748 149.469403 
-L 244.481173 149.831173 
-L 243.490597 150.190542 
-L 242.500022 150.547541 
-L 241.509447 150.902201 
-L 240.518872 151.254552 
-L 239.528297 151.604624 
-L 238.537722 151.952447 
-L 237.547147 152.29805 
-L 236.556571 152.64146 
-L 235.565996 152.982704 
-L 234.575421 153.321812 
-L 233.584846 153.658808 
-L 232.594271 153.993719 
-L 231.603696 154.326571 
-L 230.613121 154.657388 
-L 229.622545 154.986196 
-L 228.63197 155.313019 
-L 227.641395 155.63788 
-L 226.65082 155.960804 
-L 225.660245 156.281812 
-L 224.66967 156.600928 
-L 223.679095 156.918174 
-L 222.688519 157.233571 
-L 221.697944 157.547142 
-L 220.707369 157.858906 
-L 219.716794 158.168885 
-L 218.726219 158.477099 
-L 217.735644 158.783568 
-L 216.745069 159.088312 
-L 215.754493 159.391349 
-L 214.763918 159.6927 
-L 213.773343 159.992382 
-L 212.782768 160.290415 
-L 211.792193 160.586815 
-L 210.801618 160.881601 
-L 209.811043 161.174791 
-L 208.820467 161.466401 
-L 207.829892 161.756449 
-L 206.839317 162.044951 
-L 205.848742 162.331923 
-L 204.858167 162.617382 
-L 203.867592 162.901344 
-L 202.877017 163.183823 
-L 201.886441 163.464836 
-L 200.895866 163.744398 
-L 199.905291 164.022524 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 148.721195 
+L 246.462323 149.090858 
+L 245.471748 149.458014 
+L 244.481173 149.822696 
+L 243.490597 150.184938 
+L 242.500022 150.544772 
+L 241.509447 150.90223 
+L 240.518872 151.257343 
+L 239.528297 151.610141 
+L 238.537722 151.960655 
+L 237.547147 152.308914 
+L 236.556571 152.654946 
+L 235.565996 152.998781 
+L 234.575421 153.340445 
+L 233.584846 153.679966 
+L 232.594271 154.017371 
+L 231.603696 154.352686 
+L 230.613121 154.685937 
+L 229.622545 155.017149 
+L 228.63197 155.346346 
+L 227.641395 155.673554 
+L 226.65082 155.998795 
+L 225.660245 156.322094 
+L 224.66967 156.643474 
+L 223.679095 156.962956 
+L 222.688519 157.280565 
+L 221.697944 157.59632 
+L 220.707369 157.910244 
+L 219.716794 158.222359 
+L 218.726219 158.532684 
+L 217.735644 158.84124 
+L 216.745069 159.148047 
+L 215.754493 159.453125 
+L 214.763918 159.756494 
+L 213.773343 160.058171 
+L 212.782768 160.358177 
+L 211.792193 160.656529 
+L 210.801618 160.953246 
+L 209.811043 161.248345 
+L 208.820467 161.541844 
+L 207.829892 161.833761 
+L 206.839317 162.124111 
+L 205.848742 162.412913 
+L 204.858167 162.700182 
+L 203.867592 162.985934 
+L 202.877017 163.270186 
+L 201.886441 163.552953 
+L 200.895866 163.83425 
+L 199.905291 164.114094 
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 199.905291 164.022524 
-L 199.705519 164.334225 
-L 199.505747 164.644142 
-L 199.305974 164.952295 
-L 199.106202 165.258703 
-L 198.90643 165.563387 
-L 198.706658 165.866365 
-L 198.506885 166.167657 
-L 198.307113 166.467281 
-L 198.107341 166.765256 
-L 197.907569 167.0616 
-L 197.707797 167.35633 
-L 197.508024 167.649464 
-L 197.308252 167.941019 
-L 197.10848 168.231012 
-L 196.908708 168.51946 
-L 196.708935 168.806379 
-L 196.509163 169.091786 
-L 196.309391 169.375695 
-L 196.109619 169.658123 
-L 195.909846 169.939085 
-L 195.710074 170.218597 
-L 195.510302 170.496672 
-L 195.31053 170.773326 
-L 195.110758 171.048574 
-L 194.910985 171.322429 
-L 194.711213 171.594906 
-L 194.511441 171.866018 
-L 194.311669 172.135778 
-L 194.111896 172.404202 
-L 193.912124 172.6713 
-L 193.712352 172.937088 
-L 193.51258 173.201576 
-L 193.312807 173.464779 
-L 193.113035 173.726708 
-L 192.913263 173.987375 
-L 192.713491 174.246794 
-L 192.513719 174.504975 
-L 192.313946 174.76193 
-L 192.114174 175.017672 
-L 191.914402 175.272211 
-L 191.71463 175.525559 
-L 191.514857 175.777726 
-L 191.315085 176.028724 
-L 191.115313 176.278564 
-L 190.915541 176.527256 
-L 190.715768 176.774811 
-L 190.515996 177.021238 
-L 190.316224 177.266549 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.905291 164.114094 
+L 199.705519 164.40488 
+L 199.505747 164.694112 
+L 199.305974 164.981807 
+L 199.106202 165.267982 
+L 198.90643 165.552651 
+L 198.706658 165.835831 
+L 198.506885 166.117537 
+L 198.307113 166.397785 
+L 198.107341 166.67659 
+L 197.907569 166.953965 
+L 197.707797 167.229927 
+L 197.508024 167.504489 
+L 197.308252 167.777666 
+L 197.10848 168.04947 
+L 196.908708 168.319917 
+L 196.708935 168.589019 
+L 196.509163 168.85679 
+L 196.309391 169.123243 
+L 196.109619 169.388391 
+L 195.909846 169.652247 
+L 195.710074 169.914822 
+L 195.510302 170.17613 
+L 195.31053 170.436183 
+L 195.110758 170.694992 
+L 194.910985 170.95257 
+L 194.711213 171.208928 
+L 194.511441 171.464078 
+L 194.311669 171.71803 
+L 194.111896 171.970797 
+L 193.912124 172.222389 
+L 193.712352 172.472817 
+L 193.51258 172.722092 
+L 193.312807 172.970224 
+L 193.113035 173.217224 
+L 192.913263 173.463102 
+L 192.713491 173.707868 
+L 192.513719 173.951532 
+L 192.313946 174.194105 
+L 192.114174 174.435595 
+L 191.914402 174.676013 
+L 191.71463 174.915368 
+L 191.514857 175.153669 
+L 191.315085 175.390925 
+L 191.115313 175.627146 
+L 190.915541 175.862341 
+L 190.715768 176.096518 
+L 190.515996 176.329687 
+L 190.316224 176.561855 
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 190.316224 177.266549 
-L 189.7983 177.515516 
-L 189.280375 177.763344 
-L 188.762451 178.010041 
-L 188.244527 178.25562 
-L 187.726603 178.50009 
-L 187.208678 178.74346 
-L 186.690754 178.985741 
-L 186.17283 179.226943 
-L 185.654906 179.467075 
-L 185.136981 179.706146 
-L 184.619057 179.944166 
-L 184.101133 180.181143 
-L 183.583208 180.417088 
-L 183.065284 180.652009 
-L 182.54736 180.885915 
-L 182.029436 181.118815 
-L 181.511511 181.350716 
-L 180.993587 181.581629 
-L 180.475663 181.81156 
-L 179.957739 182.040519 
-L 179.439814 182.268514 
-L 178.92189 182.495553 
-L 178.403966 182.721643 
-L 177.886041 182.946793 
-L 177.368117 183.17101 
-L 176.850193 183.394302 
-L 176.332269 183.616677 
-L 175.814344 183.838142 
-L 175.29642 184.058705 
-L 174.778496 184.278373 
-L 174.260572 184.497153 
-L 173.742647 184.715052 
-L 173.224723 184.932078 
-L 172.706799 185.148237 
-L 172.188874 185.363536 
-L 171.67095 185.577982 
-L 171.153026 185.791583 
-L 170.635102 186.004343 
-L 170.117177 186.216271 
-L 169.599253 186.427372 
-L 169.081329 186.637653 
-L 168.563404 186.84712 
-L 168.04548 187.05578 
-L 167.527556 187.263639 
-L 167.009632 187.470703 
-L 166.491707 187.676977 
-L 165.973783 187.882469 
-L 165.455859 188.087183 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 190.316224 176.561855 
+L 189.7983 176.783117 
+L 189.280375 177.003479 
+L 188.762451 177.222947 
+L 188.244527 177.441528 
+L 187.726603 177.659231 
+L 187.208678 177.876061 
+L 186.690754 178.092027 
+L 186.17283 178.307134 
+L 185.654906 178.52139 
+L 185.136981 178.734801 
+L 184.619057 178.947374 
+L 184.101133 179.159116 
+L 183.583208 179.370032 
+L 183.065284 179.58013 
+L 182.54736 179.789416 
+L 182.029436 179.997895 
+L 181.511511 180.205575 
+L 180.993587 180.412461 
+L 180.475663 180.61856 
+L 179.957739 180.823876 
+L 179.439814 181.028417 
+L 178.92189 181.232188 
+L 178.403966 181.435194 
+L 177.886041 181.637442 
+L 177.368117 181.838938 
+L 176.850193 182.039686 
+L 176.332269 182.239692 
+L 175.814344 182.438962 
+L 175.29642 182.637501 
+L 174.778496 182.835315 
+L 174.260572 183.032408 
+L 173.742647 183.228786 
+L 173.224723 183.424455 
+L 172.706799 183.619419 
+L 172.188874 183.813683 
+L 171.67095 184.007252 
+L 171.153026 184.200132 
+L 170.635102 184.392327 
+L 170.117177 184.583842 
+L 169.599253 184.774681 
+L 169.081329 184.964851 
+L 168.563404 185.154354 
+L 168.04548 185.343197 
+L 167.527556 185.531382 
+L 167.009632 185.718916 
+L 166.491707 185.905803 
+L 165.973783 186.092046 
+L 165.455859 186.277651 
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 165.455859 188.087183 
-L 165.324313 188.296864 
-L 165.192767 188.505736 
-L 165.061221 188.713806 
-L 164.929675 188.921078 
-L 164.79813 189.12756 
-L 164.666584 189.333257 
-L 164.535038 189.538176 
-L 164.403492 189.742322 
-L 164.271946 189.945701 
-L 164.1404 190.148318 
-L 164.008855 190.35018 
-L 163.877309 190.551292 
-L 163.745763 190.75166 
-L 163.614217 190.951288 
-L 163.482671 191.150183 
-L 163.351125 191.34835 
-L 163.21958 191.545794 
-L 163.088034 191.742521 
-L 162.956488 191.938535 
-L 162.824942 192.133842 
-L 162.693396 192.328447 
-L 162.56185 192.522355 
-L 162.430305 192.715571 
-L 162.298759 192.908099 
-L 162.167213 193.099945 
-L 162.035667 193.291114 
-L 161.904121 193.481609 
-L 161.772575 193.671437 
-L 161.64103 193.860602 
-L 161.509484 194.049107 
-L 161.377938 194.236959 
-L 161.246392 194.424161 
-L 161.114846 194.610717 
-L 160.9833 194.796633 
-L 160.851754 194.981913 
-L 160.720209 195.16656 
-L 160.588663 195.35058 
-L 160.457117 195.533977 
-L 160.325571 195.716754 
-L 160.194025 195.898916 
-L 160.062479 196.080467 
-L 159.930934 196.261411 
-L 159.799388 196.441753 
-L 159.667842 196.621495 
-L 159.536296 196.800643 
-L 159.40475 196.9792 
-L 159.273204 197.15717 
-L 159.141659 197.334556 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.455859 186.277651 
+L 165.324313 186.491513 
+L 165.192767 186.704534 
+L 165.061221 186.91672 
+L 164.929675 187.128077 
+L 164.79813 187.338612 
+L 164.666584 187.548331 
+L 164.535038 187.757241 
+L 164.403492 187.965348 
+L 164.271946 188.172658 
+L 164.1404 188.379177 
+L 164.008855 188.584911 
+L 163.877309 188.789866 
+L 163.745763 188.994048 
+L 163.614217 189.197463 
+L 163.482671 189.400116 
+L 163.351125 189.602013 
+L 163.21958 189.80316 
+L 163.088034 190.003563 
+L 162.956488 190.203226 
+L 162.824942 190.402155 
+L 162.693396 190.600356 
+L 162.56185 190.797835 
+L 162.430305 190.994595 
+L 162.298759 191.190642 
+L 162.167213 191.385982 
+L 162.035667 191.58062 
+L 161.904121 191.774561 
+L 161.772575 191.967809 
+L 161.64103 192.160369 
+L 161.509484 192.352247 
+L 161.377938 192.543448 
+L 161.246392 192.733975 
+L 161.114846 192.923834 
+L 160.9833 193.11303 
+L 160.851754 193.301566 
+L 160.720209 193.489448 
+L 160.588663 193.676681 
+L 160.457117 193.863267 
+L 160.325571 194.049213 
+L 160.194025 194.234523 
+L 160.062479 194.4192 
+L 159.930934 194.603249 
+L 159.799388 194.786675 
+L 159.667842 194.969481 
+L 159.536296 195.151672 
+L 159.40475 195.333252 
+L 159.273204 195.514225 
+L 159.141659 195.694594 
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 159.141659 197.334556 
-L 159.121631 197.426645 
-L 159.101604 197.518577 
-L 159.081576 197.610354 
-L 159.061549 197.701975 
-L 159.041522 197.793441 
-L 159.021494 197.884753 
-L 159.001467 197.975912 
-L 158.98144 198.066917 
-L 158.961412 198.157769 
-L 158.941385 198.248469 
-L 158.921357 198.339018 
-L 158.90133 198.429415 
-L 158.881303 198.519661 
-L 158.861275 198.609757 
-L 158.841248 198.699704 
-L 158.82122 198.789501 
-L 158.801193 198.87915 
-L 158.781166 198.96865 
-L 158.761138 199.058003 
-L 158.741111 199.147208 
-L 158.721084 199.236267 
-L 158.701056 199.325179 
-L 158.681029 199.413946 
-L 158.661001 199.502567 
-L 158.640974 199.591043 
-L 158.620947 199.679375 
-L 158.600919 199.767563 
-L 158.580892 199.855608 
-L 158.560865 199.943509 
-L 158.540837 200.031269 
-L 158.52081 200.118886 
-L 158.500782 200.206361 
-L 158.480755 200.293696 
-L 158.460728 200.380889 
-L 158.4407 200.467943 
-L 158.420673 200.554856 
-L 158.400645 200.641631 
-L 158.380618 200.728266 
-L 158.360591 200.814763 
-L 158.340563 200.901122 
-L 158.320536 200.987344 
-L 158.300509 201.073428 
-L 158.280481 201.159376 
-L 158.260454 201.245188 
-L 158.240426 201.330863 
-L 158.220399 201.416404 
-L 158.200372 201.501809 
-L 158.180344 201.58708 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.141659 195.694594 
+L 159.121631 195.789286 
+L 159.101604 195.883813 
+L 159.081576 195.978175 
+L 159.061549 196.072373 
+L 159.041522 196.166407 
+L 159.021494 196.260278 
+L 159.001467 196.353987 
+L 158.98144 196.447534 
+L 158.961412 196.540919 
+L 158.941385 196.634143 
+L 158.921357 196.727208 
+L 158.90133 196.820112 
+L 158.881303 196.912857 
+L 158.861275 197.005444 
+L 158.841248 197.097873 
+L 158.82122 197.190144 
+L 158.801193 197.282258 
+L 158.781166 197.374215 
+L 158.761138 197.466017 
+L 158.741111 197.557663 
+L 158.721084 197.649154 
+L 158.701056 197.740491 
+L 158.681029 197.831674 
+L 158.661001 197.922704 
+L 158.640974 198.013581 
+L 158.620947 198.104305 
+L 158.600919 198.194878 
+L 158.580892 198.285299 
+L 158.560865 198.37557 
+L 158.540837 198.46569 
+L 158.52081 198.555661 
+L 158.500782 198.645482 
+L 158.480755 198.735155 
+L 158.460728 198.824679 
+L 158.4407 198.914055 
+L 158.420673 199.003284 
+L 158.400645 199.092367 
+L 158.380618 199.181303 
+L 158.360591 199.270093 
+L 158.340563 199.358737 
+L 158.320536 199.447237 
+L 158.300509 199.535592 
+L 158.280481 199.623803 
+L 158.260454 199.711871 
+L 158.240426 199.799796 
+L 158.220399 199.887578 
+L 158.200372 199.975218 
+L 158.180344 200.062716 
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 158.180344 201.58708 
-L 157.387145 206.06209 
-L 156.593946 210.195234 
-L 155.800746 214.03506 
-L 155.007547 217.620454 
-L 154.214348 220.98305 
-L 153.421148 224.148925 
-L 152.627949 227.139828 
-L 151.83475 229.974093 
-L 151.04155 232.667313 
-L 150.248351 235.232863 
-L 149.455152 237.6823 
-L 148.661952 240.025683 
-L 147.868753 242.271814 
-L 147.075554 244.428445 
-L 146.282354 246.502436 
-L 145.489155 248.499888 
-L 144.695956 250.426249 
-L 143.902756 252.286406 
-L 143.109557 254.084758 
-L 142.316358 255.825282 
-L 141.523159 257.511581 
-L 140.729959 259.146931 
-L 139.93676 260.734321 
-L 139.143561 262.276484 
-L 138.350361 263.775926 
-L 137.557162 265.234951 
-L 136.763963 266.65568 
-L 135.970763 268.040072 
-L 135.177564 269.389939 
-L 134.384365 270.706963 
-L 133.591165 271.992702 
-L 132.797966 273.24861 
-L 132.004767 274.476039 
-L 131.211567 275.676251 
-L 130.418368 276.850429 
-L 129.625169 277.999676 
-L 128.831969 279.125031 
-L 128.03877 280.227466 
-L 127.245571 281.307896 
-L 126.452371 282.367183 
-L 125.659172 283.406138 
-L 124.865973 284.425527 
-L 124.072774 285.426074 
-L 123.279574 286.408461 
-L 122.486375 287.373338 
-L 121.693176 288.321316 
-L 120.899976 289.252978 
-L 120.106777 290.168877 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.180344 200.062716 
+L 157.387145 204.660581 
+L 156.593946 208.898299 
+L 155.800746 212.828214 
+L 155.007547 216.492028 
+L 154.214348 219.923503 
+L 153.421148 223.150357 
+L 152.627949 226.195628 
+L 151.83475 229.078666 
+L 151.04155 231.815887 
+L 150.248351 234.421333 
+L 149.455152 236.907111 
+L 148.661952 239.283734 
+L 147.868753 241.560385 
+L 147.075554 243.745137 
+L 146.282354 245.845122 
+L 145.489155 247.866673 
+L 144.695956 249.815438 
+L 143.902756 251.696477 
+L 143.109557 253.514341 
+L 142.316358 255.273134 
+L 141.523159 256.976575 
+L 140.729959 258.628043 
+L 139.93676 260.230615 
+L 139.143561 261.787103 
+L 138.350361 263.300084 
+L 137.557162 264.771924 
+L 136.763963 266.204802 
+L 135.970763 267.600727 
+L 135.177564 268.961557 
+L 134.384365 270.289014 
+L 133.591165 271.584695 
+L 132.797966 272.850087 
+L 132.004767 274.086573 
+L 131.211567 275.295444 
+L 130.418368 276.477907 
+L 129.625169 277.635091 
+L 128.831969 278.768055 
+L 128.03877 279.877791 
+L 127.245571 280.965232 
+L 126.452371 282.031258 
+L 125.659172 283.076695 
+L 124.865973 284.102323 
+L 124.072774 285.10888 
+L 123.279574 286.097061 
+L 122.486375 287.067525 
+L 121.693176 288.020897 
+L 120.899976 288.957768 
+L 120.106777 289.878699 
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 120.106777 290.168877 
-L 119.642039 290.905888 
-L 119.177301 291.633 
-L 118.712564 292.350475 
-L 118.247826 293.058564 
-L 117.783088 293.75751 
-L 117.31835 294.447546 
-L 116.853612 295.128896 
-L 116.388875 295.801777 
-L 115.924137 296.466396 
-L 115.459399 297.122954 
-L 114.994661 297.771644 
-L 114.529924 298.412652 
-L 114.065186 299.046158 
-L 113.600448 299.672336 
-L 113.13571 300.291353 
-L 112.670972 300.903371 
-L 112.206235 301.508547 
-L 111.741497 302.107032 
-L 111.276759 302.698973 
-L 110.812021 303.28451 
-L 110.347283 303.863781 
-L 109.882546 304.436919 
-L 109.417808 305.004052 
-L 108.95307 305.565305 
-L 108.488332 306.120798 
-L 108.023595 306.670648 
-L 107.558857 307.21497 
-L 107.094119 307.753872 
-L 106.629381 308.287463 
-L 106.164643 308.815844 
-L 105.699906 309.339118 
-L 105.235168 309.857382 
-L 104.77043 310.370731 
-L 104.305692 310.879258 
-L 103.840955 311.383051 
-L 103.376217 311.882199 
-L 102.911479 312.376787 
-L 102.446741 312.866896 
-L 101.982003 313.352608 
-L 101.517266 313.834 
-L 101.052528 314.311149 
-L 100.58779 314.784128 
-L 100.123052 315.253011 
-L 99.658315 315.717867 
-L 99.193577 316.178765 
-L 98.728839 316.635772 
-L 98.264101 317.088953 
-L 97.799363 317.538371 
-" clip-path="url(#p1264520be9)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 120.106777 289.878699 
+L 119.642039 290.609441 
+L 119.177301 291.330448 
+L 118.712564 292.041979 
+L 118.247826 292.744277 
+L 117.783088 293.437581 
+L 117.31835 294.122117 
+L 116.853612 294.798105 
+L 116.388875 295.465755 
+L 115.924137 296.12527 
+L 115.459399 296.776847 
+L 114.994661 297.420674 
+L 114.529924 298.056933 
+L 114.065186 298.6858 
+L 113.600448 299.307446 
+L 113.13571 299.922033 
+L 112.670972 300.529721 
+L 112.206235 301.130663 
+L 111.741497 301.725006 
+L 111.276759 302.312894 
+L 110.812021 302.894467 
+L 110.347283 303.469857 
+L 109.882546 304.039196 
+L 109.417808 304.602608 
+L 108.95307 305.160217 
+L 108.488332 305.71214 
+L 108.023595 306.258493 
+L 107.558857 306.799386 
+L 107.094119 307.334928 
+L 106.629381 307.865224 
+L 106.164643 308.390375 
+L 105.699906 308.91048 
+L 105.235168 309.425635 
+L 104.77043 309.935934 
+L 104.305692 310.441467 
+L 103.840955 310.942323 
+L 103.376217 311.438587 
+L 102.911479 311.930342 
+L 102.446741 312.417671 
+L 101.982003 312.900651 
+L 101.517266 313.37936 
+L 101.052528 313.853872 
+L 100.58779 314.324261 
+L 100.123052 314.790598 
+L 99.658315 315.252952 
+L 99.193577 315.71139 
+L 98.728839 316.165977 
+L 98.264101 316.61678 
+L 97.799363 317.063858 
+" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.380391 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.540625 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6201,6 +6201,31 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6331,13 +6356,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6377,109 +6402,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1264520be9">
+  <clipPath id="p992d2108cc">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m10ddb3791a" d="M 0 0 
+       <path id="mc1c44ca963" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m10ddb3791a" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc1c44ca963" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m10ddb3791a" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc1c44ca963" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m10ddb3791a" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc1c44ca963" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m10ddb3791a" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc1c44ca963" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m10ddb3791a" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc1c44ca963" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m10ddb3791a" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc1c44ca963" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m10ddb3791a" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc1c44ca963" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.82245 
 L 637.2 391.82245 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mf1276d5b6b" d="M 0 0 
+       <path id="m3885937e1e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mf1276d5b6b" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3885937e1e" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 265.911133 
 L 637.2 265.911133 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf1276d5b6b" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3885937e1e" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 265.911133
      <g id="line2d_19">
       <path d="M 49.078125 139.999816 
 L 637.2 139.999816 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf1276d5b6b" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3885937e1e" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.999816
      <g id="line2d_21">
       <path d="M 49.078125 411.32636 
 L 637.2 411.32636 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="me0aeefcdb5" d="M 0 0 
+       <path id="m585014357a" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 404.024518 
 L 637.2 404.024518 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 404.024518
      <g id="line2d_25">
       <path d="M 49.078125 397.583836 
 L 637.2 397.583836 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.583836
      <g id="line2d_27">
       <path d="M 49.078125 353.919367 
 L 637.2 353.919367 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 353.919367
      <g id="line2d_29">
       <path d="M 49.078125 331.747485 
 L 637.2 331.747485 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 331.747485
      <g id="line2d_31">
       <path d="M 49.078125 316.016284 
 L 637.2 316.016284 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 316.016284
      <g id="line2d_33">
       <path d="M 49.078125 303.814216 
 L 637.2 303.814216 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 303.814216
      <g id="line2d_35">
       <path d="M 49.078125 293.844402 
 L 637.2 293.844402 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 293.844402
      <g id="line2d_37">
       <path d="M 49.078125 285.415043 
 L 637.2 285.415043 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 285.415043
      <g id="line2d_39">
       <path d="M 49.078125 278.113201 
 L 637.2 278.113201 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 278.113201
      <g id="line2d_41">
       <path d="M 49.078125 271.672519 
 L 637.2 271.672519 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 271.672519
      <g id="line2d_43">
       <path d="M 49.078125 228.00805 
 L 637.2 228.00805 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 228.00805
      <g id="line2d_45">
       <path d="M 49.078125 205.836168 
 L 637.2 205.836168 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 205.836168
      <g id="line2d_47">
       <path d="M 49.078125 190.104967 
 L 637.2 190.104967 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 190.104967
      <g id="line2d_49">
       <path d="M 49.078125 177.9029 
 L 637.2 177.9029 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.9029
      <g id="line2d_51">
       <path d="M 49.078125 167.933085 
 L 637.2 167.933085 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.933085
      <g id="line2d_53">
       <path d="M 49.078125 159.503726 
 L 637.2 159.503726 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.503726
      <g id="line2d_55">
       <path d="M 49.078125 152.201884 
 L 637.2 152.201884 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 152.201884
      <g id="line2d_57">
       <path d="M 49.078125 145.761202 
 L 637.2 145.761202 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.761202
      <g id="line2d_59">
       <path d="M 49.078125 102.096733 
 L 637.2 102.096733 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.096733
      <g id="line2d_61">
       <path d="M 49.078125 79.924851 
 L 637.2 79.924851 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 79.924851
      <g id="line2d_63">
       <path d="M 49.078125 64.19365 
 L 637.2 64.19365 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.19365
      <g id="line2d_65">
       <path d="M 49.078125 51.991583 
 L 637.2 51.991583 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#me0aeefcdb5" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m585014357a" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p53de07b09c)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pd08b8f9436)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m18bdc1f6e2" d="M -2.5 2.5 
+     <path id="m7e46a9d22c" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p53de07b09c)">
-     <use xlink:href="#m18bdc1f6e2" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m18bdc1f6e2" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd08b8f9436)">
+     <use xlink:href="#m7e46a9d22c" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7e46a9d22c" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m4374a419a2" d="M 0 -2.5 
+     <path id="m2ae54ac107" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p53de07b09c)">
-     <use xlink:href="#m4374a419a2" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4374a419a2" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd08b8f9436)">
+     <use xlink:href="#m2ae54ac107" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2ae54ac107" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m0f37c0f409" d="M -0 3.535534 
+     <path id="m2149ef188d" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p53de07b09c)">
-     <use xlink:href="#m0f37c0f409" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m0f37c0f409" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd08b8f9436)">
+     <use xlink:href="#m2149ef188d" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2149ef188d" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="m5b9c5fa09c" d="M -0.833333 2.5 
+     <path id="me4b4210f6e" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p53de07b09c)">
-     <use xlink:href="#m5b9c5fa09c" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5b9c5fa09c" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd08b8f9436)">
+     <use xlink:href="#me4b4210f6e" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#me4b4210f6e" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m5909457a59" d="M -1.25 2.5 
+     <path id="m55fba3781e" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p53de07b09c)">
-     <use xlink:href="#m5909457a59" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5909457a59" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd08b8f9436)">
+     <use xlink:href="#m55fba3781e" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m55fba3781e" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m7f17f7ef48" d="M 0 -2.5 
+     <path id="m8e9c232bb0" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p53de07b09c)">
-     <use xlink:href="#m7f17f7ef48" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m7f17f7ef48" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pd08b8f9436)">
+     <use xlink:href="#m8e9c232bb0" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8e9c232bb0" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="mfc93105d4e" d="M 0 -2.5 
+     <path id="m888ebdcdcc" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p53de07b09c)">
-     <use xlink:href="#mfc93105d4e" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfc93105d4e" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pd08b8f9436)">
+     <use xlink:href="#m888ebdcdcc" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m888ebdcdcc" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="mbf2aa6c9f7" d="M 0 3.5 
+      <path id="m8b5662da94" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#mbf2aa6c9f7" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m8b5662da94" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m18bdc1f6e2" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7e46a9d22c" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m4374a419a2" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2ae54ac107" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m0f37c0f409" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2149ef188d" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#m5b9c5fa09c" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#me4b4210f6e" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m5909457a59" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m55fba3781e" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m7f17f7ef48" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m8e9c232bb0" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#mfc93105d4e" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m888ebdcdcc" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p53de07b09c)">
-     <use xlink:href="#mbf2aa6c9f7" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#mbf2aa6c9f7" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pd08b8f9436)">
+     <use xlink:href="#m8b5662da94" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m8b5662da94" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3184,7 +3184,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p53de07b09c">
+  <clipPath id="pd08b8f9436">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.788615 308.04375 
 L 290.788615 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m9fc54921cb" d="M 0 0 
+       <path id="m082e1dc1ab" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9fc54921cb" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m082e1dc1ab" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 447.590599 308.04375 
 L 447.590599 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9fc54921cb" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m082e1dc1ab" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.188732 308.04375 
 L 181.188732 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m1b14bcd49e" d="M 0 0 
+       <path id="mf6582778b5" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m1b14bcd49e" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.800191 308.04375 
 L 208.800191 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.800191 56.7075
      <g id="line2d_9">
       <path d="M 228.390833 308.04375 
 L 228.390833 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.390833 56.7075
      <g id="line2d_11">
       <path d="M 243.586515 308.04375 
 L 243.586515 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.586515 56.7075
      <g id="line2d_13">
       <path d="M 256.002291 308.04375 
 L 256.002291 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 256.002291 56.7075
      <g id="line2d_15">
       <path d="M 266.499681 308.04375 
 L 266.499681 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.499681 56.7075
      <g id="line2d_17">
       <path d="M 275.592933 308.04375 
 L 275.592933 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.592933 56.7075
      <g id="line2d_19">
       <path d="M 283.61375 308.04375 
 L 283.61375 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.61375 56.7075
      <g id="line2d_21">
       <path d="M 337.990716 308.04375 
 L 337.990716 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.990716 56.7075
      <g id="line2d_23">
       <path d="M 365.602174 308.04375 
 L 365.602174 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.602174 56.7075
      <g id="line2d_25">
       <path d="M 385.192816 308.04375 
 L 385.192816 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 385.192816 56.7075
      <g id="line2d_27">
       <path d="M 400.388498 308.04375 
 L 400.388498 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 400.388498 56.7075
      <g id="line2d_29">
       <path d="M 412.804275 308.04375 
 L 412.804275 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.804275 56.7075
      <g id="line2d_31">
       <path d="M 423.301664 308.04375 
 L 423.301664 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 423.301664 56.7075
      <g id="line2d_33">
       <path d="M 432.394917 308.04375 
 L 432.394917 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 432.394917 56.7075
      <g id="line2d_35">
       <path d="M 440.415734 308.04375 
 L 440.415734 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 440.415734 56.7075
      <g id="line2d_37">
       <path d="M 494.792699 308.04375 
 L 494.792699 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.792699 56.7075
      <g id="line2d_39">
       <path d="M 522.404158 308.04375 
 L 522.404158 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 522.404158 56.7075
      <g id="line2d_41">
       <path d="M 541.9948 308.04375 
 L 541.9948 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.9948 56.7075
      <g id="line2d_43">
       <path d="M 557.190482 308.04375 
 L 557.190482 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m1b14bcd49e" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mf6582778b5" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="ma5322bd913" d="M 0 0 
+       <path id="m6cdbcb600c" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma5322bd913" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6cdbcb600c" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#ma5322bd913" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6cdbcb600c" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1129,7 +1129,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#ma5322bd913" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6cdbcb600c" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1242,7 +1242,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#ma5322bd913" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6cdbcb600c" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#ma5322bd913" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6cdbcb600c" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#ma5322bd913" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6cdbcb600c" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#ma5322bd913" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6cdbcb600c" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#ma5322bd913" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6cdbcb600c" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.556151 296.619375 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 162.32653 263.978304 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 178.681331 231.337232 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 201.044126 198.696161 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.976983 166.055089 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.121093 133.414018 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 247.282543 100.772946 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.279501 68.131875 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.286834 308.04375 
 L 542.286834 56.7075 
-" clip-path="url(#p1cdf579760)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p51e3dc949a)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1875,7 +1875,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m967abd190c" d="M 0 3 
+     <path id="m3c8596cc55" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1887,13 +1887,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p1cdf579760)">
-     <use xlink:href="#m967abd190c" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p51e3dc949a)">
+     <use xlink:href="#m3c8596cc55" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m638182d298" d="M 0 3 
+     <path id="m0621a243c8" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1905,13 +1905,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p1cdf579760)">
-     <use xlink:href="#m638182d298" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p51e3dc949a)">
+     <use xlink:href="#m0621a243c8" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="mb1dab30f48" d="M 0 5 
+     <path id="m1b561e1993" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1923,13 +1923,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p1cdf579760)">
-     <use xlink:href="#mb1dab30f48" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p51e3dc949a)">
+     <use xlink:href="#m1b561e1993" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="mbcf6175b92" d="M 0 3 
+     <path id="mef769565ad" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1941,13 +1941,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p1cdf579760)">
-     <use xlink:href="#mbcf6175b92" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p51e3dc949a)">
+     <use xlink:href="#mef769565ad" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m3f1f3f82f5" d="M 0 3 
+     <path id="m5c4ea028b1" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1959,13 +1959,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p1cdf579760)">
-     <use xlink:href="#m3f1f3f82f5" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p51e3dc949a)">
+     <use xlink:href="#m5c4ea028b1" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m4ab57ae9ab" d="M 0 3 
+     <path id="m757e60eabd" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1977,13 +1977,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p1cdf579760)">
-     <use xlink:href="#m4ab57ae9ab" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p51e3dc949a)">
+     <use xlink:href="#m757e60eabd" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m290ac19bc2" d="M 0 3 
+     <path id="m8414f58f45" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1995,13 +1995,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p1cdf579760)">
-     <use xlink:href="#m290ac19bc2" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p51e3dc949a)">
+     <use xlink:href="#m8414f58f45" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m389a7a9982" d="M 0 3 
+     <path id="mfce90f15b1" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2013,8 +2013,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p1cdf579760)">
-     <use xlink:href="#m389a7a9982" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p51e3dc949a)">
+     <use xlink:href="#mfce90f15b1" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2869,7 +2869,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p1cdf579760">
+  <clipPath id="p51e3dc949a">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p5b0afe3818)">
+   <g clip-path="url(#p36b1f23e96)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image937c365c0f" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image9e204f6a67" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7d7d4236ac" d="M 0 0 
+       <path id="m8871c9e245" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7d7d4236ac" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m7d7d4236ac" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8871c9e245" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m09c8e87ad7" d="M 0 0 
+       <path id="md71e2e0388" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m09c8e87ad7" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md71e2e0388" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m09c8e87ad7" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md71e2e0388" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m09c8e87ad7" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md71e2e0388" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m09c8e87ad7" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md71e2e0388" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m09c8e87ad7" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md71e2e0388" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m09c8e87ad7" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md71e2e0388" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m09c8e87ad7" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md71e2e0388" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m09c8e87ad7" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md71e2e0388" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image9a4381bed8" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imaged5437b8331" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m3cc6ddca55" d="M 0 0 
+       <path id="m7fbdf2055d" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3cc6ddca55" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fbdf2055d" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m3cc6ddca55" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fbdf2055d" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m3cc6ddca55" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fbdf2055d" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m3cc6ddca55" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fbdf2055d" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m3cc6ddca55" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m7fbdf2055d" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.380391 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.540625 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2871,13 +2871,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p5b0afe3818">
+  <clipPath id="p36b1f23e96">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.639219pt" height="386.202469pt" viewBox="0 0 575.639219 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.31875pt" height="386.202469pt" viewBox="0 0 575.31875 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.639219 386.202469 
-L 575.639219 0 
+L 575.31875 386.202469 
+L 575.31875 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.944609 104.1264 
-L 294.569609 104.1264 
-L 294.569609 74.7432 
-L 189.944609 74.7432 
+    <path d="M 189.784375 104.1264 
+L 294.409375 104.1264 
+L 294.409375 74.7432 
+L 189.784375 74.7432 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.569609 104.1264 
-L 399.194609 104.1264 
-L 399.194609 74.7432 
-L 294.569609 74.7432 
+    <path d="M 294.409375 104.1264 
+L 399.034375 104.1264 
+L 399.034375 74.7432 
+L 294.409375 74.7432 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.194609 104.1264 
-L 503.819609 104.1264 
-L 503.819609 74.7432 
-L 399.194609 74.7432 
+    <path d="M 399.034375 104.1264 
+L 503.659375 104.1264 
+L 503.659375 74.7432 
+L 399.034375 74.7432 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.944609 133.5096 
-L 294.569609 133.5096 
-L 294.569609 104.1264 
-L 189.944609 104.1264 
+    <path d="M 189.784375 133.5096 
+L 294.409375 133.5096 
+L 294.409375 104.1264 
+L 189.784375 104.1264 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.569609 133.5096 
-L 399.194609 133.5096 
-L 399.194609 104.1264 
-L 294.569609 104.1264 
+    <path d="M 294.409375 133.5096 
+L 399.034375 133.5096 
+L 399.034375 104.1264 
+L 294.409375 104.1264 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.194609 133.5096 
-L 503.819609 133.5096 
-L 503.819609 104.1264 
-L 399.194609 104.1264 
+    <path d="M 399.034375 133.5096 
+L 503.659375 133.5096 
+L 503.659375 104.1264 
+L 399.034375 104.1264 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.944609 162.8928 
-L 294.569609 162.8928 
-L 294.569609 133.5096 
-L 189.944609 133.5096 
+    <path d="M 189.784375 162.8928 
+L 294.409375 162.8928 
+L 294.409375 133.5096 
+L 189.784375 133.5096 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.569609 162.8928 
-L 399.194609 162.8928 
-L 399.194609 133.5096 
-L 294.569609 133.5096 
+    <path d="M 294.409375 162.8928 
+L 399.034375 162.8928 
+L 399.034375 133.5096 
+L 294.409375 133.5096 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.194609 162.8928 
-L 503.819609 162.8928 
-L 503.819609 133.5096 
-L 399.194609 133.5096 
+    <path d="M 399.034375 162.8928 
+L 503.659375 162.8928 
+L 503.659375 133.5096 
+L 399.034375 133.5096 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.944609 192.276 
-L 294.569609 192.276 
-L 294.569609 162.8928 
-L 189.944609 162.8928 
+    <path d="M 189.784375 192.276 
+L 294.409375 192.276 
+L 294.409375 162.8928 
+L 189.784375 162.8928 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.569609 192.276 
-L 399.194609 192.276 
-L 399.194609 162.8928 
-L 294.569609 162.8928 
+    <path d="M 294.409375 192.276 
+L 399.034375 192.276 
+L 399.034375 162.8928 
+L 294.409375 162.8928 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.194609 192.276 
-L 503.819609 192.276 
-L 503.819609 162.8928 
-L 399.194609 162.8928 
+    <path d="M 399.034375 192.276 
+L 503.659375 192.276 
+L 503.659375 162.8928 
+L 399.034375 162.8928 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.944609 221.6592 
-L 294.569609 221.6592 
-L 294.569609 192.276 
-L 189.944609 192.276 
+    <path d="M 189.784375 221.6592 
+L 294.409375 221.6592 
+L 294.409375 192.276 
+L 189.784375 192.276 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.569609 221.6592 
-L 399.194609 221.6592 
-L 399.194609 192.276 
-L 294.569609 192.276 
+    <path d="M 294.409375 221.6592 
+L 399.034375 221.6592 
+L 399.034375 192.276 
+L 294.409375 192.276 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.194609 221.6592 
-L 503.819609 221.6592 
-L 503.819609 192.276 
-L 399.194609 192.276 
+    <path d="M 399.034375 221.6592 
+L 503.659375 221.6592 
+L 503.659375 192.276 
+L 399.034375 192.276 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.944609 251.0424 
-L 294.569609 251.0424 
-L 294.569609 221.6592 
-L 189.944609 221.6592 
+    <path d="M 189.784375 251.0424 
+L 294.409375 251.0424 
+L 294.409375 221.6592 
+L 189.784375 221.6592 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.569609 251.0424 
-L 399.194609 251.0424 
-L 399.194609 221.6592 
-L 294.569609 221.6592 
+    <path d="M 294.409375 251.0424 
+L 399.034375 251.0424 
+L 399.034375 221.6592 
+L 294.409375 221.6592 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.194609 251.0424 
-L 503.819609 251.0424 
-L 503.819609 221.6592 
-L 399.194609 221.6592 
+    <path d="M 399.034375 251.0424 
+L 503.659375 251.0424 
+L 503.659375 221.6592 
+L 399.034375 221.6592 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.944609 280.4256 
-L 294.569609 280.4256 
-L 294.569609 251.0424 
-L 189.944609 251.0424 
+    <path d="M 189.784375 280.4256 
+L 294.409375 280.4256 
+L 294.409375 251.0424 
+L 189.784375 251.0424 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.569609 280.4256 
-L 399.194609 280.4256 
-L 399.194609 251.0424 
-L 294.569609 251.0424 
+    <path d="M 294.409375 280.4256 
+L 399.034375 280.4256 
+L 399.034375 251.0424 
+L 294.409375 251.0424 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.194609 280.4256 
-L 503.819609 280.4256 
-L 503.819609 251.0424 
-L 399.194609 251.0424 
+    <path d="M 399.034375 280.4256 
+L 503.659375 280.4256 
+L 503.659375 251.0424 
+L 399.034375 251.0424 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #f88950; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.944609 309.8088 
-L 294.569609 309.8088 
-L 294.569609 280.4256 
-L 189.944609 280.4256 
+    <path d="M 189.784375 309.8088 
+L 294.409375 309.8088 
+L 294.409375 280.4256 
+L 189.784375 280.4256 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.569609 309.8088 
-L 399.194609 309.8088 
-L 399.194609 280.4256 
-L 294.569609 280.4256 
+    <path d="M 294.409375 309.8088 
+L 399.034375 309.8088 
+L 399.034375 280.4256 
+L 294.409375 280.4256 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.194609 309.8088 
-L 503.819609 309.8088 
-L 503.819609 280.4256 
-L 399.194609 280.4256 
+    <path d="M 399.034375 309.8088 
+L 503.659375 309.8088 
+L 503.659375 280.4256 
+L 399.034375 280.4256 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.944609 339.192 
-L 294.569609 339.192 
-L 294.569609 309.8088 
-L 189.944609 309.8088 
+    <path d="M 189.784375 339.192 
+L 294.409375 339.192 
+L 294.409375 309.8088 
+L 189.784375 309.8088 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.569609 339.192 
-L 399.194609 339.192 
-L 399.194609 309.8088 
-L 294.569609 309.8088 
+    <path d="M 294.409375 339.192 
+L 399.034375 339.192 
+L 399.034375 309.8088 
+L 294.409375 309.8088 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.194609 339.192 
-L 503.819609 339.192 
-L 503.819609 309.8088 
-L 399.194609 309.8088 
+    <path d="M 399.034375 339.192 
+L 503.659375 339.192 
+L 503.659375 309.8088 
+L 399.034375 309.8088 
 z
-" clip-path="url(#p75cb7941c7)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p9698cc5e4d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.931875 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.771641 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.216094 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.055859 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.788203 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.627969 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(407.139922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.979688 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.869609 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.709375 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(230.805859 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(339.247109 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(339.086875 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(443.872109 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.507734 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.3475 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(230.805859 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(341.792109 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(443.872109 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(101.200859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(101.040625 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(230.805859 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(341.792109 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(443.872109 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(122.233359 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(122.073125 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(230.805859 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(341.792109 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(443.872109 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(130.770859 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(130.610625 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(230.805859 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(341.792109 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(443.872109 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(114.077109 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(113.916875 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(230.805859 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,14 +1634,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(341.792109 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 527 -->
-    <g transform="translate(443.872109 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(443.711875 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1649,7 +1649,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.578984 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.41875 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1758,7 +1758,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.325 -->
-    <g transform="translate(229.605234 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.445 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1876,9 +1876,72 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 28 -->
-    <g transform="translate(341.315859 267.9415) scale(0.08 -0.08)">
+    <!-- 29 -->
+    <g transform="translate(341.155625 267.9415) scale(0.08 -0.08)">
      <defs>
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 178 -->
+    <g transform="translate(442.9975 267.9415) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-38" d="M 2228 2088 
 Q 1891 2088 1709 1903 
 Q 1528 1719 1528 1375 
@@ -1919,66 +1982,14 @@ Q 1631 3694 1631 3419
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 174 -->
-    <g transform="translate(443.157734 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
-L 1038 1722 
-L 2356 1722 
-L 2356 3675 
-z
-M 2156 4666 
-L 3494 4666 
-L 3494 1722 
-L 4159 1722 
-L 4159 850 
-L 3494 850 
-L 3494 0 
-L 2356 0 
-L 2356 850 
-L 288 850 
-L 288 1881 
-L 2156 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.693984 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.53375 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2043,7 +2054,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(230.805859 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2053,21 +2064,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(341.792109 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.631875 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(446.417109 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(446.256875 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.915234 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.755 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2078,7 +2089,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(230.805859 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.645625 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2088,13 +2099,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(344.337109 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.176875 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.507109 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.346875 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2110,7 +2121,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(154.421328 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(154.261094 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2254,7 +2265,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-06T00:06:40Z  ·  Linux chungus2 x86_64  ·  commit 93184402  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2396,13 +2407,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2442,110 +2453,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3262.744141 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3326.367188 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3389.990234 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3453.613281 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3517.236328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3580.859375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3612.646484 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3644.433594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3676.220703 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3708.007812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3739.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3767.578125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3829.101562 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3890.380859 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3953.759766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4017.236328 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4056.099609 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4117.28125 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4176.460938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4237.984375 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4279.097656 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4312.789062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4340.572266 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4402.095703 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4463.375 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4526.753906 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4590.376953 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4624.068359 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4683.248047 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4746.871094 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4778.658203 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4842.28125 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4905.904297 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4937.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(5001.314453 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5037.398438 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5076.261719 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5131.242188 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5194.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5226.652344 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5258.439453 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5290.226562 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5322.013672 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5353.800781 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5393.009766 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5456.388672 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5495.251953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5556.433594 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5619.8125 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5683.289062 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5746.667969 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5810.144531 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5873.523438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5912.732422 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5944.519531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6028.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6060.095703 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6157.507812 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6219.03125 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6282.507812 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6310.291016 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6371.570312 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6434.949219 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6466.736328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6518.835938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6582.214844 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6643.494141 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6706.970703 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6759.070312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6822.449219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6883.630859 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6922.839844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6956.53125 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6988.318359 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7029.431641 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7090.710938 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7129.919922 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7157.703125 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7218.884766 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7250.671875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7278.455078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7330.554688 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7362.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7425.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7487.341797 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7526.550781 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7588.074219 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7627.4375 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7724.849609 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7752.632812 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7816.011719 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7843.794922 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7895.894531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7935.103516 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7962.886719 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
+    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p75cb7941c7">
-   <rect x="85.319609" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p9698cc5e4d">
+   <rect x="85.159375" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-06T00:06:40Z",
+  "date": "2026-07-06T01:55:32Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "93184402",
+  "git_commit": "8a96b29e",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 67.42,
-   "decompress_mbps": 111.9
+   "compress_mbps": 67.68,
+   "decompress_mbps": 109.96
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 48.86,
-   "decompress_mbps": 124.33
+   "compress_mbps": 49.05,
+   "decompress_mbps": 121.93
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 43.6,
-   "decompress_mbps": 135.39
+   "compress_mbps": 43.73,
+   "decompress_mbps": 132.94
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54681,
    "ratio": 0.3595,
-   "compress_mbps": 31.9,
-   "decompress_mbps": 138.99
+   "compress_mbps": 31.91,
+   "decompress_mbps": 136.97
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54437,
    "ratio": 0.3579,
-   "compress_mbps": 25.31,
-   "decompress_mbps": 146.06
+   "compress_mbps": 25.2,
+   "decompress_mbps": 144.28
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54348,
    "ratio": 0.3573,
-   "compress_mbps": 23.37,
-   "decompress_mbps": 150.38
+   "compress_mbps": 24.29,
+   "decompress_mbps": 148.76
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54140,
    "ratio": 0.356,
-   "compress_mbps": 20.15,
-   "decompress_mbps": 150.96
+   "compress_mbps": 20.84,
+   "decompress_mbps": 149.47
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 19.6,
-   "decompress_mbps": 151.28
+   "compress_mbps": 20.16,
+   "decompress_mbps": 149.68
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.09,
-   "decompress_mbps": 151.56
+   "compress_mbps": 4.13,
+   "decompress_mbps": 150.13
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.27,
+   "compress_mbps": 2.31,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 61.19,
-   "decompress_mbps": 105.19
+   "compress_mbps": 61.88,
+   "decompress_mbps": 103.8
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 45.81,
-   "decompress_mbps": 112.81
+   "compress_mbps": 45.91,
+   "decompress_mbps": 111.31
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 41.49,
-   "decompress_mbps": 122.15
+   "compress_mbps": 41.55,
+   "decompress_mbps": 120.65
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48992,
    "ratio": 0.3914,
-   "compress_mbps": 30.31,
-   "decompress_mbps": 126.99
+   "compress_mbps": 30.17,
+   "decompress_mbps": 125.54
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48891,
    "ratio": 0.3906,
-   "compress_mbps": 26.17,
-   "decompress_mbps": 133.14
+   "compress_mbps": 26.02,
+   "decompress_mbps": 131.2
   },
   {
    "compressor": "native",
@@ -164,8 +164,8 @@
    "level": 6,
    "out_size": 48715,
    "ratio": 0.3892,
-   "compress_mbps": 22.58,
-   "decompress_mbps": 136.14
+   "compress_mbps": 23.66,
+   "decompress_mbps": 134.59
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 21.11,
-   "decompress_mbps": 136.19
+   "compress_mbps": 21.97,
+   "decompress_mbps": 134.84
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 21.07,
-   "decompress_mbps": 136.77
+   "compress_mbps": 21.88,
+   "decompress_mbps": 135.03
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47430,
    "ratio": 0.3789,
-   "compress_mbps": 4.46,
-   "decompress_mbps": 136.89
+   "compress_mbps": 4.51,
+   "decompress_mbps": 135.53
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46865,
    "ratio": 0.3744,
-   "compress_mbps": 2.65,
+   "compress_mbps": 2.7,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 61.16,
-   "decompress_mbps": 124.74
+   "compress_mbps": 61.4,
+   "decompress_mbps": 124.24
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 50.87,
-   "decompress_mbps": 129.03
+   "compress_mbps": 51.2,
+   "decompress_mbps": 128.35
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 49.21,
-   "decompress_mbps": 131.97
+   "compress_mbps": 48.74,
+   "decompress_mbps": 131.39
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 42.93,
-   "decompress_mbps": 138.34
+   "compress_mbps": 42.95,
+   "decompress_mbps": 137.66
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7932,
    "ratio": 0.3224,
-   "compress_mbps": 35.53,
-   "decompress_mbps": 142.07
+   "compress_mbps": 35.54,
+   "decompress_mbps": 141.53
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7938,
    "ratio": 0.3226,
-   "compress_mbps": 29.57,
-   "decompress_mbps": 143.34
+   "compress_mbps": 34.92,
+   "decompress_mbps": 142.96
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 28.01,
-   "decompress_mbps": 145.14
+   "compress_mbps": 32.82,
+   "decompress_mbps": 144.43
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 27.99,
-   "decompress_mbps": 144.83
+   "compress_mbps": 32.81,
+   "decompress_mbps": 144.01
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.71,
-   "decompress_mbps": 144.7
+   "compress_mbps": 4.77,
+   "decompress_mbps": 144.19
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.79,
+   "compress_mbps": 2.83,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 46.9,
-   "decompress_mbps": 99.83
+   "compress_mbps": 46.88,
+   "decompress_mbps": 100.38
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 40.68,
-   "decompress_mbps": 102.96
+   "compress_mbps": 40.91,
+   "decompress_mbps": 103.27
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 39.7,
-   "decompress_mbps": 106.1
+   "compress_mbps": 39.67,
+   "decompress_mbps": 106.9
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 35.65,
-   "decompress_mbps": 108.65
+   "compress_mbps": 35.57,
+   "decompress_mbps": 108.69
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 31.5,
-   "decompress_mbps": 110.19
+   "compress_mbps": 31.31,
+   "decompress_mbps": 110.84
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3135,
    "ratio": 0.2812,
-   "compress_mbps": 27.17,
-   "decompress_mbps": 111.34
+   "compress_mbps": 31.53,
+   "decompress_mbps": 111.63
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 26.1,
-   "decompress_mbps": 111.76
+   "compress_mbps": 30.08,
+   "decompress_mbps": 111.84
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 26.08,
-   "decompress_mbps": 112.41
+   "compress_mbps": 30.17,
+   "decompress_mbps": 111.71
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.23,
-   "decompress_mbps": 112.13
+   "compress_mbps": 5.25,
+   "decompress_mbps": 111.81
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3032,
    "ratio": 0.2719,
-   "compress_mbps": 2.92,
+   "compress_mbps": 2.95,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 24.49,
-   "decompress_mbps": 56.81
+   "compress_mbps": 24.67,
+   "decompress_mbps": 56.78
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 22.99,
-   "decompress_mbps": 57.5
+   "compress_mbps": 23.16,
+   "decompress_mbps": 57.44
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 22.87,
-   "decompress_mbps": 57.45
+   "compress_mbps": 22.94,
+   "decompress_mbps": 57.63
   },
   {
    "compressor": "native",
@@ -444,7 +444,7 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 22.05,
+   "compress_mbps": 22.2,
    "decompress_mbps": 58.67
   },
   {
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.34,
-   "decompress_mbps": 59.07
+   "compress_mbps": 21.52,
+   "decompress_mbps": 59.29
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 17.92,
-   "decompress_mbps": 59.21
+   "compress_mbps": 20.8,
+   "decompress_mbps": 59.27
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 17.9,
-   "decompress_mbps": 59.12
+   "compress_mbps": 20.79,
+   "decompress_mbps": 59.36
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 17.88,
-   "decompress_mbps": 59.16
+   "compress_mbps": 20.73,
+   "decompress_mbps": 59.52
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.81,
-   "decompress_mbps": 59.28
+   "compress_mbps": 4.8,
+   "decompress_mbps": 59.68
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.87,
+   "compress_mbps": 2.88,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 127.59,
-   "decompress_mbps": 208.75
+   "compress_mbps": 129.72,
+   "decompress_mbps": 204.26
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 89.08,
-   "decompress_mbps": 223.03
+   "compress_mbps": 89.82,
+   "decompress_mbps": 220.21
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 75.34,
-   "decompress_mbps": 232.79
+   "compress_mbps": 76.32,
+   "decompress_mbps": 229.46
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239804,
    "ratio": 0.2329,
-   "compress_mbps": 69.9,
-   "decompress_mbps": 240.1
+   "compress_mbps": 70.26,
+   "decompress_mbps": 235.65
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 215530,
    "ratio": 0.2093,
-   "compress_mbps": 39.78,
-   "decompress_mbps": 234.76
+   "compress_mbps": 39.72,
+   "decompress_mbps": 231.89
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 201414,
    "ratio": 0.1956,
-   "compress_mbps": 31.12,
-   "decompress_mbps": 242.38
+   "compress_mbps": 32.87,
+   "decompress_mbps": 238.67
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 20.89,
-   "decompress_mbps": 245.23
+   "compress_mbps": 21.39,
+   "decompress_mbps": 240.51
   },
   {
    "compressor": "native",
@@ -584,8 +584,8 @@
    "level": 8,
    "out_size": 200719,
    "ratio": 0.1949,
-   "compress_mbps": 14.56,
-   "decompress_mbps": 247.84
+   "compress_mbps": 14.84,
+   "decompress_mbps": 243.5
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182508,
    "ratio": 0.1772,
-   "compress_mbps": 2.96,
-   "decompress_mbps": 248.54
+   "compress_mbps": 3.01,
+   "decompress_mbps": 245.04
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178067,
    "ratio": 0.1729,
-   "compress_mbps": 1.33,
+   "compress_mbps": 1.34,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 72.63,
-   "decompress_mbps": 118.86
+   "compress_mbps": 73.74,
+   "decompress_mbps": 118.26
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 51.15,
-   "decompress_mbps": 105.3
+   "compress_mbps": 52.54,
+   "decompress_mbps": 126.74
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 45.79,
-   "decompress_mbps": 140.98
+   "compress_mbps": 46.47,
+   "decompress_mbps": 139.75
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 145631,
    "ratio": 0.3413,
-   "compress_mbps": 34.34,
-   "decompress_mbps": 144.94
+   "compress_mbps": 34.19,
+   "decompress_mbps": 144.73
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 145321,
    "ratio": 0.3405,
-   "compress_mbps": 27.16,
-   "decompress_mbps": 151.94
+   "compress_mbps": 27.71,
+   "decompress_mbps": 151.91
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 145046,
    "ratio": 0.3399,
-   "compress_mbps": 24.63,
-   "decompress_mbps": 151.3
+   "compress_mbps": 26.05,
+   "decompress_mbps": 155.69
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 144554,
    "ratio": 0.3387,
-   "compress_mbps": 22.35,
-   "decompress_mbps": 158.34
+   "compress_mbps": 22.93,
+   "decompress_mbps": 156.35
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 144540,
    "ratio": 0.3387,
-   "compress_mbps": 21.74,
-   "decompress_mbps": 157.9
+   "compress_mbps": 22.39,
+   "decompress_mbps": 156.51
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140322,
    "ratio": 0.3288,
-   "compress_mbps": 3.96,
-   "decompress_mbps": 157.51
+   "compress_mbps": 4.11,
+   "decompress_mbps": 156.33
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138830,
    "ratio": 0.3253,
-   "compress_mbps": 2.37,
+   "compress_mbps": 2.41,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 61.1,
-   "decompress_mbps": 100.14
+   "compress_mbps": 62.44,
+   "decompress_mbps": 97.65
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 44.64,
-   "decompress_mbps": 109.12
+   "compress_mbps": 44.8,
+   "decompress_mbps": 106.36
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 39.45,
-   "decompress_mbps": 119.54
+   "compress_mbps": 39.75,
+   "decompress_mbps": 116.41
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 195460,
    "ratio": 0.4056,
-   "compress_mbps": 26.67,
-   "decompress_mbps": 122.85
+   "compress_mbps": 26.09,
+   "decompress_mbps": 120.63
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 194902,
    "ratio": 0.4045,
-   "compress_mbps": 22.37,
-   "decompress_mbps": 128.97
+   "compress_mbps": 21.99,
+   "decompress_mbps": 126.86
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 195177,
    "ratio": 0.405,
-   "compress_mbps": 21.19,
-   "decompress_mbps": 132.96
+   "compress_mbps": 21.86,
+   "decompress_mbps": 130.38
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 194385,
    "ratio": 0.4034,
-   "compress_mbps": 18.51,
-   "decompress_mbps": 133.13
+   "compress_mbps": 18.6,
+   "decompress_mbps": 130.8
   },
   {
    "compressor": "native",
@@ -784,8 +784,8 @@
    "level": 8,
    "out_size": 194380,
    "ratio": 0.4034,
-   "compress_mbps": 18.38,
-   "decompress_mbps": 133.49
+   "compress_mbps": 18.59,
+   "decompress_mbps": 130.87
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189365,
    "ratio": 0.393,
-   "compress_mbps": 3.89,
-   "decompress_mbps": 133.39
+   "compress_mbps": 3.9,
+   "decompress_mbps": 131.79
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186147,
    "ratio": 0.3863,
-   "compress_mbps": 2.35,
+   "compress_mbps": 2.37,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 205.6,
-   "decompress_mbps": 343.71
+   "compress_mbps": 207.36,
+   "decompress_mbps": 339.57
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 152.89,
-   "decompress_mbps": 359.12
+   "compress_mbps": 149.97,
+   "decompress_mbps": 355.0
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 131.82,
-   "decompress_mbps": 381.94
+   "compress_mbps": 130.12,
+   "decompress_mbps": 378.55
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55673,
    "ratio": 0.1085,
-   "compress_mbps": 88.0,
-   "decompress_mbps": 357.98
+   "compress_mbps": 87.5,
+   "decompress_mbps": 346.68
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 54950,
    "ratio": 0.1071,
-   "compress_mbps": 60.35,
-   "decompress_mbps": 380.37
+   "compress_mbps": 59.71,
+   "decompress_mbps": 369.4
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55259,
    "ratio": 0.1077,
-   "compress_mbps": 49.82,
-   "decompress_mbps": 406.27
+   "compress_mbps": 51.21,
+   "decompress_mbps": 399.5
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 53713,
    "ratio": 0.1047,
-   "compress_mbps": 35.97,
-   "decompress_mbps": 428.28
+   "compress_mbps": 36.5,
+   "decompress_mbps": 423.98
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 52897,
    "ratio": 0.1031,
-   "compress_mbps": 29.87,
-   "decompress_mbps": 458.65
+   "compress_mbps": 30.26,
+   "decompress_mbps": 454.8
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52729,
    "ratio": 0.1027,
-   "compress_mbps": 5.07,
-   "decompress_mbps": 469.76
+   "compress_mbps": 5.13,
+   "decompress_mbps": 467.85
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52234,
    "ratio": 0.1018,
-   "compress_mbps": 3.39,
+   "compress_mbps": 3.41,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 51.67,
-   "decompress_mbps": 113.74
+   "compress_mbps": 51.8,
+   "decompress_mbps": 113.62
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 44.99,
-   "decompress_mbps": 116.27
+   "compress_mbps": 45.16,
+   "decompress_mbps": 115.99
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 43.35,
-   "decompress_mbps": 117.9
+   "compress_mbps": 43.4,
+   "decompress_mbps": 118.03
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13366,
    "ratio": 0.3495,
-   "compress_mbps": 37.02,
-   "decompress_mbps": 124.0
+   "compress_mbps": 36.93,
+   "decompress_mbps": 123.69
   },
   {
    "compressor": "native",
@@ -954,8 +954,8 @@
    "level": 5,
    "out_size": 13346,
    "ratio": 0.349,
-   "compress_mbps": 31.42,
-   "decompress_mbps": 129.69
+   "compress_mbps": 31.52,
+   "decompress_mbps": 130.33
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 13040,
    "ratio": 0.341,
-   "compress_mbps": 16.57,
-   "decompress_mbps": 132.43
+   "compress_mbps": 18.11,
+   "decompress_mbps": 132.57
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 13035,
    "ratio": 0.3409,
-   "compress_mbps": 14.86,
-   "decompress_mbps": 133.38
+   "compress_mbps": 16.02,
+   "decompress_mbps": 133.59
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 13028,
    "ratio": 0.3407,
-   "compress_mbps": 13.26,
-   "decompress_mbps": 135.04
+   "compress_mbps": 14.2,
+   "decompress_mbps": 134.95
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 4.8,
-   "decompress_mbps": 136.55
+   "compress_mbps": 4.79,
+   "decompress_mbps": 136.14
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12274,
    "ratio": 0.321,
-   "compress_mbps": 2.83,
+   "compress_mbps": 2.85,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 25.77,
-   "decompress_mbps": 57.95
+   "compress_mbps": 25.68,
+   "decompress_mbps": 58.64
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 24.22,
-   "decompress_mbps": 58.44
+   "compress_mbps": 24.13,
+   "decompress_mbps": 59.24
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 24.17,
-   "decompress_mbps": 58.56
+   "compress_mbps": 24.03,
+   "decompress_mbps": 59.32
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 23.41,
-   "decompress_mbps": 59.7
+   "compress_mbps": 23.32,
+   "decompress_mbps": 60.56
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 22.92,
-   "decompress_mbps": 59.88
+   "compress_mbps": 22.79,
+   "decompress_mbps": 61.12
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 18.22,
-   "decompress_mbps": 60.04
+   "compress_mbps": 21.83,
+   "decompress_mbps": 60.87
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 18.23,
-   "decompress_mbps": 59.96
+   "compress_mbps": 21.92,
+   "decompress_mbps": 60.95
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 18.22,
-   "decompress_mbps": 60.01
+   "compress_mbps": 21.92,
+   "decompress_mbps": 60.83
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.27,
-   "decompress_mbps": 59.96
+   "compress_mbps": 5.26,
+   "decompress_mbps": 60.85
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.17,
+   "compress_mbps": 3.19,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 64.05,
-   "decompress_mbps": 104.86
+   "compress_mbps": 65.01,
+   "decompress_mbps": 103.65
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 46.09,
-   "decompress_mbps": 113.03
+   "compress_mbps": 46.1,
+   "decompress_mbps": 111.89
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 40.96,
-   "decompress_mbps": 124.13
+   "compress_mbps": 40.79,
+   "decompress_mbps": 122.89
   },
   {
    "compressor": "native",
@@ -4445,7 +4445,7 @@
    "out_size": 3882303,
    "ratio": 0.3809,
    "compress_mbps": 28.68,
-   "decompress_mbps": 127.44
+   "decompress_mbps": 125.64
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3870984,
    "ratio": 0.3798,
-   "compress_mbps": 24.02,
-   "decompress_mbps": 133.1
+   "compress_mbps": 23.77,
+   "decompress_mbps": 131.71
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3878499,
    "ratio": 0.3805,
-   "compress_mbps": 23.14,
-   "decompress_mbps": 137.73
+   "compress_mbps": 23.6,
+   "decompress_mbps": 136.07
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3865234,
    "ratio": 0.3792,
-   "compress_mbps": 19.88,
-   "decompress_mbps": 138.33
+   "compress_mbps": 20.24,
+   "decompress_mbps": 136.52
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3864805,
    "ratio": 0.3792,
-   "compress_mbps": 19.58,
-   "decompress_mbps": 138.09
+   "compress_mbps": 19.88,
+   "decompress_mbps": 136.71
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766584,
    "ratio": 0.3695,
-   "compress_mbps": 3.96,
-   "decompress_mbps": 140.73
+   "compress_mbps": 4.0,
+   "decompress_mbps": 139.27
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711172,
    "ratio": 0.3641,
-   "compress_mbps": 2.34,
+   "compress_mbps": 2.36,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 79.48,
-   "decompress_mbps": 132.62
+   "compress_mbps": 79.65,
+   "decompress_mbps": 132.15
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 61.94,
-   "decompress_mbps": 140.45
+   "compress_mbps": 62.95,
+   "decompress_mbps": 138.69
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 58.38,
-   "decompress_mbps": 141.12
+   "compress_mbps": 59.62,
+   "decompress_mbps": 139.18
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20393572,
    "ratio": 0.3982,
-   "compress_mbps": 44.78,
-   "decompress_mbps": 150.85
+   "compress_mbps": 44.77,
+   "decompress_mbps": 149.66
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20264932,
    "ratio": 0.3956,
-   "compress_mbps": 32.98,
-   "decompress_mbps": 158.8
+   "compress_mbps": 32.91,
+   "decompress_mbps": 158.41
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 19208910,
    "ratio": 0.375,
-   "compress_mbps": 22.93,
-   "decompress_mbps": 162.75
+   "compress_mbps": 23.82,
+   "decompress_mbps": 161.59
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 19177573,
    "ratio": 0.3744,
-   "compress_mbps": 18.0,
-   "decompress_mbps": 162.98
+   "compress_mbps": 18.42,
+   "decompress_mbps": 161.98
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 19172591,
    "ratio": 0.3743,
-   "compress_mbps": 15.24,
-   "decompress_mbps": 163.43
+   "compress_mbps": 15.52,
+   "decompress_mbps": 162.12
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18686872,
    "ratio": 0.3648,
-   "compress_mbps": 3.98,
-   "decompress_mbps": 160.12
+   "compress_mbps": 3.96,
+   "decompress_mbps": 161.29
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18539905,
    "ratio": 0.362,
-   "compress_mbps": 2.18,
+   "compress_mbps": 2.19,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 78.89,
-   "decompress_mbps": 120.29
+   "compress_mbps": 79.62,
+   "decompress_mbps": 120.73
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 60.37,
-   "decompress_mbps": 128.63
+   "compress_mbps": 60.19,
+   "decompress_mbps": 127.8
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 52.15,
-   "decompress_mbps": 140.5
+   "compress_mbps": 51.89,
+   "decompress_mbps": 137.04
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3707604,
    "ratio": 0.3719,
-   "compress_mbps": 33.71,
-   "decompress_mbps": 132.15
+   "compress_mbps": 33.84,
+   "decompress_mbps": 131.47
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3705174,
    "ratio": 0.3716,
-   "compress_mbps": 26.47,
-   "decompress_mbps": 137.99
+   "compress_mbps": 26.54,
+   "decompress_mbps": 137.31
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3612809,
    "ratio": 0.3623,
-   "compress_mbps": 23.22,
-   "decompress_mbps": 142.79
+   "compress_mbps": 24.04,
+   "decompress_mbps": 143.2
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3608980,
    "ratio": 0.362,
-   "compress_mbps": 19.82,
-   "decompress_mbps": 145.03
+   "compress_mbps": 20.31,
+   "decompress_mbps": 143.84
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3609490,
    "ratio": 0.362,
-   "compress_mbps": 18.04,
-   "decompress_mbps": 148.27
+   "compress_mbps": 18.41,
+   "decompress_mbps": 147.53
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581441,
    "ratio": 0.3592,
-   "compress_mbps": 4.39,
-   "decompress_mbps": 152.36
+   "compress_mbps": 4.45,
+   "decompress_mbps": 151.64
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3512886,
    "ratio": 0.3523,
-   "compress_mbps": 2.72,
+   "compress_mbps": 2.74,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 227.72,
-   "decompress_mbps": 365.8
+   "compress_mbps": 231.6,
+   "decompress_mbps": 359.08
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 145.98,
-   "decompress_mbps": 411.45
+   "compress_mbps": 145.5,
+   "decompress_mbps": 405.24
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 125.21,
-   "decompress_mbps": 458.08
+   "compress_mbps": 123.83,
+   "decompress_mbps": 450.05
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3225450,
    "ratio": 0.0961,
-   "compress_mbps": 93.71,
-   "decompress_mbps": 468.59
+   "compress_mbps": 92.92,
+   "decompress_mbps": 462.16
   },
   {
    "compressor": "native",
@@ -4754,8 +4754,8 @@
    "level": 5,
    "out_size": 3145121,
    "ratio": 0.0937,
-   "compress_mbps": 63.14,
-   "decompress_mbps": 534.1
+   "compress_mbps": 62.52,
+   "decompress_mbps": 525.73
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3158854,
    "ratio": 0.0941,
-   "compress_mbps": 63.49,
-   "decompress_mbps": 572.62
+   "compress_mbps": 63.67,
+   "decompress_mbps": 565.78
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3124878,
    "ratio": 0.0931,
-   "compress_mbps": 43.98,
-   "decompress_mbps": 585.84
+   "compress_mbps": 44.12,
+   "decompress_mbps": 576.39
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3112207,
    "ratio": 0.0928,
-   "compress_mbps": 35.69,
-   "decompress_mbps": 603.15
+   "compress_mbps": 35.81,
+   "decompress_mbps": 597.97
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3034875,
    "ratio": 0.0904,
-   "compress_mbps": 3.14,
-   "decompress_mbps": 609.5
+   "compress_mbps": 3.13,
+   "decompress_mbps": 602.73
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902186,
    "ratio": 0.0865,
-   "compress_mbps": 1.82,
+   "compress_mbps": 1.84,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 56.42,
-   "decompress_mbps": 91.93
+   "compress_mbps": 56.15,
+   "decompress_mbps": 91.85
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 46.16,
-   "decompress_mbps": 94.41
+   "compress_mbps": 46.27,
+   "decompress_mbps": 94.07
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 43.73,
-   "decompress_mbps": 98.46
+   "compress_mbps": 44.52,
+   "decompress_mbps": 96.65
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3237094,
    "ratio": 0.5262,
-   "compress_mbps": 35.82,
-   "decompress_mbps": 104.05
+   "compress_mbps": 35.81,
+   "decompress_mbps": 105.81
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3233792,
    "ratio": 0.5256,
-   "compress_mbps": 31.95,
-   "decompress_mbps": 108.69
+   "compress_mbps": 32.45,
+   "decompress_mbps": 108.46
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3168386,
    "ratio": 0.515,
-   "compress_mbps": 21.7,
-   "decompress_mbps": 110.91
+   "compress_mbps": 22.52,
+   "decompress_mbps": 110.37
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3165783,
    "ratio": 0.5146,
-   "compress_mbps": 20.06,
-   "decompress_mbps": 111.08
+   "compress_mbps": 20.83,
+   "decompress_mbps": 110.59
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3165909,
    "ratio": 0.5146,
-   "compress_mbps": 19.23,
-   "decompress_mbps": 111.08
+   "compress_mbps": 19.68,
+   "decompress_mbps": 111.53
   },
   {
    "compressor": "native",
@@ -4895,7 +4895,7 @@
    "out_size": 3048772,
    "ratio": 0.4956,
    "compress_mbps": 4.84,
-   "decompress_mbps": 114.16
+   "decompress_mbps": 113.1
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3021986,
    "ratio": 0.4912,
-   "compress_mbps": 3.04,
+   "compress_mbps": 3.07,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 89.59,
-   "decompress_mbps": 157.81
+   "compress_mbps": 90.37,
+   "decompress_mbps": 157.22
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 66.89,
-   "decompress_mbps": 163.12
+   "compress_mbps": 66.44,
+   "decompress_mbps": 161.82
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 64.36,
-   "decompress_mbps": 167.92
+   "compress_mbps": 64.22,
+   "decompress_mbps": 167.16
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3706928,
    "ratio": 0.3675,
-   "compress_mbps": 56.35,
-   "decompress_mbps": 180.63
+   "compress_mbps": 55.9,
+   "decompress_mbps": 172.26
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3707010,
    "ratio": 0.3676,
-   "compress_mbps": 52.6,
-   "decompress_mbps": 187.18
+   "compress_mbps": 52.26,
+   "decompress_mbps": 179.62
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3707065,
    "ratio": 0.3676,
-   "compress_mbps": 40.77,
-   "decompress_mbps": 195.98
+   "compress_mbps": 41.42,
+   "decompress_mbps": 186.42
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 40.74,
-   "decompress_mbps": 199.07
+   "compress_mbps": 41.21,
+   "decompress_mbps": 189.44
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 40.75,
-   "decompress_mbps": 197.91
+   "compress_mbps": 41.43,
+   "decompress_mbps": 189.76
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3665069,
    "ratio": 0.3634,
-   "compress_mbps": 5.65,
-   "decompress_mbps": 196.82
+   "compress_mbps": 5.69,
+   "decompress_mbps": 194.74
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647321,
    "ratio": 0.3616,
-   "compress_mbps": 3.24,
+   "compress_mbps": 3.29,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 82.66,
-   "decompress_mbps": 131.77
+   "compress_mbps": 82.88,
+   "decompress_mbps": 130.82
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 55.64,
-   "decompress_mbps": 142.94
+   "compress_mbps": 55.68,
+   "decompress_mbps": 140.51
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 45.81,
-   "decompress_mbps": 160.85
+   "compress_mbps": 45.59,
+   "decompress_mbps": 155.67
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1901081,
    "ratio": 0.2869,
-   "compress_mbps": 28.11,
-   "decompress_mbps": 161.15
+   "compress_mbps": 28.05,
+   "decompress_mbps": 159.72
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1874829,
    "ratio": 0.2829,
-   "compress_mbps": 17.01,
-   "decompress_mbps": 172.37
+   "compress_mbps": 16.92,
+   "decompress_mbps": 171.18
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1867098,
    "ratio": 0.2817,
-   "compress_mbps": 20.33,
-   "decompress_mbps": 127.9
+   "compress_mbps": 20.56,
+   "decompress_mbps": 180.01
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1843421,
    "ratio": 0.2782,
-   "compress_mbps": 13.54,
-   "decompress_mbps": 186.11
+   "compress_mbps": 13.59,
+   "decompress_mbps": 184.21
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1841388,
    "ratio": 0.2779,
-   "compress_mbps": 11.8,
-   "decompress_mbps": 185.96
+   "compress_mbps": 11.81,
+   "decompress_mbps": 186.08
   },
   {
    "compressor": "native",
@@ -5095,7 +5095,7 @@
    "out_size": 1773447,
    "ratio": 0.2676,
    "compress_mbps": 2.74,
-   "decompress_mbps": 194.58
+   "decompress_mbps": 191.89
   },
   {
    "compressor": "native",
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 110.0,
-   "decompress_mbps": 196.67
+   "compress_mbps": 110.28,
+   "decompress_mbps": 194.99
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 81.35,
-   "decompress_mbps": 209.1
+   "compress_mbps": 81.6,
+   "decompress_mbps": 206.98
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 73.44,
-   "decompress_mbps": 218.17
+   "compress_mbps": 73.85,
+   "decompress_mbps": 215.65
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5880979,
    "ratio": 0.2722,
-   "compress_mbps": 54.6,
-   "decompress_mbps": 228.81
+   "compress_mbps": 54.52,
+   "decompress_mbps": 226.64
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5839944,
    "ratio": 0.2703,
-   "compress_mbps": 35.52,
-   "decompress_mbps": 240.5
+   "compress_mbps": 41.59,
+   "decompress_mbps": 238.58
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5425813,
    "ratio": 0.2511,
-   "compress_mbps": 33.39,
-   "decompress_mbps": 244.82
+   "compress_mbps": 34.63,
+   "decompress_mbps": 242.83
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5409983,
    "ratio": 0.2504,
-   "compress_mbps": 29.06,
-   "decompress_mbps": 247.13
+   "compress_mbps": 29.62,
+   "decompress_mbps": 244.91
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5407066,
    "ratio": 0.2503,
-   "compress_mbps": 26.94,
-   "decompress_mbps": 247.18
+   "compress_mbps": 27.44,
+   "decompress_mbps": 242.22
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5235865,
    "ratio": 0.2423,
-   "compress_mbps": 4.44,
-   "decompress_mbps": 248.81
+   "compress_mbps": 4.48,
+   "decompress_mbps": 246.97
   },
   {
    "compressor": "native",
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177560,
    "ratio": 0.2396,
-   "compress_mbps": 2.44,
+   "compress_mbps": 2.47,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 46.95,
-   "decompress_mbps": 92.41
+   "compress_mbps": 46.79,
+   "decompress_mbps": 92.34
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 39.54,
-   "decompress_mbps": 94.24
+   "compress_mbps": 39.48,
+   "decompress_mbps": 94.55
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 36.96,
-   "decompress_mbps": 96.85
+   "compress_mbps": 36.85,
+   "decompress_mbps": 97.04
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5498823,
    "ratio": 0.7583,
-   "compress_mbps": 29.88,
-   "decompress_mbps": 100.23
+   "compress_mbps": 29.89,
+   "decompress_mbps": 100.36
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5496802,
    "ratio": 0.758,
-   "compress_mbps": 27.93,
-   "decompress_mbps": 103.93
+   "compress_mbps": 28.3,
+   "decompress_mbps": 103.01
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5478405,
    "ratio": 0.7554,
-   "compress_mbps": 20.88,
-   "decompress_mbps": 104.98
+   "compress_mbps": 20.99,
+   "decompress_mbps": 104.31
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5474648,
    "ratio": 0.7549,
-   "compress_mbps": 19.59,
-   "decompress_mbps": 104.22
+   "compress_mbps": 20.17,
+   "decompress_mbps": 103.63
   },
   {
    "compressor": "native",
@@ -5284,8 +5284,8 @@
    "level": 8,
    "out_size": 5474139,
    "ratio": 0.7549,
-   "compress_mbps": 19.38,
-   "decompress_mbps": 104.19
+   "compress_mbps": 19.93,
+   "decompress_mbps": 103.84
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284536,
    "ratio": 0.7287,
-   "compress_mbps": 4.9,
-   "decompress_mbps": 105.48
+   "compress_mbps": 4.95,
+   "decompress_mbps": 105.62
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262319,
    "ratio": 0.7256,
-   "compress_mbps": 3.42,
+   "compress_mbps": 3.55,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 82.48,
-   "decompress_mbps": 138.19
+   "compress_mbps": 83.41,
+   "decompress_mbps": 136.09
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 60.76,
-   "decompress_mbps": 149.84
+   "compress_mbps": 61.29,
+   "decompress_mbps": 147.5
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 55.86,
-   "decompress_mbps": 160.82
+   "compress_mbps": 56.11,
+   "decompress_mbps": 158.48
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12229398,
    "ratio": 0.295,
-   "compress_mbps": 40.73,
-   "decompress_mbps": 167.98
+   "compress_mbps": 40.56,
+   "decompress_mbps": 165.74
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12123671,
    "ratio": 0.2924,
-   "compress_mbps": 29.88,
-   "decompress_mbps": 176.47
+   "compress_mbps": 29.75,
+   "decompress_mbps": 174.19
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12167341,
    "ratio": 0.2935,
-   "compress_mbps": 30.38,
-   "decompress_mbps": 181.51
+   "compress_mbps": 31.05,
+   "decompress_mbps": 179.58
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12109369,
    "ratio": 0.2921,
-   "compress_mbps": 24.79,
-   "decompress_mbps": 183.46
+   "compress_mbps": 25.14,
+   "decompress_mbps": 181.11
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12106058,
    "ratio": 0.292,
-   "compress_mbps": 23.83,
-   "decompress_mbps": 183.64
+   "compress_mbps": 24.1,
+   "decompress_mbps": 182.15
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806466,
    "ratio": 0.2848,
-   "compress_mbps": 3.69,
-   "decompress_mbps": 184.49
+   "compress_mbps": 3.72,
+   "decompress_mbps": 182.73
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636727,
    "ratio": 0.2807,
-   "compress_mbps": 1.93,
+   "compress_mbps": 1.94,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 43.38,
-   "decompress_mbps": 77.61
+   "compress_mbps": 43.5,
+   "decompress_mbps": 77.87
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 41.66,
-   "decompress_mbps": 77.96
+   "compress_mbps": 41.3,
+   "decompress_mbps": 78.47
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 41.62,
-   "decompress_mbps": 79.72
+   "compress_mbps": 41.54,
+   "decompress_mbps": 80.0
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 38.8,
-   "decompress_mbps": 79.2
+   "compress_mbps": 39.01,
+   "decompress_mbps": 80.25
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 38.63,
-   "decompress_mbps": 81.58
+   "compress_mbps": 39.17,
+   "decompress_mbps": 81.93
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 13.99,
-   "decompress_mbps": 81.64
+   "compress_mbps": 16.55,
+   "decompress_mbps": 82.79
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 13.92,
-   "decompress_mbps": 82.22
+   "compress_mbps": 16.54,
+   "decompress_mbps": 82.76
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 13.88,
-   "decompress_mbps": 82.45
+   "compress_mbps": 16.52,
+   "decompress_mbps": 82.71
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952505,
    "ratio": 0.7024,
-   "compress_mbps": 5.86,
-   "decompress_mbps": 83.35
+   "compress_mbps": 5.82,
+   "decompress_mbps": 83.65
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5848663,
    "ratio": 0.6902,
-   "compress_mbps": 4.29,
+   "compress_mbps": 4.22,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 175.27,
-   "decompress_mbps": 283.22
+   "compress_mbps": 175.18,
+   "decompress_mbps": 264.04
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 112.6,
-   "decompress_mbps": 299.44
+   "compress_mbps": 112.71,
+   "decompress_mbps": 301.69
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 103.16,
-   "decompress_mbps": 337.23
+   "compress_mbps": 101.83,
+   "decompress_mbps": 331.59
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 721655,
    "ratio": 0.135,
-   "compress_mbps": 74.57,
-   "decompress_mbps": 336.11
+   "compress_mbps": 74.19,
+   "decompress_mbps": 329.7
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 710636,
    "ratio": 0.1329,
-   "compress_mbps": 54.2,
-   "decompress_mbps": 376.56
+   "compress_mbps": 53.76,
+   "decompress_mbps": 372.84
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 688375,
    "ratio": 0.1288,
-   "compress_mbps": 51.18,
-   "decompress_mbps": 405.91
+   "compress_mbps": 51.7,
+   "decompress_mbps": 400.89
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 676544,
    "ratio": 0.1266,
-   "compress_mbps": 40.51,
-   "decompress_mbps": 416.9
+   "compress_mbps": 40.81,
+   "decompress_mbps": 409.48
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 674362,
    "ratio": 0.1262,
-   "compress_mbps": 34.88,
-   "decompress_mbps": 426.2
+   "compress_mbps": 35.18,
+   "decompress_mbps": 421.47
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659417,
    "ratio": 0.1234,
-   "compress_mbps": 4.14,
-   "decompress_mbps": 446.85
+   "compress_mbps": 4.23,
+   "decompress_mbps": 448.84
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643093,
    "ratio": 0.1203,
-   "compress_mbps": 2.85,
+   "compress_mbps": 2.88,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR makes the observation-divergence split heuristic cheap by fusing its passes and moving its counters into scalar loop state. The heuristic cost 6.1% (L6 dickens) / 6.6% (L6 mozilla) of compress (chungus, 2026-07-05); a local before/after over the Canterbury corpus (plrabn12, kennedy.xls, lcet10, ptt5, alice29) measures `chooseSplitsHeuristicP` at 1.33 ms/call before and 0.61 ms/call after — ~2.2x on the function itself — with byte-identical cut lists on every file.

Three separable wastes in `chooseSplitsHeuristicP` go away:

1. The separate full pass computing `totalBytes` before the main loop is gone. The whole-stream output byte count is now a parameter: the dispatch and tests pass `data.size`, since the LZ77 token stream decodes to exactly `data` (`Σ splitTokenBytesP = data.size`). The main walk tracks a running byte suffix `remaining` (start `totalBytes`, minus each token) instead of a `doneBytes` prefix, so the min-block floor is gated without a second pass.
2. `splitTokenBytesP` is computed once per token instead of twice.
3. The ten observation counters move from a boxed `Array Nat` (updated with `set!`/`getD` per token) into scalar loop state threaded through a tail-recursive well-founded loop, so the hot accumulators compile to register arithmetic. The full ten-counter arrays are materialized only at a divergence check (every `checkTokens` tokens once the floors clear), where the shared boxed `splitEndBlockCheck` reads them.

The heuristic stays proof-free (`emitSharedBlocksAtP` clamps arbitrary cuts, so any cut list is correctness-safe); the `totalBytes` signature change threads `data.size` through the dispatch, the roundtrip/padding specs, and the conformance, size-helper, and mid-sweep call sites. Output is byte-identical: the `PackedTokens` conformance pin (`chooseSplitsHeuristicP` against the boxed `chooseSplitsHeuristic` over the `unpackTok` view) and the `SizeHelpers` byte-identity checks pass unchanged.

Item 4 from the issue (derive whole-file frequencies by summing the per-block frequencies the split-sizing pass already computes) is deferred to a follow-up, https://github.com/kim-em/lean-zip/issues/2772: unlike the proof-free heuristic, the base candidate feeds the verified roundtrip/padding specs, so it needs a proven EOB-corrected partition-sum equality (`tokenFreqsP` pre-counts symbol 256, so summing k blocks over-counts it by k-1) threaded through the clamped sizing recursion — real proof infrastructure that does not belong bundled with this low-risk heuristic rewrite.

Addresses https://github.com/kim-em/lean-zip/issues/2762 (items 1-3). Item 4 tracked in https://github.com/kim-em/lean-zip/issues/2772.

🤖 Prepared with Claude Code
