### PR TITLE
perf: half-depth lazy lookahead probe (libdeflate)

### DIFF
--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1328,6 +1328,13 @@ where
     Huffman-distribution effect no *local* deferral rule captures (that needs the
     cost-model parse of #2526 part 2).
 
+    The lookahead walk at `pos+1` runs at `lazyDepth` chain steps, a separate knob
+    from the `pos` walk's `maxChain`. It defaults to `maxChain` (full-depth probe,
+    the original behavior); callers pass a reduced value (libdeflate probes its
+    first lookahead at *half* depth) to buy back the second full-depth walk each
+    matched position otherwise pays. Depth is a pure heuristic — `chainWalk_spec`
+    holds for any fuel — so any `lazyDepth` keeps the encoder contracts.
+
     Match-finding stays opaque to correctness — `chainWalk_spec` holds for *any*
     chain state and *any* deferral predicate, so validity is re-established at
     emission exactly as for `lz77Chain`. `pos+1` is intentionally *not* inserted
@@ -1336,17 +1343,18 @@ where
     `updateHashes` and `lz77Greedy.trailing`. Equal-quality contracts proven in
     `LZ77ChainLazyCorrect`. -/
 def lz77ChainLazy (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258) :
+    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
+    (lazyDepth : Nat := maxChain) :
     Array LZ77Token :=
   if data.size < 3 then
     (lz77Greedy.trailing data 0).toArray
   else
     let hashSize := 65536
     (mainLoop data windowSize hashSize maxChain
-      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 insertCap goodMatch niceLen).toArray
+      (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 insertCap goodMatch niceLen lazyDepth).toArray
 where
   mainLoop (data : ByteArray) (windowSize hashSize maxChain : Nat)
-      (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen : Nat) : List LZ77Token :=
+      (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) : List LZ77Token :=
     if hlt : pos + 2 < data.size then
       let h := lz77Greedy.hash3 data pos hashSize hlt
       let head := headProbeGuarded hashTable h
@@ -1369,7 +1377,7 @@ where
               let maxLen2 := min 258 (data.size - (pos + 1))
               have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
               let m2 :=
-                lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 maxChain 0 0
+                lz77Chain.chainWalk data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 lazyDepth 0 0
               let matchLen2 := m2.1
               let matchPos2 := m2.2
               if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
@@ -1380,39 +1388,39 @@ where
                     lz77Chain.updateHashes data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
                   .literal (data[pos]'(by omega)) ::
                     .reference matchLen2 (pos + 1 - matchPos2) ::
-                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap goodMatch niceLen
+                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1 + matchLen2) insertCap goodMatch niceLen lazyDepth
                 else
                   -- matchLen2 spills past data: keep match at pos
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
                   .reference matchLen (pos - matchPos) ::
-                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen
+                    mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
               else
                 -- No better match at pos+1: keep match at pos
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
                 .reference matchLen (pos - matchPos) ::
-                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen
+                  mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
             else
               -- Gated: long first match, skip the lookahead; still insert interior hashes.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 lz77Chain.updateHashes data hashSize hashTable prev pos 1 matchLen insertCap
               .reference matchLen (pos - matchPos) ::
-                mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen
+                mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
           else
             -- Near end of data: keep match at pos
             have : data.size - (pos + matchLen) < data.size - pos := by omega
             .reference matchLen (pos - matchPos) ::
-              mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen
+              mainLoop data windowSize hashSize maxChain hashTable prev (pos + matchLen) insertCap goodMatch niceLen lazyDepth
         else
           .literal (data[pos]'(by omega)) ::
-            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen
+            mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen lazyDepth
       else
         .literal (data[pos]'(by omega)) ::
-          mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen
+          mainLoop data windowSize hashSize maxChain hashTable prev (pos + 1) insertCap goodMatch niceLen lazyDepth
     else
       lz77Greedy.trailing data pos
   termination_by data.size - pos
@@ -1424,16 +1432,17 @@ where
     token-emitting `mainLoop` differs (push vs. cons). Proven equal to
     `lz77ChainLazy` in `LZ77ChainLazyCorrect`. -/
 def lz77ChainLazyIter (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258) :
+    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
+    (lazyDepth : Nat := maxChain) :
     Array LZ77Token :=
   if data.size < 3 then
     lz77GreedyIter.trailing data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen
+    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth
       (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0 #[]
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen : Nat)
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
       (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
       Array LZ77Token :=
     if hlt : pos + 2 < data.size then
@@ -1457,7 +1466,7 @@ where
               let maxLen2 := min 258 (data.size - (pos + 1))
               have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
               let r2 :=
-                chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 maxChain 0 0
+                chainWalkGuardedPacked data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 lazyDepth 0 0
               let matchLen2 := r2 % 512
               let matchPos2 := r2 / 512
               if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
@@ -1465,37 +1474,37 @@ where
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1 + matchLen2)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1 + matchLen2)
                     (acc.push (.literal (data[pos]'(by omega))) |>.push
                       (.reference matchLen2 (pos + 1 - matchPos2)))
                 else
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
                     (acc.push (.reference matchLen (pos - matchPos)))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
+                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
                   (acc.push (.reference matchLen (pos - matchPos)))
             else
               -- Gated: long first match, skip the lookahead; still insert interior hashes.
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
+              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
                 (acc.push (.reference matchLen (pos - matchPos)))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
+            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
               (acc.push (.reference matchLen (pos - matchPos)))
         else
-          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1)
+          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
             (acc.push (.literal (data[pos]'(by omega))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1)
+        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
           (acc.push (.literal (data[pos]'(by omega))))
     else
       lz77GreedyIter.trailing data pos acc
@@ -1569,17 +1578,18 @@ where
     identical control flow and chain state, `Array UInt32` accumulator.
     Equal to `(lz77ChainLazyIter ..).map packTok` (`lz77ChainLazyIterP_eq`). -/
 def lz77ChainLazyIterP (data : ByteArray) (maxChain : Nat) (windowSize : Nat := 32768)
-    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258) :
+    (insertCap : Nat := 1000000000) (goodMatch : Nat := 259) (niceLen : Nat := 258)
+    (lazyDepth : Nat := maxChain) :
     Array UInt32 :=
   if data.size < 3 then
     trailingP data 0 #[]
   else
     let hashSize := 65536
-    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen
+    mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth
       (.replicate hashSize data.size) (.replicate (min chainWinSize data.size) data.size) 0
       (Array.emptyWithCapacity data.size)
 where
-  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen : Nat)
+  mainLoop (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
       (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array UInt32) :
       Array UInt32 :=
     if hlt : pos + 2 < data.size then
@@ -1606,7 +1616,7 @@ where
               let maxLen2 := min 258 (data.size - (pos + 1))
               have hmaxLen2P : (pos + 1) + maxLen2 ≤ data.size := by omega
               let r2 :=
-                chainWalkGuardedPackedU data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 maxChain 0 0
+                chainWalkGuardedPackedU data prev windowSize (pos + 1) maxLen2 niceLen hmaxLen2P head2 lazyDepth 0 0
               let matchLen2 := r2 % 512
               let matchPos2 := r2 / 512
               if matchLen2 > matchLen ∧ pos + 1 - matchPos2 ≤ pos - matchPos then
@@ -1614,20 +1624,20 @@ where
                   have : data.size - (pos + 1 + matchLen2) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 (matchLen2 + 1) insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1 + matchLen2)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1 + matchLen2)
                     (acc.push (packTok (.literal (data[pos]'(by omega)))) |>.push
                       (packTok (.reference matchLen2 (pos + 1 - matchPos2))))
                 else
                   have : data.size - (pos + matchLen) < data.size - pos := by omega
                   let (hashTable, prev) :=
                     updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
+                  mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
                     (acc.push (packTok (.reference matchLen (pos - matchPos))))
               else
                 have : data.size - (pos + matchLen) < data.size - pos := by omega
                 let (hashTable, prev) :=
                   updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
+                mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
                   (acc.push (packTok (.reference matchLen (pos - matchPos))))
             else
               -- Gated: first match already long; skip the lookahead, but still insert
@@ -1635,17 +1645,17 @@ where
               have : data.size - (pos + matchLen) < data.size - pos := by omega
               let (hashTable, prev) :=
                 updateHashesGuarded data hashSize hashTable prev pos 1 matchLen insertCap
-              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
+              mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
                 (acc.push (packTok (.reference matchLen (pos - matchPos))))
           else
             have : data.size - (pos + matchLen) < data.size - pos := by omega
-            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + matchLen)
+            mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + matchLen)
               (acc.push (packTok (.reference matchLen (pos - matchPos))))
         else
-          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1)
+          mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
             (acc.push (packTok (.literal (data[pos]'(by omega)))))
       else
-        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev (pos + 1)
+        mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev (pos + 1)
           (acc.push (packTok (.literal (data[pos]'(by omega)))))
     else
       trailingP data pos acc

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -657,14 +657,31 @@ def niceLen (level : UInt8) : Nat :=
   else if level ≤ 7 then 130
   else 258
 
+/-- Lazy lookahead probe depth (libdeflate `deflate_compress.c`): the second
+    `chainWalk` at `pos+1` runs at *half* the `pos` walk's `chainDepth`, not full
+    depth. Since the `goodMatch` gate is disabled at L5+ (`goodMatch = 259`), every
+    matched position otherwise pays two full-depth chain walks; libdeflate probes
+    its first lookahead at half depth (and its second at quarter) and still holds
+    better ratios than us, so the deferral quality a half-depth probe gives up is
+    slack. The probe still runs — it is shallower, not skipped — so the ratio cost
+    stays in the noise while the second walk's cycles roughly halve.
+
+    Only levels ≥ 4 (the lazy `deflate_slow` tier) consult this; the greedy
+    matcher (1–3) has no lookahead. Depth is a pure heuristic — the chain is
+    re-verified at emission (`chainWalk_spec` holds for any fuel) — so any value
+    keeps the encoder contracts. -/
+def lazyDepth (level : UInt8) : Nat :=
+  chainDepth level / 2
+
 /-- The per-level LZ77 matcher (zlib-faithful): levels 1–3 (`deflate_fast`) use the
     greedy hash-chain matcher; levels ≥ 4 (`deflate_slow`) use the one-byte-lookahead
     lazy variant, which improves ratio at equal window/chain depth. Both share the
     same `(chainDepth, insertCap, niceLen)` ladder and satisfy the same encoder
     contracts (`lzMatch_{encodable,empty,resolves}` in `DeflateBlockSplit`), so the
-    choice is transparent to the roundtrip proof. -/
+    choice is transparent to the roundtrip proof. The lazy tier probes its `pos+1`
+    lookahead at `lazyDepth` (half-depth), a heuristic knob invisible to the proof. -/
 def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
-  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
+  if 4 ≤ level then lz77ChainLazyIter data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
   else lz77ChainIter data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-- Packed-token form of `lzMatch` (Wave 3b stage A): the same per-level
@@ -673,7 +690,7 @@ def lzMatch (data : ByteArray) (level : UInt8) : Array LZ77Token :=
     `lzMatch` exactly (`lzMatchP_map` in `Zip/Spec/LZ77PackedCorrect.lean`);
     downstream consumers still run on `lzMatch` — stage B moves them here. -/
 def lzMatchP (data : ByteArray) (level : UInt8) : Array UInt32 :=
-  if 4 ≤ level then lz77ChainLazyIterP data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
+  if 4 ≤ level then lz77ChainLazyIterP data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
   else lz77ChainIterP data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-! ## Self-contained block-split dynamic compression

--- a/Zip/Spec/DeflateBlockSplit.lean
+++ b/Zip/Spec/DeflateBlockSplit.lean
@@ -34,7 +34,7 @@ theorem lzMatch_encodable (data : ByteArray) (level : UInt8) :
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
+  · exact lz77ChainLazyIter_encodable data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
       (by omega) (by omega)
   · exact lz77ChainIter_encodable data (chainDepth level) 32768 (insertCap level) (niceLen level)
       (by omega) (by omega)
@@ -43,7 +43,7 @@ theorem lzMatch_empty (data : ByteArray) (level : UInt8) (hz : data.size = 0) :
     lzMatch data level = #[] := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) hz
+  · exact lz77ChainLazyIter_empty data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) hz
   · exact lz77ChainIter_empty data (chainDepth level) 32768 (insertCap level) (niceLen level) hz
 
 theorem lzMatch_resolves (data : ByteArray) (level : UInt8) :
@@ -51,7 +51,7 @@ theorem lzMatch_resolves (data : ByteArray) (level : UInt8) :
       some data.data.toList := by
   unfold lzMatch
   split
-  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (by omega)
+  · exact lz77ChainLazyIter_resolves data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level) (by omega)
   · exact lz77ChainIter_resolves data (chainDepth level) 32768 (insertCap level) (niceLen level) (by omega)
 
 set_option maxHeartbeats 800000 in

--- a/Zip/Spec/LZ77ChainLazyCorrect.lean
+++ b/Zip/Spec/LZ77ChainLazyCorrect.lean
@@ -25,9 +25,9 @@ set_option backward.split false in
     reference cases use `chainWalk_spec` (at `pos`, and again at `pos+1` for the
     lookahead) exactly as `lz77Chain_mainLoop_valid` does for the single match. -/
 theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize maxChain : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen : Nat) (hw : windowSize > 0) :
+    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) (hw : windowSize > 0) :
     ValidDecomp data pos
-      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen) := by
+      (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth) := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -52,7 +52,7 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
                 windowSize (pos + 1) (min 258 (data.size - (pos + 1))) niceLen (by omega)
                 (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)[
                   lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!
-                maxChain 0 0 (Or.inl rfl)
+                lazyDepth 0 0 (Or.inl rfl)
               split
               · split
                 · rename_i hle2
@@ -61,38 +61,38 @@ theorem lz77ChainLazy_mainLoop_valid (data : ByteArray) (windowSize hashSize max
                   · exact .literal (by omega) (getElem!_pos data pos (by omega))
                       (lazyRef_at_pos data (pos + 1) _ _ hQ2.1 (by omega) hle2
                         (fun i hi => hQ2.2.2.2.1 i hi)
-                        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw))
+                        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw))
                 · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
+                    (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
               · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
+                  (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
             · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
+                (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
           · exact lazyRef_at_pos data pos _ _ hQ.1 hge hle (fun i hi => hQ.2.2.2.1 i hi)
-              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
+              (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
       · exact .literal (by omega) (getElem!_pos data pos (by omega))
-          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
+          (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
     · exact .literal (by omega) (getElem!_pos data pos (by omega))
-        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ hw)
+        (lz77ChainLazy_mainLoop_valid _ _ _ _ _ _ _ _ _ _ _ hw)
   · exact trailing_valid data pos
 termination_by data.size - pos
 decreasing_by all_goals omega
 
 /-- `lz77ChainLazy` produces a valid decomposition of the input data. -/
-theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
+theorem lz77ChainLazy_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen).toList := by
+    ValidDecomp data 0 (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList := by
   simp only [lz77ChainLazy]
   split
   · simp only; exact trailing_valid data 0
-  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen hw
+  · simp only; exact lz77ChainLazy_mainLoop_valid data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen lazyDepth hw
 
 /-- Resolving the LZ77 tokens produced by `lz77ChainLazy` recovers the original data. -/
-theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
+theorem lz77ChainLazy_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth)) [] =
       some data.data.toList :=
-  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen hw)
+  validDecomp_resolves data _ (lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw)
 
 /-! ## Encodability -/
 
@@ -104,8 +104,8 @@ private def Enc (t : LZ77Token) : Prop :=
 
 set_option backward.split false in
 theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize maxChain : Nat)
-    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen, Enc t := by
+    (hashTable : Array Nat) (prev : Array Nat) (pos insertCap goodMatch niceLen lazyDepth : Nat) (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
+    ∀ t ∈ lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth, Enc t := by
   unfold lz77ChainLazy.mainLoop
   split
   · rename_i hlt
@@ -130,7 +130,7 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
                 windowSize (pos + 1) (min 258 (data.size - (pos + 1))) niceLen (by omega)
                 (hashTable.set! (lz77Greedy.hash3 data pos hashSize hlt) pos)[
                   lz77Greedy.hash3 data (pos + 1) hashSize (by omega)]!
-                maxChain 0 0 (Or.inl rfl)
+                lazyDepth 0 0 (Or.inl rfl)
               split
               · split
                 · rename_i hle2
@@ -142,40 +142,40 @@ theorem lz77ChainLazy_mainLoop_encodable (data : ByteArray) (windowSize hashSize
                     | tail _ h =>
                       cases h with
                       | head => exact ⟨by omega, by omega, by omega, by omega⟩
-                      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
+                      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
                 · intro t ht
                   cases ht with
                   | head => exact ⟨hge, by omega, by omega, by omega⟩
-                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
+                  | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
               · intro t ht
                 cases ht with
                 | head => exact ⟨hge, by omega, by omega, by omega⟩
-                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
+                | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
             · intro t ht
               cases ht with
               | head => exact ⟨hge, by omega, by omega, by omega⟩
-              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
+              | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
           · intro t ht
             cases ht with
             | head => exact ⟨hge, by omega, by omega, by omega⟩
-            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
+            | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
       · intro t ht
         cases ht with
         | head => trivial
-        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
+        | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
     · intro t ht
       cases ht with
       | head => trivial
-      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ hw hws t h
+      | tail _ h => exact lz77ChainLazy_mainLoop_encodable _ _ _ _ _ _ _ _ _ _ _ hw hws t h
   · intro t ht
     exact trailing_encodable data pos t ht
 termination_by data.size - pos
 decreasing_by all_goals omega
 
 /-- Every token `lz77ChainLazy` emits satisfies the encoder bounds. -/
-theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
+theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen).toList,
+    ∀ t ∈ (lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
@@ -184,17 +184,17 @@ theorem lz77ChainLazy_encodable (data : ByteArray) (maxChain windowSize insertCa
   · intro t ht
     exact trailing_encodable data 0 t ht
   · intro t ht
-    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen hw hws t ht
+    exact lz77ChainLazy_mainLoop_encodable data windowSize 65536 maxChain _ _ 0 insertCap goodMatch niceLen lazyDepth hw hws t ht
 
 /-! ## Iterative version: equivalence + transferred contracts -/
 
 /-- The iterative lazy chain `mainLoop` is the accumulator form of the recursive
     one — identical branch structure, push vs. cons at each emission (two pushes in
     the lookahead arm). -/
-private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen : Nat)
+private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
     (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev pos acc =
-    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen).toArray := by
+    lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev pos acc =
+    acc ++ (lz77ChainLazy.mainLoop data windowSize hashSize maxChain hashTable prev pos insertCap goodMatch niceLen lazyDepth).toArray := by
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
     unfold lz77ChainLazyIter.mainLoop lz77ChainLazy.mainLoop
@@ -241,37 +241,37 @@ private theorem mainLoop_eq_chainLazy (data : ByteArray) (windowSize hashSize ma
       exact trailing_eq data pos acc
 
 /-- `lz77ChainLazyIter` produces exactly the same tokens as `lz77ChainLazy`. -/
-theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat) :
-    lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen =
-      lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen := by
+theorem lz77ChainLazyIter_eq_lz77ChainLazy (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) :
+    lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth =
+      lz77ChainLazy data maxChain windowSize insertCap goodMatch niceLen lazyDepth := by
   unfold lz77ChainLazyIter lz77ChainLazy
   split
   · rw [trailing_eq]; simp only [List.append_toArray, List.nil_append]
   · rw [mainLoop_eq_chainLazy]; simp only [List.append_toArray, List.nil_append]
 
-theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
+theorem lz77ChainLazyIter_valid (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
     (hw : windowSize > 0) :
-    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen).toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen hw
+    ValidDecomp data 0 (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList := by
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_valid data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw
 
-theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
+theorem lz77ChainLazyIter_resolves (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
     (hw : windowSize > 0) :
-    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen)) [] =
+    Deflate.Spec.resolveLZ77 (tokensToSymbols (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth)) [] =
       some data.data.toList := by
-  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch niceLen hw
+  rw [lz77ChainLazyIter_eq_lz77ChainLazy]; exact lz77ChainLazy_resolves data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw
 
-theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
+theorem lz77ChainLazyIter_encodable (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen).toList,
+    ∀ t ∈ (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth).toList,
       match t with
       | .literal _ => True
       | .reference len dist => 3 ≤ len ∧ len ≤ 258 ∧ 1 ≤ dist ∧ dist ≤ 32768 := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
-  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch niceLen hw hws
+  exact lz77ChainLazy_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw hws
 
 /-- The lazy chain matcher emits no tokens on empty input. -/
-theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
-    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen = #[] := by
+theorem lz77ChainLazyIter_empty (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
+    (hzero : data.size = 0) : lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth = #[] := by
   rw [lz77ChainLazyIter_eq_lz77ChainLazy]
   simp only [lz77ChainLazy, show data.size < 3 from by omega, ↓reduceIte]
   have htrail : lz77Greedy.trailing data 0 = [] := by

--- a/Zip/Spec/LZ77PackedCorrect.lean
+++ b/Zip/Spec/LZ77PackedCorrect.lean
@@ -80,11 +80,11 @@ theorem lz77ChainIterP_eq (data : ByteArray) (maxChain windowSize insertCap nice
 /-- The packed lazy `mainLoop` is the packed image of the boxed one. The gate
     (`matchLen < goodMatch`) is applied identically in both, so the branch tree
     stays in lockstep — one extra split versus the ungated proof. -/
-private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen : Nat)
+private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth : Nat)
     (hashTable : Array Nat) (prev : Array Nat) (pos : Nat) (acc : Array LZ77Token) :
-    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev pos
+    lz77ChainLazyIterP.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev pos
         (acc.map packTok) =
-      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen hashTable prev pos
+      (lz77ChainLazyIter.mainLoop data windowSize hashSize maxChain insertCap goodMatch niceLen lazyDepth hashTable prev pos
         acc).map packTok := by
   induction h : data.size - pos using Nat.strongRecOn generalizing pos acc hashTable prev with
   | _ n ih =>
@@ -113,14 +113,14 @@ private theorem mainLoopLazyP_eq (data : ByteArray) (windowSize hashSize maxChai
 
 /-- `lz77ChainLazyIterP` produces exactly the `packTok` image of
     `lz77ChainLazyIter`. -/
-theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat) :
-    lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen =
-      (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen).map packTok := by
+theorem lz77ChainLazyIterP_eq (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat) :
+    lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth =
+      (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth).map packTok := by
   unfold lz77ChainLazyIterP lz77ChainLazyIter
   split
   · simpa only [List.map_toArray, List.map_nil] using trailingP_eq data 0 #[]
   · simpa only [List.map_toArray, List.map_nil, Array.emptyWithCapacity_eq] using
-      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap goodMatch niceLen _ _ 0 #[]
+      mainLoopLazyP_eq data windowSize 65536 maxChain insertCap goodMatch niceLen lazyDepth _ _ 0 #[]
 
 /-! ## View direction: the boxed view recovers the boxed matchers
 
@@ -140,15 +140,15 @@ theorem lz77ChainIterP_map (data : ByteArray) (maxChain windowSize insertCap nic
   rw [hcongr, Array.map_id]
 
 /-- The boxed view of the packed lazy matcher is the boxed lazy matcher. -/
-theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen : Nat)
+theorem lz77ChainLazyIterP_map (data : ByteArray) (maxChain windowSize insertCap goodMatch niceLen lazyDepth : Nat)
     (hw : windowSize > 0) (hws : windowSize ≤ 32768) :
-    (lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen).map unpackTok =
-      lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen := by
-  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap goodMatch niceLen hw hws
+    (lz77ChainLazyIterP data maxChain windowSize insertCap goodMatch niceLen lazyDepth).map unpackTok =
+      lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth := by
+  have henc := lz77ChainLazyIter_encodable data maxChain windowSize insertCap goodMatch niceLen lazyDepth hw hws
   rw [lz77ChainLazyIterP_eq, Array.map_map]
   have hcongr : Array.map (unpackTok ∘ packTok)
-        (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen) =
-      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen) :=
+        (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth) =
+      Array.map id (lz77ChainLazyIter data maxChain windowSize insertCap goodMatch niceLen lazyDepth) :=
     Array.map_congr_left fun t ht => unpackTok_packTok t (henc t (by simpa only [Array.mem_toList_iff] using ht))
   rw [hcongr, Array.map_id]
 
@@ -159,7 +159,7 @@ theorem lzMatchP_eq (data : ByteArray) (level : UInt8) :
     lzMatchP data level = (lzMatch data level).map packTok := by
   unfold lzMatchP lzMatch
   split
-  · exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
+  · exact lz77ChainLazyIterP_eq data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
   · exact lz77ChainIterP_eq data (chainDepth level) 32768 (insertCap level) (niceLen level)
 
 /-- The boxed view of the packed token stream is exactly `lzMatch`'s stream:
@@ -169,7 +169,7 @@ theorem lzMatchP_map (data : ByteArray) (level : UInt8) :
     (lzMatchP data level).map unpackTok = lzMatch data level := by
   unfold lzMatchP lzMatch
   split
-  · exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level)
+  · exact lz77ChainLazyIterP_map data (chainDepth level) 32768 (insertCap level) (goodMatch level) (niceLen level) (lazyDepth level)
       (by omega) (by omega)
   · exact lz77ChainIterP_map data (chainDepth level) 32768 (insertCap level) (niceLen level)
       (by omega) (by omega)

--- a/ZipTest/NativeDeflate.lean
+++ b/ZipTest/NativeDeflate.lean
@@ -393,6 +393,18 @@ def ZipTest.NativeDeflate.tests : IO Unit := do
     unless iterTokens == recTokens do
       throw (IO.userError s!"lz77ChainLazyIter vs lz77ChainLazy mismatch on {name}: \
         {iterTokens.size} vs {recTokens.size} tokens")
+    -- Reduced lookahead probe depth (#2763 half-depth lazy probe): the three
+    -- twins must stay in lockstep at any `lazyDepth`, not just the default.
+    -- Exercise a non-default depth (32) that actually changes deferral choices.
+    let iterShallow := Zip.Native.Deflate.lz77ChainLazyIter data 64 32768 1000000000 259 258 32
+    let recShallow := Zip.Native.Deflate.lz77ChainLazy data 64 32768 1000000000 259 258 32
+    unless iterShallow == recShallow do
+      throw (IO.userError s!"lz77ChainLazyIter vs lz77ChainLazy (lazyDepth=32) mismatch on {name}: \
+        {iterShallow.size} vs {recShallow.size} tokens")
+    let packedShallow := Zip.Native.Deflate.lz77ChainLazyIterP data 64 32768 1000000000 259 258 32
+    unless packedShallow == iterShallow.map Zip.Native.Deflate.packTok do
+      throw (IO.userError s!"lz77ChainLazyIterP vs lz77ChainLazyIter (lazyDepth=32) mismatch on {name}: \
+        {packedShallow.size} vs {iterShallow.size} tokens")
 
   -- deflateRaw at every lazy level (4–9) → native inflate AND FFI decompress, on
   -- varied shapes incl. edge cases. Exercises the lazy path end to end.

--- a/bench/ZipMidSweep.lean
+++ b/bench/ZipMidSweep.lean
@@ -81,7 +81,9 @@ def timedConfigs : List TimedConfig := [
 /-- Compress `data` under one candidate config, returning the emitted size
     (consumed so the work is not dead-code-eliminated). -/
 def runConfig (cfg : TimedConfig) (data : ByteArray) : Nat :=
-  let ptoks := lz77ChainLazyIterP data cfg.chain 32768 1000000000 cfg.gm cfg.nl
+  -- Half-depth lazy lookahead probe (#2763): the `pos+1` walk runs at `chain / 2`,
+  -- matching production `DeflateDynamic.lazyDepth`, so timings model the shipped path.
+  let ptoks := lz77ChainLazyIterP data cfg.chain 32768 1000000000 cfg.gm cfg.nl (cfg.chain / 2)
   let base := deflateRawBaseP data ptoks
   if cfg.mode == 0 then base.size
   else
@@ -120,7 +122,7 @@ def main (args : List String) : IO Unit := do
     let name := (path.splitOn "/").getLastD path
     for chain in chainGrid do
       for gm in gmGrid do
-        let ptoks := lz77ChainLazyIterP data chain 32768 1000000000 gm
+        let ptoks := lz77ChainLazyIterP data chain 32768 1000000000 gm 258 (chain / 2)
         let base := (deflateRawBaseP data ptoks).size
         let cad := fixedCadenceCuts sharedTokChunk ptoks.size
         let cadSize := if cad.isEmpty then base

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pb65fad7f22)">
+   <g clip-path="url(#pa0395a7d35)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJDElEQVR4nO3YvYpdVQCG4ZyZM5qYMQTBJBgIipaClTba23shXoGN1+AdiGAvgoW1jaXYKAgSYkDUUfMzM5mcHwvBK3gXy2ye5wq+zWLv85612v39+f4Sz5bzR7MXjPNkmc+2vzifPWGY1bUbsyeM8fwLsxeMszqYvWCMp8t9z5Z6ZvuTe7MnDLPMEwMAmEhgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDE1ndXJ7M3DHGxPZ89YZhb11+dPWGY492N2ROGWJ09mD1hmG/Ofpg9YYhXnnt59oRhtrvN7AlDPNyczp4wzGa/nT1hiLdfvD17wjBusAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2Pj66PnvDELv1bvaEYY4vXZ49YZy/7s5eMMT+7MHsCcO8c+fd2ROGON0s98weL/TZ3jh+c/aEYS5Wm9kThtj//N3sCcO4wQIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAIDY+srh8ewNQ5xvT2dPGGe14C6+fG32giFWCz6zo81m9oQhlnxmV9fLfM9+vbg/e8Iwm93F7AlD3L56ffaEYZb7BQEAmERgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGy1/f7j/ewR8J/dbvYC+NeB/5/PHN8P/kd8QQAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC2/vC3u7M3DPHgyXb2hGG+vf9w9oRhvvzgvdkThrh55c7sCcO89elnsycM8f7rL82eMMxPf57NnjDElfXh7AnDfPHVj7MnDHH6yUezJwzjBgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiq83u6/3sESNsd5vZE4Y5WC23iw/PT2dPGONwPXvBOI9PZi8YYnv91uwJw+z2u9kThjhaLfc9e7pf5m/a0WaZz3XpkhssAICcwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiK0P9rMnDHKwnr1gmIOTe7MnjPPo99kLhthfPJ09YZjVzddmTxjicLXcb8h2fz57whiPT2YvGObo6TLPbP/HL7MnDOMGCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGL/AMJZgtdUCitGAAAAAElFTkSuQmCC" id="imageae30efa079" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJD0lEQVR4nO3YvYpdVQCG4TkzZzQxYwiCMSQQBAUbwUob7e29EK/AxmvwDkSwF8HC2sZSbBQEiRIQQ6L5mZlMzo+F4BW8i2U2z3MF32Kx93nPXu3+/nJ/wPPl/PHsBeM8XebZ9hfnsycMs7p6ffaEMV58afaCcVaHsxeM8Wy5z9lS72x///fZE4ZZ5o0BAEwksAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYus7q/uzNwxxsT2fPWGYG9denz1hmJPd9dkThlidPZw9YZjvzn6aPWGImy+8OnvCMNvdZvaEIR5tTmdPGGaz386eMMS7L9+aPWEYX7AAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtj45vjZ7wxC79W72hGFODi7NnjDOX3dmLxhif/Zw9oRh3rv9/uwJQ5xulntnTxZ6tjdP3p49YZiL1Wb2hCH2v/4we8IwvmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbH356GT2hiHOt6ezJ4yzWnAXX7o6e8EQqwXf2fFmM3vCEEu+syvrZT5nf1zcnT1hmM3uYvaEIW5duTZ7wjDLfYMAAEwisAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC22v746X72CPjPbjd7Afzr0P/P5473B/8j3iAAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQW3/8553ZG4Z4+HQ7e8Iw3999NHvCMF9/9MHsCUO8dvn27AnDvPP5F7MnDPHhG6/MnjDMLw/OZk8Y4vL6aPaEYb765ufZE4Y4/eyT2ROG8QULACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYqvN7tv97BEjbHeb2ROGOVwtt4uPzk9nTxjjaD17wThP7s9eMMT22o3ZE4bZ7XezJwxxvFruc/Zsv8zftOPNMs91cOALFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMTWhwttrP1qmec6ODg4OHpwd/aEcR7fm71giP3Fs9kThlndfGv2hCGOVuvZE4a52D6ePWGI44vT2ROGWerZ9vd+mz1hmOVWCADAJAILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACD2D5wOguau5SzBAAAAAElFTkSuQmCC" id="image6991ef8c58" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m0482965940" d="M 0 0 
+       <path id="ma3e44726bf" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0482965940" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m0482965940" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m0482965940" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0482965940" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m0482965940" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0482965940" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m0482965940" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0482965940" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m0482965940" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0482965940" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m0482965940" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#ma3e44726bf" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="md551c2000d" d="M 0 0 
+       <path id="m0d7c49f754" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md551c2000d" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d7c49f754" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#md551c2000d" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d7c49f754" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md551c2000d" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d7c49f754" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md551c2000d" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d7c49f754" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md551c2000d" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d7c49f754" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md551c2000d" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d7c49f754" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md551c2000d" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d7c49f754" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md551c2000d" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0d7c49f754" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1303,15 +1303,8 @@ L 527.435033 49.4355
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_20">
-    <!-- -5 -->
-    <g transform="translate(112.061298 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_21">
-    <!-- +4 -->
-    <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
+    <!-- +0 -->
+    <g transform="translate(110.510438 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
 L 2944 2272 
@@ -1328,41 +1321,14 @@ L 2419 4013
 L 2944 4013 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
     </g>
    </g>
-   <g id="text_22">
-    <!-- -49 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -80 -->
-    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+   <g id="text_21">
+    <!-- +8 -->
+    <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1404,9 +1370,57 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -48 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -79 -->
+    <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_24">
@@ -1418,8 +1432,16 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- -34 -->
+    <!-- -28 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- +3 -->
+    <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1454,40 +1476,32 @@ Q 3006 2619 2597 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -1 -->
-    <g transform="translate(347.566088 68.904519) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +13 -->
+    <!-- +21 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
-    <!-- -33 -->
+    <!-- -27 -->
     <g transform="translate(423.999873 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
-    <!-- -45 -->
+    <!-- -43 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1547,18 +1561,6 @@ z
    <g id="text_37">
     <!-- +7 -->
     <g transform="translate(346.015229 104.25537) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
@@ -2178,18 +2180,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image440c7b4646" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image49f3902d8f" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m81963e1e02" d="M 0 0 
+       <path id="m632aa345f4" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m81963e1e02" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m632aa345f4" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2212,7 +2214,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m81963e1e02" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m632aa345f4" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2226,7 +2228,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m81963e1e02" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m632aa345f4" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2240,7 +2242,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m81963e1e02" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m632aa345f4" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2253,7 +2255,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m81963e1e02" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m632aa345f4" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2266,7 +2268,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m81963e1e02" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m632aa345f4" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2279,7 +2281,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m81963e1e02" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m632aa345f4" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2940,8 +2942,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.540625 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.467344 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3011,12 +3013,12 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3057,109 +3059,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb65fad7f22">
+  <clipPath id="pa0395a7d35">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m97f20478be" d="M 0 0 
+       <path id="m8c72a28ee8" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m97f20478be" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c72a28ee8" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m97f20478be" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c72a28ee8" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m97f20478be" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c72a28ee8" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m97f20478be" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c72a28ee8" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m97f20478be" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c72a28ee8" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m97f20478be" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c72a28ee8" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m97f20478be" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c72a28ee8" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="mb1d83d222f" d="M 0 0 
+       <path id="m1cf1c89a8f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb1d83d222f" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cf1c89a8f" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb1d83d222f" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cf1c89a8f" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb1d83d222f" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m1cf1c89a8f" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mae2b5af5bc" d="M 0 0 
+       <path id="m97694042c8" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mae2b5af5bc" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m97694042c8" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 147.424043) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 147.134805) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 297.6298) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 296.934364) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="m5167237d69" d="M -2.5 2.5 
+     <path id="mba84fce6e9" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p80e98dc6c6)">
-     <use xlink:href="#m5167237d69" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5167237d69" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5167237d69" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5167237d69" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5167237d69" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5167237d69" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5167237d69" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5167237d69" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m5167237d69" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3994ffe252)">
+     <use xlink:href="#mba84fce6e9" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba84fce6e9" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba84fce6e9" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba84fce6e9" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba84fce6e9" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba84fce6e9" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba84fce6e9" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba84fce6e9" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mba84fce6e9" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m2986e0f99e" d="M 0 -2.5 
+     <path id="m9fdd092363" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p80e98dc6c6)">
-     <use xlink:href="#m2986e0f99e" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2986e0f99e" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2986e0f99e" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2986e0f99e" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2986e0f99e" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2986e0f99e" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2986e0f99e" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2986e0f99e" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2986e0f99e" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3994ffe252)">
+     <use xlink:href="#m9fdd092363" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fdd092363" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fdd092363" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fdd092363" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fdd092363" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fdd092363" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fdd092363" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fdd092363" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9fdd092363" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="mf1b6edff00" d="M -0 3.535534 
+     <path id="m4d8c8dde8b" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p80e98dc6c6)">
-     <use xlink:href="#mf1b6edff00" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1b6edff00" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3994ffe252)">
+     <use xlink:href="#m4d8c8dde8b" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m4d8c8dde8b" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m16974966b3" d="M -0 2.5 
+     <path id="m80e4329e73" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p80e98dc6c6)">
-     <use xlink:href="#m16974966b3" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3994ffe252)">
+     <use xlink:href="#m80e4329e73" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m3810016285" d="M -0.833333 2.5 
+     <path id="m6cd6278396" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p80e98dc6c6)">
-     <use xlink:href="#m3810016285" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3810016285" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3810016285" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3810016285" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3810016285" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3810016285" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3810016285" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3810016285" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m3810016285" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3994ffe252)">
+     <use xlink:href="#m6cd6278396" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6cd6278396" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6cd6278396" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6cd6278396" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6cd6278396" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6cd6278396" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6cd6278396" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6cd6278396" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6cd6278396" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="maad1893cc0" d="M -1.25 2.5 
+     <path id="m7ba89f72f2" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p80e98dc6c6)">
-     <use xlink:href="#maad1893cc0" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maad1893cc0" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maad1893cc0" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maad1893cc0" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maad1893cc0" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maad1893cc0" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maad1893cc0" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maad1893cc0" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#maad1893cc0" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3994ffe252)">
+     <use xlink:href="#m7ba89f72f2" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ba89f72f2" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ba89f72f2" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ba89f72f2" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ba89f72f2" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ba89f72f2" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ba89f72f2" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ba89f72f2" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7ba89f72f2" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m998b140789" d="M 0 -2.5 
+     <path id="m4ab7bb2153" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p80e98dc6c6)">
-     <use xlink:href="#m998b140789" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m998b140789" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m998b140789" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m998b140789" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m998b140789" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m998b140789" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m998b140789" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m998b140789" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m998b140789" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p3994ffe252)">
+     <use xlink:href="#m4ab7bb2153" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ab7bb2153" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ab7bb2153" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ab7bb2153" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ab7bb2153" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ab7bb2153" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ab7bb2153" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ab7bb2153" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m4ab7bb2153" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="m13fbd74be7" d="M 0 -2.5 
+     <path id="mf8a846b386" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p80e98dc6c6)">
-     <use xlink:href="#m13fbd74be7" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13fbd74be7" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13fbd74be7" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13fbd74be7" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13fbd74be7" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13fbd74be7" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13fbd74be7" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13fbd74be7" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m13fbd74be7" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p3994ffe252)">
+     <use xlink:href="#mf8a846b386" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8a846b386" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8a846b386" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8a846b386" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8a846b386" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8a846b386" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8a846b386" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8a846b386" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf8a846b386" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="ma4d61aa984" d="M 0 3.5 
+      <path id="m98481276c3" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#ma4d61aa984" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m98481276c3" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#m5167237d69" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mba84fce6e9" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m2986e0f99e" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9fdd092363" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#mf1b6edff00" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m4d8c8dde8b" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m16974966b3" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m80e4329e73" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m3810016285" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6cd6278396" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#maad1893cc0" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7ba89f72f2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m998b140789" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m4ab7bb2153" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#m13fbd74be7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf8a846b386" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p80e98dc6c6)">
-     <use xlink:href="#ma4d61aa984" x="289.669676" y="152.424043" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma4d61aa984" x="223.847406" y="163.470186" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma4d61aa984" x="212.215046" y="167.327928" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma4d61aa984" x="186.58897" y="177.24904" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma4d61aa984" x="169.057218" y="186.931753" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma4d61aa984" x="158.596848" y="192.034656" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma4d61aa984" x="152.867313" y="198.552958" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma4d61aa984" x="150.950891" y="201.722371" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma4d61aa984" x="115.225692" y="276.895357" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#ma4d61aa984" x="99.852312" y="302.6298" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p3994ffe252)">
+     <use xlink:href="#m98481276c3" x="289.669676" y="152.134805" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m98481276c3" x="223.847406" y="163.210726" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m98481276c3" x="212.215046" y="166.942897" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m98481276c3" x="186.761055" y="175.874562" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m98481276c3" x="171.087559" y="184.167149" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m98481276c3" x="159.117262" y="189.902598" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m98481276c3" x="154.720399" y="196.076" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m98481276c3" x="151.93026" y="198.770694" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m98481276c3" x="115.448419" y="275.506087" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m98481276c3" x="99.852312" y="301.934364" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 152.424043 
-L 288.298379 152.682491 
-L 286.927082 152.939537 
-L 285.555784 153.195197 
-L 284.184487 153.449485 
-L 282.81319 153.702416 
-L 281.441892 153.954004 
-L 280.070595 154.204264 
-L 278.699298 154.45321 
-L 277.328 154.700855 
-L 275.956703 154.947213 
-L 274.585406 155.192297 
-L 273.214109 155.436121 
-L 271.842811 155.678696 
-L 270.471514 155.920037 
-L 269.100217 156.160154 
-L 267.728919 156.399062 
-L 266.357622 156.636771 
-L 264.986325 156.873295 
-L 263.615028 157.108643 
-L 262.24373 157.342829 
-L 260.872433 157.575864 
-L 259.501136 157.807759 
-L 258.129838 158.038524 
-L 256.758541 158.268172 
-L 255.387244 158.496712 
-L 254.015947 158.724155 
-L 252.644649 158.950513 
-L 251.273352 159.175794 
-L 249.902055 159.40001 
-L 248.530757 159.62317 
-L 247.15946 159.845285 
-L 245.788163 160.066363 
-L 244.416866 160.286415 
-L 243.045568 160.505451 
-L 241.674271 160.723478 
-L 240.302974 160.940508 
-L 238.931676 161.156548 
-L 237.560379 161.371608 
-L 236.189082 161.585697 
-L 234.817784 161.798823 
-L 233.446487 162.010994 
-L 232.07519 162.222221 
-L 230.703893 162.43251 
-L 229.332595 162.641871 
-L 227.961298 162.85031 
-L 226.590001 163.057838 
-L 225.218703 163.26446 
-L 223.847406 163.470186 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 152.134805 
+L 288.298379 152.394032 
+L 286.927082 152.651848 
+L 285.555784 152.90827 
+L 284.184487 153.163313 
+L 282.81319 153.41699 
+L 281.441892 153.669317 
+L 280.070595 153.920308 
+L 278.699298 154.169976 
+L 277.328 154.418337 
+L 275.956703 154.665402 
+L 274.585406 154.911187 
+L 273.214109 155.155704 
+L 271.842811 155.398966 
+L 270.471514 155.640985 
+L 269.100217 155.881776 
+L 267.728919 156.121349 
+L 266.357622 156.359717 
+L 264.986325 156.596893 
+L 263.615028 156.832888 
+L 262.24373 157.067713 
+L 260.872433 157.301381 
+L 259.501136 157.533903 
+L 258.129838 157.765289 
+L 256.758541 157.995552 
+L 255.387244 158.224701 
+L 254.015947 158.452748 
+L 252.644649 158.679703 
+L 251.273352 158.905576 
+L 249.902055 159.130378 
+L 248.530757 159.354119 
+L 247.15946 159.576809 
+L 245.788163 159.798457 
+L 244.416866 160.019074 
+L 243.045568 160.238669 
+L 241.674271 160.45725 
+L 240.302974 160.674829 
+L 238.931676 160.891413 
+L 237.560379 161.107013 
+L 236.189082 161.321636 
+L 234.817784 161.535291 
+L 233.446487 161.747988 
+L 232.07519 161.959735 
+L 230.703893 162.170539 
+L 229.332595 162.380411 
+L 227.961298 162.589357 
+L 226.590001 162.797386 
+L 225.218703 163.004507 
+L 223.847406 163.210726 
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 163.470186 
-L 223.605065 163.553843 
-L 223.362724 163.637352 
-L 223.120384 163.720715 
-L 222.878043 163.803931 
-L 222.635702 163.887002 
-L 222.393361 163.969927 
-L 222.15102 164.052707 
-L 221.908679 164.135343 
-L 221.666339 164.217835 
-L 221.423998 164.300184 
-L 221.181657 164.38239 
-L 220.939316 164.464454 
-L 220.696975 164.546376 
-L 220.454635 164.628156 
-L 220.212294 164.709796 
-L 219.969953 164.791295 
-L 219.727612 164.872654 
-L 219.485271 164.953874 
-L 219.24293 165.034955 
-L 219.00059 165.115898 
-L 218.758249 165.196703 
-L 218.515908 165.27737 
-L 218.273567 165.3579 
-L 218.031226 165.438293 
-L 217.788885 165.518551 
-L 217.546545 165.598672 
-L 217.304204 165.678659 
-L 217.061863 165.75851 
-L 216.819522 165.838228 
-L 216.577181 165.917811 
-L 216.33484 165.997261 
-L 216.0925 166.076579 
-L 215.850159 166.155763 
-L 215.607818 166.234816 
-L 215.365477 166.313737 
-L 215.123136 166.392527 
-L 214.880795 166.471186 
-L 214.638455 166.549714 
-L 214.396114 166.628113 
-L 214.153773 166.706383 
-L 213.911432 166.784523 
-L 213.669091 166.862535 
-L 213.42675 166.940418 
-L 213.18441 167.018174 
-L 212.942069 167.095803 
-L 212.699728 167.173304 
-L 212.457387 167.250679 
-L 212.215046 167.327928 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 163.210726 
+L 223.605065 163.291553 
+L 223.362724 163.372244 
+L 223.120384 163.452797 
+L 222.878043 163.533213 
+L 222.635702 163.613493 
+L 222.393361 163.693637 
+L 222.15102 163.773646 
+L 221.908679 163.853521 
+L 221.666339 163.933261 
+L 221.423998 164.012866 
+L 221.181657 164.092339 
+L 220.939316 164.171678 
+L 220.696975 164.250885 
+L 220.454635 164.32996 
+L 220.212294 164.408903 
+L 219.969953 164.487715 
+L 219.727612 164.566396 
+L 219.485271 164.644946 
+L 219.24293 164.723367 
+L 219.00059 164.801658 
+L 218.758249 164.87982 
+L 218.515908 164.957853 
+L 218.273567 165.035758 
+L 218.031226 165.113535 
+L 217.788885 165.191185 
+L 217.546545 165.268708 
+L 217.304204 165.346104 
+L 217.061863 165.423374 
+L 216.819522 165.500519 
+L 216.577181 165.577537 
+L 216.33484 165.654431 
+L 216.0925 165.731201 
+L 215.850159 165.807846 
+L 215.607818 165.884368 
+L 215.365477 165.960766 
+L 215.123136 166.037041 
+L 214.880795 166.113194 
+L 214.638455 166.189224 
+L 214.396114 166.265133 
+L 214.153773 166.340921 
+L 213.911432 166.416587 
+L 213.669091 166.492133 
+L 213.42675 166.567559 
+L 213.18441 166.642864 
+L 212.942069 166.718051 
+L 212.699728 166.793118 
+L 212.457387 166.868067 
+L 212.215046 166.942897 
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 167.327928 
-L 211.68117 167.557285 
-L 211.147293 167.785537 
-L 210.613417 168.012696 
-L 210.07954 168.238771 
-L 209.545663 168.463773 
-L 209.011787 168.687711 
-L 208.47791 168.910597 
-L 207.944034 169.13244 
-L 207.410157 169.353249 
-L 206.87628 169.573034 
-L 206.342404 169.791805 
-L 205.808527 170.009571 
-L 205.274651 170.22634 
-L 204.740774 170.442123 
-L 204.206897 170.656929 
-L 203.673021 170.870765 
-L 203.139144 171.08364 
-L 202.605268 171.295564 
-L 202.071391 171.506545 
-L 201.537515 171.71659 
-L 201.003638 171.925709 
-L 200.469761 172.133909 
-L 199.935885 172.341199 
-L 199.402008 172.547586 
-L 198.868132 172.753079 
-L 198.334255 172.957684 
-L 197.800378 173.16141 
-L 197.266502 173.364264 
-L 196.732625 173.566254 
-L 196.198749 173.767386 
-L 195.664872 173.967669 
-L 195.130995 174.167109 
-L 194.597119 174.365713 
-L 194.063242 174.563489 
-L 193.529366 174.760442 
-L 192.995489 174.956581 
-L 192.461612 175.151911 
-L 191.927736 175.34644 
-L 191.393859 175.540174 
-L 190.859983 175.733119 
-L 190.326106 175.925282 
-L 189.79223 176.116669 
-L 189.258353 176.307286 
-L 188.724476 176.49714 
-L 188.1906 176.686236 
-L 187.656723 176.874581 
-L 187.122847 177.06218 
-L 186.58897 177.24904 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 166.942897 
+L 211.684755 167.147219 
+L 211.154463 167.350664 
+L 210.624172 167.55324 
+L 210.09388 167.754953 
+L 209.563589 167.955812 
+L 209.033297 168.155824 
+L 208.503006 168.354994 
+L 207.972714 168.553332 
+L 207.442423 168.750843 
+L 206.912131 168.947534 
+L 206.38184 169.143412 
+L 205.851548 169.338485 
+L 205.321257 169.532757 
+L 204.790966 169.726237 
+L 204.260674 169.91893 
+L 203.730383 170.110843 
+L 203.200091 170.301982 
+L 202.6698 170.492354 
+L 202.139508 170.681964 
+L 201.609217 170.870818 
+L 201.078925 171.058923 
+L 200.548634 171.246284 
+L 200.018342 171.432908 
+L 199.488051 171.6188 
+L 198.957759 171.803965 
+L 198.427468 171.98841 
+L 197.897176 172.17214 
+L 197.366885 172.355161 
+L 196.836593 172.537478 
+L 196.306302 172.719096 
+L 195.77601 172.900021 
+L 195.245719 173.080257 
+L 194.715427 173.259812 
+L 194.185136 173.438688 
+L 193.654844 173.616892 
+L 193.124553 173.794428 
+L 192.594261 173.971302 
+L 192.06397 174.147519 
+L 191.533678 174.323083 
+L 191.003387 174.497998 
+L 190.473096 174.672271 
+L 189.942804 174.845905 
+L 189.412513 175.018906 
+L 188.882221 175.191277 
+L 188.35193 175.363024 
+L 187.821638 175.534151 
+L 187.291347 175.704662 
+L 186.761055 175.874562 
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 186.58897 177.24904 
-L 186.223725 177.472319 
-L 185.85848 177.69455 
-L 185.493235 177.915744 
-L 185.127991 178.135911 
-L 184.762746 178.35506 
-L 184.397501 178.573201 
-L 184.032256 178.790342 
-L 183.667011 179.006493 
-L 183.301766 179.221662 
-L 182.936522 179.435859 
-L 182.571277 179.649093 
-L 182.206032 179.861372 
-L 181.840787 180.072704 
-L 181.475542 180.283098 
-L 181.110297 180.492562 
-L 180.745053 180.701105 
-L 180.379808 180.908734 
-L 180.014563 181.115458 
-L 179.649318 181.321284 
-L 179.284073 181.52622 
-L 178.918828 181.730274 
-L 178.553584 181.933453 
-L 178.188339 182.135765 
-L 177.823094 182.337217 
-L 177.457849 182.537817 
-L 177.092604 182.737571 
-L 176.727359 182.936487 
-L 176.362115 183.134571 
-L 175.99687 183.331831 
-L 175.631625 183.528274 
-L 175.26638 183.723906 
-L 174.901135 183.918734 
-L 174.53589 184.112764 
-L 174.170645 184.306003 
-L 173.805401 184.498457 
-L 173.440156 184.690134 
-L 173.074911 184.881038 
-L 172.709666 185.071176 
-L 172.344421 185.260555 
-L 171.979176 185.44918 
-L 171.613932 185.637058 
-L 171.248687 185.824193 
-L 170.883442 186.010593 
-L 170.518197 186.196263 
-L 170.152952 186.381208 
-L 169.787707 186.565434 
-L 169.422463 186.748947 
-L 169.057218 186.931753 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.761055 175.874562 
+L 186.434524 176.062983 
+L 186.107993 176.250658 
+L 185.781462 176.437593 
+L 185.45493 176.623794 
+L 185.128399 176.809266 
+L 184.801868 176.994015 
+L 184.475337 177.178047 
+L 184.148806 177.361367 
+L 183.822275 177.54398 
+L 183.495744 177.725893 
+L 183.169212 177.90711 
+L 182.842681 178.087638 
+L 182.51615 178.26748 
+L 182.189619 178.446642 
+L 181.863088 178.62513 
+L 181.536557 178.802948 
+L 181.210025 178.980102 
+L 180.883494 179.156595 
+L 180.556963 179.332435 
+L 180.230432 179.507624 
+L 179.903901 179.682168 
+L 179.57737 179.856072 
+L 179.250838 180.02934 
+L 178.924307 180.201977 
+L 178.597776 180.373987 
+L 178.271245 180.545375 
+L 177.944714 180.716146 
+L 177.618183 180.886304 
+L 177.291651 181.055854 
+L 176.96512 181.224798 
+L 176.638589 181.393143 
+L 176.312058 181.560892 
+L 175.985527 181.72805 
+L 175.658996 181.89462 
+L 175.332464 182.060607 
+L 175.005933 182.226014 
+L 174.679402 182.390847 
+L 174.352871 182.555108 
+L 174.02634 182.718801 
+L 173.699809 182.881932 
+L 173.373277 183.044503 
+L 173.046746 183.206518 
+L 172.720215 183.367981 
+L 172.393684 183.528896 
+L 172.067153 183.689267 
+L 171.740622 183.849097 
+L 171.414091 184.00839 
+L 171.087559 184.167149 
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 169.057218 186.931753 
-L 168.839293 187.043864 
-L 168.621369 187.155711 
-L 168.403445 187.267294 
-L 168.18552 187.378616 
-L 167.967596 187.489677 
-L 167.749672 187.600478 
-L 167.531747 187.71102 
-L 167.313823 187.821306 
-L 167.095898 187.931335 
-L 166.877974 188.04111 
-L 166.66005 188.150631 
-L 166.442125 188.259899 
-L 166.224201 188.368916 
-L 166.006277 188.477683 
-L 165.788352 188.586201 
-L 165.570428 188.694471 
-L 165.352503 188.802495 
-L 165.134579 188.910272 
-L 164.916655 189.017806 
-L 164.69873 189.125095 
-L 164.480806 189.232143 
-L 164.262882 189.338949 
-L 164.044957 189.445515 
-L 163.827033 189.551842 
-L 163.609108 189.657932 
-L 163.391184 189.763784 
-L 163.17326 189.8694 
-L 162.955335 189.974782 
-L 162.737411 190.079929 
-L 162.519487 190.184844 
-L 162.301562 190.289528 
-L 162.083638 190.39398 
-L 161.865713 190.498203 
-L 161.647789 190.602197 
-L 161.429865 190.705964 
-L 161.21194 190.809504 
-L 160.994016 190.912818 
-L 160.776092 191.015908 
-L 160.558167 191.118773 
-L 160.340243 191.221416 
-L 160.122318 191.323838 
-L 159.904394 191.426038 
-L 159.68647 191.528019 
-L 159.468545 191.62978 
-L 159.250621 191.731324 
-L 159.032697 191.83265 
-L 158.814772 191.933761 
-L 158.596848 192.034656 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 171.087559 184.167149 
+L 170.838178 184.293998 
+L 170.588797 184.420508 
+L 170.339416 184.546681 
+L 170.090035 184.672519 
+L 169.840653 184.798024 
+L 169.591272 184.923198 
+L 169.341891 185.048042 
+L 169.09251 185.172558 
+L 168.843129 185.296747 
+L 168.593747 185.420612 
+L 168.344366 185.544155 
+L 168.094985 185.667376 
+L 167.845604 185.790278 
+L 167.596223 185.912861 
+L 167.346841 186.035129 
+L 167.09746 186.157082 
+L 166.848079 186.278722 
+L 166.598698 186.400051 
+L 166.349317 186.521069 
+L 166.099935 186.64178 
+L 165.850554 186.762184 
+L 165.601173 186.882283 
+L 165.351792 187.002079 
+L 165.102411 187.121572 
+L 164.853029 187.240765 
+L 164.603648 187.359659 
+L 164.354267 187.478255 
+L 164.104886 187.596556 
+L 163.855505 187.714562 
+L 163.606123 187.832275 
+L 163.356742 187.949696 
+L 163.107361 188.066827 
+L 162.85798 188.183669 
+L 162.608599 188.300225 
+L 162.359218 188.416494 
+L 162.109836 188.532478 
+L 161.860455 188.64818 
+L 161.611074 188.7636 
+L 161.361693 188.878739 
+L 161.112312 188.993599 
+L 160.86293 189.108182 
+L 160.613549 189.222488 
+L 160.364168 189.33652 
+L 160.114787 189.450278 
+L 159.865406 189.563763 
+L 159.616024 189.676977 
+L 159.366643 189.789922 
+L 159.117262 189.902598 
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 158.596848 192.034656 
-L 158.477483 192.180011 
-L 158.358117 192.324922 
-L 158.238752 192.469392 
-L 158.119387 192.613422 
-L 158.000021 192.757016 
-L 157.880656 192.900177 
-L 157.761291 193.042906 
-L 157.641925 193.185207 
-L 157.52256 193.327081 
-L 157.403195 193.468533 
-L 157.28383 193.609564 
-L 157.164464 193.750176 
-L 157.045099 193.890372 
-L 156.925734 194.030155 
-L 156.806368 194.169527 
-L 156.687003 194.30849 
-L 156.567638 194.447047 
-L 156.448272 194.5852 
-L 156.328907 194.722952 
-L 156.209542 194.860304 
-L 156.090177 194.99726 
-L 155.970811 195.133821 
-L 155.851446 195.26999 
-L 155.732081 195.405768 
-L 155.612715 195.541159 
-L 155.49335 195.676164 
-L 155.373985 195.810786 
-L 155.254619 195.945026 
-L 155.135254 196.078888 
-L 155.015889 196.212372 
-L 154.896524 196.345482 
-L 154.777158 196.478218 
-L 154.657793 196.610585 
-L 154.538428 196.742582 
-L 154.419062 196.874213 
-L 154.299697 197.005479 
-L 154.180332 197.136383 
-L 154.060966 197.266926 
-L 153.941601 197.397111 
-L 153.822236 197.526939 
-L 153.702871 197.656413 
-L 153.583505 197.785534 
-L 153.46414 197.914304 
-L 153.344775 198.042725 
-L 153.225409 198.170799 
-L 153.106044 198.298528 
-L 152.986679 198.425914 
-L 152.867313 198.552958 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.117262 189.902598 
+L 159.025661 190.039763 
+L 158.934059 190.176532 
+L 158.842458 190.312908 
+L 158.750857 190.448893 
+L 158.659255 190.584488 
+L 158.567654 190.719697 
+L 158.476053 190.854521 
+L 158.384452 190.988963 
+L 158.29285 191.123024 
+L 158.201249 191.256708 
+L 158.109648 191.390015 
+L 158.018046 191.522949 
+L 157.926445 191.655511 
+L 157.834844 191.787703 
+L 157.743242 191.919527 
+L 157.651641 192.050986 
+L 157.56004 192.182081 
+L 157.468438 192.312815 
+L 157.376837 192.443189 
+L 157.285236 192.573205 
+L 157.193635 192.702866 
+L 157.102033 192.832173 
+L 157.010432 192.961128 
+L 156.918831 193.089734 
+L 156.827229 193.217991 
+L 156.735628 193.345902 
+L 156.644027 193.473469 
+L 156.552425 193.600694 
+L 156.460824 193.727578 
+L 156.369223 193.854123 
+L 156.277622 193.980331 
+L 156.18602 194.106205 
+L 156.094419 194.231744 
+L 156.002818 194.356953 
+L 155.911216 194.481831 
+L 155.819615 194.606381 
+L 155.728014 194.730605 
+L 155.636412 194.854504 
+L 155.544811 194.97808 
+L 155.45321 195.101334 
+L 155.361608 195.224269 
+L 155.270007 195.346886 
+L 155.178406 195.469187 
+L 155.086805 195.591172 
+L 154.995203 195.712845 
+L 154.903602 195.834206 
+L 154.812001 195.955257 
+L 154.720399 196.076 
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 152.867313 198.552958 
-L 152.827388 198.621196 
-L 152.787463 198.689336 
-L 152.747537 198.757378 
-L 152.707612 198.825322 
-L 152.667686 198.89317 
-L 152.627761 198.96092 
-L 152.587835 199.028573 
-L 152.54791 199.09613 
-L 152.507984 199.163591 
-L 152.468059 199.230956 
-L 152.428133 199.298226 
-L 152.388208 199.3654 
-L 152.348282 199.432479 
-L 152.308357 199.499463 
-L 152.268432 199.566353 
-L 152.228506 199.633149 
-L 152.188581 199.69985 
-L 152.148655 199.766458 
-L 152.10873 199.832972 
-L 152.068804 199.899393 
-L 152.028879 199.965721 
-L 151.988953 200.031957 
-L 151.949028 200.0981 
-L 151.909102 200.164151 
-L 151.869177 200.23011 
-L 151.829252 200.295977 
-L 151.789326 200.361753 
-L 151.749401 200.427438 
-L 151.709475 200.493031 
-L 151.66955 200.558535 
-L 151.629624 200.623947 
-L 151.589699 200.68927 
-L 151.549773 200.754503 
-L 151.509848 200.819646 
-L 151.469922 200.8847 
-L 151.429997 200.949664 
-L 151.390072 201.01454 
-L 151.350146 201.079327 
-L 151.310221 201.144025 
-L 151.270295 201.208635 
-L 151.23037 201.273158 
-L 151.190444 201.337592 
-L 151.150519 201.401939 
-L 151.110593 201.466199 
-L 151.070668 201.530372 
-L 151.030742 201.594458 
-L 150.990817 201.658458 
-L 150.950891 201.722371 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 154.720399 196.076 
+L 154.662271 196.133731 
+L 154.604144 196.191391 
+L 154.546016 196.248982 
+L 154.487888 196.306502 
+L 154.42976 196.363953 
+L 154.371632 196.421335 
+L 154.313504 196.478647 
+L 154.255376 196.535889 
+L 154.197248 196.593063 
+L 154.13912 196.650168 
+L 154.080992 196.707204 
+L 154.022865 196.764171 
+L 153.964737 196.82107 
+L 153.906609 196.877901 
+L 153.848481 196.934664 
+L 153.790353 196.991359 
+L 153.732225 197.047986 
+L 153.674097 197.104546 
+L 153.615969 197.161038 
+L 153.557841 197.217463 
+L 153.499713 197.273821 
+L 153.441586 197.330112 
+L 153.383458 197.386336 
+L 153.32533 197.442494 
+L 153.267202 197.498585 
+L 153.209074 197.55461 
+L 153.150946 197.610569 
+L 153.092818 197.666461 
+L 153.03469 197.722288 
+L 152.976562 197.778049 
+L 152.918434 197.833745 
+L 152.860306 197.889375 
+L 152.802179 197.94494 
+L 152.744051 198.000441 
+L 152.685923 198.055876 
+L 152.627795 198.111246 
+L 152.569667 198.166552 
+L 152.511539 198.221793 
+L 152.453411 198.27697 
+L 152.395283 198.332083 
+L 152.337155 198.387132 
+L 152.279027 198.442117 
+L 152.2209 198.497038 
+L 152.162772 198.551896 
+L 152.104644 198.60669 
+L 152.046516 198.661421 
+L 151.988388 198.716089 
+L 151.93026 198.770694 
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 150.950891 201.722371 
-L 150.206616 205.410452 
-L 149.462341 208.832166 
-L 148.718066 212.023412 
-L 147.973791 215.013286 
-L 147.229517 217.825701 
-L 146.485242 220.480547 
-L 145.740967 222.994547 
-L 144.996692 225.381897 
-L 144.252417 227.654746 
-L 143.508142 229.823577 
-L 142.763867 231.897497 
-L 142.019592 233.884464 
-L 141.275317 235.791478 
-L 140.531042 237.624724 
-L 139.786767 239.389699 
-L 139.042492 241.091305 
-L 138.298217 242.733935 
-L 137.553942 244.32154 
-L 136.809667 245.857688 
-L 136.065392 247.34561 
-L 135.321117 248.788242 
-L 134.576842 250.18826 
-L 133.832567 251.54811 
-L 133.088292 252.870031 
-L 132.344017 254.156084 
-L 131.599742 255.408162 
-L 130.855467 256.628015 
-L 130.111192 257.817261 
-L 129.366917 258.977396 
-L 128.622642 260.109814 
-L 127.878367 261.215807 
-L 127.134092 262.29658 
-L 126.389817 263.353258 
-L 125.645542 264.386892 
-L 124.901267 265.398466 
-L 124.156992 266.388901 
-L 123.412717 267.359064 
-L 122.668442 268.309766 
-L 121.924167 269.241775 
-L 121.179892 270.15581 
-L 120.435617 271.052552 
-L 119.691342 271.932643 
-L 118.947067 272.79669 
-L 118.202792 273.645268 
-L 117.458517 274.47892 
-L 116.714242 275.298164 
-L 115.969967 276.103488 
-L 115.225692 276.895357 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 151.93026 198.770694 
+L 151.170222 202.608064 
+L 150.410183 206.157897 
+L 149.650145 209.460298 
+L 148.890107 212.547523 
+L 148.130068 215.445905 
+L 147.37003 218.177222 
+L 146.609992 220.759688 
+L 145.849953 223.208692 
+L 145.089915 225.537353 
+L 144.329877 227.756947 
+L 143.569838 229.877235 
+L 142.8098 231.906724 
+L 142.049762 233.852872 
+L 141.289723 235.722255 
+L 140.529685 237.5207 
+L 139.769646 239.253394 
+L 139.009608 240.924976 
+L 138.24957 242.53961 
+L 137.489531 244.101049 
+L 136.729493 245.612686 
+L 135.969455 247.077601 
+L 135.209416 248.498595 
+L 134.449378 249.878226 
+L 133.68934 251.218833 
+L 132.929301 252.522564 
+L 132.169263 253.791392 
+L 131.409225 255.02714 
+L 130.649186 256.231486 
+L 129.889148 257.405988 
+L 129.12911 258.55209 
+L 128.369071 259.671132 
+L 127.609033 260.764363 
+L 126.848995 261.832946 
+L 126.088956 262.877969 
+L 125.328918 263.900448 
+L 124.56888 264.901335 
+L 123.808841 265.881524 
+L 123.048803 266.841853 
+L 122.288764 267.783111 
+L 121.528726 268.70604 
+L 120.768688 269.611341 
+L 120.008649 270.499675 
+L 119.248611 271.371666 
+L 118.488573 272.227905 
+L 117.728534 273.06895 
+L 116.968496 273.895331 
+L 116.208458 274.707551 
+L 115.448419 275.506087 
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.225692 276.895357 
-L 114.905413 277.60208 
-L 114.585134 278.29842 
-L 114.264856 278.984679 
-L 113.944577 279.661143 
-L 113.624298 280.328089 
-L 113.304019 280.98578 
-L 112.983741 281.63447 
-L 112.663462 282.274401 
-L 112.343183 282.905809 
-L 112.022904 283.528915 
-L 111.702626 284.143936 
-L 111.382347 284.75108 
-L 111.062068 285.350544 
-L 110.741789 285.942522 
-L 110.421511 286.527197 
-L 110.101232 287.104748 
-L 109.780953 287.675346 
-L 109.460674 288.239157 
-L 109.140396 288.79634 
-L 108.820117 289.34705 
-L 108.499838 289.891434 
-L 108.17956 290.429637 
-L 107.859281 290.961797 
-L 107.539002 291.488049 
-L 107.218723 292.008522 
-L 106.898445 292.523342 
-L 106.578166 293.03263 
-L 106.257887 293.536505 
-L 105.937608 294.035079 
-L 105.61733 294.528463 
-L 105.297051 295.016765 
-L 104.976772 295.500087 
-L 104.656493 295.978531 
-L 104.336215 296.452193 
-L 104.015936 296.921169 
-L 103.695657 297.38555 
-L 103.375378 297.845426 
-L 103.0551 298.300883 
-L 102.734821 298.752004 
-L 102.414542 299.198873 
-L 102.094264 299.641568 
-L 101.773985 300.080166 
-L 101.453706 300.514744 
-L 101.133427 300.945373 
-L 100.813149 301.372124 
-L 100.49287 301.795068 
-L 100.172591 302.214272 
-L 99.852312 302.6298 
-" clip-path="url(#p80e98dc6c6)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.448419 275.506087 
+L 115.1235 276.237494 
+L 114.798582 276.957785 
+L 114.473663 277.667294 
+L 114.148744 278.366339 
+L 113.823825 279.055225 
+L 113.498906 279.734241 
+L 113.173987 280.403667 
+L 112.849068 281.06377 
+L 112.524149 281.714807 
+L 112.19923 282.357022 
+L 111.874311 282.990652 
+L 111.549393 283.615924 
+L 111.224474 284.233054 
+L 110.899555 284.842252 
+L 110.574636 285.44372 
+L 110.249717 286.037651 
+L 109.924798 286.624232 
+L 109.599879 287.203642 
+L 109.27496 287.776055 
+L 108.950041 288.341638 
+L 108.625123 288.900551 
+L 108.300204 289.452951 
+L 107.975285 289.998987 
+L 107.650366 290.538804 
+L 107.325447 291.072542 
+L 107.000528 291.600337 
+L 106.675609 292.12232 
+L 106.35069 292.638617 
+L 106.025771 293.149351 
+L 105.700852 293.65464 
+L 105.375934 294.154599 
+L 105.051015 294.649339 
+L 104.726096 295.138969 
+L 104.401177 295.623593 
+L 104.076258 296.103312 
+L 103.751339 296.578224 
+L 103.42642 297.048426 
+L 103.101501 297.514008 
+L 102.776582 297.975062 
+L 102.451664 298.431674 
+L 102.126745 298.883929 
+L 101.801826 299.33191 
+L 101.476907 299.775697 
+L 101.151988 300.215367 
+L 100.827069 300.650996 
+L 100.50215 301.082657 
+L 100.177231 301.510424 
+L 99.852312 301.934364 
+" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.540625 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.467344 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6276,19 +6276,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3a" d="M 750 794 
-L 1409 794 
-L 1409 0 
-L 750 0 
-L 750 794 
-z
-M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-35" d="M 691 4666 
@@ -6314,6 +6301,19 @@ Q 2250 2553 1709 2553
 Q 1456 2553 1204 2497 
 Q 953 2441 691 2322 
 L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6373,36 +6373,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6444,12 +6414,12 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -6490,109 +6460,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p80e98dc6c6">
+  <clipPath id="p3994ffe252">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p4b78d9fec6)">
+   <g clip-path="url(#pda4891642b)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YzapkVx2H4arT5xxOJ9igdD7IUHAmwYETe+LYO8kVZBgyz3UkuYFAENGJKE6ciDNxJhJC0rZtdzgfdXblEjrCCv9Q7/NcwW+zq9Z+WfvtPx8fd6fmxVfTC5Y6fn1az7Pb7Xb/ev+z6QlL/fNvL6cnLPfrT34zPWG5/S9+OT1hrf3Z9IL1nn8xvWC9q0fTC5b69K2Ppicsd4L/JACA704MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACk7W8Onx+nR6x23G3TE5ban2CzXpxdTk9Y6na7np6w3MXf/zI9YbnDz59MT1jqsN1OT1ju5eH59ITlHp/Y8XD36PH0hOVO7ysLAPB/EEMAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGnnFy+fTW9Y7+ab6QVrHbfpBes9fDS9YKnL6QHfg+Pzl9MTlrv439PpCUtdbIfpCcs9PMXz7vrF9IKlLs5P78RzMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0/WH73XF6xGrH4zY9YantxJ5nt9vtLs4upycsdX88TE9Y7sGLp9MT1vvRm9MLlrrbbqcnLPf19b+nJyz39s359ISlth+/Mz1hOTdDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAEDa+V+//NP0huXOdvvpCUu98drj6QnL3W+H6QlLXT64mp6w3Ht/+OP0hOU+/NXPpicsdThu0xOW++DP/5iesNyTd16fnrDUe+8+mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO3v7n97nB6x2u399fSEpR7ur6Yn8Aq3+8P0hOX+e/PV9ITlfnL19vSEpbbjNj1huWc3X05PWO7pzRfTE5b66aN3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/1xegTwA3S4nV6w3vnl9AJe4fr+m+kJy109eG16Aq/gZggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBp59MDvg/3x8P0hKX2+9Nr1rPDab2ju9N7Rbvb3fX0hOVe311OT+AVXtw9m56w3NWp/e4enF46nOARDgDw3YkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0bwFd0YcRi+29DQAAAABJRU5ErkJggg==" id="image4f6858b781" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YQYplZx2H4Xurq4rqiA1KJzY9FJxJyCATe+LYnWQFDkPmWUfiBgSRECeiOHEizoIzCSEkbdJ2N1XVt87NEjrCF/5y3+dZwe9wON95+fbbfz467k7N86+mFyx1/Pq0nme32+3+/dvfT09Y6l//eDE9Yblff/yb6QnL7d95d3rCWvuz6QXrPftiesF6Vw+mFyz1u599OD1huRP8kgAAvj8xBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQtr85/OE4PWK1426bnrDU/gSb9eLscnrCUrfb9fSE5S7++bfpCcsdfvlkesJSh+12esJyLw7Ppics9/DEjodXDx5OT1ju9P6yAAD/AzEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB2fvHim+kN6928nF6w1nGbXrDe/QfTC5a6nB7wAzg+ezE9YbmL/z6dnrDUxXaYnrDc/VM8766fTy9Y6uL89E48N0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2T47TI1Y7HrfpCUttJ/Y8u91ud3F2OT1hqbvjYXrCcveeP52esN6P35pesNSr7XZ6wnJfX38+PWG5Rzfn0xOW2n7yeHrCcm6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0879/+ZfpDcud7fbTE5Z6842H0xOWu9sO0xOWurx3NT1huff+9OfpCct98KtfTE9Y6nDcpics9/5fP5uesNyTxz+anrDUe28/mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO1f3f3xOD1itdu76+kJS93fX01P4DVu94fpCct9e/PV9ITlfnr1aHrCUttxm56w3Dc3X05PWO7pzRfTE5b6+YO3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/Q4PQL4P3S4nV6w3vnl9AJe4/ru5fSE5a7uvTE9gddwMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC08+kBP4S742F6wlL7/ek169nhtN7Rq9N7RbvD7nZ6wnL3d5fTE3iNl4dn0xOWuzqe2K/2/PS+oxM8wgEAvj8xBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQ9h2BiIgYuC9crQAAAABJRU5ErkJggg==" id="image091e105945" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="maab05a0f5a" d="M 0 0 
+       <path id="m06f8fd8f57" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#maab05a0f5a" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#maab05a0f5a" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#maab05a0f5a" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#maab05a0f5a" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#maab05a0f5a" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#maab05a0f5a" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#maab05a0f5a" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#maab05a0f5a" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#maab05a0f5a" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#maab05a0f5a" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#maab05a0f5a" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m06f8fd8f57" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m062ba063c9" d="M 0 0 
+       <path id="m192f75045f" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m062ba063c9" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m192f75045f" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m062ba063c9" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m192f75045f" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m062ba063c9" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m192f75045f" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m062ba063c9" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m192f75045f" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m062ba063c9" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m192f75045f" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m062ba063c9" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m192f75045f" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m062ba063c9" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m192f75045f" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m062ba063c9" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m192f75045f" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1383,10 +1383,10 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- +0 -->
+    <!-- +1 -->
     <g transform="translate(450.65116 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="image24a004280d" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagea9a2cec599" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m78c517d08f" d="M 0 0 
+       <path id="m91fa0f4fc9" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m78c517d08f" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m78c517d08f" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m78c517d08f" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m78c517d08f" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m78c517d08f" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m78c517d08f" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m78c517d08f" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m78c517d08f" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m78c517d08f" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.540625 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(16.467344 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2953,12 +2953,12 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p4b78d9fec6">
+  <clipPath id="pda4891642b">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.31875pt" height="386.202469pt" viewBox="0 0 575.31875 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.465312pt" height="386.202469pt" viewBox="0 0 575.465312 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.31875 386.202469 
-L 575.31875 0 
+L 575.465312 386.202469 
+L 575.465312 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.784375 104.1264 
-L 294.409375 104.1264 
-L 294.409375 74.7432 
-L 189.784375 74.7432 
+    <path d="M 189.857656 104.1264 
+L 294.482656 104.1264 
+L 294.482656 74.7432 
+L 189.857656 74.7432 
 z
-" clip-path="url(#p389273d815)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.409375 104.1264 
-L 399.034375 104.1264 
-L 399.034375 74.7432 
-L 294.409375 74.7432 
+    <path d="M 294.482656 104.1264 
+L 399.107656 104.1264 
+L 399.107656 74.7432 
+L 294.482656 74.7432 
 z
-" clip-path="url(#p389273d815)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.034375 104.1264 
-L 503.659375 104.1264 
-L 503.659375 74.7432 
-L 399.034375 74.7432 
+    <path d="M 399.107656 104.1264 
+L 503.732656 104.1264 
+L 503.732656 74.7432 
+L 399.107656 74.7432 
 z
-" clip-path="url(#p389273d815)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.784375 133.5096 
-L 294.409375 133.5096 
-L 294.409375 104.1264 
-L 189.784375 104.1264 
+    <path d="M 189.857656 133.5096 
+L 294.482656 133.5096 
+L 294.482656 104.1264 
+L 189.857656 104.1264 
 z
-" clip-path="url(#p389273d815)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.409375 133.5096 
-L 399.034375 133.5096 
-L 399.034375 104.1264 
-L 294.409375 104.1264 
+    <path d="M 294.482656 133.5096 
+L 399.107656 133.5096 
+L 399.107656 104.1264 
+L 294.482656 104.1264 
 z
-" clip-path="url(#p389273d815)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.034375 133.5096 
-L 503.659375 133.5096 
-L 503.659375 104.1264 
-L 399.034375 104.1264 
+    <path d="M 399.107656 133.5096 
+L 503.732656 133.5096 
+L 503.732656 104.1264 
+L 399.107656 104.1264 
 z
-" clip-path="url(#p389273d815)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.784375 162.8928 
-L 294.409375 162.8928 
-L 294.409375 133.5096 
-L 189.784375 133.5096 
+    <path d="M 189.857656 162.8928 
+L 294.482656 162.8928 
+L 294.482656 133.5096 
+L 189.857656 133.5096 
 z
-" clip-path="url(#p389273d815)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.409375 162.8928 
-L 399.034375 162.8928 
-L 399.034375 133.5096 
-L 294.409375 133.5096 
+    <path d="M 294.482656 162.8928 
+L 399.107656 162.8928 
+L 399.107656 133.5096 
+L 294.482656 133.5096 
 z
-" clip-path="url(#p389273d815)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.034375 162.8928 
-L 503.659375 162.8928 
-L 503.659375 133.5096 
-L 399.034375 133.5096 
+    <path d="M 399.107656 162.8928 
+L 503.732656 162.8928 
+L 503.732656 133.5096 
+L 399.107656 133.5096 
 z
-" clip-path="url(#p389273d815)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.784375 192.276 
-L 294.409375 192.276 
-L 294.409375 162.8928 
-L 189.784375 162.8928 
+    <path d="M 189.857656 192.276 
+L 294.482656 192.276 
+L 294.482656 162.8928 
+L 189.857656 162.8928 
 z
-" clip-path="url(#p389273d815)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.409375 192.276 
-L 399.034375 192.276 
-L 399.034375 162.8928 
-L 294.409375 162.8928 
+    <path d="M 294.482656 192.276 
+L 399.107656 192.276 
+L 399.107656 162.8928 
+L 294.482656 162.8928 
 z
-" clip-path="url(#p389273d815)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.034375 192.276 
-L 503.659375 192.276 
-L 503.659375 162.8928 
-L 399.034375 162.8928 
+    <path d="M 399.107656 192.276 
+L 503.732656 192.276 
+L 503.732656 162.8928 
+L 399.107656 162.8928 
 z
-" clip-path="url(#p389273d815)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.784375 221.6592 
-L 294.409375 221.6592 
-L 294.409375 192.276 
-L 189.784375 192.276 
+    <path d="M 189.857656 221.6592 
+L 294.482656 221.6592 
+L 294.482656 192.276 
+L 189.857656 192.276 
 z
-" clip-path="url(#p389273d815)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.409375 221.6592 
-L 399.034375 221.6592 
-L 399.034375 192.276 
-L 294.409375 192.276 
+    <path d="M 294.482656 221.6592 
+L 399.107656 221.6592 
+L 399.107656 192.276 
+L 294.482656 192.276 
 z
-" clip-path="url(#p389273d815)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.034375 221.6592 
-L 503.659375 221.6592 
-L 503.659375 192.276 
-L 399.034375 192.276 
+    <path d="M 399.107656 221.6592 
+L 503.732656 221.6592 
+L 503.732656 192.276 
+L 399.107656 192.276 
 z
-" clip-path="url(#p389273d815)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.784375 251.0424 
-L 294.409375 251.0424 
-L 294.409375 221.6592 
-L 189.784375 221.6592 
+    <path d="M 189.857656 251.0424 
+L 294.482656 251.0424 
+L 294.482656 221.6592 
+L 189.857656 221.6592 
 z
-" clip-path="url(#p389273d815)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.409375 251.0424 
-L 399.034375 251.0424 
-L 399.034375 221.6592 
-L 294.409375 221.6592 
+    <path d="M 294.482656 251.0424 
+L 399.107656 251.0424 
+L 399.107656 221.6592 
+L 294.482656 221.6592 
 z
-" clip-path="url(#p389273d815)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.034375 251.0424 
-L 503.659375 251.0424 
-L 503.659375 221.6592 
-L 399.034375 221.6592 
+    <path d="M 399.107656 251.0424 
+L 503.732656 251.0424 
+L 503.732656 221.6592 
+L 399.107656 221.6592 
 z
-" clip-path="url(#p389273d815)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.784375 280.4256 
-L 294.409375 280.4256 
-L 294.409375 251.0424 
-L 189.784375 251.0424 
+    <path d="M 189.857656 280.4256 
+L 294.482656 280.4256 
+L 294.482656 251.0424 
+L 189.857656 251.0424 
 z
-" clip-path="url(#p389273d815)" style="fill: #f2faae; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #f4fab0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.409375 280.4256 
-L 399.034375 280.4256 
-L 399.034375 251.0424 
-L 294.409375 251.0424 
+    <path d="M 294.482656 280.4256 
+L 399.107656 280.4256 
+L 399.107656 251.0424 
+L 294.482656 251.0424 
 z
-" clip-path="url(#p389273d815)" style="fill: #fa9857; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.034375 280.4256 
-L 503.659375 280.4256 
-L 503.659375 251.0424 
-L 399.034375 251.0424 
+    <path d="M 399.107656 280.4256 
+L 503.732656 280.4256 
+L 503.732656 251.0424 
+L 399.107656 251.0424 
 z
-" clip-path="url(#p389273d815)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.784375 309.8088 
-L 294.409375 309.8088 
-L 294.409375 280.4256 
-L 189.784375 280.4256 
+    <path d="M 189.857656 309.8088 
+L 294.482656 309.8088 
+L 294.482656 280.4256 
+L 189.857656 280.4256 
 z
-" clip-path="url(#p389273d815)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.409375 309.8088 
-L 399.034375 309.8088 
-L 399.034375 280.4256 
-L 294.409375 280.4256 
+    <path d="M 294.482656 309.8088 
+L 399.107656 309.8088 
+L 399.107656 280.4256 
+L 294.482656 280.4256 
 z
-" clip-path="url(#p389273d815)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.034375 309.8088 
-L 503.659375 309.8088 
-L 503.659375 280.4256 
-L 399.034375 280.4256 
+    <path d="M 399.107656 309.8088 
+L 503.732656 309.8088 
+L 503.732656 280.4256 
+L 399.107656 280.4256 
 z
-" clip-path="url(#p389273d815)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.784375 339.192 
-L 294.409375 339.192 
-L 294.409375 309.8088 
-L 189.784375 309.8088 
+    <path d="M 189.857656 339.192 
+L 294.482656 339.192 
+L 294.482656 309.8088 
+L 189.857656 309.8088 
 z
-" clip-path="url(#p389273d815)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.409375 339.192 
-L 399.034375 339.192 
-L 399.034375 309.8088 
-L 294.409375 309.8088 
+    <path d="M 294.482656 339.192 
+L 399.107656 339.192 
+L 399.107656 309.8088 
+L 294.482656 309.8088 
 z
-" clip-path="url(#p389273d815)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.034375 339.192 
-L 503.659375 339.192 
-L 503.659375 309.8088 
-L 399.034375 309.8088 
+    <path d="M 399.107656 339.192 
+L 503.732656 339.192 
+L 503.732656 309.8088 
+L 399.107656 309.8088 
 z
-" clip-path="url(#p389273d815)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb46d830823)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.771641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.844922 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.055859 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.129141 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.627969 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.70125 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.979688 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(407.052969 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.709375 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.782656 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(230.645625 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(339.086875 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(339.160156 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(443.711875 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.3475 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.420781 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(230.645625 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(341.631875 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(443.711875 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(130.610625 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(130.683906 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(230.645625 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(341.631875 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(443.711875 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(101.040625 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(101.113906 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(230.645625 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(341.631875 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(443.711875 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.916875 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.990156 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(230.645625 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(341.631875 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(443.711875 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(122.073125 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(122.146406 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(230.645625 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(341.631875 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(446.256875 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(446.330156 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.41875 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.492031 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.298 -->
-    <g transform="translate(229.445 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.518281 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1883,27 +1883,15 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 27 -->
-    <g transform="translate(341.155625 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <!-- 28 -->
+    <g transform="translate(341.228906 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 136 -->
-    <g transform="translate(442.9975 267.9415) scale(0.08 -0.08)">
+    <!-- 138 -->
+    <g transform="translate(443.070781 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1951,45 +1939,15 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
-Q 2000 2303 1842 2098 
-Q 1684 1894 1684 1484 
-Q 1684 1075 1842 870 
-Q 2000 666 2316 666 
-Q 2634 666 2792 870 
-Q 2950 1075 2950 1484 
-Q 2950 1894 2792 2098 
-Q 2634 2303 2316 2303 
-z
-M 3803 4544 
-L 3803 3681 
-Q 3506 3822 3243 3889 
-Q 2981 3956 2731 3956 
-Q 2194 3956 1894 3657 
-Q 1594 3359 1544 2772 
-Q 1750 2925 1990 3001 
-Q 2231 3078 2516 3078 
-Q 3231 3078 3670 2659 
-Q 4109 2241 4109 1563 
-Q 4109 813 3618 361 
-Q 3128 -91 2303 -91 
-Q 1394 -91 895 523 
-Q 397 1138 397 2266 
-Q 397 3422 980 4083 
-Q 1563 4744 2578 4744 
-Q 2900 4744 3203 4694 
-Q 3506 4644 3803 4544 
-z
-" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.53375 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.607031 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2054,7 +2012,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(230.645625 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2064,14 +2022,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(341.631875 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(443.711875 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2079,7 +2037,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.755 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.828281 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2090,7 +2048,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(230.645625 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2100,13 +2058,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(344.176875 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.250156 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.346875 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.420156 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2122,7 +2080,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(137.168125 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(137.241406 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2261,6 +2219,36 @@ L 653 256
 L 653 1209 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
     </defs>
     <use xlink:href="#DejaVuSans-Bold-63"/>
     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(59.277344 0)"/>
@@ -2305,7 +2293,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2447,12 +2435,12 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2493,110 +2481,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p389273d815">
-   <rect x="85.159375" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pb46d830823">
+   <rect x="85.232656" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p36c68af620)">
+   <g clip-path="url(#p9b90173a96)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9klEQVR4nO3YP45kVx2G4emumnZPWxrGY9HyWE5wgpADZCQLsQ3WQUTKGtgAGSELIHDiwAGSSRw6wvI/pNEAFh6NxkV3dbcXYZ33N1w9zwq+0qlb961zcvufP9/d27Krl9ML1jo5nV6w1u1xesFaWz+/49X0grUuHk0vWOt/L6YX8GPszqYXrLX17+f98+kFS2387QcAwKtGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNp/evxqesNSZ/f30xOWOhyvpics9eTh29MTlvry+dfTE5Y6ntxMT1jqFw8eT09Y6vja+fSEpf754pvpCUtdPricnrDU4ew4PWGpk3svpycs5QYUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7S8vLqc3LPXk9XenJyz17OVX0xOWeuuw7f9ID9/85fSEpc5259MTlrq5PU5PWGrr57f5z3e67c+3P31nesJS54fD9ISltv12BwDglSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7V/bXUxvWOrbw9PpCUtt/fxu3ng8PWGpr//76fSEpV5cH6YnLPXBGx9MT1jq6u44PWGpL59/Pj1hqffe/NX0hKU+efq36QlLvf/TbZ+fG1AAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACA1MnNx7+/mx6x1O3t9AJ+jK2f36n/gDBm68+f38//b8fj9IKlNn56AAC8agQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/eUnn01vWGp3tpuesNSzz/41PWGpP/3u/ekJS/3x79s+v9+883B6wlJ/+ejz6QlL/eG3P5+esNRf//Hd9ISlfvbowfSEpb79/np6wlK/fnIxPWEpN6AAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEDq5Prmw7vpESvtrq+mJ6y1O5tesNbxML1grf359IK1dvvpBWvd3U4vWOt648/fycbvYE63/fxdn2z7+bt/PE5PWGrjTx8AAK8aAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGp/c3ec3rDU7vvn0xPWev3x9IK1vns6vWCtn7w1vWCtbf+83Lt3up9esNbzZ9ML1nr09vSCtY6H6QVL3f/3F9MT1rp4NL1gKTegAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAAKkfAKcSecnZ7ogIAAAAAElFTkSuQmCC" id="image12e1c1856d" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9ElEQVR4nO3YPY5k1R2HYbqrpulp8JjPFoNI7MSyCCwsIcvb8DocOfUa2AAZoRfgwIkDB0iQEJJgJMCW0PBlo9G46K7u9iLQef/D1fOs4Fc6deq+dU9uv3nv7pktu3oyvWCtk9PpBWvdHqcXrLX18zteTS9Y6+KF6QVr/fB4egE/xu5sesFaW/9+3jufXrDUxp9+AAA8bQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/UfHz6c3LHV2bz89YanD8Wp6wlIPH7w+PWGpz77/YnrCUseTm+kJS/36/kvTE5Y6Pns+PWGpfz/+1/SEpS7vX05PWOpwdpyesNTJM0+mJyzlDSgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaX15cTm9Y6uFzv5yesNSjJ59PT1jqtcO2/yM9ePk30xOWOtudT09Y6ub2OD1hqa2f3+Y/3+m2P9/+9I3pCUudHw7TE5ba9tMdAICnjgAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1f3Z3Mb1hqW8PX05PWGrr53fz4kvTE5b64j8fTU9Y6vH1YXrCUm+/+Pb0hKWu7o7TE5b67PtPpycs9ebLv52esNQHX74/PWGpt17d9vl5AwoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQOrn5x5/upkcsdXs7vYAfY+vnd+o/IIzZ+v3z+/nTdjxOL1hq46cHAMDTRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaX37w8fSGpXZnu+kJSz36+KvpCUu9+8e3pics9c6H2z6/37/xYHrCUn/5+6fTE5b68x9+NT1hqb/+87/TE5b6xQv3pycs9e3/rqcnLPW7hxfTE5byBhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEidXN/87W56xEq766vpCWvtzqYXrHU8TC9Ya38+vWCt3X56wVp3t9ML1rre+P072fg7mNNt37/rk23fv3vH4/SEpTZ++wAAeNoIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUvvDzZPpDUs998NhesJaP7ucXrDWd19PL1jr569NL1jratu/LzfnF9MTlto93vr9e316wVq3x+kFS9179Mn0hLWef2V6wVLegAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk/g8Sr3vdaRLPNQAAAABJRU5ErkJggg==" id="imageb3b16c29f8" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m8c823a0aae" d="M 0 0 
+       <path id="mbb9f7bc651" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8c823a0aae" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m8c823a0aae" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m8c823a0aae" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8c823a0aae" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m8c823a0aae" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8c823a0aae" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m8c823a0aae" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8c823a0aae" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m8c823a0aae" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8c823a0aae" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m8c823a0aae" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8c823a0aae" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbb9f7bc651" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="mb6efe2ef25" d="M 0 0 
+       <path id="m6269f7bbc3" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb6efe2ef25" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6269f7bbc3" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb6efe2ef25" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6269f7bbc3" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mb6efe2ef25" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6269f7bbc3" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mb6efe2ef25" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6269f7bbc3" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#mb6efe2ef25" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6269f7bbc3" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb6efe2ef25" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6269f7bbc3" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#mb6efe2ef25" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6269f7bbc3" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mb6efe2ef25" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6269f7bbc3" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +11 -->
+    <!-- +17 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1170,15 +1170,196 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -31 -->
+    <!-- -26 -->
     <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- -1 -->
+    <g transform="translate(193.129395 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -40 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -12 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -17 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- +5 -->
+    <g transform="translate(352.68813 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- -36 -->
+    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-33" d="M 2597 2516 
 Q 3050 2419 3304 2112 
@@ -1215,304 +1396,43 @@ z
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -8 -->
-    <g transform="translate(193.129395 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-38" d="M 2034 2216 
-Q 1584 2216 1326 1975 
-Q 1069 1734 1069 1313 
-Q 1069 891 1326 650 
-Q 1584 409 2034 409 
-Q 2484 409 2743 651 
-Q 3003 894 3003 1313 
-Q 3003 1734 2745 1975 
-Q 2488 2216 2034 2216 
-z
-M 1403 2484 
-Q 997 2584 770 2862 
-Q 544 3141 544 3541 
-Q 544 4100 942 4425 
-Q 1341 4750 2034 4750 
-Q 2731 4750 3128 4425 
-Q 3525 4100 3525 3541 
-Q 3525 3141 3298 2862 
-Q 3072 2584 2669 2484 
-Q 3125 2378 3379 2068 
-Q 3634 1759 3634 1313 
-Q 3634 634 3220 271 
-Q 2806 -91 2034 -91 
-Q 1263 -91 848 271 
-Q 434 634 434 1313 
-Q 434 1759 690 2068 
-Q 947 2378 1403 2484 
-z
-M 1172 3481 
-Q 1172 3119 1398 2916 
-Q 1625 2713 2034 2713 
-Q 2441 2713 2670 2916 
-Q 2900 3119 2900 3481 
-Q 2900 3844 2670 4047 
-Q 2441 4250 2034 4250 
-Q 1625 4250 1398 4047 
-Q 1172 3844 1172 3481 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -44 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -15 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -16 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-36" d="M 2113 2584 
-Q 1688 2584 1439 2293 
-Q 1191 2003 1191 1497 
-Q 1191 994 1439 701 
-Q 1688 409 2113 409 
-Q 2538 409 2786 701 
-Q 3034 994 3034 1497 
-Q 3034 2003 2786 2293 
-Q 2538 2584 2113 2584 
-z
-M 3366 4563 
-L 3366 3988 
-Q 3128 4100 2886 4159 
-Q 2644 4219 2406 4219 
-Q 1781 4219 1451 3797 
-Q 1122 3375 1075 2522 
-Q 1259 2794 1537 2939 
-Q 1816 3084 2150 3084 
-Q 2853 3084 3261 2657 
-Q 3669 2231 3669 1497 
-Q 3669 778 3244 343 
-Q 2819 -91 2113 -91 
-Q 1303 -91 875 529 
-Q 447 1150 447 2328 
-Q 447 3434 972 4092 
-Q 1497 4750 2381 4750 
-Q 2619 4750 2861 4703 
-Q 3103 4656 3366 4563 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_27">
+   <g id="text_29">
+    <!-- -6 -->
+    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(36.083984 0)"/>
+    </g>
+   </g>
+   <g id="text_30">
     <!-- -10 -->
-    <g transform="translate(352.171177 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
-   <g id="text_28">
-    <!-- -39 -->
-    <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_29">
-    <!-- -9 -->
-    <g transform="translate(434.793786 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_30">
-    <!-- -15 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
    <g id="text_31">
-    <!-- -52 -->
+    <!-- -53 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531 
-L 3431 531 
-L 3431 0 
-L 469 0 
-L 469 531 
-Q 828 903 1448 1529 
-Q 2069 2156 2228 2338 
-Q 2531 2678 2651 2914 
-Q 2772 3150 2772 3378 
-Q 2772 3750 2511 3984 
-Q 2250 4219 1831 4219 
-Q 1534 4219 1204 4116 
-Q 875 4013 500 3803 
-L 500 4441 
-Q 881 4594 1212 4672 
-Q 1544 4750 1819 4750 
-Q 2544 4750 2975 4387 
-Q 3406 4025 3406 3419 
-Q 3406 3131 3298 2873 
-Q 3191 2616 2906 2266 
-Q 2828 2175 2409 1742 
-Q 1991 1309 1228 531 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- -35 -->
+    <!-- -30 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- +7 -->
     <g transform="translate(111.023738 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
     </g>
@@ -1587,6 +1507,38 @@ z
    <g id="text_43">
     <!-- +9 -->
     <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
@@ -1647,6 +1599,47 @@ z
    <g id="text_50">
     <!-- +184 -->
     <g transform="translate(308.275106 143.2248) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(147.412109 0)"/>
@@ -2196,18 +2189,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="imageee5f537581" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image72e9f67e74" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m72e69078bd" d="M 0 0 
+       <path id="md75de07880" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m72e69078bd" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md75de07880" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2230,7 +2223,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m72e69078bd" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md75de07880" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2244,7 +2237,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m72e69078bd" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md75de07880" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2258,7 +2251,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m72e69078bd" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md75de07880" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2271,7 +2264,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m72e69078bd" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md75de07880" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2284,7 +2277,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m72e69078bd" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md75de07880" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2297,7 +2290,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m72e69078bd" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#md75de07880" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2913,8 +2906,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.540625 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.467344 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3006,12 +2999,12 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -3052,109 +3045,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p36c68af620">
+  <clipPath id="p9b90173a96">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mb0320c9bc4" d="M 0 0 
+       <path id="m8346af2443" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb0320c9bc4" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8346af2443" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mb0320c9bc4" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8346af2443" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mb0320c9bc4" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8346af2443" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mb0320c9bc4" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8346af2443" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb0320c9bc4" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8346af2443" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb0320c9bc4" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8346af2443" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb0320c9bc4" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8346af2443" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m7fc7328a31" d="M 0 0 
+       <path id="m28b740e96d" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7fc7328a31" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m28b740e96d" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m7fc7328a31" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m28b740e96d" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7fc7328a31" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m28b740e96d" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mf29406200d" d="M 0 0 
+       <path id="mb624f864c8" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mf29406200d" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mb624f864c8" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 122.942665) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 122.797254) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 312.063858) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 311.815309) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m6a980d8f59" d="M -2.5 2.5 
+     <path id="m901485b555" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p992d2108cc)">
-     <use xlink:href="#m6a980d8f59" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a980d8f59" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a980d8f59" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a980d8f59" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a980d8f59" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a980d8f59" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a980d8f59" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a980d8f59" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6a980d8f59" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p931dae7db1)">
+     <use xlink:href="#m901485b555" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m901485b555" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m901485b555" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m901485b555" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m901485b555" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m901485b555" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m901485b555" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m901485b555" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m901485b555" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m7b5e28d8f0" d="M 0 -2.5 
+     <path id="m87ae9942f9" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p992d2108cc)">
-     <use xlink:href="#m7b5e28d8f0" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7b5e28d8f0" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7b5e28d8f0" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7b5e28d8f0" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7b5e28d8f0" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7b5e28d8f0" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7b5e28d8f0" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7b5e28d8f0" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7b5e28d8f0" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p931dae7db1)">
+     <use xlink:href="#m87ae9942f9" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ae9942f9" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ae9942f9" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ae9942f9" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ae9942f9" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ae9942f9" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ae9942f9" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ae9942f9" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ae9942f9" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="meb7478391e" d="M -0 3.535534 
+     <path id="mf765730cdc" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p992d2108cc)">
-     <use xlink:href="#meb7478391e" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#meb7478391e" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p931dae7db1)">
+     <use xlink:href="#mf765730cdc" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf765730cdc" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="mb00d7d0063" d="M -0 2.5 
+     <path id="m92aced012f" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p992d2108cc)">
-     <use xlink:href="#mb00d7d0063" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p931dae7db1)">
+     <use xlink:href="#m92aced012f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="m8bcfca8398" d="M -0.833333 2.5 
+     <path id="mee0c7e31fb" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p992d2108cc)">
-     <use xlink:href="#m8bcfca8398" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8bcfca8398" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8bcfca8398" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8bcfca8398" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8bcfca8398" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8bcfca8398" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8bcfca8398" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8bcfca8398" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m8bcfca8398" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p931dae7db1)">
+     <use xlink:href="#mee0c7e31fb" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee0c7e31fb" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee0c7e31fb" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee0c7e31fb" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee0c7e31fb" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee0c7e31fb" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee0c7e31fb" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee0c7e31fb" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mee0c7e31fb" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="m75bc00daba" d="M -1.25 2.5 
+     <path id="mbb46e5c2a2" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p992d2108cc)">
-     <use xlink:href="#m75bc00daba" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75bc00daba" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75bc00daba" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75bc00daba" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75bc00daba" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75bc00daba" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75bc00daba" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75bc00daba" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m75bc00daba" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p931dae7db1)">
+     <use xlink:href="#mbb46e5c2a2" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb46e5c2a2" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb46e5c2a2" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb46e5c2a2" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb46e5c2a2" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb46e5c2a2" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb46e5c2a2" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb46e5c2a2" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mbb46e5c2a2" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="m5d65e4db83" d="M 0 -2.5 
+     <path id="mc515657357" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p992d2108cc)">
-     <use xlink:href="#m5d65e4db83" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d65e4db83" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d65e4db83" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d65e4db83" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d65e4db83" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d65e4db83" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d65e4db83" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d65e4db83" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m5d65e4db83" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p931dae7db1)">
+     <use xlink:href="#mc515657357" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc515657357" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc515657357" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc515657357" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc515657357" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc515657357" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc515657357" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc515657357" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mc515657357" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="m33b92f56e7" d="M 0 -2.5 
+     <path id="mfbbf324ae2" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p992d2108cc)">
-     <use xlink:href="#m33b92f56e7" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33b92f56e7" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33b92f56e7" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33b92f56e7" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33b92f56e7" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33b92f56e7" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33b92f56e7" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33b92f56e7" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m33b92f56e7" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p931dae7db1)">
+     <use xlink:href="#mfbbf324ae2" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfbbf324ae2" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfbbf324ae2" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfbbf324ae2" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfbbf324ae2" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfbbf324ae2" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfbbf324ae2" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfbbf324ae2" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mfbbf324ae2" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m53739538dd" d="M 0 3.5 
+      <path id="m5cac22a7ae" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m53739538dd" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m5cac22a7ae" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m6a980d8f59" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m901485b555" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m7b5e28d8f0" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m87ae9942f9" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#meb7478391e" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf765730cdc" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#mb00d7d0063" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m92aced012f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#m8bcfca8398" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mee0c7e31fb" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#m75bc00daba" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mbb46e5c2a2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#m5d65e4db83" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mc515657357" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#m33b92f56e7" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mfbbf324ae2" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p992d2108cc)">
-     <use xlink:href="#m53739538dd" x="319.643112" y="127.942665" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m53739538dd" x="269.129958" y="143.706845" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m53739538dd" x="247.452898" y="148.721195" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m53739538dd" x="199.905291" y="164.114094" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m53739538dd" x="190.316224" y="176.561855" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m53739538dd" x="165.455859" y="186.277651" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m53739538dd" x="159.141659" y="195.694594" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m53739538dd" x="158.180344" y="200.062716" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m53739538dd" x="120.106777" y="289.878699" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m53739538dd" x="97.799363" y="317.063858" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p931dae7db1)">
+     <use xlink:href="#m5cac22a7ae" x="319.643112" y="127.797254" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5cac22a7ae" x="269.129958" y="143.505192" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5cac22a7ae" x="247.452898" y="148.47912" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5cac22a7ae" x="199.911377" y="162.26353" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5cac22a7ae" x="190.761816" y="173.189283" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5cac22a7ae" x="165.858468" y="183.360893" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5cac22a7ae" x="159.340043" y="192.900333" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5cac22a7ae" x="158.195355" y="196.946157" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5cac22a7ae" x="120.106777" y="289.153815" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m5cac22a7ae" x="97.799363" y="316.815309" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 127.942665 
-L 318.590755 128.322571 
-L 317.538397 128.69983 
-L 316.48604 129.074478 
-L 315.433682 129.44655 
-L 314.381325 129.816083 
-L 313.328968 130.18311 
-L 312.27661 130.547665 
-L 311.224253 130.909782 
-L 310.171896 131.269492 
-L 309.119538 131.626828 
-L 308.067181 131.98182 
-L 307.014823 132.334499 
-L 305.962466 132.684896 
-L 304.910109 133.033039 
-L 303.857751 133.378957 
-L 302.805394 133.722678 
-L 301.753037 134.064231 
-L 300.700679 134.403642 
-L 299.648322 134.740939 
-L 298.595965 135.076146 
-L 297.543607 135.409291 
-L 296.49125 135.740398 
-L 295.438892 136.069491 
-L 294.386535 136.396597 
-L 293.334178 136.721737 
-L 292.28182 137.044936 
-L 291.229463 137.366217 
-L 290.177106 137.685602 
-L 289.124748 138.003114 
-L 288.072391 138.318774 
-L 287.020033 138.632604 
-L 285.967676 138.944626 
-L 284.915319 139.254859 
-L 283.862961 139.563324 
-L 282.810604 139.870041 
-L 281.758247 140.17503 
-L 280.705889 140.478311 
-L 279.653532 140.779901 
-L 278.601175 141.079821 
-L 277.548817 141.378088 
-L 276.49646 141.674721 
-L 275.444102 141.969737 
-L 274.391745 142.263154 
-L 273.339388 142.554988 
-L 272.28703 142.845259 
-L 271.234673 143.13398 
-L 270.182316 143.42117 
-L 269.129958 143.706845 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 127.797254 
+L 318.590755 128.175605 
+L 317.538397 128.551329 
+L 316.48604 128.924463 
+L 315.433682 129.295043 
+L 314.381325 129.663104 
+L 313.328968 130.028678 
+L 312.27661 130.3918 
+L 311.224253 130.752503 
+L 310.171896 131.110818 
+L 309.119538 131.466776 
+L 308.067181 131.82041 
+L 307.014823 132.171748 
+L 305.962466 132.52082 
+L 304.910109 132.867656 
+L 303.857751 133.212283 
+L 302.805394 133.55473 
+L 301.753037 133.895025 
+L 300.700679 134.233194 
+L 299.648322 134.569263 
+L 298.595965 134.903258 
+L 297.543607 135.235206 
+L 296.49125 135.56513 
+L 295.438892 135.893055 
+L 294.386535 136.219006 
+L 293.334178 136.543006 
+L 292.28182 136.865078 
+L 291.229463 137.185246 
+L 290.177106 137.50353 
+L 289.124748 137.819955 
+L 288.072391 138.13454 
+L 287.020033 138.447307 
+L 285.967676 138.758278 
+L 284.915319 139.067473 
+L 283.862961 139.374911 
+L 282.810604 139.680613 
+L 281.758247 139.984599 
+L 280.705889 140.286887 
+L 279.653532 140.587496 
+L 278.601175 140.886445 
+L 277.548817 141.183752 
+L 276.49646 141.479435 
+L 275.444102 141.773512 
+L 274.391745 142.066 
+L 273.339388 142.356916 
+L 272.28703 142.646277 
+L 271.234673 142.934099 
+L 270.182316 143.220399 
+L 269.129958 143.505192 
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 143.706845 
-L 268.678353 143.816191 
-L 268.226747 143.925317 
-L 267.775142 144.034224 
-L 267.323537 144.142912 
-L 266.871931 144.251382 
-L 266.420326 144.359635 
-L 265.96872 144.467672 
-L 265.517115 144.575494 
-L 265.065509 144.683102 
-L 264.613904 144.790496 
-L 264.162299 144.897677 
-L 263.710693 145.004647 
-L 263.259088 145.111405 
-L 262.807482 145.217954 
-L 262.355877 145.324293 
-L 261.904271 145.430424 
-L 261.452666 145.536347 
-L 261.001061 145.642063 
-L 260.549455 145.747573 
-L 260.09785 145.852878 
-L 259.646244 145.957979 
-L 259.194639 146.062875 
-L 258.743034 146.167569 
-L 258.291428 146.272061 
-L 257.839823 146.376352 
-L 257.388217 146.480441 
-L 256.936612 146.584332 
-L 256.485006 146.688023 
-L 256.033401 146.791516 
-L 255.581796 146.894811 
-L 255.13019 146.99791 
-L 254.678585 147.100812 
-L 254.226979 147.20352 
-L 253.775374 147.306033 
-L 253.323769 147.408352 
-L 252.872163 147.510478 
-L 252.420558 147.612412 
-L 251.968952 147.714154 
-L 251.517347 147.815705 
-L 251.065741 147.917067 
-L 250.614136 148.018238 
-L 250.162531 148.119221 
-L 249.710925 148.220016 
-L 249.25932 148.320624 
-L 248.807714 148.421045 
-L 248.356109 148.52128 
-L 247.904503 148.62133 
-L 247.452898 148.721195 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 143.505192 
+L 268.678353 143.613617 
+L 268.226747 143.721825 
+L 267.775142 143.829818 
+L 267.323537 143.937595 
+L 266.871931 144.045158 
+L 266.420326 144.152508 
+L 265.96872 144.259645 
+L 265.517115 144.366571 
+L 265.065509 144.473285 
+L 264.613904 144.57979 
+L 264.162299 144.686086 
+L 263.710693 144.792174 
+L 263.259088 144.898054 
+L 262.807482 145.003727 
+L 262.355877 145.109194 
+L 261.904271 145.214456 
+L 261.452666 145.319514 
+L 261.001061 145.424369 
+L 260.549455 145.529021 
+L 260.09785 145.63347 
+L 259.646244 145.737719 
+L 259.194639 145.841767 
+L 258.743034 145.945616 
+L 258.291428 146.049266 
+L 257.839823 146.152718 
+L 257.388217 146.255972 
+L 256.936612 146.35903 
+L 256.485006 146.461892 
+L 256.033401 146.564559 
+L 255.581796 146.667031 
+L 255.13019 146.76931 
+L 254.678585 146.871396 
+L 254.226979 146.97329 
+L 253.775374 147.074993 
+L 253.323769 147.176504 
+L 252.872163 147.277826 
+L 252.420558 147.378958 
+L 251.968952 147.479902 
+L 251.517347 147.580658 
+L 251.065741 147.681227 
+L 250.614136 147.781609 
+L 250.162531 147.881806 
+L 249.710925 147.981817 
+L 249.25932 148.081644 
+L 248.807714 148.181287 
+L 248.356109 148.280747 
+L 247.904503 148.380025 
+L 247.452898 148.47912 
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 148.721195 
-L 246.462323 149.090858 
-L 245.471748 149.458014 
-L 244.481173 149.822696 
-L 243.490597 150.184938 
-L 242.500022 150.544772 
-L 241.509447 150.90223 
-L 240.518872 151.257343 
-L 239.528297 151.610141 
-L 238.537722 151.960655 
-L 237.547147 152.308914 
-L 236.556571 152.654946 
-L 235.565996 152.998781 
-L 234.575421 153.340445 
-L 233.584846 153.679966 
-L 232.594271 154.017371 
-L 231.603696 154.352686 
-L 230.613121 154.685937 
-L 229.622545 155.017149 
-L 228.63197 155.346346 
-L 227.641395 155.673554 
-L 226.65082 155.998795 
-L 225.660245 156.322094 
-L 224.66967 156.643474 
-L 223.679095 156.962956 
-L 222.688519 157.280565 
-L 221.697944 157.59632 
-L 220.707369 157.910244 
-L 219.716794 158.222359 
-L 218.726219 158.532684 
-L 217.735644 158.84124 
-L 216.745069 159.148047 
-L 215.754493 159.453125 
-L 214.763918 159.756494 
-L 213.773343 160.058171 
-L 212.782768 160.358177 
-L 211.792193 160.656529 
-L 210.801618 160.953246 
-L 209.811043 161.248345 
-L 208.820467 161.541844 
-L 207.829892 161.833761 
-L 206.839317 162.124111 
-L 205.848742 162.412913 
-L 204.858167 162.700182 
-L 203.867592 162.985934 
-L 202.877017 163.270186 
-L 201.886441 163.552953 
-L 200.895866 163.83425 
-L 199.905291 164.114094 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 148.47912 
+L 246.46245 148.805188 
+L 245.472001 149.129302 
+L 244.481553 149.451488 
+L 243.491105 149.771768 
+L 242.500656 150.090163 
+L 241.510208 150.406697 
+L 240.51976 150.721391 
+L 239.529311 151.034265 
+L 238.538863 151.345342 
+L 237.548414 151.654641 
+L 236.557966 151.962183 
+L 235.567518 152.267988 
+L 234.577069 152.572074 
+L 233.586621 152.874462 
+L 232.596173 153.17517 
+L 231.605724 153.474217 
+L 230.615276 153.771621 
+L 229.624828 154.0674 
+L 228.634379 154.361571 
+L 227.643931 154.654153 
+L 226.653483 154.945161 
+L 225.663034 155.234614 
+L 224.672586 155.522527 
+L 223.682137 155.808916 
+L 222.691689 156.093799 
+L 221.701241 156.37719 
+L 220.710792 156.659105 
+L 219.720344 156.939559 
+L 218.729896 157.218568 
+L 217.739447 157.496146 
+L 216.748999 157.772308 
+L 215.758551 158.047069 
+L 214.768102 158.320441 
+L 213.777654 158.59244 
+L 212.787206 158.863079 
+L 211.796757 159.132372 
+L 210.806309 159.400332 
+L 209.81586 159.666972 
+L 208.825412 159.932305 
+L 207.834964 160.196343 
+L 206.844515 160.4591 
+L 205.854067 160.720588 
+L 204.863619 160.980818 
+L 203.87317 161.239804 
+L 202.882722 161.497556 
+L 201.892274 161.754087 
+L 200.901825 162.009408 
+L 199.911377 162.26353 
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 199.905291 164.114094 
-L 199.705519 164.40488 
-L 199.505747 164.694112 
-L 199.305974 164.981807 
-L 199.106202 165.267982 
-L 198.90643 165.552651 
-L 198.706658 165.835831 
-L 198.506885 166.117537 
-L 198.307113 166.397785 
-L 198.107341 166.67659 
-L 197.907569 166.953965 
-L 197.707797 167.229927 
-L 197.508024 167.504489 
-L 197.308252 167.777666 
-L 197.10848 168.04947 
-L 196.908708 168.319917 
-L 196.708935 168.589019 
-L 196.509163 168.85679 
-L 196.309391 169.123243 
-L 196.109619 169.388391 
-L 195.909846 169.652247 
-L 195.710074 169.914822 
-L 195.510302 170.17613 
-L 195.31053 170.436183 
-L 195.110758 170.694992 
-L 194.910985 170.95257 
-L 194.711213 171.208928 
-L 194.511441 171.464078 
-L 194.311669 171.71803 
-L 194.111896 171.970797 
-L 193.912124 172.222389 
-L 193.712352 172.472817 
-L 193.51258 172.722092 
-L 193.312807 172.970224 
-L 193.113035 173.217224 
-L 192.913263 173.463102 
-L 192.713491 173.707868 
-L 192.513719 173.951532 
-L 192.313946 174.194105 
-L 192.114174 174.435595 
-L 191.914402 174.676013 
-L 191.71463 174.915368 
-L 191.514857 175.153669 
-L 191.315085 175.390925 
-L 191.115313 175.627146 
-L 190.915541 175.862341 
-L 190.715768 176.096518 
-L 190.515996 176.329687 
-L 190.316224 176.561855 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.911377 162.26353 
+L 199.720761 162.515162 
+L 199.530145 162.76563 
+L 199.339529 163.014944 
+L 199.148913 163.263115 
+L 198.958298 163.510153 
+L 198.767682 163.75607 
+L 198.577066 164.000874 
+L 198.38645 164.244576 
+L 198.195834 164.487185 
+L 198.005218 164.728713 
+L 197.814603 164.969167 
+L 197.623987 165.208558 
+L 197.433371 165.446895 
+L 197.242755 165.684187 
+L 197.052139 165.920443 
+L 196.861523 166.155673 
+L 196.670907 166.389885 
+L 196.480292 166.623088 
+L 196.289676 166.855291 
+L 196.09906 167.086502 
+L 195.908444 167.316729 
+L 195.717828 167.545982 
+L 195.527212 167.774267 
+L 195.336596 168.001594 
+L 195.145981 168.22797 
+L 194.955365 168.453404 
+L 194.764749 168.677902 
+L 194.574133 168.901474 
+L 194.383517 169.124125 
+L 194.192901 169.345865 
+L 194.002286 169.5667 
+L 193.81167 169.786638 
+L 193.621054 170.005686 
+L 193.430438 170.223851 
+L 193.239822 170.44114 
+L 193.049206 170.65756 
+L 192.85859 170.873119 
+L 192.667975 171.087823 
+L 192.477359 171.301678 
+L 192.286743 171.514692 
+L 192.096127 171.726871 
+L 191.905511 171.938221 
+L 191.714895 172.14875 
+L 191.524279 172.358463 
+L 191.333664 172.567366 
+L 191.143048 172.775467 
+L 190.952432 172.98277 
+L 190.761816 173.189283 
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 190.316224 176.561855 
-L 189.7983 176.783117 
-L 189.280375 177.003479 
-L 188.762451 177.222947 
-L 188.244527 177.441528 
-L 187.726603 177.659231 
-L 187.208678 177.876061 
-L 186.690754 178.092027 
-L 186.17283 178.307134 
-L 185.654906 178.52139 
-L 185.136981 178.734801 
-L 184.619057 178.947374 
-L 184.101133 179.159116 
-L 183.583208 179.370032 
-L 183.065284 179.58013 
-L 182.54736 179.789416 
-L 182.029436 179.997895 
-L 181.511511 180.205575 
-L 180.993587 180.412461 
-L 180.475663 180.61856 
-L 179.957739 180.823876 
-L 179.439814 181.028417 
-L 178.92189 181.232188 
-L 178.403966 181.435194 
-L 177.886041 181.637442 
-L 177.368117 181.838938 
-L 176.850193 182.039686 
-L 176.332269 182.239692 
-L 175.814344 182.438962 
-L 175.29642 182.637501 
-L 174.778496 182.835315 
-L 174.260572 183.032408 
-L 173.742647 183.228786 
-L 173.224723 183.424455 
-L 172.706799 183.619419 
-L 172.188874 183.813683 
-L 171.67095 184.007252 
-L 171.153026 184.200132 
-L 170.635102 184.392327 
-L 170.117177 184.583842 
-L 169.599253 184.774681 
-L 169.081329 184.964851 
-L 168.563404 185.154354 
-L 168.04548 185.343197 
-L 167.527556 185.531382 
-L 167.009632 185.718916 
-L 166.491707 185.905803 
-L 165.973783 186.092046 
-L 165.455859 186.277651 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 190.761816 173.189283 
+L 190.242996 173.421908 
+L 189.724177 173.653538 
+L 189.205357 173.884181 
+L 188.686537 174.113846 
+L 188.167717 174.34254 
+L 187.648898 174.570272 
+L 187.130078 174.79705 
+L 186.611258 175.022882 
+L 186.092438 175.247775 
+L 185.573619 175.471739 
+L 185.054799 175.694779 
+L 184.535979 175.916904 
+L 184.017159 176.138121 
+L 183.498339 176.358438 
+L 182.97952 176.577862 
+L 182.4607 176.7964 
+L 181.94188 177.01406 
+L 181.42306 177.230847 
+L 180.904241 177.44677 
+L 180.385421 177.661835 
+L 179.866601 177.876049 
+L 179.347781 178.089419 
+L 178.828962 178.301951 
+L 178.310142 178.513651 
+L 177.791322 178.724527 
+L 177.272502 178.934585 
+L 176.753683 179.143831 
+L 176.234863 179.352271 
+L 175.716043 179.559911 
+L 175.197223 179.766758 
+L 174.678404 179.972817 
+L 174.159584 180.178096 
+L 173.640764 180.382598 
+L 173.121944 180.586331 
+L 172.603125 180.7893 
+L 172.084305 180.991511 
+L 171.565485 181.192969 
+L 171.046665 181.39368 
+L 170.527846 181.59365 
+L 170.009026 181.792884 
+L 169.490206 181.991387 
+L 168.971386 182.189165 
+L 168.452566 182.386223 
+L 167.933747 182.582566 
+L 167.414927 182.7782 
+L 166.896107 182.973129 
+L 166.377287 183.167358 
+L 165.858468 183.360893 
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 165.455859 186.277651 
-L 165.324313 186.491513 
-L 165.192767 186.704534 
-L 165.061221 186.91672 
-L 164.929675 187.128077 
-L 164.79813 187.338612 
-L 164.666584 187.548331 
-L 164.535038 187.757241 
-L 164.403492 187.965348 
-L 164.271946 188.172658 
-L 164.1404 188.379177 
-L 164.008855 188.584911 
-L 163.877309 188.789866 
-L 163.745763 188.994048 
-L 163.614217 189.197463 
-L 163.482671 189.400116 
-L 163.351125 189.602013 
-L 163.21958 189.80316 
-L 163.088034 190.003563 
-L 162.956488 190.203226 
-L 162.824942 190.402155 
-L 162.693396 190.600356 
-L 162.56185 190.797835 
-L 162.430305 190.994595 
-L 162.298759 191.190642 
-L 162.167213 191.385982 
-L 162.035667 191.58062 
-L 161.904121 191.774561 
-L 161.772575 191.967809 
-L 161.64103 192.160369 
-L 161.509484 192.352247 
-L 161.377938 192.543448 
-L 161.246392 192.733975 
-L 161.114846 192.923834 
-L 160.9833 193.11303 
-L 160.851754 193.301566 
-L 160.720209 193.489448 
-L 160.588663 193.676681 
-L 160.457117 193.863267 
-L 160.325571 194.049213 
-L 160.194025 194.234523 
-L 160.062479 194.4192 
-L 159.930934 194.603249 
-L 159.799388 194.786675 
-L 159.667842 194.969481 
-L 159.536296 195.151672 
-L 159.40475 195.333252 
-L 159.273204 195.514225 
-L 159.141659 195.694594 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.858468 183.360893 
+L 165.722667 183.577784 
+L 165.586867 183.793809 
+L 165.451066 184.008975 
+L 165.315266 184.223289 
+L 165.179465 184.436759 
+L 165.043665 184.649389 
+L 164.907864 184.861188 
+L 164.772064 185.072161 
+L 164.636263 185.282316 
+L 164.500463 185.491657 
+L 164.364662 185.700192 
+L 164.228862 185.907927 
+L 164.093061 186.114867 
+L 163.957261 186.32102 
+L 163.82146 186.52639 
+L 163.685659 186.730984 
+L 163.549859 186.934808 
+L 163.414058 187.137867 
+L 163.278258 187.340167 
+L 163.142457 187.541714 
+L 163.006657 187.742514 
+L 162.870856 187.942571 
+L 162.735056 188.141892 
+L 162.599255 188.340481 
+L 162.463455 188.538345 
+L 162.327654 188.735488 
+L 162.191854 188.931915 
+L 162.056053 189.127632 
+L 161.920253 189.322645 
+L 161.784452 189.516957 
+L 161.648652 189.710574 
+L 161.512851 189.903501 
+L 161.377051 190.095743 
+L 161.24125 190.287305 
+L 161.10545 190.478191 
+L 160.969649 190.668406 
+L 160.833849 190.857955 
+L 160.698048 191.046843 
+L 160.562248 191.235074 
+L 160.426447 191.422653 
+L 160.290647 191.609584 
+L 160.154846 191.795872 
+L 160.019046 191.981521 
+L 159.883245 192.166535 
+L 159.747445 192.350919 
+L 159.611644 192.534677 
+L 159.475844 192.717814 
+L 159.340043 192.900333 
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 159.141659 195.694594 
-L 159.121631 195.789286 
-L 159.101604 195.883813 
-L 159.081576 195.978175 
-L 159.061549 196.072373 
-L 159.041522 196.166407 
-L 159.021494 196.260278 
-L 159.001467 196.353987 
-L 158.98144 196.447534 
-L 158.961412 196.540919 
-L 158.941385 196.634143 
-L 158.921357 196.727208 
-L 158.90133 196.820112 
-L 158.881303 196.912857 
-L 158.861275 197.005444 
-L 158.841248 197.097873 
-L 158.82122 197.190144 
-L 158.801193 197.282258 
-L 158.781166 197.374215 
-L 158.761138 197.466017 
-L 158.741111 197.557663 
-L 158.721084 197.649154 
-L 158.701056 197.740491 
-L 158.681029 197.831674 
-L 158.661001 197.922704 
-L 158.640974 198.013581 
-L 158.620947 198.104305 
-L 158.600919 198.194878 
-L 158.580892 198.285299 
-L 158.560865 198.37557 
-L 158.540837 198.46569 
-L 158.52081 198.555661 
-L 158.500782 198.645482 
-L 158.480755 198.735155 
-L 158.460728 198.824679 
-L 158.4407 198.914055 
-L 158.420673 199.003284 
-L 158.400645 199.092367 
-L 158.380618 199.181303 
-L 158.360591 199.270093 
-L 158.340563 199.358737 
-L 158.320536 199.447237 
-L 158.300509 199.535592 
-L 158.280481 199.623803 
-L 158.260454 199.711871 
-L 158.240426 199.799796 
-L 158.220399 199.887578 
-L 158.200372 199.975218 
-L 158.180344 200.062716 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.340043 192.900333 
+L 159.316195 192.98778 
+L 159.292348 193.075086 
+L 159.2685 193.162251 
+L 159.244652 193.249277 
+L 159.220805 193.336163 
+L 159.196957 193.422909 
+L 159.173109 193.509517 
+L 159.149262 193.595986 
+L 159.125414 193.682318 
+L 159.101566 193.768512 
+L 159.077719 193.854569 
+L 159.053871 193.940489 
+L 159.030023 194.026273 
+L 159.006176 194.111922 
+L 158.982328 194.197435 
+L 158.95848 194.282813 
+L 158.934633 194.368057 
+L 158.910785 194.453167 
+L 158.886937 194.538143 
+L 158.86309 194.622986 
+L 158.839242 194.707696 
+L 158.815394 194.792274 
+L 158.791547 194.87672 
+L 158.767699 194.961035 
+L 158.743851 195.045218 
+L 158.720004 195.12927 
+L 158.696156 195.213193 
+L 158.672308 195.296985 
+L 158.648461 195.380648 
+L 158.624613 195.464182 
+L 158.600765 195.547587 
+L 158.576918 195.630863 
+L 158.55307 195.714012 
+L 158.529222 195.797034 
+L 158.505375 195.879928 
+L 158.481527 195.962695 
+L 158.457679 196.045336 
+L 158.433832 196.127851 
+L 158.409984 196.210241 
+L 158.386136 196.292505 
+L 158.362289 196.374644 
+L 158.338441 196.456659 
+L 158.314593 196.53855 
+L 158.290746 196.620318 
+L 158.266898 196.701961 
+L 158.24305 196.783482 
+L 158.219203 196.864881 
+L 158.195355 196.946157 
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 158.180344 200.062716 
-L 157.387145 204.660581 
-L 156.593946 208.898299 
-L 155.800746 212.828214 
-L 155.007547 216.492028 
-L 154.214348 219.923503 
-L 153.421148 223.150357 
-L 152.627949 226.195628 
-L 151.83475 229.078666 
-L 151.04155 231.815887 
-L 150.248351 234.421333 
-L 149.455152 236.907111 
-L 148.661952 239.283734 
-L 147.868753 241.560385 
-L 147.075554 243.745137 
-L 146.282354 245.845122 
-L 145.489155 247.866673 
-L 144.695956 249.815438 
-L 143.902756 251.696477 
-L 143.109557 253.514341 
-L 142.316358 255.273134 
-L 141.523159 256.976575 
-L 140.729959 258.628043 
-L 139.93676 260.230615 
-L 139.143561 261.787103 
-L 138.350361 263.300084 
-L 137.557162 264.771924 
-L 136.763963 266.204802 
-L 135.970763 267.600727 
-L 135.177564 268.961557 
-L 134.384365 270.289014 
-L 133.591165 271.584695 
-L 132.797966 272.850087 
-L 132.004767 274.086573 
-L 131.211567 275.295444 
-L 130.418368 276.477907 
-L 129.625169 277.635091 
-L 128.831969 278.768055 
-L 128.03877 279.877791 
-L 127.245571 280.965232 
-L 126.452371 282.031258 
-L 125.659172 283.076695 
-L 124.865973 284.102323 
-L 124.072774 285.10888 
-L 123.279574 286.097061 
-L 122.486375 287.067525 
-L 121.693176 288.020897 
-L 120.899976 288.957768 
-L 120.106777 289.878699 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.195355 196.946157 
+L 157.401843 201.789386 
+L 156.608331 206.234645 
+L 155.814819 210.3424 
+L 155.021307 214.160304 
+L 154.227795 217.72658 
+L 153.434283 221.072354 
+L 152.640771 224.223313 
+L 151.847259 227.200902 
+L 151.053747 230.023208 
+L 150.260234 232.705627 
+L 149.466722 235.261374 
+L 148.67321 237.701875 
+L 147.879698 240.037077 
+L 147.086186 242.275691 
+L 146.292674 244.425392 
+L 145.499162 246.492973 
+L 144.70565 248.484478 
+L 143.912138 250.405307 
+L 143.118626 252.260306 
+L 142.325114 254.053837 
+L 141.531602 255.789844 
+L 140.73809 257.471903 
+L 139.944578 259.103265 
+L 139.151066 260.686897 
+L 138.357554 262.225513 
+L 137.564042 263.721602 
+L 136.77053 265.177452 
+L 135.977018 266.59517 
+L 135.183506 267.976703 
+L 134.389994 269.323852 
+L 133.596482 270.638288 
+L 132.80297 271.921561 
+L 132.009458 273.175116 
+L 131.215945 274.400296 
+L 130.422433 275.59836 
+L 129.628921 276.77048 
+L 128.835409 277.917757 
+L 128.041897 279.041221 
+L 127.248385 280.141843 
+L 126.454873 281.220531 
+L 125.661361 282.278143 
+L 124.867849 283.315487 
+L 124.074337 284.333325 
+L 123.280825 285.332377 
+L 122.487313 286.313325 
+L 121.693801 287.276811 
+L 120.900289 288.223448 
+L 120.106777 289.153815 
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 120.106777 289.878699 
-L 119.642039 290.609441 
-L 119.177301 291.330448 
-L 118.712564 292.041979 
-L 118.247826 292.744277 
-L 117.783088 293.437581 
-L 117.31835 294.122117 
-L 116.853612 294.798105 
-L 116.388875 295.465755 
-L 115.924137 296.12527 
-L 115.459399 296.776847 
-L 114.994661 297.420674 
-L 114.529924 298.056933 
-L 114.065186 298.6858 
-L 113.600448 299.307446 
-L 113.13571 299.922033 
-L 112.670972 300.529721 
-L 112.206235 301.130663 
-L 111.741497 301.725006 
-L 111.276759 302.312894 
-L 110.812021 302.894467 
-L 110.347283 303.469857 
-L 109.882546 304.039196 
-L 109.417808 304.602608 
-L 108.95307 305.160217 
-L 108.488332 305.71214 
-L 108.023595 306.258493 
-L 107.558857 306.799386 
-L 107.094119 307.334928 
-L 106.629381 307.865224 
-L 106.164643 308.390375 
-L 105.699906 308.91048 
-L 105.235168 309.425635 
-L 104.77043 309.935934 
-L 104.305692 310.441467 
-L 103.840955 310.942323 
-L 103.376217 311.438587 
-L 102.911479 311.930342 
-L 102.446741 312.417671 
-L 101.982003 312.900651 
-L 101.517266 313.37936 
-L 101.052528 313.853872 
-L 100.58779 314.324261 
-L 100.123052 314.790598 
-L 99.658315 315.252952 
-L 99.193577 315.71139 
-L 98.728839 316.165977 
-L 98.264101 316.61678 
-L 97.799363 317.063858 
-" clip-path="url(#p992d2108cc)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 120.106777 289.153815 
+L 119.642039 289.900803 
+L 119.177301 290.637622 
+L 118.712564 291.364547 
+L 118.247826 292.081839 
+L 117.783088 292.789751 
+L 117.31835 293.488524 
+L 116.853612 294.178392 
+L 116.388875 294.859578 
+L 115.924137 295.532298 
+L 115.459399 296.196761 
+L 114.994661 296.853166 
+L 114.529924 297.501707 
+L 114.065186 298.14257 
+L 113.600448 298.775934 
+L 113.13571 299.401973 
+L 112.670972 300.020855 
+L 112.206235 300.632741 
+L 111.741497 301.237787 
+L 111.276759 301.836145 
+L 110.812021 302.427962 
+L 110.347283 303.013377 
+L 109.882546 303.59253 
+L 109.417808 304.165552 
+L 108.95307 304.732571 
+L 108.488332 305.293712 
+L 108.023595 305.849096 
+L 107.558857 306.39884 
+L 107.094119 306.943056 
+L 106.629381 307.481856 
+L 106.164643 308.015345 
+L 105.699906 308.543628 
+L 105.235168 309.066805 
+L 104.77043 309.584974 
+L 104.305692 310.09823 
+L 103.840955 310.606665 
+L 103.376217 311.110369 
+L 102.911479 311.609429 
+L 102.446741 312.10393 
+L 101.982003 312.593954 
+L 101.517266 313.079582 
+L 101.052528 313.560892 
+L 100.58779 314.03796 
+L 100.123052 314.510861 
+L 99.658315 314.979666 
+L 99.193577 315.444445 
+L 98.728839 315.905268 
+L 98.264101 316.362201 
+L 97.799363 316.815309 
+" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.540625 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.467344 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6188,19 +6188,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3a" d="M 750 794 
-L 1409 794 
-L 1409 0 
-L 750 0 
-L 750 794 
-z
-M 750 3309 
-L 1409 3309 
-L 1409 2516 
-L 750 2516 
-L 750 3309 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-35" d="M 691 4666 
@@ -6226,6 +6213,19 @@ Q 2250 2553 1709 2553
 Q 1456 2553 1204 2497 
 Q 953 2441 691 2322 
 L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-b7" d="M 684 2619 
@@ -6285,36 +6285,6 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6356,12 +6326,12 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -6402,109 +6372,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p992d2108cc">
+  <clipPath id="p931dae7db1">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="mc1c44ca963" d="M 0 0 
+       <path id="maa893f17ff" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc1c44ca963" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa893f17ff" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mc1c44ca963" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa893f17ff" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mc1c44ca963" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa893f17ff" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mc1c44ca963" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa893f17ff" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mc1c44ca963" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa893f17ff" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mc1c44ca963" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa893f17ff" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mc1c44ca963" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#maa893f17ff" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.82245 
 L 637.2 391.82245 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m3885937e1e" d="M 0 0 
+       <path id="m3291c2fef2" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3885937e1e" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3291c2fef2" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 265.911133 
 L 637.2 265.911133 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3885937e1e" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3291c2fef2" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 265.911133
      <g id="line2d_19">
       <path d="M 49.078125 139.999816 
 L 637.2 139.999816 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3885937e1e" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3291c2fef2" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.999816
      <g id="line2d_21">
       <path d="M 49.078125 411.32636 
 L 637.2 411.32636 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m585014357a" d="M 0 0 
+       <path id="md4fa40ca18" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 404.024518 
 L 637.2 404.024518 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 404.024518
      <g id="line2d_25">
       <path d="M 49.078125 397.583836 
 L 637.2 397.583836 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.583836
      <g id="line2d_27">
       <path d="M 49.078125 353.919367 
 L 637.2 353.919367 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 353.919367
      <g id="line2d_29">
       <path d="M 49.078125 331.747485 
 L 637.2 331.747485 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 331.747485
      <g id="line2d_31">
       <path d="M 49.078125 316.016284 
 L 637.2 316.016284 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 316.016284
      <g id="line2d_33">
       <path d="M 49.078125 303.814216 
 L 637.2 303.814216 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 303.814216
      <g id="line2d_35">
       <path d="M 49.078125 293.844402 
 L 637.2 293.844402 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 293.844402
      <g id="line2d_37">
       <path d="M 49.078125 285.415043 
 L 637.2 285.415043 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 285.415043
      <g id="line2d_39">
       <path d="M 49.078125 278.113201 
 L 637.2 278.113201 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 278.113201
      <g id="line2d_41">
       <path d="M 49.078125 271.672519 
 L 637.2 271.672519 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 271.672519
      <g id="line2d_43">
       <path d="M 49.078125 228.00805 
 L 637.2 228.00805 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 228.00805
      <g id="line2d_45">
       <path d="M 49.078125 205.836168 
 L 637.2 205.836168 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 205.836168
      <g id="line2d_47">
       <path d="M 49.078125 190.104967 
 L 637.2 190.104967 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 190.104967
      <g id="line2d_49">
       <path d="M 49.078125 177.9029 
 L 637.2 177.9029 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.9029
      <g id="line2d_51">
       <path d="M 49.078125 167.933085 
 L 637.2 167.933085 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.933085
      <g id="line2d_53">
       <path d="M 49.078125 159.503726 
 L 637.2 159.503726 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.503726
      <g id="line2d_55">
       <path d="M 49.078125 152.201884 
 L 637.2 152.201884 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 152.201884
      <g id="line2d_57">
       <path d="M 49.078125 145.761202 
 L 637.2 145.761202 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.761202
      <g id="line2d_59">
       <path d="M 49.078125 102.096733 
 L 637.2 102.096733 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.096733
      <g id="line2d_61">
       <path d="M 49.078125 79.924851 
 L 637.2 79.924851 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 79.924851
      <g id="line2d_63">
       <path d="M 49.078125 64.19365 
 L 637.2 64.19365 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.19365
      <g id="line2d_65">
       <path d="M 49.078125 51.991583 
 L 637.2 51.991583 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m585014357a" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#md4fa40ca18" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#pd08b8f9436)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p1426252be7)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m7e46a9d22c" d="M -2.5 2.5 
+     <path id="m7bee23be3f" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd08b8f9436)">
-     <use xlink:href="#m7e46a9d22c" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7e46a9d22c" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1426252be7)">
+     <use xlink:href="#m7bee23be3f" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m7bee23be3f" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="m2ae54ac107" d="M 0 -2.5 
+     <path id="md04406f221" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd08b8f9436)">
-     <use xlink:href="#m2ae54ac107" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2ae54ac107" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1426252be7)">
+     <use xlink:href="#md04406f221" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md04406f221" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m2149ef188d" d="M -0 3.535534 
+     <path id="m2e009cffac" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd08b8f9436)">
-     <use xlink:href="#m2149ef188d" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2149ef188d" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1426252be7)">
+     <use xlink:href="#m2e009cffac" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m2e009cffac" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="me4b4210f6e" d="M -0.833333 2.5 
+     <path id="md03f756d09" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd08b8f9436)">
-     <use xlink:href="#me4b4210f6e" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#me4b4210f6e" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1426252be7)">
+     <use xlink:href="#md03f756d09" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#md03f756d09" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m55fba3781e" d="M -1.25 2.5 
+     <path id="m1ed9c5d6df" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd08b8f9436)">
-     <use xlink:href="#m55fba3781e" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m55fba3781e" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1426252be7)">
+     <use xlink:href="#m1ed9c5d6df" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m1ed9c5d6df" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m8e9c232bb0" d="M 0 -2.5 
+     <path id="m8bc952b190" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pd08b8f9436)">
-     <use xlink:href="#m8e9c232bb0" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8e9c232bb0" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p1426252be7)">
+     <use xlink:href="#m8bc952b190" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m8bc952b190" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="m888ebdcdcc" d="M 0 -2.5 
+     <path id="mf1e8dc5d01" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#pd08b8f9436)">
-     <use xlink:href="#m888ebdcdcc" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m888ebdcdcc" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1426252be7)">
+     <use xlink:href="#mf1e8dc5d01" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf1e8dc5d01" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m8b5662da94" d="M 0 3.5 
+      <path id="m1487120ad8" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m8b5662da94" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m1487120ad8" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m7e46a9d22c" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m7bee23be3f" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#m2ae54ac107" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md04406f221" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m2149ef188d" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m2e009cffac" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#me4b4210f6e" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#md03f756d09" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m55fba3781e" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m1ed9c5d6df" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m8e9c232bb0" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m8bc952b190" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#m888ebdcdcc" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf1e8dc5d01" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#pd08b8f9436)">
-     <use xlink:href="#m8b5662da94" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m8b5662da94" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p1426252be7)">
+     <use xlink:href="#m1487120ad8" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m1487120ad8" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3184,7 +3184,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pd08b8f9436">
+  <clipPath id="p1426252be7">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.788615 308.04375 
 L 290.788615 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m082e1dc1ab" d="M 0 0 
+       <path id="m5c613c82e4" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m082e1dc1ab" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c613c82e4" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 447.590599 308.04375 
 L 447.590599 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m082e1dc1ab" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5c613c82e4" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.188732 308.04375 
 L 181.188732 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="mf6582778b5" d="M 0 0 
+       <path id="m80769aa95f" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mf6582778b5" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.800191 308.04375 
 L 208.800191 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mf6582778b5" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.800191 56.7075
      <g id="line2d_9">
       <path d="M 228.390833 308.04375 
 L 228.390833 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mf6582778b5" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.390833 56.7075
      <g id="line2d_11">
       <path d="M 243.586515 308.04375 
 L 243.586515 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mf6582778b5" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.586515 56.7075
      <g id="line2d_13">
       <path d="M 256.002291 308.04375 
 L 256.002291 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mf6582778b5" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 256.002291 56.7075
      <g id="line2d_15">
       <path d="M 266.499681 308.04375 
 L 266.499681 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mf6582778b5" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.499681 56.7075
      <g id="line2d_17">
       <path d="M 275.592933 308.04375 
 L 275.592933 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mf6582778b5" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.592933 56.7075
      <g id="line2d_19">
       <path d="M 283.61375 308.04375 
 L 283.61375 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#mf6582778b5" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.61375 56.7075
      <g id="line2d_21">
       <path d="M 337.990716 308.04375 
 L 337.990716 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mf6582778b5" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.990716 56.7075
      <g id="line2d_23">
       <path d="M 365.602174 308.04375 
 L 365.602174 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mf6582778b5" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.602174 56.7075
      <g id="line2d_25">
       <path d="M 385.192816 308.04375 
 L 385.192816 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mf6582778b5" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 385.192816 56.7075
      <g id="line2d_27">
       <path d="M 400.388498 308.04375 
 L 400.388498 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mf6582778b5" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 400.388498 56.7075
      <g id="line2d_29">
       <path d="M 412.804275 308.04375 
 L 412.804275 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mf6582778b5" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.804275 56.7075
      <g id="line2d_31">
       <path d="M 423.301664 308.04375 
 L 423.301664 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mf6582778b5" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 423.301664 56.7075
      <g id="line2d_33">
       <path d="M 432.394917 308.04375 
 L 432.394917 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mf6582778b5" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 432.394917 56.7075
      <g id="line2d_35">
       <path d="M 440.415734 308.04375 
 L 440.415734 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mf6582778b5" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 440.415734 56.7075
      <g id="line2d_37">
       <path d="M 494.792699 308.04375 
 L 494.792699 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mf6582778b5" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.792699 56.7075
      <g id="line2d_39">
       <path d="M 522.404158 308.04375 
 L 522.404158 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mf6582778b5" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 522.404158 56.7075
      <g id="line2d_41">
       <path d="M 541.9948 308.04375 
 L 541.9948 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mf6582778b5" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.9948 56.7075
      <g id="line2d_43">
       <path d="M 557.190482 308.04375 
 L 557.190482 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mf6582778b5" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m80769aa95f" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="m6cdbcb600c" d="M 0 0 
+       <path id="mdc77b50919" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6cdbcb600c" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc77b50919" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m6cdbcb600c" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc77b50919" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1129,7 +1129,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m6cdbcb600c" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc77b50919" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1242,7 +1242,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m6cdbcb600c" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc77b50919" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m6cdbcb600c" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc77b50919" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m6cdbcb600c" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc77b50919" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m6cdbcb600c" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc77b50919" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m6cdbcb600c" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mdc77b50919" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.556151 296.619375 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 162.32653 263.978304 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 178.681331 231.337232 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 201.044126 198.696161 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.976983 166.055089 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.121093 133.414018 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 247.282543 100.772946 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.279501 68.131875 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.286834 308.04375 
 L 542.286834 56.7075 
-" clip-path="url(#p51e3dc949a)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p226beb7eef)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1875,7 +1875,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="m3c8596cc55" d="M 0 3 
+     <path id="ma411708496" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1887,13 +1887,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p51e3dc949a)">
-     <use xlink:href="#m3c8596cc55" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p226beb7eef)">
+     <use xlink:href="#ma411708496" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m0621a243c8" d="M 0 3 
+     <path id="m1cf1554c37" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1905,13 +1905,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p51e3dc949a)">
-     <use xlink:href="#m0621a243c8" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p226beb7eef)">
+     <use xlink:href="#m1cf1554c37" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="m1b561e1993" d="M 0 5 
+     <path id="mfeefa3e48a" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1923,13 +1923,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p51e3dc949a)">
-     <use xlink:href="#m1b561e1993" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p226beb7eef)">
+     <use xlink:href="#mfeefa3e48a" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="mef769565ad" d="M 0 3 
+     <path id="m998b032618" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1941,13 +1941,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p51e3dc949a)">
-     <use xlink:href="#mef769565ad" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p226beb7eef)">
+     <use xlink:href="#m998b032618" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="m5c4ea028b1" d="M 0 3 
+     <path id="mc9c9953a71" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1959,13 +1959,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p51e3dc949a)">
-     <use xlink:href="#m5c4ea028b1" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p226beb7eef)">
+     <use xlink:href="#mc9c9953a71" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="m757e60eabd" d="M 0 3 
+     <path id="mff19055156" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1977,13 +1977,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p51e3dc949a)">
-     <use xlink:href="#m757e60eabd" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p226beb7eef)">
+     <use xlink:href="#mff19055156" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m8414f58f45" d="M 0 3 
+     <path id="m43c7729c95" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1995,13 +1995,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p51e3dc949a)">
-     <use xlink:href="#m8414f58f45" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p226beb7eef)">
+     <use xlink:href="#m43c7729c95" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="mfce90f15b1" d="M 0 3 
+     <path id="m94dbf7a018" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2013,8 +2013,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p51e3dc949a)">
-     <use xlink:href="#mfce90f15b1" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p226beb7eef)">
+     <use xlink:href="#m94dbf7a018" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2869,7 +2869,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p51e3dc949a">
+  <clipPath id="p226beb7eef">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p36b1f23e96)">
+   <g clip-path="url(#p748564b91f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ+klEQVR4nO3YvY5dVx2H4TOZ8Yc8jse2SIgwCAlbFIQAHQoFElIqBAXXwBXQUFEh7oCKG6BDEaWblJECSYCQAiLChzDImBg7JjL2eDyHK3gLFC390dHzXMHvaB+t/e61d3r7J9vNDjr+6c3pCUuceeWl6QnL7D3/qekJS2x//ZvpCUvsfenF6QlLbB8+mJ6wzJ3vvzo9YYnnf/St6QlL7F395PSENY4fTi9Y5vQXu3nePzM9AACA/19iEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAJBYBAEhiEQCAtPfv41e30yNWOPzXnekJS3xw6cL0hGX+c/LR9IQlPvPh8fSEJT587oXpCUucbk+nJyxz5eDq9IQ17v55esESD67s5vN69k+/n56wzPbzX52esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAA0sHh3dvTG9a4cHl6wRLb7fH0hGU+/dqb0xPWeOWb0wuWOPrg79MT1jg9mV6wzuGOnh/nLk4vWOLSP3fz/Xzvs9enJyxz5a/vTE9Yws0iAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkMQiAABJLAIAkPaePL25nR6xwv6dP05PWOL2s2enJyzz0ZP70xOWuP6X+9MTljj54temJyzx8OTB9IRljvYvT09YYvv+L6cnLPHocy9NT1ji/DtvTE9Y5vGXX56esISbRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACCJRQAAklgEACDt/fz9722nR6xw9fzh9IQl3rt/d3rCMt/98dvTE5b41Q+/PT1hiaNzR9MTlvjB629NT1jm69fOT09Y4jvXX56esMRrt96YnrDExTO7+T/cbDabn/3h3vSEJdwsAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAEksAgCQxCIAAGnvydOb2+kRK9x7fGd6whKHB5emJyzz3v3fTk9Y4sblF6cnLLHdnk5PWOLiye5+Q//tdDfPxWuHN6YnLPHo6cPpCUvs6tmx2Ww2+88cTE9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAAKSD/b2D6Q1LfGL/6vSENfbPTi9Y5ujc0fSEJQ4PLk1PWOLp9mR6whKnZ3b3G/qF7YXpCfwPdvX9fLx9ND1hmQeP70xPWGJ3T0UAAD42sQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQBKLAAAksQgAQDrYbE+nN6yxo7/rH49uTU9Y5tLZq9MT1rj9u+kFS+w/d2N6wiK7eXZsNpvN8d7J9IQl9m+9Oz1hjWtfmF6wxIV335qesMzhV74xPWEJN4sAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABA+i834ZgMqgskXAAAAABJRU5ErkJggg==" id="image9e204f6a67" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ90lEQVR4nO3YvY5dVx2H4TOe8Yc8jse2khBhEBK2KAghJQoFNKkQFFwDV0BDRYW4AypugA5FlG5SIgUIHyEFRIQPYZAxMXZMZOzxeA5X8BYoWvqjo+e5gt/RPlr73Wvv9M4Pt5sddPyjW9MTljj7+ivTE5bZe/GT0xOW2P76N9MTltj74svTE5bYPno4PWGZu995Y3rCEi9+/+vTE5bYu/aJ6QlrHD+aXrDM6c9287w/Mz0AAID/X2IRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC09+/jN7bTI1Y4/Nfd6QlLfHD54vSEZf5z8tH0hCU+/eHx9IQlPnzhpekJS5xuT6cnLHP14Nr0hDXu/Xl6wRIPr+7m83ruT7+fnrDM9nNfmp6whJtFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSweG9O9Mb1rh4ZXrBEtvt8fSEZT715i+mJ6zx+temFyxx9MHfpyescXoyvWCdwx09P85fml6wxOV/7ub7+f5nbkxPWObqX9+ZnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T19dms7PWKF/bt/nJ6wxJ3nzk1PWOajpw+mJyxx4y8PpicscfKFL09PWOLRycPpCcsc7V+ZnrDE9v2fT09Y4vFnX5mesMSFd96anrDMk1dfm56whJtFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIO395P1vb6dHrHDtwuH0hCXee3BvesIy3/rBL6cnLPGr731jesISR+ePpics8d2fvj09YZmvXL8wPWGJb954bXrCEm/efmt6whKXzu7m/3Cz2Wx+/If70xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApL2nz25tp0escP/J3ekJSxweXJ6esMx7D347PWGJm1denp6wxHZ7Oj1hiUsnu/sN/bfT3TwXrx/enJ6wxONnj6YnLLGrZ8dms9nsnzmYnrDE7p6KAAB8bGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASAf7ewfTG5Z4fv/a9IQ19s9NL1jm6PzR9IQlDg8uT09Y4tn2ZHrCEqdnd/cb+qXtxekJ/A929f18vH08PWGZh0/uTk9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOthsT6c3rLGjv+sfj29PT1jm6Nzz0xPWuPO76QVL7L9wc3rCGtuT6QXLHJ/ZzXNx//a70xPWuP756QVLXHz37ekJyxy++tXpCUu4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSfwFIxJkM6WST9QAAAABJRU5ErkJggg==" id="image293be742a2" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m8871c9e245" d="M 0 0 
+       <path id="m11853e6c73" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8871c9e245" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m8871c9e245" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m8871c9e245" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8871c9e245" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m8871c9e245" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8871c9e245" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m8871c9e245" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8871c9e245" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m8871c9e245" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8871c9e245" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m8871c9e245" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8871c9e245" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m11853e6c73" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="md71e2e0388" d="M 0 0 
+       <path id="m772a10c669" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md71e2e0388" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m772a10c669" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#md71e2e0388" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m772a10c669" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#md71e2e0388" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m772a10c669" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#md71e2e0388" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m772a10c669" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#md71e2e0388" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m772a10c669" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#md71e2e0388" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m772a10c669" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#md71e2e0388" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m772a10c669" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#md71e2e0388" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m772a10c669" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="imaged5437b8331" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image9ec91250df" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m7fbdf2055d" d="M 0 0 
+       <path id="m4a8aad0b4e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7fbdf2055d" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a8aad0b4e" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m7fbdf2055d" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a8aad0b4e" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m7fbdf2055d" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a8aad0b4e" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m7fbdf2055d" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a8aad0b4e" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m7fbdf2055d" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4a8aad0b4e" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.540625 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(43.467344 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2871,12 +2871,12 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p36b1f23e96">
+  <clipPath id="p748564b91f">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.31875pt" height="386.202469pt" viewBox="0 0 575.31875 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.465312pt" height="386.202469pt" viewBox="0 0 575.465312 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.31875 386.202469 
-L 575.31875 0 
+L 575.465312 386.202469 
+L 575.465312 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.784375 104.1264 
-L 294.409375 104.1264 
-L 294.409375 74.7432 
-L 189.784375 74.7432 
+    <path d="M 189.857656 104.1264 
+L 294.482656 104.1264 
+L 294.482656 74.7432 
+L 189.857656 74.7432 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.409375 104.1264 
-L 399.034375 104.1264 
-L 399.034375 74.7432 
-L 294.409375 74.7432 
+    <path d="M 294.482656 104.1264 
+L 399.107656 104.1264 
+L 399.107656 74.7432 
+L 294.482656 74.7432 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.034375 104.1264 
-L 503.659375 104.1264 
-L 503.659375 74.7432 
-L 399.034375 74.7432 
+    <path d="M 399.107656 104.1264 
+L 503.732656 104.1264 
+L 503.732656 74.7432 
+L 399.107656 74.7432 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.784375 133.5096 
-L 294.409375 133.5096 
-L 294.409375 104.1264 
-L 189.784375 104.1264 
+    <path d="M 189.857656 133.5096 
+L 294.482656 133.5096 
+L 294.482656 104.1264 
+L 189.857656 104.1264 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.409375 133.5096 
-L 399.034375 133.5096 
-L 399.034375 104.1264 
-L 294.409375 104.1264 
+    <path d="M 294.482656 133.5096 
+L 399.107656 133.5096 
+L 399.107656 104.1264 
+L 294.482656 104.1264 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.034375 133.5096 
-L 503.659375 133.5096 
-L 503.659375 104.1264 
-L 399.034375 104.1264 
+    <path d="M 399.107656 133.5096 
+L 503.732656 133.5096 
+L 503.732656 104.1264 
+L 399.107656 104.1264 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.784375 162.8928 
-L 294.409375 162.8928 
-L 294.409375 133.5096 
-L 189.784375 133.5096 
+    <path d="M 189.857656 162.8928 
+L 294.482656 162.8928 
+L 294.482656 133.5096 
+L 189.857656 133.5096 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.409375 162.8928 
-L 399.034375 162.8928 
-L 399.034375 133.5096 
-L 294.409375 133.5096 
+    <path d="M 294.482656 162.8928 
+L 399.107656 162.8928 
+L 399.107656 133.5096 
+L 294.482656 133.5096 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.034375 162.8928 
-L 503.659375 162.8928 
-L 503.659375 133.5096 
-L 399.034375 133.5096 
+    <path d="M 399.107656 162.8928 
+L 503.732656 162.8928 
+L 503.732656 133.5096 
+L 399.107656 133.5096 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.784375 192.276 
-L 294.409375 192.276 
-L 294.409375 162.8928 
-L 189.784375 162.8928 
+    <path d="M 189.857656 192.276 
+L 294.482656 192.276 
+L 294.482656 162.8928 
+L 189.857656 162.8928 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.409375 192.276 
-L 399.034375 192.276 
-L 399.034375 162.8928 
-L 294.409375 162.8928 
+    <path d="M 294.482656 192.276 
+L 399.107656 192.276 
+L 399.107656 162.8928 
+L 294.482656 162.8928 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.034375 192.276 
-L 503.659375 192.276 
-L 503.659375 162.8928 
-L 399.034375 162.8928 
+    <path d="M 399.107656 192.276 
+L 503.732656 192.276 
+L 503.732656 162.8928 
+L 399.107656 162.8928 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.784375 221.6592 
-L 294.409375 221.6592 
-L 294.409375 192.276 
-L 189.784375 192.276 
+    <path d="M 189.857656 221.6592 
+L 294.482656 221.6592 
+L 294.482656 192.276 
+L 189.857656 192.276 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.409375 221.6592 
-L 399.034375 221.6592 
-L 399.034375 192.276 
-L 294.409375 192.276 
+    <path d="M 294.482656 221.6592 
+L 399.107656 221.6592 
+L 399.107656 192.276 
+L 294.482656 192.276 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.034375 221.6592 
-L 503.659375 221.6592 
-L 503.659375 192.276 
-L 399.034375 192.276 
+    <path d="M 399.107656 221.6592 
+L 503.732656 221.6592 
+L 503.732656 192.276 
+L 399.107656 192.276 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.784375 251.0424 
-L 294.409375 251.0424 
-L 294.409375 221.6592 
-L 189.784375 221.6592 
+    <path d="M 189.857656 251.0424 
+L 294.482656 251.0424 
+L 294.482656 221.6592 
+L 189.857656 221.6592 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.409375 251.0424 
-L 399.034375 251.0424 
-L 399.034375 221.6592 
-L 294.409375 221.6592 
+    <path d="M 294.482656 251.0424 
+L 399.107656 251.0424 
+L 399.107656 221.6592 
+L 294.482656 221.6592 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.034375 251.0424 
-L 503.659375 251.0424 
-L 503.659375 221.6592 
-L 399.034375 221.6592 
+    <path d="M 399.107656 251.0424 
+L 503.732656 251.0424 
+L 503.732656 221.6592 
+L 399.107656 221.6592 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.784375 280.4256 
-L 294.409375 280.4256 
-L 294.409375 251.0424 
-L 189.784375 251.0424 
+    <path d="M 189.857656 280.4256 
+L 294.482656 280.4256 
+L 294.482656 251.0424 
+L 189.857656 251.0424 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.409375 280.4256 
-L 399.034375 280.4256 
-L 399.034375 251.0424 
-L 294.409375 251.0424 
+    <path d="M 294.482656 280.4256 
+L 399.107656 280.4256 
+L 399.107656 251.0424 
+L 294.482656 251.0424 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.034375 280.4256 
-L 503.659375 280.4256 
-L 503.659375 251.0424 
-L 399.034375 251.0424 
+    <path d="M 399.107656 280.4256 
+L 503.732656 280.4256 
+L 503.732656 251.0424 
+L 399.107656 251.0424 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.784375 309.8088 
-L 294.409375 309.8088 
-L 294.409375 280.4256 
-L 189.784375 280.4256 
+    <path d="M 189.857656 309.8088 
+L 294.482656 309.8088 
+L 294.482656 280.4256 
+L 189.857656 280.4256 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.409375 309.8088 
-L 399.034375 309.8088 
-L 399.034375 280.4256 
-L 294.409375 280.4256 
+    <path d="M 294.482656 309.8088 
+L 399.107656 309.8088 
+L 399.107656 280.4256 
+L 294.482656 280.4256 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.034375 309.8088 
-L 503.659375 309.8088 
-L 503.659375 280.4256 
-L 399.034375 280.4256 
+    <path d="M 399.107656 309.8088 
+L 503.732656 309.8088 
+L 503.732656 280.4256 
+L 399.107656 280.4256 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.784375 339.192 
-L 294.409375 339.192 
-L 294.409375 309.8088 
-L 189.784375 309.8088 
+    <path d="M 189.857656 339.192 
+L 294.482656 339.192 
+L 294.482656 309.8088 
+L 189.857656 309.8088 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.409375 339.192 
-L 399.034375 339.192 
-L 399.034375 309.8088 
-L 294.409375 309.8088 
+    <path d="M 294.482656 339.192 
+L 399.107656 339.192 
+L 399.107656 309.8088 
+L 294.482656 309.8088 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.034375 339.192 
-L 503.659375 339.192 
-L 503.659375 309.8088 
-L 399.034375 309.8088 
+    <path d="M 399.107656 339.192 
+L 503.732656 339.192 
+L 503.732656 309.8088 
+L 399.107656 309.8088 
 z
-" clip-path="url(#p9698cc5e4d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pb007eb364d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.771641 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(122.844922 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.055859 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(230.129141 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.627969 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(308.70125 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(406.979688 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(407.052969 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.709375 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(118.782656 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(230.645625 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(339.086875 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(339.160156 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(443.711875 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.3475 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(113.420781 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(230.645625 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(341.631875 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(443.711875 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(101.040625 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(101.113906 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(230.645625 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(341.631875 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(443.711875 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(122.073125 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(122.146406 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(230.645625 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(341.631875 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(443.711875 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(130.610625 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(130.683906 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(230.645625 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(341.631875 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(443.711875 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(113.916875 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(113.990156 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(230.645625 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,14 +1634,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(341.631875 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 527 -->
-    <g transform="translate(443.711875 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(443.785156 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1649,7 +1649,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.41875 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(100.492031 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1758,7 +1758,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.325 -->
-    <g transform="translate(229.445 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(229.518281 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1876,9 +1876,40 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 29 -->
-    <g transform="translate(341.155625 267.9415) scale(0.08 -0.08)">
+    <!-- 30 -->
+    <g transform="translate(341.228906 267.9415) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 179 -->
+    <g transform="translate(443.070781 267.9415) scale(0.08 -0.08)">
      <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-39" d="M 641 103 
 L 641 966 
 Q 928 831 1190 764 
@@ -1910,86 +1941,14 @@ Q 1809 2350 2125 2350
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-32"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 178 -->
-    <g transform="translate(442.9975 267.9415) scale(0.08 -0.08)">
-     <defs>
-      <path id="DejaVuSans-Bold-31" d="M 750 831 
-L 1813 831 
-L 1813 3847 
-L 722 3622 
-L 722 4441 
-L 1806 4666 
-L 2950 4666 
-L 2950 831 
-L 4013 831 
-L 4013 0 
-L 750 0 
-L 750 831 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-37" d="M 428 4666 
-L 3944 4666 
-L 3944 3988 
-L 2125 0 
-L 953 0 
-L 2675 3781 
-L 428 3781 
-L 428 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
-Q 1891 2088 1709 1903 
-Q 1528 1719 1528 1375 
-Q 1528 1031 1709 848 
-Q 1891 666 2228 666 
-Q 2563 666 2741 848 
-Q 2919 1031 2919 1375 
-Q 2919 1722 2741 1905 
-Q 2563 2088 2228 2088 
-z
-M 1350 2484 
-Q 925 2613 709 2878 
-Q 494 3144 494 3541 
-Q 494 4131 934 4440 
-Q 1375 4750 2228 4750 
-Q 3075 4750 3515 4442 
-Q 3956 4134 3956 3541 
-Q 3956 3144 3739 2878 
-Q 3522 2613 3097 2484 
-Q 3572 2353 3814 2058 
-Q 4056 1763 4056 1313 
-Q 4056 619 3595 264 
-Q 3134 -91 2228 -91 
-Q 1319 -91 855 264 
-Q 391 619 391 1313 
-Q 391 1763 633 2058 
-Q 875 2353 1350 2484 
-z
-M 1631 3419 
-Q 1631 3141 1786 2991 
-Q 1941 2841 2228 2841 
-Q 2509 2841 2662 2991 
-Q 2816 3141 2816 3419 
-Q 2816 3697 2662 3845 
-Q 2509 3994 2228 3994 
-Q 1941 3994 1786 3844 
-Q 1631 3694 1631 3419 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.53375 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(98.607031 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2054,7 +2013,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(230.645625 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2064,21 +2023,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(341.631875 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(341.705156 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(446.256875 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(446.330156 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.755 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(126.828281 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2089,7 +2048,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(230.645625 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(230.718906 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2099,13 +2058,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(344.176875 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(344.250156 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.346875 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(447.420156 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2121,7 +2080,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(154.261094 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(154.334375 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2265,7 +2224,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-06T01:55:32Z  ·  Linux chungus2 x86_64  ·  commit 8a96b29e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2407,12 +2366,12 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
     <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
@@ -2453,110 +2412,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-38" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3196.777344 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(3387.5 0)"/>
-    <use xlink:href="#DejaVuSans-39" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3576.269531 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3608.056641 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3639.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3671.630859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3703.417969 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3735.205078 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3762.988281 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3824.511719 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3885.791016 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3949.169922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4012.646484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4051.509766 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4112.691406 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4171.871094 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4233.394531 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4274.507812 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4308.199219 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4335.982422 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4397.505859 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4458.785156 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4522.164062 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4585.787109 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4619.478516 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4678.658203 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4742.28125 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4774.068359 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4837.691406 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4901.314453 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4933.101562 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4996.724609 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5032.808594 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5071.671875 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5126.652344 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5190.275391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5222.0625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5253.849609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5285.636719 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5317.423828 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5349.210938 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5388.419922 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5451.798828 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5490.662109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5551.84375 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5615.222656 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5678.699219 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5742.078125 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5805.554688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5868.933594 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5908.142578 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5939.929688 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6023.71875 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6055.505859 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6152.917969 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6214.441406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6277.917969 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6305.701172 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6366.980469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6430.359375 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6462.146484 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6514.246094 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6577.625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6638.904297 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6702.380859 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6754.480469 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6817.859375 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6879.041016 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6918.25 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6951.941406 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6983.728516 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7024.841797 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7086.121094 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7125.330078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7153.113281 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7214.294922 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7246.082031 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7273.865234 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7325.964844 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7357.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7421.228516 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7482.751953 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7521.960938 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7583.484375 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7622.847656 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7720.259766 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7748.042969 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7811.421875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7839.205078 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7891.304688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7930.513672 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7958.296875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9698cc5e4d">
-   <rect x="85.159375" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pb007eb364d">
+   <rect x="85.232656" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-06T01:55:32Z",
+  "date": "2026-07-06T05:11:12Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "8a96b29e",
+  "git_commit": "05a43b60",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,8 +14,8 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 67.68,
-   "decompress_mbps": 109.96
+   "compress_mbps": 68.25,
+   "decompress_mbps": 112.5
   },
   {
    "compressor": "native",
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 49.05,
-   "decompress_mbps": 121.93
+   "compress_mbps": 49.33,
+   "decompress_mbps": 124.7
   },
   {
    "compressor": "native",
@@ -34,48 +34,48 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 43.73,
-   "decompress_mbps": 132.94
+   "compress_mbps": 43.97,
+   "decompress_mbps": 135.81
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 4,
-   "out_size": 54681,
-   "ratio": 0.3595,
-   "compress_mbps": 31.91,
-   "decompress_mbps": 136.97
+   "out_size": 54690,
+   "ratio": 0.3596,
+   "compress_mbps": 33.09,
+   "decompress_mbps": 139.45
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 5,
-   "out_size": 54437,
-   "ratio": 0.3579,
-   "compress_mbps": 25.2,
-   "decompress_mbps": 144.28
+   "out_size": 54441,
+   "ratio": 0.358,
+   "compress_mbps": 26.57,
+   "decompress_mbps": 146.5
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 6,
-   "out_size": 54348,
-   "ratio": 0.3573,
-   "compress_mbps": 24.29,
-   "decompress_mbps": 148.76
+   "out_size": 54359,
+   "ratio": 0.3574,
+   "compress_mbps": 25.54,
+   "decompress_mbps": 151.09
   },
   {
    "compressor": "native",
    "pattern": "canterbury/alice29.txt",
    "size": 152089,
    "level": 7,
-   "out_size": 54140,
+   "out_size": 54142,
    "ratio": 0.356,
-   "compress_mbps": 20.84,
-   "decompress_mbps": 149.47
+   "compress_mbps": 21.49,
+   "decompress_mbps": 151.72
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 20.16,
-   "decompress_mbps": 149.68
+   "compress_mbps": 20.59,
+   "decompress_mbps": 152.11
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.13,
-   "decompress_mbps": 150.13
+   "compress_mbps": 4.14,
+   "decompress_mbps": 152.22
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.31,
+   "compress_mbps": 2.32,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 61.88,
-   "decompress_mbps": 103.8
+   "compress_mbps": 62.4,
+   "decompress_mbps": 105.88
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 45.91,
-   "decompress_mbps": 111.31
+   "compress_mbps": 46.3,
+   "decompress_mbps": 113.65
   },
   {
    "compressor": "native",
@@ -134,38 +134,38 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 41.55,
-   "decompress_mbps": 120.65
+   "compress_mbps": 41.65,
+   "decompress_mbps": 123.05
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 4,
-   "out_size": 48992,
+   "out_size": 48996,
    "ratio": 0.3914,
-   "compress_mbps": 30.17,
-   "decompress_mbps": 125.54
+   "compress_mbps": 31.18,
+   "decompress_mbps": 127.73
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 5,
-   "out_size": 48891,
+   "out_size": 48894,
    "ratio": 0.3906,
-   "compress_mbps": 26.02,
-   "decompress_mbps": 131.2
+   "compress_mbps": 26.77,
+   "decompress_mbps": 133.61
   },
   {
    "compressor": "native",
    "pattern": "canterbury/asyoulik.txt",
    "size": 125179,
    "level": 6,
-   "out_size": 48715,
+   "out_size": 48719,
    "ratio": 0.3892,
-   "compress_mbps": 23.66,
-   "decompress_mbps": 134.59
+   "compress_mbps": 24.53,
+   "decompress_mbps": 136.87
   },
   {
    "compressor": "native",
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 21.97,
-   "decompress_mbps": 134.84
+   "compress_mbps": 22.27,
+   "decompress_mbps": 136.76
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 21.88,
-   "decompress_mbps": 135.03
+   "compress_mbps": 22.06,
+   "decompress_mbps": 137.22
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47430,
    "ratio": 0.3789,
-   "compress_mbps": 4.51,
-   "decompress_mbps": 135.53
+   "compress_mbps": 4.53,
+   "decompress_mbps": 137.23
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46865,
    "ratio": 0.3744,
-   "compress_mbps": 2.7,
+   "compress_mbps": 2.72,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 61.4,
-   "decompress_mbps": 124.24
+   "compress_mbps": 61.76,
+   "decompress_mbps": 125.64
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 51.2,
-   "decompress_mbps": 128.35
+   "compress_mbps": 51.47,
+   "decompress_mbps": 130.19
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 48.74,
-   "decompress_mbps": 131.39
+   "compress_mbps": 49.59,
+   "decompress_mbps": 132.85
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 42.95,
-   "decompress_mbps": 137.66
+   "compress_mbps": 43.27,
+   "decompress_mbps": 139.0
   },
   {
    "compressor": "native",
@@ -254,18 +254,18 @@
    "level": 5,
    "out_size": 7932,
    "ratio": 0.3224,
-   "compress_mbps": 35.54,
-   "decompress_mbps": 141.53
+   "compress_mbps": 36.03,
+   "decompress_mbps": 142.91
   },
   {
    "compressor": "native",
    "pattern": "canterbury/cp.html",
    "size": 24603,
    "level": 6,
-   "out_size": 7938,
-   "ratio": 0.3226,
-   "compress_mbps": 34.92,
-   "decompress_mbps": 142.96
+   "out_size": 7940,
+   "ratio": 0.3227,
+   "compress_mbps": 35.87,
+   "decompress_mbps": 144.43
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 32.82,
-   "decompress_mbps": 144.43
+   "compress_mbps": 32.55,
+   "decompress_mbps": 146.26
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 32.81,
-   "decompress_mbps": 144.01
+   "compress_mbps": 32.53,
+   "decompress_mbps": 145.81
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.77,
-   "decompress_mbps": 144.19
+   "compress_mbps": 4.81,
+   "decompress_mbps": 146.36
   },
   {
    "compressor": "native",
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 46.88,
-   "decompress_mbps": 100.38
+   "compress_mbps": 47.21,
+   "decompress_mbps": 101.47
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 40.91,
-   "decompress_mbps": 103.27
+   "compress_mbps": 41.04,
+   "decompress_mbps": 104.47
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 39.67,
-   "decompress_mbps": 106.9
+   "compress_mbps": 39.65,
+   "decompress_mbps": 107.83
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 35.57,
-   "decompress_mbps": 108.69
+   "compress_mbps": 35.95,
+   "decompress_mbps": 110.13
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 31.31,
-   "decompress_mbps": 110.84
+   "compress_mbps": 31.97,
+   "decompress_mbps": 112.14
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3135,
    "ratio": 0.2812,
-   "compress_mbps": 31.53,
-   "decompress_mbps": 111.63
+   "compress_mbps": 32.41,
+   "decompress_mbps": 113.24
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 30.08,
-   "decompress_mbps": 111.84
+   "compress_mbps": 30.34,
+   "decompress_mbps": 113.08
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 30.17,
-   "decompress_mbps": 111.71
+   "compress_mbps": 30.16,
+   "decompress_mbps": 113.18
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.25,
-   "decompress_mbps": 111.81
+   "compress_mbps": 5.28,
+   "decompress_mbps": 112.67
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3032,
    "ratio": 0.2719,
-   "compress_mbps": 2.95,
+   "compress_mbps": 2.96,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 24.67,
-   "decompress_mbps": 56.78
+   "compress_mbps": 24.84,
+   "decompress_mbps": 57.18
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 23.16,
-   "decompress_mbps": 57.44
+   "compress_mbps": 23.32,
+   "decompress_mbps": 57.88
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 22.94,
-   "decompress_mbps": 57.63
+   "compress_mbps": 23.05,
+   "decompress_mbps": 57.81
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 22.2,
-   "decompress_mbps": 58.67
+   "compress_mbps": 22.24,
+   "decompress_mbps": 58.94
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.52,
-   "decompress_mbps": 59.29
+   "compress_mbps": 21.42,
+   "decompress_mbps": 59.33
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.8,
-   "decompress_mbps": 59.27
+   "compress_mbps": 21.07,
+   "decompress_mbps": 59.64
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.79,
-   "decompress_mbps": 59.36
+   "compress_mbps": 20.9,
+   "decompress_mbps": 59.46
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.73,
-   "decompress_mbps": 59.52
+   "compress_mbps": 20.91,
+   "decompress_mbps": 59.55
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.8,
-   "decompress_mbps": 59.68
+   "compress_mbps": 4.88,
+   "decompress_mbps": 59.55
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.88,
+   "compress_mbps": 2.91,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 129.72,
-   "decompress_mbps": 204.26
+   "compress_mbps": 129.58,
+   "decompress_mbps": 208.05
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 89.82,
-   "decompress_mbps": 220.21
+   "compress_mbps": 89.26,
+   "decompress_mbps": 223.46
   },
   {
    "compressor": "native",
@@ -534,58 +534,58 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 76.32,
-   "decompress_mbps": 229.46
+   "compress_mbps": 76.4,
+   "decompress_mbps": 233.04
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 4,
-   "out_size": 239804,
-   "ratio": 0.2329,
-   "compress_mbps": 70.26,
-   "decompress_mbps": 235.65
+   "out_size": 239996,
+   "ratio": 0.2331,
+   "compress_mbps": 72.57,
+   "decompress_mbps": 240.1
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 5,
-   "out_size": 215530,
-   "ratio": 0.2093,
-   "compress_mbps": 39.72,
-   "decompress_mbps": 231.89
+   "out_size": 218163,
+   "ratio": 0.2119,
+   "compress_mbps": 49.19,
+   "decompress_mbps": 236.59
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 6,
-   "out_size": 201414,
-   "ratio": 0.1956,
-   "compress_mbps": 32.87,
-   "decompress_mbps": 238.67
+   "out_size": 201839,
+   "ratio": 0.196,
+   "compress_mbps": 36.15,
+   "decompress_mbps": 243.51
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 7,
-   "out_size": 200711,
-   "ratio": 0.1949,
-   "compress_mbps": 21.39,
-   "decompress_mbps": 240.51
+   "out_size": 201287,
+   "ratio": 0.1955,
+   "compress_mbps": 27.85,
+   "decompress_mbps": 246.01
   },
   {
    "compressor": "native",
    "pattern": "canterbury/kennedy.xls",
    "size": 1029744,
    "level": 8,
-   "out_size": 200719,
+   "out_size": 200711,
    "ratio": 0.1949,
-   "compress_mbps": 14.84,
-   "decompress_mbps": 243.5
+   "compress_mbps": 21.17,
+   "decompress_mbps": 249.18
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182508,
    "ratio": 0.1772,
-   "compress_mbps": 3.01,
-   "decompress_mbps": 245.04
+   "compress_mbps": 3.39,
+   "decompress_mbps": 249.28
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178067,
    "ratio": 0.1729,
-   "compress_mbps": 1.34,
+   "compress_mbps": 1.42,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 73.74,
-   "decompress_mbps": 118.26
+   "compress_mbps": 73.94,
+   "decompress_mbps": 120.0
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 52.54,
-   "decompress_mbps": 126.74
+   "compress_mbps": 52.75,
+   "decompress_mbps": 129.28
   },
   {
    "compressor": "native",
@@ -634,58 +634,58 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 46.47,
-   "decompress_mbps": 139.75
+   "compress_mbps": 46.66,
+   "decompress_mbps": 142.33
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 4,
-   "out_size": 145631,
+   "out_size": 145641,
    "ratio": 0.3413,
-   "compress_mbps": 34.19,
-   "decompress_mbps": 144.73
+   "compress_mbps": 35.6,
+   "decompress_mbps": 147.26
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 5,
-   "out_size": 145321,
+   "out_size": 145327,
    "ratio": 0.3405,
-   "compress_mbps": 27.71,
-   "decompress_mbps": 151.91
+   "compress_mbps": 28.91,
+   "decompress_mbps": 154.56
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 6,
-   "out_size": 145046,
+   "out_size": 145066,
    "ratio": 0.3399,
-   "compress_mbps": 26.05,
-   "decompress_mbps": 155.69
+   "compress_mbps": 27.11,
+   "decompress_mbps": 157.73
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 7,
-   "out_size": 144554,
+   "out_size": 144558,
    "ratio": 0.3387,
-   "compress_mbps": 22.93,
-   "decompress_mbps": 156.35
+   "compress_mbps": 23.34,
+   "decompress_mbps": 158.77
   },
   {
    "compressor": "native",
    "pattern": "canterbury/lcet10.txt",
    "size": 426754,
    "level": 8,
-   "out_size": 144540,
+   "out_size": 144538,
    "ratio": 0.3387,
-   "compress_mbps": 22.39,
-   "decompress_mbps": 156.51
+   "compress_mbps": 22.6,
+   "decompress_mbps": 159.28
   },
   {
    "compressor": "native",
@@ -695,7 +695,7 @@
    "out_size": 140322,
    "ratio": 0.3288,
    "compress_mbps": 4.11,
-   "decompress_mbps": 156.33
+   "decompress_mbps": 159.31
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138830,
    "ratio": 0.3253,
-   "compress_mbps": 2.41,
+   "compress_mbps": 2.42,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 62.44,
-   "decompress_mbps": 97.65
+   "compress_mbps": 62.7,
+   "decompress_mbps": 100.1
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 44.8,
-   "decompress_mbps": 106.36
+   "compress_mbps": 44.78,
+   "decompress_mbps": 109.1
   },
   {
    "compressor": "native",
@@ -734,58 +734,58 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 39.75,
-   "decompress_mbps": 116.41
+   "compress_mbps": 39.87,
+   "decompress_mbps": 118.48
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 4,
-   "out_size": 195460,
+   "out_size": 195465,
    "ratio": 0.4056,
-   "compress_mbps": 26.09,
-   "decompress_mbps": 120.63
+   "compress_mbps": 28.15,
+   "decompress_mbps": 123.38
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 5,
-   "out_size": 194902,
+   "out_size": 194911,
    "ratio": 0.4045,
-   "compress_mbps": 21.99,
-   "decompress_mbps": 126.86
+   "compress_mbps": 23.46,
+   "decompress_mbps": 129.76
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 6,
-   "out_size": 195177,
-   "ratio": 0.405,
-   "compress_mbps": 21.86,
-   "decompress_mbps": 130.38
+   "out_size": 195183,
+   "ratio": 0.4051,
+   "compress_mbps": 23.4,
+   "decompress_mbps": 133.07
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 7,
-   "out_size": 194385,
+   "out_size": 194387,
    "ratio": 0.4034,
-   "compress_mbps": 18.6,
-   "decompress_mbps": 130.8
+   "compress_mbps": 19.48,
+   "decompress_mbps": 133.35
   },
   {
    "compressor": "native",
    "pattern": "canterbury/plrabn12.txt",
    "size": 481861,
    "level": 8,
-   "out_size": 194380,
+   "out_size": 194379,
    "ratio": 0.4034,
-   "compress_mbps": 18.59,
-   "decompress_mbps": 130.87
+   "compress_mbps": 18.96,
+   "decompress_mbps": 133.67
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189365,
    "ratio": 0.393,
-   "compress_mbps": 3.9,
-   "decompress_mbps": 131.79
+   "compress_mbps": 3.94,
+   "decompress_mbps": 133.73
   },
   {
    "compressor": "native",
@@ -804,7 +804,7 @@
    "level": 10,
    "out_size": 186147,
    "ratio": 0.3863,
-   "compress_mbps": 2.37,
+   "compress_mbps": 2.33,
    "decompress_mbps": null
   },
   {
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 207.36,
-   "decompress_mbps": 339.57
+   "compress_mbps": 208.2,
+   "decompress_mbps": 343.45
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 149.97,
-   "decompress_mbps": 355.0
+   "compress_mbps": 152.36,
+   "decompress_mbps": 359.39
   },
   {
    "compressor": "native",
@@ -834,68 +834,68 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 130.12,
-   "decompress_mbps": 378.55
+   "compress_mbps": 133.54,
+   "decompress_mbps": 382.59
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 4,
-   "out_size": 55673,
+   "out_size": 55688,
    "ratio": 0.1085,
-   "compress_mbps": 87.5,
-   "decompress_mbps": 346.68
+   "compress_mbps": 90.23,
+   "decompress_mbps": 355.87
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 5,
-   "out_size": 54950,
-   "ratio": 0.1071,
-   "compress_mbps": 59.71,
-   "decompress_mbps": 369.4
+   "out_size": 55213,
+   "ratio": 0.1076,
+   "compress_mbps": 68.03,
+   "decompress_mbps": 378.74
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 6,
-   "out_size": 55259,
-   "ratio": 0.1077,
-   "compress_mbps": 51.21,
-   "decompress_mbps": 399.5
+   "out_size": 55321,
+   "ratio": 0.1078,
+   "compress_mbps": 56.24,
+   "decompress_mbps": 404.83
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 7,
-   "out_size": 53713,
-   "ratio": 0.1047,
-   "compress_mbps": 36.5,
-   "decompress_mbps": 423.98
+   "out_size": 54414,
+   "ratio": 0.106,
+   "compress_mbps": 40.94,
+   "decompress_mbps": 428.74
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 8,
-   "out_size": 52897,
-   "ratio": 0.1031,
-   "compress_mbps": 30.26,
-   "decompress_mbps": 454.8
+   "out_size": 53303,
+   "ratio": 0.1039,
+   "compress_mbps": 35.33,
+   "decompress_mbps": 455.27
   },
   {
    "compressor": "native",
    "pattern": "canterbury/ptt5",
    "size": 513216,
    "level": 9,
-   "out_size": 52729,
-   "ratio": 0.1027,
-   "compress_mbps": 5.13,
-   "decompress_mbps": 467.85
+   "out_size": 52835,
+   "ratio": 0.1029,
+   "compress_mbps": 5.44,
+   "decompress_mbps": 472.88
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52234,
    "ratio": 0.1018,
-   "compress_mbps": 3.41,
+   "compress_mbps": 3.55,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 51.8,
-   "decompress_mbps": 113.62
+   "compress_mbps": 52.42,
+   "decompress_mbps": 114.22
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 45.16,
-   "decompress_mbps": 115.99
+   "compress_mbps": 45.53,
+   "decompress_mbps": 117.16
   },
   {
    "compressor": "native",
@@ -934,58 +934,58 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 43.4,
-   "decompress_mbps": 118.03
+   "compress_mbps": 43.86,
+   "decompress_mbps": 119.11
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 4,
-   "out_size": 13366,
-   "ratio": 0.3495,
-   "compress_mbps": 36.93,
-   "decompress_mbps": 123.69
+   "out_size": 13370,
+   "ratio": 0.3496,
+   "compress_mbps": 38.46,
+   "decompress_mbps": 124.97
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 5,
-   "out_size": 13346,
-   "ratio": 0.349,
-   "compress_mbps": 31.52,
-   "decompress_mbps": 130.33
+   "out_size": 13343,
+   "ratio": 0.3489,
+   "compress_mbps": 33.71,
+   "decompress_mbps": 130.88
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 6,
-   "out_size": 13040,
-   "ratio": 0.341,
-   "compress_mbps": 18.11,
-   "decompress_mbps": 132.57
+   "out_size": 13047,
+   "ratio": 0.3412,
+   "compress_mbps": 18.77,
+   "decompress_mbps": 133.51
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 7,
-   "out_size": 13035,
-   "ratio": 0.3409,
-   "compress_mbps": 16.02,
-   "decompress_mbps": 133.59
+   "out_size": 13040,
+   "ratio": 0.341,
+   "compress_mbps": 17.19,
+   "decompress_mbps": 134.34
   },
   {
    "compressor": "native",
    "pattern": "canterbury/sum",
    "size": 38240,
    "level": 8,
-   "out_size": 13028,
-   "ratio": 0.3407,
-   "compress_mbps": 14.2,
-   "decompress_mbps": 134.95
+   "out_size": 13036,
+   "ratio": 0.3409,
+   "compress_mbps": 15.8,
+   "decompress_mbps": 136.35
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 4.79,
-   "decompress_mbps": 136.14
+   "compress_mbps": 5.2,
+   "decompress_mbps": 137.48
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12274,
    "ratio": 0.321,
-   "compress_mbps": 2.85,
+   "compress_mbps": 2.97,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 25.68,
-   "decompress_mbps": 58.64
+   "compress_mbps": 25.91,
+   "decompress_mbps": 58.67
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 24.13,
-   "decompress_mbps": 59.24
+   "compress_mbps": 24.36,
+   "decompress_mbps": 59.21
   },
   {
    "compressor": "native",
@@ -1034,7 +1034,7 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 24.03,
+   "compress_mbps": 24.4,
    "decompress_mbps": 59.32
   },
   {
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 23.32,
-   "decompress_mbps": 60.56
+   "compress_mbps": 23.55,
+   "decompress_mbps": 60.52
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 22.79,
-   "decompress_mbps": 61.12
+   "compress_mbps": 23.06,
+   "decompress_mbps": 60.97
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 21.83,
-   "decompress_mbps": 60.87
+   "compress_mbps": 22.02,
+   "decompress_mbps": 60.95
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 21.92,
-   "decompress_mbps": 60.95
+   "compress_mbps": 22.18,
+   "decompress_mbps": 60.8
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 21.92,
-   "decompress_mbps": 60.83
+   "compress_mbps": 22.14,
+   "decompress_mbps": 60.98
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.26,
-   "decompress_mbps": 60.85
+   "compress_mbps": 5.34,
+   "decompress_mbps": 60.87
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.19,
+   "compress_mbps": 3.22,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 65.01,
-   "decompress_mbps": 103.65
+   "compress_mbps": 65.73,
+   "decompress_mbps": 105.06
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 46.1,
-   "decompress_mbps": 111.89
+   "compress_mbps": 46.74,
+   "decompress_mbps": 112.77
   },
   {
    "compressor": "native",
@@ -4434,58 +4434,58 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 40.79,
-   "decompress_mbps": 122.89
+   "compress_mbps": 41.3,
+   "decompress_mbps": 123.64
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 4,
-   "out_size": 3882303,
+   "out_size": 3882625,
    "ratio": 0.3809,
-   "compress_mbps": 28.68,
-   "decompress_mbps": 125.64
+   "compress_mbps": 30.18,
+   "decompress_mbps": 127.4
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 5,
-   "out_size": 3870984,
+   "out_size": 3871163,
    "ratio": 0.3798,
-   "compress_mbps": 23.77,
-   "decompress_mbps": 131.71
+   "compress_mbps": 25.09,
+   "decompress_mbps": 132.67
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 6,
-   "out_size": 3878499,
-   "ratio": 0.3805,
-   "compress_mbps": 23.6,
-   "decompress_mbps": 136.07
+   "out_size": 3878951,
+   "ratio": 0.3806,
+   "compress_mbps": 24.79,
+   "decompress_mbps": 137.99
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 7,
-   "out_size": 3865234,
+   "out_size": 3865304,
    "ratio": 0.3792,
-   "compress_mbps": 20.24,
-   "decompress_mbps": 136.52
+   "compress_mbps": 20.93,
+   "decompress_mbps": 138.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/dickens",
    "size": 10192446,
    "level": 8,
-   "out_size": 3864805,
+   "out_size": 3864629,
    "ratio": 0.3792,
-   "compress_mbps": 19.88,
-   "decompress_mbps": 136.71
+   "compress_mbps": 20.21,
+   "decompress_mbps": 137.95
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766584,
    "ratio": 0.3695,
-   "compress_mbps": 4.0,
-   "decompress_mbps": 139.27
+   "compress_mbps": 4.03,
+   "decompress_mbps": 141.57
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711172,
    "ratio": 0.3641,
-   "compress_mbps": 2.36,
+   "compress_mbps": 2.38,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 79.65,
-   "decompress_mbps": 132.15
+   "compress_mbps": 80.74,
+   "decompress_mbps": 132.8
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 62.95,
-   "decompress_mbps": 138.69
+   "compress_mbps": 63.14,
+   "decompress_mbps": 140.18
   },
   {
    "compressor": "native",
@@ -4534,58 +4534,58 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 59.62,
-   "decompress_mbps": 139.18
+   "compress_mbps": 59.09,
+   "decompress_mbps": 144.73
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 4,
-   "out_size": 20393572,
+   "out_size": 20395611,
    "ratio": 0.3982,
-   "compress_mbps": 44.77,
-   "decompress_mbps": 149.66
+   "compress_mbps": 47.03,
+   "decompress_mbps": 148.32
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 5,
-   "out_size": 20264932,
-   "ratio": 0.3956,
-   "compress_mbps": 32.91,
-   "decompress_mbps": 158.41
+   "out_size": 20267480,
+   "ratio": 0.3957,
+   "compress_mbps": 37.2,
+   "decompress_mbps": 161.18
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 6,
-   "out_size": 19208910,
-   "ratio": 0.375,
-   "compress_mbps": 23.82,
-   "decompress_mbps": 161.59
+   "out_size": 19212471,
+   "ratio": 0.3751,
+   "compress_mbps": 25.33,
+   "decompress_mbps": 163.54
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 7,
-   "out_size": 19177573,
-   "ratio": 0.3744,
-   "compress_mbps": 18.42,
-   "decompress_mbps": 161.98
+   "out_size": 19179977,
+   "ratio": 0.3745,
+   "compress_mbps": 20.75,
+   "decompress_mbps": 164.75
   },
   {
    "compressor": "native",
    "pattern": "silesia/mozilla",
    "size": 51220480,
    "level": 8,
-   "out_size": 19172591,
+   "out_size": 19171663,
    "ratio": 0.3743,
-   "compress_mbps": 15.52,
-   "decompress_mbps": 162.12
+   "compress_mbps": 18.07,
+   "decompress_mbps": 165.08
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18686872,
    "ratio": 0.3648,
-   "compress_mbps": 3.96,
-   "decompress_mbps": 161.29
+   "compress_mbps": 4.21,
+   "decompress_mbps": 160.87
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18539905,
    "ratio": 0.362,
-   "compress_mbps": 2.19,
+   "compress_mbps": 2.27,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 79.62,
-   "decompress_mbps": 120.73
+   "compress_mbps": 79.15,
+   "decompress_mbps": 120.12
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 60.19,
-   "decompress_mbps": 127.8
+   "compress_mbps": 61.09,
+   "decompress_mbps": 129.57
   },
   {
    "compressor": "native",
@@ -4634,58 +4634,58 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 51.89,
-   "decompress_mbps": 137.04
+   "compress_mbps": 52.38,
+   "decompress_mbps": 140.74
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 4,
-   "out_size": 3707604,
-   "ratio": 0.3719,
-   "compress_mbps": 33.84,
-   "decompress_mbps": 131.47
+   "out_size": 3708985,
+   "ratio": 0.372,
+   "compress_mbps": 35.94,
+   "decompress_mbps": 132.71
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 5,
-   "out_size": 3705174,
+   "out_size": 3705516,
    "ratio": 0.3716,
-   "compress_mbps": 26.54,
-   "decompress_mbps": 137.31
+   "compress_mbps": 28.34,
+   "decompress_mbps": 138.49
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 6,
-   "out_size": 3612809,
-   "ratio": 0.3623,
-   "compress_mbps": 24.04,
-   "decompress_mbps": 143.2
+   "out_size": 3613753,
+   "ratio": 0.3624,
+   "compress_mbps": 25.9,
+   "decompress_mbps": 143.31
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 7,
-   "out_size": 3608980,
-   "ratio": 0.362,
-   "compress_mbps": 20.31,
-   "decompress_mbps": 143.84
+   "out_size": 3610087,
+   "ratio": 0.3621,
+   "compress_mbps": 20.83,
+   "decompress_mbps": 144.93
   },
   {
    "compressor": "native",
    "pattern": "silesia/mr",
    "size": 9970564,
    "level": 8,
-   "out_size": 3609490,
+   "out_size": 3609561,
    "ratio": 0.362,
-   "compress_mbps": 18.41,
-   "decompress_mbps": 147.53
+   "compress_mbps": 18.84,
+   "decompress_mbps": 148.39
   },
   {
    "compressor": "native",
@@ -4695,7 +4695,7 @@
    "out_size": 3581441,
    "ratio": 0.3592,
    "compress_mbps": 4.45,
-   "decompress_mbps": 151.64
+   "decompress_mbps": 153.74
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3512886,
    "ratio": 0.3523,
-   "compress_mbps": 2.74,
+   "compress_mbps": 2.77,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 231.6,
-   "decompress_mbps": 359.08
+   "compress_mbps": 234.97,
+   "decompress_mbps": 366.16
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 145.5,
-   "decompress_mbps": 405.24
+   "compress_mbps": 145.72,
+   "decompress_mbps": 411.99
   },
   {
    "compressor": "native",
@@ -4734,58 +4734,58 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 123.83,
-   "decompress_mbps": 450.05
+   "compress_mbps": 124.5,
+   "decompress_mbps": 457.09
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 4,
-   "out_size": 3225450,
+   "out_size": 3225558,
    "ratio": 0.0961,
-   "compress_mbps": 92.92,
-   "decompress_mbps": 462.16
+   "compress_mbps": 95.14,
+   "decompress_mbps": 469.25
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 5,
-   "out_size": 3145121,
-   "ratio": 0.0937,
-   "compress_mbps": 62.52,
-   "decompress_mbps": 525.73
+   "out_size": 3147396,
+   "ratio": 0.0938,
+   "compress_mbps": 70.32,
+   "decompress_mbps": 533.46
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 6,
-   "out_size": 3158854,
-   "ratio": 0.0941,
-   "compress_mbps": 63.67,
-   "decompress_mbps": 565.78
+   "out_size": 3161943,
+   "ratio": 0.0942,
+   "compress_mbps": 68.66,
+   "decompress_mbps": 570.16
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 7,
-   "out_size": 3124878,
-   "ratio": 0.0931,
-   "compress_mbps": 44.12,
-   "decompress_mbps": 576.39
+   "out_size": 3125514,
+   "ratio": 0.0932,
+   "compress_mbps": 51.11,
+   "decompress_mbps": 584.63
   },
   {
    "compressor": "native",
    "pattern": "silesia/nci",
    "size": 33553445,
    "level": 8,
-   "out_size": 3112207,
+   "out_size": 3113556,
    "ratio": 0.0928,
-   "compress_mbps": 35.81,
-   "decompress_mbps": 597.97
+   "compress_mbps": 42.67,
+   "decompress_mbps": 611.8
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3034875,
    "ratio": 0.0904,
-   "compress_mbps": 3.13,
-   "decompress_mbps": 602.73
+   "compress_mbps": 3.21,
+   "decompress_mbps": 613.33
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902186,
    "ratio": 0.0865,
-   "compress_mbps": 1.84,
+   "compress_mbps": 1.86,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 56.15,
-   "decompress_mbps": 91.85
+   "compress_mbps": 56.82,
+   "decompress_mbps": 92.92
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 46.27,
-   "decompress_mbps": 94.07
+   "compress_mbps": 46.21,
+   "decompress_mbps": 94.56
   },
   {
    "compressor": "native",
@@ -4834,58 +4834,58 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 44.52,
-   "decompress_mbps": 96.65
+   "compress_mbps": 44.67,
+   "decompress_mbps": 97.03
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 4,
-   "out_size": 3237094,
+   "out_size": 3237289,
    "ratio": 0.5262,
-   "compress_mbps": 35.81,
-   "decompress_mbps": 105.81
+   "compress_mbps": 36.87,
+   "decompress_mbps": 105.11
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 5,
-   "out_size": 3233792,
-   "ratio": 0.5256,
-   "compress_mbps": 32.45,
-   "decompress_mbps": 108.46
+   "out_size": 3233957,
+   "ratio": 0.5257,
+   "compress_mbps": 33.11,
+   "decompress_mbps": 108.95
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 6,
-   "out_size": 3168386,
-   "ratio": 0.515,
-   "compress_mbps": 22.52,
-   "decompress_mbps": 110.37
+   "out_size": 3168742,
+   "ratio": 0.5151,
+   "compress_mbps": 23.36,
+   "decompress_mbps": 111.57
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 7,
-   "out_size": 3165783,
+   "out_size": 3166089,
    "ratio": 0.5146,
-   "compress_mbps": 20.83,
-   "decompress_mbps": 110.59
+   "compress_mbps": 21.26,
+   "decompress_mbps": 111.75
   },
   {
    "compressor": "native",
    "pattern": "silesia/ooffice",
    "size": 6152192,
    "level": 8,
-   "out_size": 3165909,
+   "out_size": 3165757,
    "ratio": 0.5146,
-   "compress_mbps": 19.68,
-   "decompress_mbps": 111.53
+   "compress_mbps": 20.55,
+   "decompress_mbps": 112.02
   },
   {
    "compressor": "native",
@@ -4894,8 +4894,8 @@
    "level": 9,
    "out_size": 3048772,
    "ratio": 0.4956,
-   "compress_mbps": 4.84,
-   "decompress_mbps": 113.1
+   "compress_mbps": 4.9,
+   "decompress_mbps": 113.95
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3021986,
    "ratio": 0.4912,
-   "compress_mbps": 3.07,
+   "compress_mbps": 3.06,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 90.37,
-   "decompress_mbps": 157.22
+   "compress_mbps": 89.77,
+   "decompress_mbps": 159.51
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 66.44,
-   "decompress_mbps": 161.82
+   "compress_mbps": 65.94,
+   "decompress_mbps": 164.66
   },
   {
    "compressor": "native",
@@ -4934,18 +4934,18 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 64.22,
-   "decompress_mbps": 167.16
+   "compress_mbps": 63.54,
+   "decompress_mbps": 167.69
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 4,
-   "out_size": 3706928,
+   "out_size": 3706949,
    "ratio": 0.3675,
-   "compress_mbps": 55.9,
-   "decompress_mbps": 172.26
+   "compress_mbps": 55.61,
+   "decompress_mbps": 174.35
   },
   {
    "compressor": "native",
@@ -4954,28 +4954,28 @@
    "level": 5,
    "out_size": 3707010,
    "ratio": 0.3676,
-   "compress_mbps": 52.26,
-   "decompress_mbps": 179.62
+   "compress_mbps": 52.0,
+   "decompress_mbps": 178.32
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 6,
-   "out_size": 3707065,
+   "out_size": 3707088,
    "ratio": 0.3676,
-   "compress_mbps": 41.42,
-   "decompress_mbps": 186.42
+   "compress_mbps": 41.39,
+   "decompress_mbps": 186.82
   },
   {
    "compressor": "native",
    "pattern": "silesia/osdb",
    "size": 10085684,
    "level": 7,
-   "out_size": 3706769,
+   "out_size": 3706770,
    "ratio": 0.3675,
-   "compress_mbps": 41.21,
-   "decompress_mbps": 189.44
+   "compress_mbps": 41.25,
+   "decompress_mbps": 189.88
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 41.43,
-   "decompress_mbps": 189.76
+   "compress_mbps": 41.45,
+   "decompress_mbps": 190.2
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3665069,
    "ratio": 0.3634,
-   "compress_mbps": 5.69,
-   "decompress_mbps": 194.74
+   "compress_mbps": 5.75,
+   "decompress_mbps": 194.95
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647321,
    "ratio": 0.3616,
-   "compress_mbps": 3.29,
+   "compress_mbps": 3.27,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 82.88,
-   "decompress_mbps": 130.82
+   "compress_mbps": 80.93,
+   "decompress_mbps": 130.88
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 55.68,
-   "decompress_mbps": 140.51
+   "compress_mbps": 56.12,
+   "decompress_mbps": 142.35
   },
   {
    "compressor": "native",
@@ -5034,58 +5034,58 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 45.59,
-   "decompress_mbps": 155.67
+   "compress_mbps": 46.06,
+   "decompress_mbps": 158.55
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 4,
-   "out_size": 1901081,
-   "ratio": 0.2869,
-   "compress_mbps": 28.05,
-   "decompress_mbps": 159.72
+   "out_size": 1900947,
+   "ratio": 0.2868,
+   "compress_mbps": 31.05,
+   "decompress_mbps": 161.86
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 5,
-   "out_size": 1874829,
-   "ratio": 0.2829,
-   "compress_mbps": 16.92,
-   "decompress_mbps": 171.18
+   "out_size": 1875392,
+   "ratio": 0.283,
+   "compress_mbps": 19.96,
+   "decompress_mbps": 172.48
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 6,
-   "out_size": 1867098,
-   "ratio": 0.2817,
-   "compress_mbps": 20.56,
-   "decompress_mbps": 180.01
+   "out_size": 1867552,
+   "ratio": 0.2818,
+   "compress_mbps": 23.99,
+   "decompress_mbps": 183.96
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 7,
-   "out_size": 1843421,
+   "out_size": 1843831,
    "ratio": 0.2782,
-   "compress_mbps": 13.59,
-   "decompress_mbps": 184.21
+   "compress_mbps": 15.27,
+   "decompress_mbps": 187.03
   },
   {
    "compressor": "native",
    "pattern": "silesia/reymont",
    "size": 6627202,
    "level": 8,
-   "out_size": 1841388,
+   "out_size": 1841549,
    "ratio": 0.2779,
-   "compress_mbps": 11.81,
-   "decompress_mbps": 186.08
+   "compress_mbps": 13.23,
+   "decompress_mbps": 189.37
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773447,
    "ratio": 0.2676,
-   "compress_mbps": 2.74,
-   "decompress_mbps": 191.89
+   "compress_mbps": 2.81,
+   "decompress_mbps": 194.24
   },
   {
    "compressor": "native",
@@ -5104,7 +5104,7 @@
    "level": 10,
    "out_size": 1718500,
    "ratio": 0.2593,
-   "compress_mbps": 1.5,
+   "compress_mbps": 1.51,
    "decompress_mbps": null
   },
   {
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 110.28,
-   "decompress_mbps": 194.99
+   "compress_mbps": 111.07,
+   "decompress_mbps": 198.0
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 81.6,
-   "decompress_mbps": 206.98
+   "compress_mbps": 81.42,
+   "decompress_mbps": 210.15
   },
   {
    "compressor": "native",
@@ -5134,58 +5134,58 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 73.85,
-   "decompress_mbps": 215.65
+   "compress_mbps": 74.51,
+   "decompress_mbps": 219.25
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 4,
-   "out_size": 5880979,
+   "out_size": 5881226,
    "ratio": 0.2722,
-   "compress_mbps": 54.52,
-   "decompress_mbps": 226.64
+   "compress_mbps": 56.19,
+   "decompress_mbps": 229.02
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 5,
-   "out_size": 5839944,
+   "out_size": 5840132,
    "ratio": 0.2703,
-   "compress_mbps": 41.59,
-   "decompress_mbps": 238.58
+   "compress_mbps": 44.01,
+   "decompress_mbps": 242.11
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 6,
-   "out_size": 5425813,
+   "out_size": 5425229,
    "ratio": 0.2511,
-   "compress_mbps": 34.63,
-   "decompress_mbps": 242.83
+   "compress_mbps": 36.34,
+   "decompress_mbps": 244.97
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 7,
-   "out_size": 5409983,
+   "out_size": 5410113,
    "ratio": 0.2504,
-   "compress_mbps": 29.62,
-   "decompress_mbps": 244.91
+   "compress_mbps": 31.04,
+   "decompress_mbps": 247.84
   },
   {
    "compressor": "native",
    "pattern": "silesia/samba",
    "size": 21606400,
    "level": 8,
-   "out_size": 5407066,
+   "out_size": 5407142,
    "ratio": 0.2503,
-   "compress_mbps": 27.44,
-   "decompress_mbps": 242.22
+   "compress_mbps": 28.85,
+   "decompress_mbps": 247.59
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5235865,
    "ratio": 0.2423,
-   "compress_mbps": 4.48,
-   "decompress_mbps": 246.97
+   "compress_mbps": 4.46,
+   "decompress_mbps": 250.82
   },
   {
    "compressor": "native",
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177560,
    "ratio": 0.2396,
-   "compress_mbps": 2.47,
+   "compress_mbps": 2.48,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 46.79,
-   "decompress_mbps": 92.34
+   "compress_mbps": 47.19,
+   "decompress_mbps": 93.21
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 39.48,
-   "decompress_mbps": 94.55
+   "compress_mbps": 39.43,
+   "decompress_mbps": 96.11
   },
   {
    "compressor": "native",
@@ -5234,58 +5234,58 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 36.85,
-   "decompress_mbps": 97.04
+   "compress_mbps": 37.03,
+   "decompress_mbps": 98.37
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 4,
-   "out_size": 5498823,
-   "ratio": 0.7583,
-   "compress_mbps": 29.89,
-   "decompress_mbps": 100.36
+   "out_size": 5500212,
+   "ratio": 0.7584,
+   "compress_mbps": 30.63,
+   "decompress_mbps": 102.06
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 5,
-   "out_size": 5496802,
-   "ratio": 0.758,
-   "compress_mbps": 28.3,
-   "decompress_mbps": 103.01
+   "out_size": 5497345,
+   "ratio": 0.7581,
+   "compress_mbps": 28.65,
+   "decompress_mbps": 104.6
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 6,
-   "out_size": 5478405,
+   "out_size": 5477997,
    "ratio": 0.7554,
-   "compress_mbps": 20.99,
-   "decompress_mbps": 104.31
+   "compress_mbps": 21.7,
+   "decompress_mbps": 105.54
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 7,
-   "out_size": 5474648,
-   "ratio": 0.7549,
-   "compress_mbps": 20.17,
-   "decompress_mbps": 103.63
+   "out_size": 5474894,
+   "ratio": 0.755,
+   "compress_mbps": 20.43,
+   "decompress_mbps": 106.98
   },
   {
    "compressor": "native",
    "pattern": "silesia/sao",
    "size": 7251944,
    "level": 8,
-   "out_size": 5474139,
-   "ratio": 0.7549,
-   "compress_mbps": 19.93,
-   "decompress_mbps": 103.84
+   "out_size": 5475351,
+   "ratio": 0.755,
+   "compress_mbps": 20.18,
+   "decompress_mbps": 106.5
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284536,
    "ratio": 0.7287,
-   "compress_mbps": 4.95,
-   "decompress_mbps": 105.62
+   "compress_mbps": 4.91,
+   "decompress_mbps": 106.86
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262319,
    "ratio": 0.7256,
-   "compress_mbps": 3.55,
+   "compress_mbps": 3.47,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 83.41,
-   "decompress_mbps": 136.09
+   "compress_mbps": 83.25,
+   "decompress_mbps": 138.48
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 61.29,
-   "decompress_mbps": 147.5
+   "compress_mbps": 61.52,
+   "decompress_mbps": 149.85
   },
   {
    "compressor": "native",
@@ -5334,58 +5334,58 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 56.11,
-   "decompress_mbps": 158.48
+   "compress_mbps": 55.96,
+   "decompress_mbps": 160.85
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 4,
-   "out_size": 12229398,
+   "out_size": 12231168,
    "ratio": 0.295,
-   "compress_mbps": 40.56,
-   "decompress_mbps": 165.74
+   "compress_mbps": 42.16,
+   "decompress_mbps": 168.3
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 5,
-   "out_size": 12123671,
-   "ratio": 0.2924,
-   "compress_mbps": 29.75,
-   "decompress_mbps": 174.19
+   "out_size": 12125487,
+   "ratio": 0.2925,
+   "compress_mbps": 32.18,
+   "decompress_mbps": 177.09
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 6,
-   "out_size": 12167341,
-   "ratio": 0.2935,
-   "compress_mbps": 31.05,
-   "decompress_mbps": 179.58
+   "out_size": 12172470,
+   "ratio": 0.2936,
+   "compress_mbps": 32.89,
+   "decompress_mbps": 182.6
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 7,
-   "out_size": 12109369,
+   "out_size": 12110320,
    "ratio": 0.2921,
-   "compress_mbps": 25.14,
-   "decompress_mbps": 181.11
+   "compress_mbps": 26.15,
+   "decompress_mbps": 184.08
   },
   {
    "compressor": "native",
    "pattern": "silesia/webster",
    "size": 41458703,
    "level": 8,
-   "out_size": 12106058,
+   "out_size": 12106137,
    "ratio": 0.292,
-   "compress_mbps": 24.1,
-   "decompress_mbps": 182.15
+   "compress_mbps": 24.63,
+   "decompress_mbps": 185.05
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806466,
    "ratio": 0.2848,
-   "compress_mbps": 3.72,
-   "decompress_mbps": 182.73
+   "compress_mbps": 3.77,
+   "decompress_mbps": 184.18
   },
   {
    "compressor": "native",
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 43.5,
-   "decompress_mbps": 77.87
+   "compress_mbps": 43.11,
+   "decompress_mbps": 78.36
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 41.3,
-   "decompress_mbps": 78.47
+   "compress_mbps": 41.68,
+   "decompress_mbps": 79.2
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 41.54,
-   "decompress_mbps": 80.0
+   "compress_mbps": 42.03,
+   "decompress_mbps": 80.67
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 39.01,
-   "decompress_mbps": 80.25
+   "compress_mbps": 38.66,
+   "decompress_mbps": 81.03
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 39.17,
-   "decompress_mbps": 81.93
+   "compress_mbps": 38.69,
+   "decompress_mbps": 82.94
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 16.55,
-   "decompress_mbps": 82.79
+   "compress_mbps": 16.37,
+   "decompress_mbps": 83.61
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 16.54,
-   "decompress_mbps": 82.76
+   "compress_mbps": 16.36,
+   "decompress_mbps": 84.22
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 16.52,
-   "decompress_mbps": 82.71
+   "compress_mbps": 16.34,
+   "decompress_mbps": 83.29
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952505,
    "ratio": 0.7024,
-   "compress_mbps": 5.82,
-   "decompress_mbps": 83.65
+   "compress_mbps": 5.87,
+   "decompress_mbps": 84.55
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5848663,
    "ratio": 0.6902,
-   "compress_mbps": 4.22,
+   "compress_mbps": 4.25,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 175.18,
-   "decompress_mbps": 264.04
+   "compress_mbps": 177.47,
+   "decompress_mbps": 269.64
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 112.71,
-   "decompress_mbps": 301.69
+   "compress_mbps": 113.06,
+   "decompress_mbps": 305.41
   },
   {
    "compressor": "native",
@@ -5534,58 +5534,58 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 101.83,
-   "decompress_mbps": 331.59
+   "compress_mbps": 102.81,
+   "decompress_mbps": 339.98
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 4,
-   "out_size": 721655,
+   "out_size": 721777,
    "ratio": 0.135,
-   "compress_mbps": 74.19,
-   "decompress_mbps": 329.7
+   "compress_mbps": 75.41,
+   "decompress_mbps": 337.71
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 5,
-   "out_size": 710636,
-   "ratio": 0.1329,
-   "compress_mbps": 53.76,
-   "decompress_mbps": 372.84
+   "out_size": 711251,
+   "ratio": 0.1331,
+   "compress_mbps": 57.8,
+   "decompress_mbps": 379.62
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 6,
-   "out_size": 688375,
-   "ratio": 0.1288,
-   "compress_mbps": 51.7,
-   "decompress_mbps": 400.89
+   "out_size": 689202,
+   "ratio": 0.1289,
+   "compress_mbps": 55.32,
+   "decompress_mbps": 382.83
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 7,
-   "out_size": 676544,
+   "out_size": 676922,
    "ratio": 0.1266,
-   "compress_mbps": 40.81,
-   "decompress_mbps": 409.48
+   "compress_mbps": 43.7,
+   "decompress_mbps": 416.42
   },
   {
    "compressor": "native",
    "pattern": "silesia/xml",
    "size": 5345280,
    "level": 8,
-   "out_size": 674362,
+   "out_size": 674389,
    "ratio": 0.1262,
-   "compress_mbps": 35.18,
-   "decompress_mbps": 421.47
+   "compress_mbps": 38.62,
+   "decompress_mbps": 448.34
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659417,
    "ratio": 0.1234,
-   "compress_mbps": 4.23,
-   "decompress_mbps": 448.84
+   "compress_mbps": 4.27,
+   "decompress_mbps": 437.75
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643093,
    "ratio": 0.1203,
-   "compress_mbps": 2.88,
+   "compress_mbps": 2.89,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR threads a `lazyDepth` knob into the lazy hash-chain matcher's `pos+1` lookahead so the second chain walk runs at reduced depth instead of the full `maxChain`, then wires the production levels to half depth (`chainDepth / 2`, libdeflate's value). Since the `goodMatch` gate is disabled at L5+ (`goodMatch = 259`, the #2737 mid-sweep verdict), every matched position otherwise pays two full-depth chain walks — and the chain walk is 41% of L6 dickens, so the lookahead's share is material. libdeflate probes its first lookahead at half depth and still holds better ratios than us, so the deferral quality a half-depth probe gives up is slack: the probe still runs, just shallower, so the second walk's cycles roughly halve while the ratio cost stays in the noise.

The parameter threads identically through the three lazy twins (`lz77ChainLazy`, `lz77ChainLazyIter`, `lz77ChainLazyIterP`), defaulting to `maxChain` so existing callers are a no-op; only `DeflateDynamic.lzMatch`/`lzMatchP` opt into `lazyDepth level = chainDepth level / 2`. Depth is a pure heuristic — `chainWalk_spec` holds for any fuel — so the equivalence (`lz77ChainLazyIter_eq_lz77ChainLazy`, `lz77ChainLazyIterP_eq`) and validity/encodability/resolves contracts are re-proven generic over `lazyDepth` and re-established at emission exactly as before. The conformance test now also checks the three twins agree at a non-default depth (32), and the `mid-sweep` timing tool models the shipped half-depth probe. No new `sorry`; full build and test suite pass.

Closes https://github.com/kim-em/lean-zip/issues/2763

🤖 Prepared with Claude Code