### PR TITLE
perf: batch literal emission via writeHuffCode2 (up to 2 Huffman codes per writer call)

### DIFF
--- a/Zip/Native/BitWriter.lean
+++ b/Zip/Native/BitWriter.lean
@@ -214,6 +214,96 @@ theorem writeHuffCode_def (bw : BitWriter) (code : UInt16) (len : UInt8) :
   · rw [flushBytesWide_eq, flushAcc_eq]
   · rfl
 
+/-- Write two Huffman codes in one merged accumulator operation — a single
+    shift/OR field and a single flush check for a pair of literals, the way
+    libdeflate writes its flush groups.
+
+    When the first code would not trigger an intermediate flush (`bitCount +
+    len1 < flushThreshold`, the common case right after a flush leaves few
+    pending bits), both reversed codes are merged into one 64-bit accumulator:
+    `code1` shifted above the pending bits, `code2` shifted above that, then the
+    combined field is flushed once. The guard's `else` branch (rare: `bitCount +
+    len1 ≥ 32`) falls back to the two sequential `writeHuffCode` calls.
+
+    `writeHuffCode2_eq` proves the result **byte-identical to the two sequential
+    `writeHuffCode` calls for every input** — no length precondition, because
+    the merge and the sequential second write use the same (modular) `UInt64`
+    shift/OR arithmetic: under the guard the first field never flushes, so
+    merging the second above it lands the exact same bits with the exact same
+    single flush the sequential pair would perform on its second call.
+
+    That the merged field does not lose bits off the top of the 64-bit
+    accumulator (i.e. that the output is well-formed DEFLATE, not merely equal to
+    the sequential writer) is a **caller invariant**: DEFLATE literal/length
+    Huffman codes have `len ≤ 15`, so with the guard `bitCount + len1 < 32` the
+    top bit position `bitCount + len1 + len2 < 47` sits well inside 64. This is
+    the same `len ≤ 15` invariant the emit specs already carry
+    (`ValidLengths … 15`); it is not needed for `writeHuffCode2_eq`. -/
+def writeHuffCode2 (bw : BitWriter) (code1 : UInt16) (len1 : UInt8)
+    (code2 : UInt16) (len2 : UInt8) : BitWriter :=
+  if bw.bitCount.toNat + len1.toNat < flushThreshold then
+    let rev1 : UInt64 := (reverse16 code1).toUInt64 >>> (16 - len1.toUInt64)
+    let rev2 : UInt64 := (reverse16 code2).toUInt64 >>> (16 - len2.toUInt64)
+    let acc : UInt64 :=
+      bw.bitBuf ||| (rev1 <<< bw.bitCount.toUInt64)
+        ||| (rev2 <<< (bw.bitCount.toUInt64 + len1.toUInt64))
+    let total := bw.bitCount.toNat + len1.toNat + len2.toNat
+    if total ≥ flushThreshold then
+      ⟨flushBytesWide bw.data acc (total / 8), dropBytes acc (total / 8), (total % 8).toUInt8⟩
+    else
+      ⟨bw.data, acc, total.toUInt8⟩
+  else
+    (bw.writeHuffCode code1 len1).writeHuffCode code2 len2
+
+/-- The explicit ctor-reuse flush form (`flushBytesWide`/`dropBytes`) the
+    production writers construct equals the `flushBatched` reference form —
+    exactly the bridge inside `writeBits_def`/`writeHuffCode_def`, factored out
+    so `writeHuffCode2_eq` can rewrite the batched fast path. -/
+private theorem flushExplicit_eq_flushBatched (data : ByteArray) (acc : UInt64) (total : Nat) :
+    (if total ≥ flushThreshold then
+      (⟨flushBytesWide data acc (total / 8), dropBytes acc (total / 8),
+        (total % 8).toUInt8⟩ : BitWriter)
+     else ⟨data, acc, total.toUInt8⟩) = flushBatched data acc total := by
+  unfold flushBatched
+  split
+  · rw [flushBytesWide_eq, flushAcc_eq]
+  · rfl
+
+/-- `writeHuffCode2` is byte-identical to the two sequential `writeHuffCode`
+    calls it batches, as a `BitWriter` value (not merely at the `toBits` level).
+    Under the guard the first field does not flush, so its merged accumulator is
+    exactly the pending state the second `writeHuffCode` reads; OR is
+    associative, so shifting `code2` above `code1` lands the same bits, and the
+    single flush check on `bitCount + len1 + len2` is the one the sequential
+    pair performs on its second call. -/
+theorem writeHuffCode2_eq (bw : BitWriter) (code1 : UInt16) (len1 : UInt8)
+    (code2 : UInt16) (len2 : UInt8) :
+    bw.writeHuffCode2 code1 len1 code2 len2 =
+      (bw.writeHuffCode code1 len1).writeHuffCode code2 len2 := by
+  unfold writeHuffCode2
+  split
+  · rename_i hg
+    have hg' : bw.bitCount.toNat + len1.toNat < 256 := by
+      simp only [flushThreshold] at hg; omega
+    -- The first field does not flush: it yields this explicit cell.
+    have hX : bw.writeHuffCode code1 len1 =
+        ⟨bw.data, bw.bitBuf ||| ((reverse16 code1).toUInt64 >>> (16 - len1.toUInt64))
+          <<< bw.bitCount.toUInt64, (bw.bitCount.toNat + len1.toNat).toUInt8⟩ := by
+      rw [writeHuffCode_def, flushBatched, if_neg (Nat.not_le.mpr hg)]
+    -- The pending count after the first field, as Nat and as the shift amount.
+    have htt1 : ((bw.bitCount.toNat + len1.toNat).toUInt8).toNat
+        = bw.bitCount.toNat + len1.toNat := by
+      simp only [Nat.toUInt8, UInt8.toNat_ofNat']
+      rw [show (2 : Nat) ^ 8 = 256 from rfl]; omega
+    have hshift : ((bw.bitCount.toNat + len1.toNat).toUInt8).toUInt64
+        = bw.bitCount.toUInt64 + len1.toUInt64 := by
+      apply UInt64.toNat_inj.mp
+      rw [UInt8.toNat_toUInt64, htt1, UInt64.toNat_add, UInt8.toNat_toUInt64,
+        UInt8.toNat_toUInt64, Nat.mod_eq_of_lt (by omega)]
+    -- Both sides collapse to the same `flushBatched`.
+    rw [flushExplicit_eq_flushBatched, writeHuffCode_def, hX, htt1, hshift, Nat.add_assoc]
+  · rfl
+
 /-- Flush all pending bits, padding the final partial byte with zeros. Drains
     every whole pending byte (`bitCount` may hold up to 31 bits under batching),
     then the final partial byte. Returns the final ByteArray. -/

--- a/Zip/Native/Deflate.lean
+++ b/Zip/Native/Deflate.lean
@@ -1731,19 +1731,35 @@ time. Do not inline `emitRefFixedP` back into `emitTokensP`.
 /-- Packed-token form of `emitTokens`: emit the packed `UInt32` stream as
     fixed Huffman codes. Literals (tag bit clear) read the byte field
     directly; references go through `emitRefFixedP`. Equal to `emitTokens`
-    over the boxed view for every word array (`emitTokensP_eq`). -/
+    over the boxed view for every word array (`emitTokensP_eq`).
+
+    Two consecutive literals are batched into a single `writeHuffCode2` (one
+    merged shift/OR field, one flush check) instead of two `writeHuffCode` calls
+    — the literal-emission fast path (#2764). Byte-identical to the sequential
+    emit (`writeHuffCode2_eq`); the batched branch advances by two. -/
 def emitTokensP (bw : BitWriter) (tokens : Array UInt32) (i : Nat) : BitWriter :=
   if h : i < tokens.size then
     let w := tokens[i]
     if w &&& ((1 : UInt32) <<< 31) = 0 then
       have : w.toUInt8.toNat < fixedLitCodes.size := by
         have := UInt8.toNat_lt w.toUInt8; rw [Deflate.fixedLitCodes_size]; omega
-      let (code, len) := fixedLitCodes[w.toUInt8.toNat]
-      emitTokensP (bw.writeHuffCode code len) tokens (i + 1)
+      let (code1, len1) := fixedLitCodes[w.toUInt8.toNat]
+      if h2 : i + 1 < tokens.size then
+        let w2 := tokens[i + 1]
+        if w2 &&& ((1 : UInt32) <<< 31) = 0 then
+          have : w2.toUInt8.toNat < fixedLitCodes.size := by
+            have := UInt8.toNat_lt w2.toUInt8; rw [Deflate.fixedLitCodes_size]; omega
+          let (code2, len2) := fixedLitCodes[w2.toUInt8.toNat]
+          emitTokensP (bw.writeHuffCode2 code1 len1 code2 len2) tokens (i + 2)
+        else
+          emitTokensP (bw.writeHuffCode code1 len1) tokens (i + 1)
+      else
+        emitTokensP (bw.writeHuffCode code1 len1) tokens (i + 1)
     else
       emitTokensP (emitRefFixedP bw w) tokens (i + 1)
   else bw
 termination_by tokens.size - i
+decreasing_by all_goals omega
 
 /-- Write a fixed Huffman DEFLATE block from LZ77 tokens. -/
 def deflateFixedBlock (data : ByteArray) (tokens : Array LZ77Token) : ByteArray :=

--- a/Zip/Native/DeflateDynamic.lean
+++ b/Zip/Native/DeflateDynamic.lean
@@ -94,7 +94,13 @@ proves the loop equal to `emitTokensWithCodes` over the boxed view. -/
     distance Huffman codes. Literals (tag bit clear) read the byte field
     directly; references go through `emitRefWithCodesP`. Equal to
     `emitTokensWithCodes` over the boxed view for every word array
-    (`emitTokensWithCodesP_eq`). -/
+    (`emitTokensWithCodesP_eq`).
+
+    When two consecutive tokens are literals, they are batched into a single
+    `writeHuffCode2` (one merged shift/OR field, one flush check) instead of two
+    `writeHuffCode` calls — the literal-emission fast path (#2764). This is
+    byte-identical to the sequential emit (`writeHuffCode2_eq`), so the equality
+    to the boxed emitter still holds; the batched branch advances by two. -/
 def emitTokensWithCodesP (bw : BitWriter) (tokens : Array UInt32)
     (litCodes distCodes : Array (UInt16 × UInt8))
     (hlit : litCodes.size ≥ 286) (hdist : distCodes.size ≥ 30)
@@ -104,13 +110,27 @@ def emitTokensWithCodesP (bw : BitWriter) (tokens : Array UInt32)
     if w &&& ((1 : UInt32) <<< 31) = 0 then
       have : w.toUInt8.toNat < litCodes.size := by
         have := UInt8.toNat_lt w.toUInt8; omega
-      let (code, len) := litCodes[w.toUInt8.toNat]
-      emitTokensWithCodesP (bw.writeHuffCode code len) tokens litCodes distCodes hlit hdist (i + 1)
+      let (code1, len1) := litCodes[w.toUInt8.toNat]
+      if h2 : i + 1 < tokens.size then
+        let w2 := tokens[i + 1]
+        if w2 &&& ((1 : UInt32) <<< 31) = 0 then
+          have : w2.toUInt8.toNat < litCodes.size := by
+            have := UInt8.toNat_lt w2.toUInt8; omega
+          let (code2, len2) := litCodes[w2.toUInt8.toNat]
+          emitTokensWithCodesP (bw.writeHuffCode2 code1 len1 code2 len2) tokens litCodes distCodes
+            hlit hdist (i + 2)
+        else
+          emitTokensWithCodesP (bw.writeHuffCode code1 len1) tokens litCodes distCodes
+            hlit hdist (i + 1)
+      else
+        emitTokensWithCodesP (bw.writeHuffCode code1 len1) tokens litCodes distCodes
+          hlit hdist (i + 1)
     else
       emitTokensWithCodesP (emitRefWithCodesP bw litCodes distCodes w) tokens litCodes distCodes
         hlit hdist (i + 1)
   else bw
 termination_by tokens.size - i
+decreasing_by all_goals omega
 
 
 /-- Write the dynamic Huffman tree header via BitWriter.

--- a/Zip/Spec/EmitPackedCorrect.lean
+++ b/Zip/Spec/EmitPackedCorrect.lean
@@ -115,8 +115,20 @@ theorem emitTokensP_eq (bw : BitWriter) (ws : Array UInt32) (i : Nat) :
     by_cases hi : i < ws.size
     · simp only [Array.size_map, hi, ↓reduceDIte, Array.getElem_map, unpackTok]
       by_cases hc : ws[i] &&& ((1 : UInt32) <<< 31) = 0
-      · simp only [hc, ↓reduceIte]
-        exact ih _ (by omega) _ _ rfl
+      · -- literal at i: peek the next token for the batched literal-pair path
+        by_cases h2 : i + 1 < ws.size
+        · by_cases hc2 : ws[i + 1] &&& ((1 : UInt32) <<< 31) = 0
+          · -- two consecutive literals → one `writeHuffCode2`, advance by two
+            simp only [hc, ↓reduceIte, h2, ↓reduceDIte, hc2]
+            rw [BitWriter.writeHuffCode2_eq]
+            conv => rhs; unfold emitTokens
+            simp only [Array.size_map, h2, ↓reduceDIte, Array.getElem_map, unpackTok, hc2,
+              ↓reduceIte]
+            exact ih _ (by omega) _ _ rfl
+          · simp only [hc, ↓reduceIte, h2, ↓reduceDIte, hc2]
+            exact ih _ (by omega) _ _ rfl
+        · simp only [hc, ↓reduceIte, h2, ↓reduceDIte]
+          exact ih _ (by omega) _ _ rfl
       · simp only [hc, ↓reduceIte]
         split
         · rename_i idx en ev hflc
@@ -230,8 +242,20 @@ theorem emitTokensWithCodesP_eq (bw : BitWriter) (ws : Array UInt32)
     by_cases hi : i < ws.size
     · simp only [Array.size_map, hi, ↓reduceDIte, Array.getElem_map, unpackTok]
       by_cases hc : ws[i] &&& ((1 : UInt32) <<< 31) = 0
-      · simp only [hc, ↓reduceIte]
-        exact ih _ (by omega) _ _ rfl
+      · -- literal at i: peek the next token for the batched literal-pair path
+        by_cases h2 : i + 1 < ws.size
+        · by_cases hc2 : ws[i + 1] &&& ((1 : UInt32) <<< 31) = 0
+          · -- two consecutive literals → one `writeHuffCode2`, advance by two
+            simp only [hc, ↓reduceIte, h2, ↓reduceDIte, hc2]
+            rw [BitWriter.writeHuffCode2_eq]
+            conv => rhs; unfold emitTokensWithCodes
+            simp only [Array.size_map, h2, ↓reduceDIte, Array.getElem_map, unpackTok, hc2,
+              ↓reduceIte]
+            exact ih _ (by omega) _ _ rfl
+          · simp only [hc, ↓reduceIte, h2, ↓reduceDIte, hc2]
+            exact ih _ (by omega) _ _ rfl
+        · simp only [hc, ↓reduceIte, h2, ↓reduceDIte]
+          exact ih _ (by omega) _ _ rfl
       · simp only [hc, ↓reduceIte]
         split
         · rename_i idx en ev hflc

--- a/bench/graphs/canterbury_compress_heatmap.svg
+++ b/bench/graphs/canterbury_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pa0395a7d35)">
+   <g clip-path="url(#p25dfccfe7a)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJD0lEQVR4nO3YvYpdVQCG4TkzZzQxYwiCMSQQBAUbwUob7e29EK/AxmvwDkSwF8HC2sZSbBQEiRIQQ6L5mZlMzo+F4BW8i2U2z3MF32Kx93nPXu3+/nJ/wPPl/PHsBeM8XebZ9hfnsycMs7p6ffaEMV58afaCcVaHsxeM8Wy5z9lS72x///fZE4ZZ5o0BAEwksAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYus7q/uzNwxxsT2fPWGYG9denz1hmJPd9dkThlidPZw9YZjvzn6aPWGImy+8OnvCMNvdZvaEIR5tTmdPGGaz386eMMS7L9+aPWEYX7AAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtj45vjZ7wxC79W72hGFODi7NnjDOX3dmLxhif/Zw9oRh3rv9/uwJQ5xulntnTxZ6tjdP3p49YZiL1Wb2hCH2v/4we8IwvmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBAbH356GT2hiHOt6ezJ4yzWnAXX7o6e8EQqwXf2fFmM3vCEEu+syvrZT5nf1zcnT1hmM3uYvaEIW5duTZ7wjDLfYMAAEwisAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACC22v746X72CPjPbjd7Afzr0P/P5473B/8j3iAAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQE1gAADGBBQAQW3/8553ZG4Z4+HQ7e8Iw3999NHvCMF9/9MHsCUO8dvn27AnDvPP5F7MnDPHhG6/MnjDMLw/OZk8Y4vL6aPaEYb765ufZE4Y4/eyT2ROG8QULACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYqvN7tv97BEjbHeb2ROGOVwtt4uPzk9nTxjjaD17wThP7s9eMMT22o3ZE4bZ7XezJwxxvFruc/Zsv8zftOPNMs91cOALFgBATmABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMQEFgBATGABAMTWhwttrP1qmec6ODg4OHpwd/aEcR7fm71giP3Fs9kThlndfGv2hCGOVuvZE4a52D6ePWGI44vT2ROGWerZ9vd+mz1hmOVWCADAJAILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACAmsAAAYgILACD2D5wOguau5SzBAAAAAElFTkSuQmCC" id="image6991ef8c58" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAlgAAAGJCAYAAABW7E3LAAAJEUlEQVR4nO3YvYpdVQCG4TmZM5qYMQyCMRoIgtoJVtpob++FeAU2XoN3IIK9CBbWNpZioyBI0ICoieZnZjI5PxaCV/Aultk8zxV8m8Xe5z1rtfv78/0BT5fzh7MXjPN4mc+2vzifPWGY1bXrsyeM8exzsxeMs7o0e8EYT5b7ni31zPZ3f5k9YZhlnhgAwEQCCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgJrAAAGICCwAgtr69ujt7wxAX2/PZE4a5cfLq7AnDHO+uz54wxOrs/uwJw3xz9sPsCUO88syLsycMs91tZk8Y4sHmdPaEYTb77ewJQ7z9/M3ZE4ZxgwUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx9fHRyewNQ+zWu9kThjk+uDx7wjh/3Z69YIj92f3ZE4Z559a7sycMcbpZ7pk9WuizvX785uwJw1ysNrMnDLH/+bvZE4ZxgwUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAAAxgQUAEBNYAACx9ZXD49kbhjjfns6eMM5qwV18+drsBUOsFnxmR5vN7AlDLPnMrq6X+Z79dnFn9oRhNruL2ROGuHn1ZPaEYZb7BQEAmERgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQGy1/f7j/ewR8J/dbvYC+Ncl/z+fOr4f/I/4ggAAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBMYAEAxAQWAEBs/eHvt2dvGOL+4+3sCcN8e+fB7AnDfPnBe7MnDPHSlVuzJwzz1qefzZ4wxPuvvTB7wjA/3TubPWGIK+vD2ROG+eKrH2dPGOL0k49mTxjGDRYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEBBYAQExgAQDEVpvd1/vZI0bY7jazJwxzabXcLj48P509YYzD9ewF4zy6O3vBENuTG7MnDLPb72ZPGOJotdz37Ml+mb9pR5tlPtfBgRssAICcwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiAksAICYwAIAiK0vLbSx9qtlPtfBwcHB4b07syeM8/CP2QuG2F88mT1hmNXLb8yeMMThaj17wjAX24ezJwxxdHE6e8IwR4+XeWb7P3+dPWGY5VYIAMAkAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAICawAABiAgsAIPYPQ1yC45Dd3YgAAAAASUVORK5CYII=" id="image81fc468716" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="432" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="ma3e44726bf" d="M 0 0 
+       <path id="m69613007b0" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#ma3e44726bf" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="115.301649" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#ma3e44726bf" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="154.552448" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#ma3e44726bf" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="193.803246" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#ma3e44726bf" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="233.054045" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#ma3e44726bf" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="272.304843" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#ma3e44726bf" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="311.555641" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#ma3e44726bf" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="350.80644" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#ma3e44726bf" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="390.057238" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#ma3e44726bf" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="429.308037" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#ma3e44726bf" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="468.558835" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#ma3e44726bf" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m69613007b0" x="507.809634" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m0d7c49f754" d="M 0 0 
+       <path id="m8c647daab2" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0d7c49f754" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c647daab2" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m0d7c49f754" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c647daab2" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0d7c49f754" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c647daab2" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m0d7c49f754" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c647daab2" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0d7c49f754" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c647daab2" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m0d7c49f754" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c647daab2" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0d7c49f754" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c647daab2" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m0d7c49f754" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8c647daab2" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1327,9 +1327,47 @@ z
     </g>
    </g>
    <g id="text_21">
-    <!-- +8 -->
+    <!-- +7 -->
     <g transform="translate(149.761237 68.904519) scale(0.065 -0.065)">
      <defs>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- -48 -->
+    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
 Q 1069 1734 1069 1313 
@@ -1370,34 +1408,6 @@ Q 1172 3844 1172 3481
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(83.789062 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
-    <!-- -48 -->
-    <g transform="translate(188.495082 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
@@ -1406,18 +1416,6 @@ z
    <g id="text_23">
     <!-- -79 -->
     <g transform="translate(227.74588 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
@@ -1432,60 +1430,26 @@ z
     </g>
    </g>
    <g id="text_25">
-    <!-- -28 -->
+    <!-- -29 -->
     <g transform="translate(306.247477 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_26">
-    <!-- +3 -->
+    <!-- +2 -->
     <g transform="translate(346.015229 68.904519) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(83.789062 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
     </g>
    </g>
    <g id="text_27">
-    <!-- +21 -->
+    <!-- +20 -->
     <g transform="translate(383.198215 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_28">
@@ -1497,11 +1461,11 @@ z
     </g>
    </g>
    <g id="text_29">
-    <!-- -43 -->
+    <!-- -44 -->
     <g transform="translate(463.250671 68.904519) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_30">
@@ -1576,6 +1540,40 @@ z
    <g id="text_39">
     <!-- -3 -->
     <g transform="translate(426.067685 104.25537) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
     </g>
@@ -2180,18 +2178,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="image49f3902d8f" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
+iVBORw0KGgoAAAANSUhEUgAAABAAAAE6CAYAAAAfs9KFAAABqklEQVR4nO2a0RHCMAxDnTazsDljtmGI5zvJxvzXJz8paoGub3xOgM++LnJ5wgB4ucMK+1piBS0glh9g4MJaLIoDcQZEeLigLtUWECHFvW46ACrgEKkCPQOugOaghwtsC6zAAaLcBd5I+ijX7wN6FgyifJV3wQBiyCHGDVs56vcBXUFvI4eIc6A/Cy1cwFEWP2QZ9IE8Bwmlql7BwAXcyglRVj+l8TsT7YOEAfIklmegX2GinPDr/kTZQcG4YNIH1RnsWHKIUIGegX6AQ5TVDBwgyqO81g0VjAsNzsJAdBhg4MKhb0Cc87IBLxzAIZ4Qr6BXkAAR54AykCcR28hdSFjhUSuQR3mSaFEo6hX0lebQyge9+5/gAlWQ0QeYQXWIDi7oGfAcqPtAnoMGZ8HBBX5vbNAH1YOkH8BdeJiABAYJCtiADIg4B1gBHNABIqsDA4iYQUYrwwH1C6UFRChBfxbm1mbRBw8vVQqRR3kgyiFiBgYPGA4uoOtTovz3ELGCHlFG13u0shoi/sZy6Ap0QMI/HHgF6sJA7DCgBcSJsn4F/QAHiOWT2MCFH9EwXx+8bH5cAAAAAElFTkSuQmCC" id="imaged08ad5d24a" transform="scale(1 -1) translate(0 -226.08)" x="536.4" y="-77.76" width="11.52" height="226.08"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m632aa345f4" d="M 0 0 
+       <path id="m32eced111e" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m632aa345f4" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32eced111e" x="547.779688" y="276.293905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2214,7 +2212,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m632aa345f4" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32eced111e" x="547.779688" y="247.808905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2228,7 +2226,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m632aa345f4" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32eced111e" x="547.779688" y="219.323905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2242,7 +2240,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m632aa345f4" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32eced111e" x="547.779688" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2255,7 +2253,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m632aa345f4" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32eced111e" x="547.779688" y="162.353904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2268,7 +2266,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m632aa345f4" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32eced111e" x="547.779688" y="133.868904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2281,7 +2279,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m632aa345f4" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m32eced111e" x="547.779688" y="105.383904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2942,8 +2940,8 @@ z
    </g>
   </g>
   <g id="text_117">
-   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.467344 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T06:43:08Z  ·  Linux chungus2 x86_64  ·  commit f2d5688e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.453359 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -3013,13 +3011,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3059,109 +3057,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.195312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.982422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.769531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.34375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.130859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.095703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.435547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.617188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.320312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.433594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.710938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.089844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.712891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.404297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.583984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.207031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4747.994141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.617188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.240234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.027344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.734375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.201172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.988281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.5625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.349609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.136719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.587891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.769531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.148438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.003906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.480469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5842.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.068359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5913.855469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.644531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.84375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.626953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6340.90625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.285156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.171875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.306641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.785156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6852.966797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6925.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.654297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.767578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.046875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.007812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.791016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7299.890625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.410156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.185547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7721.96875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.347656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.130859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.230469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.439453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.222656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pa0395a7d35">
+  <clipPath id="p25dfccfe7a">
    <rect x="95.67625" y="49.4355" width="431.758783" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_compress_pareto.svg
+++ b/bench/graphs/canterbury_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 79.118387 412.80375 
 L 79.118387 48.323125 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m8c72a28ee8" d="M 0 0 
+       <path id="mc4b6afa431" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8c72a28ee8" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc4b6afa431" x="79.118387" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -161,11 +161,11 @@ z
      <g id="line2d_3">
       <path d="M 166.481434 412.80375 
 L 166.481434 48.323125 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8c72a28ee8" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc4b6afa431" x="166.481434" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -216,11 +216,11 @@ z
      <g id="line2d_5">
       <path d="M 253.844481 412.80375 
 L 253.844481 48.323125 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8c72a28ee8" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc4b6afa431" x="253.844481" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -237,11 +237,11 @@ L 253.844481 48.323125
      <g id="line2d_7">
       <path d="M 341.207528 412.80375 
 L 341.207528 48.323125 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8c72a28ee8" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc4b6afa431" x="341.207528" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -279,11 +279,11 @@ z
      <g id="line2d_9">
       <path d="M 428.570575 412.80375 
 L 428.570575 48.323125 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8c72a28ee8" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc4b6afa431" x="428.570575" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -332,11 +332,11 @@ z
      <g id="line2d_11">
       <path d="M 515.933622 412.80375 
 L 515.933622 48.323125 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8c72a28ee8" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc4b6afa431" x="515.933622" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -353,11 +353,11 @@ L 515.933622 48.323125
      <g id="line2d_13">
       <path d="M 603.296669 412.80375 
 L 603.296669 48.323125 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8c72a28ee8" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc4b6afa431" x="603.296669" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -854,16 +854,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 347.786382 
 L 637.2 347.786382 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m1cf1c89a8f" d="M 0 0 
+       <path id="mf496b908b9" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m1cf1c89a8f" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf496b908b9" x="49.078125" y="347.786382" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -895,11 +895,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 238.646289 
 L 637.2 238.646289 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m1cf1c89a8f" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf496b908b9" x="49.078125" y="238.646289" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -915,11 +915,11 @@ L 637.2 238.646289
      <g id="line2d_19">
       <path d="M 49.078125 129.506196 
 L 637.2 129.506196 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m1cf1c89a8f" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf496b908b9" x="49.078125" y="129.506196" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -935,16 +935,16 @@ L 637.2 129.506196
      <g id="line2d_21">
       <path d="M 49.078125 404.853417 
 L 637.2 404.853417 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="m97694042c8" d="M 0 0 
+       <path id="me8b6eac5fb" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="404.853417" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -952,11 +952,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 391.217592 
 L 637.2 391.217592 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="391.217592" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -964,11 +964,11 @@ L 637.2 391.217592
      <g id="line2d_25">
       <path d="M 49.078125 380.640824 
 L 637.2 380.640824 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="380.640824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -976,11 +976,11 @@ L 637.2 380.640824
      <g id="line2d_27">
       <path d="M 49.078125 371.998975 
 L 637.2 371.998975 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="371.998975" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -988,11 +988,11 @@ L 637.2 371.998975
      <g id="line2d_29">
       <path d="M 49.078125 364.692396 
 L 637.2 364.692396 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="364.692396" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1000,11 +1000,11 @@ L 637.2 364.692396
      <g id="line2d_31">
       <path d="M 49.078125 358.36315 
 L 637.2 358.36315 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="358.36315" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1012,11 +1012,11 @@ L 637.2 358.36315
      <g id="line2d_33">
       <path d="M 49.078125 352.780359 
 L 637.2 352.780359 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="352.780359" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1024,11 +1024,11 @@ L 637.2 352.780359
      <g id="line2d_35">
       <path d="M 49.078125 314.93194 
 L 637.2 314.93194 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="314.93194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1036,11 +1036,11 @@ L 637.2 314.93194
      <g id="line2d_37">
       <path d="M 49.078125 295.713324 
 L 637.2 295.713324 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="295.713324" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1048,11 +1048,11 @@ L 637.2 295.713324
      <g id="line2d_39">
       <path d="M 49.078125 282.077499 
 L 637.2 282.077499 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="282.077499" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1060,11 +1060,11 @@ L 637.2 282.077499
      <g id="line2d_41">
       <path d="M 49.078125 271.500731 
 L 637.2 271.500731 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="271.500731" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1072,11 +1072,11 @@ L 637.2 271.500731
      <g id="line2d_43">
       <path d="M 49.078125 262.858882 
 L 637.2 262.858882 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="262.858882" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1084,11 +1084,11 @@ L 637.2 262.858882
      <g id="line2d_45">
       <path d="M 49.078125 255.552304 
 L 637.2 255.552304 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="255.552304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1096,11 +1096,11 @@ L 637.2 255.552304
      <g id="line2d_47">
       <path d="M 49.078125 249.223057 
 L 637.2 249.223057 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="249.223057" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1108,11 +1108,11 @@ L 637.2 249.223057
      <g id="line2d_49">
       <path d="M 49.078125 243.640266 
 L 637.2 243.640266 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="243.640266" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1120,11 +1120,11 @@ L 637.2 243.640266
      <g id="line2d_51">
       <path d="M 49.078125 205.791848 
 L 637.2 205.791848 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="205.791848" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1132,11 +1132,11 @@ L 637.2 205.791848
      <g id="line2d_53">
       <path d="M 49.078125 186.573231 
 L 637.2 186.573231 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="186.573231" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1144,11 +1144,11 @@ L 637.2 186.573231
      <g id="line2d_55">
       <path d="M 49.078125 172.937406 
 L 637.2 172.937406 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="172.937406" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1156,11 +1156,11 @@ L 637.2 172.937406
      <g id="line2d_57">
       <path d="M 49.078125 162.360638 
 L 637.2 162.360638 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="162.360638" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1168,11 +1168,11 @@ L 637.2 162.360638
      <g id="line2d_59">
       <path d="M 49.078125 153.71879 
 L 637.2 153.71879 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="153.71879" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1180,11 +1180,11 @@ L 637.2 153.71879
      <g id="line2d_61">
       <path d="M 49.078125 146.412211 
 L 637.2 146.412211 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="146.412211" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1192,11 +1192,11 @@ L 637.2 146.412211
      <g id="line2d_63">
       <path d="M 49.078125 140.082964 
 L 637.2 140.082964 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="140.082964" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1204,11 +1204,11 @@ L 637.2 140.082964
      <g id="line2d_65">
       <path d="M 49.078125 134.500173 
 L 637.2 134.500173 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="134.500173" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1216,11 +1216,11 @@ L 637.2 134.500173
      <g id="line2d_67">
       <path d="M 49.078125 96.651755 
 L 637.2 96.651755 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="96.651755" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1228,11 +1228,11 @@ L 637.2 96.651755
      <g id="line2d_69">
       <path d="M 49.078125 77.433138 
 L 637.2 77.433138 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="77.433138" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1240,11 +1240,11 @@ L 637.2 77.433138
      <g id="line2d_71">
       <path d="M 49.078125 63.797313 
 L 637.2 63.797313 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="63.797313" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1252,11 +1252,11 @@ L 637.2 63.797313
      <g id="line2d_73">
       <path d="M 49.078125 53.220545 
 L 637.2 53.220545 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m97694042c8" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#me8b6eac5fb" x="49.078125" y="53.220545" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1378,7 +1378,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(294.669676 147.134805) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(294.669676 147.364617) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1410,7 +1410,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(104.852312 296.934364) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(104.852312 297.743279) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1732,23 +1732,23 @@ z
    </g>
    <g id="line2d_75">
     <defs>
-     <path id="mba84fce6e9" d="M -2.5 2.5 
+     <path id="mb7fa9d5637" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3994ffe252)">
-     <use xlink:href="#mba84fce6e9" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba84fce6e9" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba84fce6e9" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba84fce6e9" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba84fce6e9" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba84fce6e9" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba84fce6e9" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba84fce6e9" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mba84fce6e9" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p562862b7b3)">
+     <use xlink:href="#mb7fa9d5637" x="355.479835" y="95.382063" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7fa9d5637" x="308.273931" y="102.754513" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7fa9d5637" x="271.230161" y="116.528062" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7fa9d5637" x="217.83458" y="120.013651" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7fa9d5637" x="177.077692" y="138.43462" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7fa9d5637" x="162.880539" y="157.778627" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7fa9d5637" x="160.741445" y="165.196647" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7fa9d5637" x="153.966678" y="183.405761" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb7fa9d5637" x="151.589614" y="194.488118" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_76">
@@ -1801,7 +1801,7 @@ L 311.2243 102.325849
 L 310.240844 102.469168 
 L 309.257387 102.612055 
 L 308.273931 102.754513 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_77">
     <path d="M 308.273931 102.754513 
@@ -1853,7 +1853,7 @@ L 273.545396 115.775058
 L 272.773651 116.027391 
 L 272.001906 116.278388 
 L 271.230161 116.528062 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 271.230161 116.528062 
@@ -1905,7 +1905,7 @@ L 221.171803 119.803152
 L 220.059395 119.873422 
 L 218.946988 119.943588 
 L 217.83458 120.013651 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 217.83458 120.013651 
@@ -1957,7 +1957,7 @@ L 179.624997 137.470928
 L 178.775895 137.79434 
 L 177.926794 138.115561 
 L 177.077692 138.43462 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 177.077692 138.43462 
@@ -2009,7 +2009,7 @@ L 163.767861 156.775388
 L 163.472087 157.112166 
 L 163.176313 157.446568 
 L 162.880539 157.778627 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 162.880539 157.778627 
@@ -2061,7 +2061,7 @@ L 160.875139 164.765525
 L 160.830574 164.909668 
 L 160.78601 165.053375 
 L 160.741445 165.196647 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 160.741445 165.196647 
@@ -2113,7 +2113,7 @@ L 154.390101 182.45125
 L 154.24896 182.771561 
 L 154.107819 183.089721 
 L 153.966678 183.405761 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 153.966678 183.405761 
@@ -2165,26 +2165,26 @@ L 151.73818 193.866427
 L 151.688658 194.074564 
 L 151.639136 194.281792 
 L 151.589614 194.488118 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <defs>
-     <path id="m9fdd092363" d="M 0 -2.5 
+     <path id="m8d967a92dc" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3994ffe252)">
-     <use xlink:href="#m9fdd092363" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fdd092363" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fdd092363" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fdd092363" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fdd092363" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fdd092363" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fdd092363" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fdd092363" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m9fdd092363" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p562862b7b3)">
+     <use xlink:href="#m8d967a92dc" x="531.649087" y="75.963093" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d967a92dc" x="283.721324" y="99.020035" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d967a92dc" x="218.882044" y="121.069315" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d967a92dc" x="187.447228" y="127.10685" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d967a92dc" x="176.342474" y="138.36311" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d967a92dc" x="163.054314" y="161.312135" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d967a92dc" x="162.210539" y="168.753955" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d967a92dc" x="159.303811" y="175.753345" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m8d967a92dc" x="157.793928" y="179.494802" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_85">
@@ -2237,7 +2237,7 @@ L 299.21681 97.864971
 L 294.051648 98.253128 
 L 288.886486 98.638133 
 L 283.721324 99.020035 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_86">
     <path d="M 283.721324 99.020035 
@@ -2289,7 +2289,7 @@ L 222.934499 119.954333
 L 221.583681 120.328916 
 L 220.232863 120.700561 
 L 218.882044 121.069315 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 218.882044 121.069315 
@@ -2341,7 +2341,7 @@ L 189.411904 126.751217
 L 188.757012 126.870058 
 L 188.10212 126.988602 
 L 187.447228 127.10685 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 187.447228 127.10685 
@@ -2393,7 +2393,7 @@ L 177.036521 137.732718
 L 176.805172 137.943781 
 L 176.573823 138.153909 
 L 176.342474 138.36311 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 176.342474 138.36311 
@@ -2445,7 +2445,7 @@ L 163.884824 160.161325
 L 163.607987 160.548041 
 L 163.33115 160.931628 
 L 163.054314 161.312135 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 163.054314 161.312135 
@@ -2497,7 +2497,7 @@ L 162.263275 168.321549
 L 162.245696 168.466124 
 L 162.228118 168.610258 
 L 162.210539 168.753955 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 162.210539 168.753955 
@@ -2549,7 +2549,7 @@ L 159.485481 175.344896
 L 159.424925 175.481437 
 L 159.364368 175.617586 
 L 159.303811 175.753345 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 159.303811 175.753345 
@@ -2601,30 +2601,30 @@ L 157.888296 179.269417
 L 157.85684 179.344665 
 L 157.825384 179.419793 
 L 157.793928 179.494802 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <defs>
-     <path id="m4d8c8dde8b" d="M -0 3.535534 
+     <path id="m426b3be097" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3994ffe252)">
-     <use xlink:href="#m4d8c8dde8b" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m4d8c8dde8b" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p562862b7b3)">
+     <use xlink:href="#m426b3be097" x="251.559581" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="203.775848" y="81.750179" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="186.982691" y="88.344921" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="179.779306" y="91.045312" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="157.610419" y="99.395085" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="148.722526" y="107.864022" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="144.388162" y="121.237794" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="127.071247" y="144.560664" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="124.491988" y="152.083585" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="92.613662" y="207.637263" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="87.348715" y="225.457654" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m426b3be097" x="86.053433" y="242.017529" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
@@ -2677,7 +2677,7 @@ L 206.762331 80.855075
 L 205.766837 81.155325 
 L 204.771342 81.453685 
 L 203.775848 81.750179 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 203.775848 81.750179 
@@ -2729,7 +2729,7 @@ L 188.032264 87.958568
 L 187.682406 88.087703 
 L 187.332549 88.216487 
 L 186.982691 88.344921 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 186.982691 88.344921 
@@ -2781,7 +2781,7 @@ L 180.229518 90.88097
 L 180.079447 90.935814 
 L 179.929376 90.990595 
 L 179.779306 91.045312 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <path d="M 179.779306 91.045312 
@@ -2833,7 +2833,7 @@ L 158.995974 98.914174
 L 158.534122 99.075021 
 L 158.07227 99.235323 
 L 157.610419 99.395085 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_98">
     <path d="M 157.610419 99.395085 
@@ -2885,7 +2885,7 @@ L 149.27802 107.37681
 L 149.092855 107.539771 
 L 148.907691 107.702174 
 L 148.722526 107.864022 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_99">
     <path d="M 148.722526 107.864022 
@@ -2937,7 +2937,7 @@ L 144.65906 120.50385
 L 144.568761 120.749763 
 L 144.478462 120.994407 
 L 144.388162 121.237794 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 144.388162 121.237794 
@@ -2989,7 +2989,7 @@ L 128.153555 143.395158
 L 127.792786 143.786853 
 L 127.432016 144.175338 
 L 127.071247 144.560664 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 127.071247 144.560664 
@@ -3041,7 +3041,7 @@ L 124.653192 151.646811
 L 124.599457 151.79285 
 L 124.545723 151.93844 
 L 124.491988 152.083585 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 124.491988 152.083585 
@@ -3093,7 +3093,7 @@ L 94.606058 205.546972
 L 93.941926 206.254028 
 L 93.277794 206.950691 
 L 92.613662 207.637263 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 92.613662 207.637263 
@@ -3145,7 +3145,7 @@ L 87.677774 224.520091
 L 87.568088 224.834677 
 L 87.458402 225.147189 
 L 87.348715 225.457654 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 87.348715 225.457654 
@@ -3197,23 +3197,23 @@ L 86.134388 241.135848
 L 86.107403 241.431568 
 L 86.080418 241.725454 
 L 86.053433 242.017529 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <defs>
-     <path id="m80e4329e73" d="M -0 2.5 
+     <path id="m81bbdb6ec6" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3994ffe252)">
-     <use xlink:href="#m80e4329e73" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p562862b7b3)">
+     <use xlink:href="#m81bbdb6ec6" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_106">
     <defs>
-     <path id="m6cd6278396" d="M -0.833333 2.5 
+     <path id="m116b10aa64" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3228,16 +3228,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3994ffe252)">
-     <use xlink:href="#m6cd6278396" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6cd6278396" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6cd6278396" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6cd6278396" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6cd6278396" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6cd6278396" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6cd6278396" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6cd6278396" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m6cd6278396" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p562862b7b3)">
+     <use xlink:href="#m116b10aa64" x="362.865999" y="115.428618" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m116b10aa64" x="278.798176" y="122.858526" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m116b10aa64" x="251.17632" y="128.261574" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m116b10aa64" x="200.806828" y="131.522849" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m116b10aa64" x="169.803221" y="147.931404" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m116b10aa64" x="161.916638" y="160.718659" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m116b10aa64" x="158.697104" y="167.705569" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m116b10aa64" x="154.26679" y="181.026105" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m116b10aa64" x="153.096464" y="191.924265" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_107">
@@ -3290,7 +3290,7 @@ L 284.052415 122.426763
 L 282.301002 122.571121 
 L 280.549589 122.715042 
 L 278.798176 122.858526 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_108">
     <path d="M 278.798176 122.858526 
@@ -3342,7 +3342,7 @@ L 252.902686 127.94134
 L 252.327231 128.048325 
 L 251.751776 128.155069 
 L 251.17632 128.261574 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 251.17632 128.261574 
@@ -3394,7 +3394,7 @@ L 203.954921 131.325463
 L 202.905557 131.39135 
 L 201.856192 131.457145 
 L 200.806828 131.522849 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 200.806828 131.522849 
@@ -3446,7 +3446,7 @@ L 171.740947 147.056528
 L 171.095038 147.349951 
 L 170.44913 147.64157 
 L 169.803221 147.931404 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 169.803221 147.931404 
@@ -3498,7 +3498,7 @@ L 162.409549 160.012958
 L 162.245246 160.249361 
 L 162.080942 160.484591 
 L 161.916638 160.718659 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 161.916638 160.718659 
@@ -3550,7 +3550,7 @@ L 158.898325 167.297798
 L 158.831251 167.434112 
 L 158.764178 167.570034 
 L 158.697104 167.705569 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 158.697104 167.705569 
@@ -3602,7 +3602,7 @@ L 154.543684 180.294711
 L 154.451386 180.539765 
 L 154.359088 180.783558 
 L 154.26679 181.026105 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 154.26679 181.026105 
@@ -3654,11 +3654,11 @@ L 153.16961 191.311823
 L 153.145228 191.516851 
 L 153.120846 191.720996 
 L 153.096464 191.924265 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <defs>
-     <path id="m7ba89f72f2" d="M -1.25 2.5 
+     <path id="m6b03bf86b9" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3673,16 +3673,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3994ffe252)">
-     <use xlink:href="#m7ba89f72f2" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba89f72f2" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba89f72f2" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba89f72f2" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba89f72f2" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba89f72f2" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba89f72f2" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba89f72f2" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7ba89f72f2" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p562862b7b3)">
+     <use xlink:href="#m6b03bf86b9" x="301.619021" y="150.561849" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6b03bf86b9" x="250.236474" y="156.671134" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6b03bf86b9" x="225.418659" y="160.842551" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6b03bf86b9" x="212.328936" y="161.382211" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6b03bf86b9" x="209.030149" y="166.25091" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6b03bf86b9" x="197.547749" y="171.432451" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6b03bf86b9" x="194.819287" y="175.129495" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6b03bf86b9" x="193.12279" y="181.606362" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m6b03bf86b9" x="192.79794" y="189.451167" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_116">
@@ -3735,7 +3735,7 @@ L 253.447883 156.311526
 L 252.377414 156.431699 
 L 251.306944 156.551567 
 L 250.236474 156.671134 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_117">
     <path d="M 250.236474 156.671134 
@@ -3787,7 +3787,7 @@ L 226.969772 160.592321
 L 226.452735 160.675878 
 L 225.935697 160.759287 
 L 225.418659 160.842551 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 225.418659 160.842551 
@@ -3839,7 +3839,7 @@ L 213.147044 161.348661
 L 212.874341 161.359847 
 L 212.601639 161.37103 
 L 212.328936 161.382211 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 212.328936 161.382211 
@@ -3891,7 +3891,7 @@ L 209.236323 165.960837
 L 209.167599 166.057725 
 L 209.098874 166.154416 
 L 209.030149 166.25091 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 209.030149 166.25091 
@@ -3943,7 +3943,7 @@ L 198.265399 171.124681
 L 198.026182 171.227493 
 L 197.786966 171.330083 
 L 197.547749 171.432451 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 197.547749 171.432451 
@@ -3995,7 +3995,7 @@ L 194.989815 174.906688
 L 194.932972 174.981074 
 L 194.876129 175.055342 
 L 194.819287 175.129495 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 194.819287 175.129495 
@@ -4047,7 +4047,7 @@ L 193.228821 181.226479
 L 193.193478 181.353445 
 L 193.158134 181.480072 
 L 193.12279 181.606362 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 193.12279 181.606362 
@@ -4099,11 +4099,11 @@ L 192.818243 188.997124
 L 192.811475 189.148955 
 L 192.804707 189.300302 
 L 192.79794 189.451167 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <defs>
-     <path id="m4ab7bb2153" d="M 0 -2.5 
+     <path id="med0a6742fc" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4116,16 +4116,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p3994ffe252)">
-     <use xlink:href="#m4ab7bb2153" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ab7bb2153" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ab7bb2153" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ab7bb2153" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ab7bb2153" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ab7bb2153" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ab7bb2153" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ab7bb2153" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m4ab7bb2153" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p562862b7b3)">
+     <use xlink:href="#med0a6742fc" x="206.45578" y="118.584066" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#med0a6742fc" x="206.45578" y="118.258949" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#med0a6742fc" x="206.45578" y="118.759361" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#med0a6742fc" x="206.45578" y="118.234957" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#med0a6742fc" x="171.767499" y="134.097889" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#med0a6742fc" x="163.54283" y="144.663903" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#med0a6742fc" x="160.174881" y="151.505345" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#med0a6742fc" x="154.179217" y="169.303726" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#med0a6742fc" x="152.4406" y="178.584542" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_125">
@@ -4178,7 +4178,7 @@ L 206.45578 118.279335
 L 206.45578 118.27254 
 L 206.45578 118.265745 
 L 206.45578 118.258949 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_126">
     <path d="M 206.45578 118.258949 
@@ -4230,7 +4230,7 @@ L 206.45578 118.728239
 L 206.45578 118.738615 
 L 206.45578 118.748989 
 L 206.45578 118.759361 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 206.45578 118.759361 
@@ -4282,7 +4282,7 @@ L 206.45578 118.267903
 L 206.45578 118.256924 
 L 206.45578 118.245942 
 L 206.45578 118.234957 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 206.45578 118.234957 
@@ -4334,7 +4334,7 @@ L 173.935517 133.247721
 L 173.212844 133.532808 
 L 172.490172 133.816191 
 L 171.767499 134.097889 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 171.767499 134.097889 
@@ -4386,7 +4386,7 @@ L 164.056872 144.068227
 L 163.885524 144.267619 
 L 163.714177 144.466175 
 L 163.54283 144.663903 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 163.54283 144.663903 
@@ -4438,7 +4438,7 @@ L 160.385378 151.105499
 L 160.315212 151.239156 
 L 160.245047 151.372438 
 L 160.174881 151.505345 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 160.174881 151.505345 
@@ -4490,7 +4490,7 @@ L 154.553946 168.367127
 L 154.429036 168.681387 
 L 154.304126 168.993578 
 L 154.179217 169.303726 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 154.179217 169.303726 
@@ -4542,11 +4542,11 @@ L 152.549264 178.054798
 L 152.513043 178.232038 
 L 152.476822 178.408618 
 L 152.4406 178.584542 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <defs>
-     <path id="mf8a846b386" d="M 0 -2.5 
+     <path id="m87ddac6cf9" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4555,16 +4555,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p3994ffe252)">
-     <use xlink:href="#mf8a846b386" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8a846b386" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8a846b386" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8a846b386" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8a846b386" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8a846b386" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8a846b386" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8a846b386" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf8a846b386" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p562862b7b3)">
+     <use xlink:href="#m87ddac6cf9" x="610.467188" y="172.829682" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ddac6cf9" x="592.067397" y="173.763838" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ddac6cf9" x="534.807821" y="180.385179" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ddac6cf9" x="327.802209" y="176.172104" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ddac6cf9" x="275.83761" y="186.734601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ddac6cf9" x="258.25125" y="198.783148" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ddac6cf9" x="256.777056" y="203.737732" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ddac6cf9" x="248.769854" y="217.74136" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m87ddac6cf9" x="246.264594" y="227.740017" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_134">
@@ -4617,7 +4617,7 @@ L 593.217384 173.705989
 L 592.834055 173.72528 
 L 592.450726 173.744563 
 L 592.067397 173.763838 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_135">
     <path d="M 592.067397 173.763838 
@@ -4669,7 +4669,7 @@ L 538.386544 179.997367
 L 537.193636 180.126991 
 L 536.000728 180.25626 
 L 534.807821 180.385179 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_136">
     <path d="M 534.807821 180.385179 
@@ -4721,7 +4721,7 @@ L 340.74006 176.446681
 L 336.427443 176.355332 
 L 332.114826 176.263806 
 L 327.802209 176.172104 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_137">
     <path d="M 327.802209 176.172104 
@@ -4773,7 +4773,7 @@ L 279.085397 186.139102
 L 278.002801 186.338434 
 L 276.920205 186.536931 
 L 275.83761 186.734601 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_138">
     <path d="M 275.83761 186.734601 
@@ -4825,7 +4825,7 @@ L 259.350398 198.113494
 L 258.984015 198.337765 
 L 258.617633 198.560979 
 L 258.25125 198.783148 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_139">
     <path d="M 258.25125 198.783148 
@@ -4877,7 +4877,7 @@ L 256.869193 203.442789
 L 256.838481 203.541307 
 L 256.807768 203.639621 
 L 256.777056 203.737732 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_140">
     <path d="M 256.777056 203.737732 
@@ -4929,7 +4929,7 @@ L 249.270304 216.977455
 L 249.103487 217.23346 
 L 248.93667 217.48809 
 L 248.769854 217.74136 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_141">
     <path d="M 248.769854 217.74136 
@@ -4981,7 +4981,7 @@ L 246.421172 227.173237
 L 246.368979 227.362918 
 L 246.316786 227.551842 
 L 246.264594 227.740017 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4999,7 +4999,7 @@ z
     </g>
     <g id="line2d_142">
      <defs>
-      <path id="m98481276c3" d="M 0 3.5 
+      <path id="mda7e061a6e" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -5012,7 +5012,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m98481276c3" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mda7e061a6e" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5071,7 +5071,7 @@ z
     </g>
     <g id="line2d_143">
      <g>
-      <use xlink:href="#mba84fce6e9" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb7fa9d5637" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5085,7 +5085,7 @@ z
     </g>
     <g id="line2d_144">
      <g>
-      <use xlink:href="#m9fdd092363" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m8d967a92dc" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5130,7 +5130,7 @@ z
     </g>
     <g id="line2d_145">
      <g>
-      <use xlink:href="#m4d8c8dde8b" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m426b3be097" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5173,7 +5173,7 @@ z
     </g>
     <g id="line2d_146">
      <g>
-      <use xlink:href="#m80e4329e73" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m81bbdb6ec6" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5189,7 +5189,7 @@ z
     </g>
     <g id="line2d_147">
      <g>
-      <use xlink:href="#m6cd6278396" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m116b10aa64" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5243,7 +5243,7 @@ z
     </g>
     <g id="line2d_148">
      <g>
-      <use xlink:href="#m7ba89f72f2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m6b03bf86b9" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5308,7 +5308,7 @@ z
     </g>
     <g id="line2d_149">
      <g>
-      <use xlink:href="#m4ab7bb2153" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#med0a6742fc" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5346,7 +5346,7 @@ z
     </g>
     <g id="line2d_150">
      <g>
-      <use xlink:href="#mf8a846b386" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m87ddac6cf9" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5416,486 +5416,486 @@ z
     </g>
    </g>
    <g id="line2d_151">
-    <g clip-path="url(#p3994ffe252)">
-     <use xlink:href="#m98481276c3" x="289.669676" y="152.134805" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m98481276c3" x="223.847406" y="163.210726" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m98481276c3" x="212.215046" y="166.942897" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m98481276c3" x="186.761055" y="175.874562" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m98481276c3" x="171.087559" y="184.167149" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m98481276c3" x="159.117262" y="189.902598" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m98481276c3" x="154.720399" y="196.076" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m98481276c3" x="151.93026" y="198.770694" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m98481276c3" x="115.448419" y="275.506087" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m98481276c3" x="99.852312" y="301.934364" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p562862b7b3)">
+     <use xlink:href="#mda7e061a6e" x="289.669676" y="152.364617" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mda7e061a6e" x="223.847406" y="163.435801" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mda7e061a6e" x="212.215046" y="167.322491" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mda7e061a6e" x="186.761055" y="175.885797" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mda7e061a6e" x="171.087559" y="184.140978" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mda7e061a6e" x="159.117262" y="190.278631" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mda7e061a6e" x="154.720399" y="196.283986" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mda7e061a6e" x="151.93026" y="198.967986" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mda7e061a6e" x="115.448419" y="276.391547" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mda7e061a6e" x="99.852312" y="302.743279" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_152">
-    <path d="M 289.669676 152.134805 
-L 288.298379 152.394032 
-L 286.927082 152.651848 
-L 285.555784 152.90827 
-L 284.184487 153.163313 
-L 282.81319 153.41699 
-L 281.441892 153.669317 
-L 280.070595 153.920308 
-L 278.699298 154.169976 
-L 277.328 154.418337 
-L 275.956703 154.665402 
-L 274.585406 154.911187 
-L 273.214109 155.155704 
-L 271.842811 155.398966 
-L 270.471514 155.640985 
-L 269.100217 155.881776 
-L 267.728919 156.121349 
-L 266.357622 156.359717 
-L 264.986325 156.596893 
-L 263.615028 156.832888 
-L 262.24373 157.067713 
-L 260.872433 157.301381 
-L 259.501136 157.533903 
-L 258.129838 157.765289 
-L 256.758541 157.995552 
-L 255.387244 158.224701 
-L 254.015947 158.452748 
-L 252.644649 158.679703 
-L 251.273352 158.905576 
-L 249.902055 159.130378 
-L 248.530757 159.354119 
-L 247.15946 159.576809 
-L 245.788163 159.798457 
-L 244.416866 160.019074 
-L 243.045568 160.238669 
-L 241.674271 160.45725 
-L 240.302974 160.674829 
-L 238.931676 160.891413 
-L 237.560379 161.107013 
-L 236.189082 161.321636 
-L 234.817784 161.535291 
-L 233.446487 161.747988 
-L 232.07519 161.959735 
-L 230.703893 162.170539 
-L 229.332595 162.380411 
-L 227.961298 162.589357 
-L 226.590001 162.797386 
-L 225.218703 163.004507 
-L 223.847406 163.210726 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 289.669676 152.364617 
+L 288.298379 152.62372 
+L 286.927082 152.881414 
+L 285.555784 153.137715 
+L 284.184487 153.392637 
+L 282.81319 153.646196 
+L 281.441892 153.898405 
+L 280.070595 154.14928 
+L 278.699298 154.398833 
+L 277.328 154.64708 
+L 275.956703 154.894033 
+L 274.585406 155.139706 
+L 273.214109 155.384113 
+L 271.842811 155.627265 
+L 270.471514 155.869177 
+L 269.100217 156.10986 
+L 267.728919 156.349328 
+L 266.357622 156.587591 
+L 264.986325 156.824663 
+L 263.615028 157.060555 
+L 262.24373 157.295279 
+L 260.872433 157.528846 
+L 259.501136 157.761268 
+L 258.129838 157.992556 
+L 256.758541 158.22272 
+L 255.387244 158.451773 
+L 254.015947 158.679724 
+L 252.644649 158.906583 
+L 251.273352 159.132363 
+L 249.902055 159.357072 
+L 248.530757 159.58072 
+L 247.15946 159.803318 
+L 245.788163 160.024876 
+L 244.416866 160.245403 
+L 243.045568 160.464909 
+L 241.674271 160.683402 
+L 240.302974 160.900894 
+L 238.931676 161.117391 
+L 237.560379 161.332905 
+L 236.189082 161.547443 
+L 234.817784 161.761014 
+L 233.446487 161.973627 
+L 232.07519 162.185291 
+L 230.703893 162.396014 
+L 229.332595 162.605804 
+L 227.961298 162.81467 
+L 226.590001 163.02262 
+L 225.218703 163.229661 
+L 223.847406 163.435801 
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_153">
-    <path d="M 223.847406 163.210726 
-L 223.605065 163.291553 
-L 223.362724 163.372244 
-L 223.120384 163.452797 
-L 222.878043 163.533213 
-L 222.635702 163.613493 
-L 222.393361 163.693637 
-L 222.15102 163.773646 
-L 221.908679 163.853521 
-L 221.666339 163.933261 
-L 221.423998 164.012866 
-L 221.181657 164.092339 
-L 220.939316 164.171678 
-L 220.696975 164.250885 
-L 220.454635 164.32996 
-L 220.212294 164.408903 
-L 219.969953 164.487715 
-L 219.727612 164.566396 
-L 219.485271 164.644946 
-L 219.24293 164.723367 
-L 219.00059 164.801658 
-L 218.758249 164.87982 
-L 218.515908 164.957853 
-L 218.273567 165.035758 
-L 218.031226 165.113535 
-L 217.788885 165.191185 
-L 217.546545 165.268708 
-L 217.304204 165.346104 
-L 217.061863 165.423374 
-L 216.819522 165.500519 
-L 216.577181 165.577537 
-L 216.33484 165.654431 
-L 216.0925 165.731201 
-L 215.850159 165.807846 
-L 215.607818 165.884368 
-L 215.365477 165.960766 
-L 215.123136 166.037041 
-L 214.880795 166.113194 
-L 214.638455 166.189224 
-L 214.396114 166.265133 
-L 214.153773 166.340921 
-L 213.911432 166.416587 
-L 213.669091 166.492133 
-L 213.42675 166.567559 
-L 213.18441 166.642864 
-L 212.942069 166.718051 
-L 212.699728 166.793118 
-L 212.457387 166.868067 
-L 212.215046 166.942897 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 223.847406 163.435801 
+L 223.605065 163.520111 
+L 223.362724 163.604272 
+L 223.120384 163.688283 
+L 222.878043 163.772146 
+L 222.635702 163.85586 
+L 222.393361 163.939427 
+L 222.15102 164.022847 
+L 221.908679 164.106121 
+L 221.666339 164.189248 
+L 221.423998 164.27223 
+L 221.181657 164.355066 
+L 220.939316 164.437759 
+L 220.696975 164.520307 
+L 220.454635 164.602712 
+L 220.212294 164.684973 
+L 219.969953 164.767092 
+L 219.727612 164.849069 
+L 219.485271 164.930905 
+L 219.24293 165.0126 
+L 219.00059 165.094154 
+L 218.758249 165.175568 
+L 218.515908 165.256842 
+L 218.273567 165.337977 
+L 218.031226 165.418974 
+L 217.788885 165.499832 
+L 217.546545 165.580553 
+L 217.304204 165.661136 
+L 217.061863 165.741583 
+L 216.819522 165.821893 
+L 216.577181 165.902068 
+L 216.33484 165.982107 
+L 216.0925 166.062011 
+L 215.850159 166.141781 
+L 215.607818 166.221416 
+L 215.365477 166.300918 
+L 215.123136 166.380287 
+L 214.880795 166.459524 
+L 214.638455 166.538628 
+L 214.396114 166.6176 
+L 214.153773 166.696441 
+L 213.911432 166.775151 
+L 213.669091 166.853731 
+L 213.42675 166.93218 
+L 213.18441 167.0105 
+L 212.942069 167.08869 
+L 212.699728 167.166752 
+L 212.457387 167.244686 
+L 212.215046 167.322491 
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_154">
-    <path d="M 212.215046 166.942897 
-L 211.684755 167.147219 
-L 211.154463 167.350664 
-L 210.624172 167.55324 
-L 210.09388 167.754953 
-L 209.563589 167.955812 
-L 209.033297 168.155824 
-L 208.503006 168.354994 
-L 207.972714 168.553332 
-L 207.442423 168.750843 
-L 206.912131 168.947534 
-L 206.38184 169.143412 
-L 205.851548 169.338485 
-L 205.321257 169.532757 
-L 204.790966 169.726237 
-L 204.260674 169.91893 
-L 203.730383 170.110843 
-L 203.200091 170.301982 
-L 202.6698 170.492354 
-L 202.139508 170.681964 
-L 201.609217 170.870818 
-L 201.078925 171.058923 
-L 200.548634 171.246284 
-L 200.018342 171.432908 
-L 199.488051 171.6188 
-L 198.957759 171.803965 
-L 198.427468 171.98841 
-L 197.897176 172.17214 
-L 197.366885 172.355161 
-L 196.836593 172.537478 
-L 196.306302 172.719096 
-L 195.77601 172.900021 
-L 195.245719 173.080257 
-L 194.715427 173.259812 
-L 194.185136 173.438688 
-L 193.654844 173.616892 
-L 193.124553 173.794428 
-L 192.594261 173.971302 
-L 192.06397 174.147519 
-L 191.533678 174.323083 
-L 191.003387 174.497998 
-L 190.473096 174.672271 
-L 189.942804 174.845905 
-L 189.412513 175.018906 
-L 188.882221 175.191277 
-L 188.35193 175.363024 
-L 187.821638 175.534151 
-L 187.291347 175.704662 
-L 186.761055 175.874562 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 212.215046 167.322491 
+L 211.684755 167.517623 
+L 211.154463 167.711954 
+L 210.624172 167.905492 
+L 210.09388 168.098243 
+L 209.563589 168.290213 
+L 209.033297 168.481409 
+L 208.503006 168.671837 
+L 207.972714 168.861502 
+L 207.442423 169.050412 
+L 206.912131 169.238572 
+L 206.38184 169.425988 
+L 205.851548 169.612666 
+L 205.321257 169.798611 
+L 204.790966 169.98383 
+L 204.260674 170.168328 
+L 203.730383 170.35211 
+L 203.200091 170.535183 
+L 202.6698 170.717551 
+L 202.139508 170.899221 
+L 201.609217 171.080196 
+L 201.078925 171.260484 
+L 200.548634 171.440088 
+L 200.018342 171.619014 
+L 199.488051 171.797267 
+L 198.957759 171.974853 
+L 198.427468 172.151775 
+L 197.897176 172.32804 
+L 197.366885 172.503651 
+L 196.836593 172.678615 
+L 196.306302 172.852935 
+L 195.77601 173.026616 
+L 195.245719 173.199663 
+L 194.715427 173.37208 
+L 194.185136 173.543873 
+L 193.654844 173.715045 
+L 193.124553 173.885602 
+L 192.594261 174.055547 
+L 192.06397 174.224884 
+L 191.533678 174.393619 
+L 191.003387 174.561755 
+L 190.473096 174.729297 
+L 189.942804 174.896249 
+L 189.412513 175.062615 
+L 188.882221 175.228399 
+L 188.35193 175.393605 
+L 187.821638 175.558238 
+L 187.291347 175.7223 
+L 186.761055 175.885797 
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_155">
-    <path d="M 186.761055 175.874562 
-L 186.434524 176.062983 
-L 186.107993 176.250658 
-L 185.781462 176.437593 
-L 185.45493 176.623794 
-L 185.128399 176.809266 
-L 184.801868 176.994015 
-L 184.475337 177.178047 
-L 184.148806 177.361367 
-L 183.822275 177.54398 
-L 183.495744 177.725893 
-L 183.169212 177.90711 
-L 182.842681 178.087638 
-L 182.51615 178.26748 
-L 182.189619 178.446642 
-L 181.863088 178.62513 
-L 181.536557 178.802948 
-L 181.210025 178.980102 
-L 180.883494 179.156595 
-L 180.556963 179.332435 
-L 180.230432 179.507624 
-L 179.903901 179.682168 
-L 179.57737 179.856072 
-L 179.250838 180.02934 
-L 178.924307 180.201977 
-L 178.597776 180.373987 
-L 178.271245 180.545375 
-L 177.944714 180.716146 
-L 177.618183 180.886304 
-L 177.291651 181.055854 
-L 176.96512 181.224798 
-L 176.638589 181.393143 
-L 176.312058 181.560892 
-L 175.985527 181.72805 
-L 175.658996 181.89462 
-L 175.332464 182.060607 
-L 175.005933 182.226014 
-L 174.679402 182.390847 
-L 174.352871 182.555108 
-L 174.02634 182.718801 
-L 173.699809 182.881932 
-L 173.373277 183.044503 
-L 173.046746 183.206518 
-L 172.720215 183.367981 
-L 172.393684 183.528896 
-L 172.067153 183.689267 
-L 171.740622 183.849097 
-L 171.414091 184.00839 
-L 171.087559 184.167149 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 186.761055 175.885797 
+L 186.434524 176.073294 
+L 186.107993 176.260052 
+L 185.781462 176.446077 
+L 185.45493 176.631375 
+L 185.128399 176.815951 
+L 184.801868 176.999812 
+L 184.475337 177.182962 
+L 184.148806 177.365407 
+L 183.822275 177.547152 
+L 183.495744 177.728203 
+L 183.169212 177.908565 
+L 182.842681 178.088244 
+L 182.51615 178.267244 
+L 182.189619 178.445571 
+L 181.863088 178.623229 
+L 181.536557 178.800223 
+L 181.210025 178.97656 
+L 180.883494 179.152243 
+L 180.556963 179.327276 
+L 180.230432 179.501666 
+L 179.903901 179.675417 
+L 179.57737 179.848533 
+L 179.250838 180.021019 
+L 178.924307 180.19288 
+L 178.597776 180.36412 
+L 178.271245 180.534743 
+L 177.944714 180.704755 
+L 177.618183 180.874159 
+L 177.291651 181.042959 
+L 176.96512 181.211161 
+L 176.638589 181.378767 
+L 176.312058 181.545784 
+L 175.985527 181.712213 
+L 175.658996 181.878061 
+L 175.332464 182.04333 
+L 175.005933 182.208025 
+L 174.679402 182.372149 
+L 174.352871 182.535707 
+L 174.02634 182.698703 
+L 173.699809 182.86114 
+L 173.373277 183.023023 
+L 173.046746 183.184354 
+L 172.720215 183.345138 
+L 172.393684 183.505379 
+L 172.067153 183.66508 
+L 171.740622 183.824244 
+L 171.414091 183.982876 
+L 171.087559 184.140978 
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_156">
-    <path d="M 171.087559 184.167149 
-L 170.838178 184.293998 
-L 170.588797 184.420508 
-L 170.339416 184.546681 
-L 170.090035 184.672519 
-L 169.840653 184.798024 
-L 169.591272 184.923198 
-L 169.341891 185.048042 
-L 169.09251 185.172558 
-L 168.843129 185.296747 
-L 168.593747 185.420612 
-L 168.344366 185.544155 
-L 168.094985 185.667376 
-L 167.845604 185.790278 
-L 167.596223 185.912861 
-L 167.346841 186.035129 
-L 167.09746 186.157082 
-L 166.848079 186.278722 
-L 166.598698 186.400051 
-L 166.349317 186.521069 
-L 166.099935 186.64178 
-L 165.850554 186.762184 
-L 165.601173 186.882283 
-L 165.351792 187.002079 
-L 165.102411 187.121572 
-L 164.853029 187.240765 
-L 164.603648 187.359659 
-L 164.354267 187.478255 
-L 164.104886 187.596556 
-L 163.855505 187.714562 
-L 163.606123 187.832275 
-L 163.356742 187.949696 
-L 163.107361 188.066827 
-L 162.85798 188.183669 
-L 162.608599 188.300225 
-L 162.359218 188.416494 
-L 162.109836 188.532478 
-L 161.860455 188.64818 
-L 161.611074 188.7636 
-L 161.361693 188.878739 
-L 161.112312 188.993599 
-L 160.86293 189.108182 
-L 160.613549 189.222488 
-L 160.364168 189.33652 
-L 160.114787 189.450278 
-L 159.865406 189.563763 
-L 159.616024 189.676977 
-L 159.366643 189.789922 
-L 159.117262 189.902598 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 171.087559 184.140978 
+L 170.838178 184.277298 
+L 170.588797 184.413227 
+L 170.339416 184.548766 
+L 170.090035 184.68392 
+L 169.840653 184.818689 
+L 169.591272 184.953076 
+L 169.341891 185.087083 
+L 169.09251 185.220712 
+L 168.843129 185.353966 
+L 168.593747 185.486846 
+L 168.344366 185.619354 
+L 168.094985 185.751494 
+L 167.845604 185.883265 
+L 167.596223 186.014672 
+L 167.346841 186.145715 
+L 167.09746 186.276397 
+L 166.848079 186.406719 
+L 166.598698 186.536685 
+L 166.349317 186.666295 
+L 166.099935 186.795551 
+L 165.850554 186.924456 
+L 165.601173 187.053011 
+L 165.351792 187.181219 
+L 165.102411 187.30908 
+L 164.853029 187.436598 
+L 164.603648 187.563774 
+L 164.354267 187.690609 
+L 164.104886 187.817106 
+L 163.855505 187.943266 
+L 163.606123 188.069091 
+L 163.356742 188.194583 
+L 163.107361 188.319743 
+L 162.85798 188.444575 
+L 162.608599 188.569078 
+L 162.359218 188.693255 
+L 162.109836 188.817107 
+L 161.860455 188.940637 
+L 161.611074 189.063845 
+L 161.361693 189.186735 
+L 161.112312 189.309306 
+L 160.86293 189.431561 
+L 160.613549 189.553502 
+L 160.364168 189.67513 
+L 160.114787 189.796446 
+L 159.865406 189.917453 
+L 159.616024 190.038152 
+L 159.366643 190.158544 
+L 159.117262 190.278631 
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_157">
-    <path d="M 159.117262 189.902598 
-L 159.025661 190.039763 
-L 158.934059 190.176532 
-L 158.842458 190.312908 
-L 158.750857 190.448893 
-L 158.659255 190.584488 
-L 158.567654 190.719697 
-L 158.476053 190.854521 
-L 158.384452 190.988963 
-L 158.29285 191.123024 
-L 158.201249 191.256708 
-L 158.109648 191.390015 
-L 158.018046 191.522949 
-L 157.926445 191.655511 
-L 157.834844 191.787703 
-L 157.743242 191.919527 
-L 157.651641 192.050986 
-L 157.56004 192.182081 
-L 157.468438 192.312815 
-L 157.376837 192.443189 
-L 157.285236 192.573205 
-L 157.193635 192.702866 
-L 157.102033 192.832173 
-L 157.010432 192.961128 
-L 156.918831 193.089734 
-L 156.827229 193.217991 
-L 156.735628 193.345902 
-L 156.644027 193.473469 
-L 156.552425 193.600694 
-L 156.460824 193.727578 
-L 156.369223 193.854123 
-L 156.277622 193.980331 
-L 156.18602 194.106205 
-L 156.094419 194.231744 
-L 156.002818 194.356953 
-L 155.911216 194.481831 
-L 155.819615 194.606381 
-L 155.728014 194.730605 
-L 155.636412 194.854504 
-L 155.544811 194.97808 
-L 155.45321 195.101334 
-L 155.361608 195.224269 
-L 155.270007 195.346886 
-L 155.178406 195.469187 
-L 155.086805 195.591172 
-L 154.995203 195.712845 
-L 154.903602 195.834206 
-L 154.812001 195.955257 
-L 154.720399 196.076 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.117262 190.278631 
+L 159.025661 190.411826 
+L 158.934059 190.544649 
+L 158.842458 190.6771 
+L 158.750857 190.809182 
+L 158.659255 190.940897 
+L 158.567654 191.072247 
+L 158.476053 191.203234 
+L 158.384452 191.33386 
+L 158.29285 191.464127 
+L 158.201249 191.594037 
+L 158.109648 191.723592 
+L 158.018046 191.852794 
+L 157.926445 191.981644 
+L 157.834844 192.110145 
+L 157.743242 192.238299 
+L 157.651641 192.366108 
+L 157.56004 192.493572 
+L 157.468438 192.620695 
+L 157.376837 192.747477 
+L 157.285236 192.873922 
+L 157.193635 193.00003 
+L 157.102033 193.125803 
+L 157.010432 193.251244 
+L 156.918831 193.376353 
+L 156.827229 193.501133 
+L 156.735628 193.625586 
+L 156.644027 193.749712 
+L 156.552425 193.873515 
+L 156.460824 193.996994 
+L 156.369223 194.120153 
+L 156.277622 194.242993 
+L 156.18602 194.365516 
+L 156.094419 194.487722 
+L 156.002818 194.609614 
+L 155.911216 194.731193 
+L 155.819615 194.852462 
+L 155.728014 194.973421 
+L 155.636412 195.094072 
+L 155.544811 195.214416 
+L 155.45321 195.334456 
+L 155.361608 195.454193 
+L 155.270007 195.573628 
+L 155.178406 195.692763 
+L 155.086805 195.811599 
+L 154.995203 195.930138 
+L 154.903602 196.048381 
+L 154.812001 196.16633 
+L 154.720399 196.283986 
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_158">
-    <path d="M 154.720399 196.076 
-L 154.662271 196.133731 
-L 154.604144 196.191391 
-L 154.546016 196.248982 
-L 154.487888 196.306502 
-L 154.42976 196.363953 
-L 154.371632 196.421335 
-L 154.313504 196.478647 
-L 154.255376 196.535889 
-L 154.197248 196.593063 
-L 154.13912 196.650168 
-L 154.080992 196.707204 
-L 154.022865 196.764171 
-L 153.964737 196.82107 
-L 153.906609 196.877901 
-L 153.848481 196.934664 
-L 153.790353 196.991359 
-L 153.732225 197.047986 
-L 153.674097 197.104546 
-L 153.615969 197.161038 
-L 153.557841 197.217463 
-L 153.499713 197.273821 
-L 153.441586 197.330112 
-L 153.383458 197.386336 
-L 153.32533 197.442494 
-L 153.267202 197.498585 
-L 153.209074 197.55461 
-L 153.150946 197.610569 
-L 153.092818 197.666461 
-L 153.03469 197.722288 
-L 152.976562 197.778049 
-L 152.918434 197.833745 
-L 152.860306 197.889375 
-L 152.802179 197.94494 
-L 152.744051 198.000441 
-L 152.685923 198.055876 
-L 152.627795 198.111246 
-L 152.569667 198.166552 
-L 152.511539 198.221793 
-L 152.453411 198.27697 
-L 152.395283 198.332083 
-L 152.337155 198.387132 
-L 152.279027 198.442117 
-L 152.2209 198.497038 
-L 152.162772 198.551896 
-L 152.104644 198.60669 
-L 152.046516 198.661421 
-L 151.988388 198.716089 
-L 151.93026 198.770694 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 154.720399 196.283986 
+L 154.662271 196.341481 
+L 154.604144 196.398907 
+L 154.546016 196.456263 
+L 154.487888 196.51355 
+L 154.42976 196.570767 
+L 154.371632 196.627916 
+L 154.313504 196.684996 
+L 154.255376 196.742007 
+L 154.197248 196.79895 
+L 154.13912 196.855824 
+L 154.080992 196.91263 
+L 154.022865 196.969368 
+L 153.964737 197.026039 
+L 153.906609 197.082642 
+L 153.848481 197.139177 
+L 153.790353 197.195644 
+L 153.732225 197.252045 
+L 153.674097 197.308379 
+L 153.615969 197.364645 
+L 153.557841 197.420845 
+L 153.499713 197.476979 
+L 153.441586 197.533046 
+L 153.383458 197.589047 
+L 153.32533 197.644981 
+L 153.267202 197.70085 
+L 153.209074 197.756653 
+L 153.150946 197.812391 
+L 153.092818 197.868063 
+L 153.03469 197.923669 
+L 152.976562 197.979211 
+L 152.918434 198.034687 
+L 152.860306 198.090099 
+L 152.802179 198.145446 
+L 152.744051 198.200728 
+L 152.685923 198.255946 
+L 152.627795 198.3111 
+L 152.569667 198.366189 
+L 152.511539 198.421215 
+L 152.453411 198.476177 
+L 152.395283 198.531075 
+L 152.337155 198.58591 
+L 152.279027 198.640681 
+L 152.2209 198.695389 
+L 152.162772 198.750034 
+L 152.104644 198.804616 
+L 152.046516 198.859135 
+L 151.988388 198.913592 
+L 151.93026 198.967986 
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_159">
-    <path d="M 151.93026 198.770694 
-L 151.170222 202.608064 
-L 150.410183 206.157897 
-L 149.650145 209.460298 
-L 148.890107 212.547523 
-L 148.130068 215.445905 
-L 147.37003 218.177222 
-L 146.609992 220.759688 
-L 145.849953 223.208692 
-L 145.089915 225.537353 
-L 144.329877 227.756947 
-L 143.569838 229.877235 
-L 142.8098 231.906724 
-L 142.049762 233.852872 
-L 141.289723 235.722255 
-L 140.529685 237.5207 
-L 139.769646 239.253394 
-L 139.009608 240.924976 
-L 138.24957 242.53961 
-L 137.489531 244.101049 
-L 136.729493 245.612686 
-L 135.969455 247.077601 
-L 135.209416 248.498595 
-L 134.449378 249.878226 
-L 133.68934 251.218833 
-L 132.929301 252.522564 
-L 132.169263 253.791392 
-L 131.409225 255.02714 
-L 130.649186 256.231486 
-L 129.889148 257.405988 
-L 129.12911 258.55209 
-L 128.369071 259.671132 
-L 127.609033 260.764363 
-L 126.848995 261.832946 
-L 126.088956 262.877969 
-L 125.328918 263.900448 
-L 124.56888 264.901335 
-L 123.808841 265.881524 
-L 123.048803 266.841853 
-L 122.288764 267.783111 
-L 121.528726 268.70604 
-L 120.768688 269.611341 
-L 120.008649 270.499675 
-L 119.248611 271.371666 
-L 118.488573 272.227905 
-L 117.728534 273.06895 
-L 116.968496 273.895331 
-L 116.208458 274.707551 
-L 115.448419 275.506087 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 151.93026 198.967986 
+L 151.170222 202.872535 
+L 150.410183 206.479777 
+L 149.650145 209.831803 
+L 148.890107 212.962352 
+L 148.130068 215.898886 
+L 147.37003 218.664056 
+L 146.609992 221.276764 
+L 145.849953 223.752949 
+L 145.089915 226.106171 
+L 144.329877 228.348068 
+L 143.569838 230.488698 
+L 142.8098 232.536816 
+L 142.049762 234.500088 
+L 141.289723 236.385265 
+L 140.529685 238.198323 
+L 139.769646 239.944577 
+L 139.009608 241.628776 
+L 138.24957 243.255179 
+L 137.489531 244.827621 
+L 136.729493 246.349569 
+L 135.969455 247.824164 
+L 135.209416 249.254266 
+L 134.449378 250.642479 
+L 133.68934 251.991189 
+L 132.929301 253.302582 
+L 132.169263 254.578667 
+L 131.409225 255.821295 
+L 130.649186 257.032177 
+L 129.889148 258.212894 
+L 129.12911 259.364912 
+L 128.369071 260.489594 
+L 127.609033 261.588207 
+L 126.848995 262.661932 
+L 126.088956 263.711872 
+L 125.328918 264.739058 
+L 124.56888 265.744455 
+L 123.808841 266.728968 
+L 123.048803 267.693447 
+L 122.288764 268.638692 
+L 121.528726 269.565454 
+L 120.768688 270.474443 
+L 120.008649 271.366328 
+L 119.248611 272.241739 
+L 118.488573 273.101276 
+L 117.728534 273.945503 
+L 116.968496 274.774956 
+L 116.208458 275.590143 
+L 115.448419 276.391547 
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_160">
-    <path d="M 115.448419 275.506087 
-L 115.1235 276.237494 
-L 114.798582 276.957785 
-L 114.473663 277.667294 
-L 114.148744 278.366339 
-L 113.823825 279.055225 
-L 113.498906 279.734241 
-L 113.173987 280.403667 
-L 112.849068 281.06377 
-L 112.524149 281.714807 
-L 112.19923 282.357022 
-L 111.874311 282.990652 
-L 111.549393 283.615924 
-L 111.224474 284.233054 
-L 110.899555 284.842252 
-L 110.574636 285.44372 
-L 110.249717 286.037651 
-L 109.924798 286.624232 
-L 109.599879 287.203642 
-L 109.27496 287.776055 
-L 108.950041 288.341638 
-L 108.625123 288.900551 
-L 108.300204 289.452951 
-L 107.975285 289.998987 
-L 107.650366 290.538804 
-L 107.325447 291.072542 
-L 107.000528 291.600337 
-L 106.675609 292.12232 
-L 106.35069 292.638617 
-L 106.025771 293.149351 
-L 105.700852 293.65464 
-L 105.375934 294.154599 
-L 105.051015 294.649339 
-L 104.726096 295.138969 
-L 104.401177 295.623593 
-L 104.076258 296.103312 
-L 103.751339 296.578224 
-L 103.42642 297.048426 
-L 103.101501 297.514008 
-L 102.776582 297.975062 
-L 102.451664 298.431674 
-L 102.126745 298.883929 
-L 101.801826 299.33191 
-L 101.476907 299.775697 
-L 101.151988 300.215367 
-L 100.827069 300.650996 
-L 100.50215 301.082657 
-L 100.177231 301.510424 
-L 99.852312 301.934364 
-" clip-path="url(#p3994ffe252)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 115.448419 276.391547 
+L 115.1235 277.120213 
+L 114.798582 277.837847 
+L 114.473663 278.544777 
+L 114.148744 279.241319 
+L 113.823825 279.927772 
+L 113.498906 280.604426 
+L 113.173987 281.271557 
+L 112.849068 281.929427 
+L 112.524149 282.578292 
+L 112.19923 283.218393 
+L 111.874311 283.849966 
+L 111.549393 284.473233 
+L 111.224474 285.088412 
+L 110.899555 285.695708 
+L 110.574636 286.295321 
+L 110.249717 286.887444 
+L 109.924798 287.472261 
+L 109.599879 288.049951 
+L 109.27496 288.620684 
+L 108.950041 289.184627 
+L 108.625123 289.741939 
+L 108.300204 290.292774 
+L 107.975285 290.837281 
+L 107.650366 291.375604 
+L 107.325447 291.907882 
+L 107.000528 292.434249 
+L 106.675609 292.954834 
+L 106.35069 293.469764 
+L 106.025771 293.97916 
+L 105.700852 294.48314 
+L 105.375934 294.981817 
+L 105.051015 295.475303 
+L 104.726096 295.963703 
+L 104.401177 296.447122 
+L 104.076258 296.925661 
+L 103.751339 297.399416 
+L 103.42642 297.868483 
+L 103.101501 298.332954 
+L 102.776582 298.792917 
+L 102.451664 299.24846 
+L 102.126745 299.699666 
+L 101.801826 300.146618 
+L 101.476907 300.589394 
+L 101.151988 301.028072 
+L 100.827069 301.462728 
+L 100.50215 301.893434 
+L 100.177231 302.320261 
+L 99.852312 302.743279 
+" clip-path="url(#p562862b7b3)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6254,8 +6254,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.467344 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-06T06:43:08Z  ·  Linux chungus2 x86_64  ·  commit f2d5688e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.453359 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6276,31 +6276,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6373,6 +6348,31 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6414,13 +6414,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6460,109 +6460,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.195312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.982422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.769531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.34375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.130859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.095703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.435547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.617188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.320312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.433594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.710938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.089844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.712891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.404297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.583984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.207031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4747.994141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.617188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.240234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.027344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.734375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.201172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.988281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.5625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.349609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.136719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.587891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.769531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.148438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.003906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.480469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5842.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.068359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5913.855469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.644531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.84375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.626953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6340.90625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.285156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.171875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.306641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.785156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6852.966797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6925.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.654297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.767578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.046875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.007812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.791016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7299.890625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.410156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.185547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7721.96875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.347656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.130859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.230469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.439453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.222656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p3994ffe252">
+  <clipPath id="p562862b7b3">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_ratio_heatmap.svg
+++ b/bench/graphs/canterbury_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.4355
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#pda4891642b)">
+   <g clip-path="url(#p4ddd8574b3)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YQYplZx2H4Xurq4rqiA1KJzY9FJxJyCATe+LYnWQFDkPmWUfiBgSRECeiOHEizoIzCSEkbdJ2N1XVt87NEjrCF/5y3+dZwe9wON95+fbbfz467k7N86+mFyx1/Pq0nme32+3+/dvfT09Y6l//eDE9Yblff/yb6QnL7d95d3rCWvuz6QXrPftiesF6Vw+mFyz1u599OD1huRP8kgAAvj8xBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQtr85/OE4PWK1426bnrDU/gSb9eLscnrCUrfb9fSE5S7++bfpCcsdfvlkesJSh+12esJyLw7Ppics9/DEjodXDx5OT1ju9P6yAAD/AzEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB2fvHim+kN6928nF6w1nGbXrDe/QfTC5a6nB7wAzg+ezE9YbmL/z6dnrDUxXaYnrDc/VM8766fTy9Y6uL89E48N0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2T47TI1Y7HrfpCUttJ/Y8u91ud3F2OT1hqbvjYXrCcveeP52esN6P35pesNSr7XZ6wnJfX38+PWG5Rzfn0xOW2n7yeHrCcm6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0879/+ZfpDcud7fbTE5Z6842H0xOWu9sO0xOWurx3NT1huff+9OfpCct98KtfTE9Y6nDcpics9/5fP5uesNyTxz+anrDUe28/mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO1f3f3xOD1itdu76+kJS93fX01P4DVu94fpCct9e/PV9ITlfnr1aHrCUttxm56w3Dc3X05PWO7pzRfTE5b6+YO3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/Q4PQL4P3S4nV6w3vnl9AJe4/ru5fSE5a7uvTE9gddwMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC08+kBP4S742F6wlL7/ek169nhtN7Rq9N7RbvD7nZ6wnL3d5fTE3iNl4dn0xOWuzqe2K/2/PS+oxM8wgEAvj8xBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQ9h2BiIgYuC9crQAAAABJRU5ErkJggg==" id="image091e105945" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
+iVBORw0KGgoAAAANSUhEUgAAAkMAAAGJCAYAAACJojfUAAAI9UlEQVR4nO3YQYplZx2H4Xurq4rqiA1KJzY9FJxJyCATe+LYnWQFDkPmWUfiBgSRECeiOHEizoIzCSEkbdJ2N1XVt87NEjrCF/5y3+dZwe9wON95+fbbfz467k7N86+mFyx1/Pq0nme32+3+/dvfT09Y6l//eDE9Yblff/yb6QnL7d95d3rCWvuz6QXrPftiesF6Vw+mFyz1u599OD1huRP8kgAAvj8xBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQtr85/OE4PWK1426bnrDU/gSb9eLscnrCUrfb9fSE5S7++bfpCcsdfvlkesJSh+12esJyLw7Ppics9/DEjodXDx5OT1ju9P6yAAD/AzEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJB2fvHim+kN6928nF6w1nGbXrDe/QfTC5a6nB7wAzg+ezE9YbmL/z6dnrDUxXaYnrDc/VM8766fTy9Y6uL89E48N0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABI2x+2T47TI1Y7HrfpCUttJ/Y8u91ud3F2OT1hqbvjYXrCcveeP52esN6P35pesNSr7XZ6wnJfX38+PWG5Rzfn0xOW2n7yeHrCcm6GAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC0879/+ZfpDcud7fbTE5Z6842H0xOWu9sO0xOWurx3NT1huff+9OfpCct98KtfTE9Y6nDcpics9/5fP5uesNyTxz+anrDUe28/mZ6wnJshACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApO1f3f3xOD1itdu76+kJS93fX01P4DVu94fpCct9e/PV9ITlfnr1aHrCUttxm56w3Dc3X05PWO7pzRfTE5b6+YO3pycs52YIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaftt+/Q4PQL4P3S4nV6w3vnl9AJe4/ru5fSE5a7uvTE9gddwMwQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIC08+kBP4S742F6wlL7/ek169nhtN7Rq9N7RbvD7nZ6wnL3d5fTE3iNl4dn0xOWuzqe2K/2/PS+oxM8wgEAvj8xBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQJoYAgDQxBACkiSEAIE0MAQBpYggASBNDAECaGAIA0sQQAJAmhgCANDEEAKSJIQAgTQwBAGliCABIE0MAQJoYAgDSxBAAkCaGAIA0MQQApIkhACBNDAEAaWIIAEgTQwBAmhgCANLEEACQ9h2BiIgYuC9crQAAAABJRU5ErkJggg==" id="image0db56ab116" transform="scale(1 -1) translate(0 -282.96)" x="95.67625" y="-49.282309" width="416.88" height="282.96"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m06f8fd8f57" d="M 0 0 
+       <path id="m8bc4b2fb8c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m06f8fd8f57" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="114.611309" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -271,7 +271,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m06f8fd8f57" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="152.481427" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -402,7 +402,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m06f8fd8f57" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="190.351545" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -498,7 +498,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m06f8fd8f57" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="228.221663" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -567,7 +567,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m06f8fd8f57" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="266.091781" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -643,7 +643,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m06f8fd8f57" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="303.961899" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -687,7 +687,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m06f8fd8f57" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="341.832017" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -746,7 +746,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m06f8fd8f57" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="379.702135" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -798,7 +798,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m06f8fd8f57" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="417.572253" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -841,7 +841,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m06f8fd8f57" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="455.442371" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -856,7 +856,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m06f8fd8f57" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8bc4b2fb8c" x="493.312489" y="332.242309" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -877,12 +877,12 @@ z
     <g id="ytick_1">
      <g id="line2d_12">
       <defs>
-       <path id="m192f75045f" d="M 0 0 
+       <path id="m10c7cae95e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m192f75045f" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10c7cae95e" x="95.67625" y="67.110926" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -970,7 +970,7 @@ z
     <g id="ytick_2">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m192f75045f" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10c7cae95e" x="95.67625" y="102.461777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -1002,7 +1002,7 @@ z
     <g id="ytick_3">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m192f75045f" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10c7cae95e" x="95.67625" y="137.812628" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -1024,7 +1024,7 @@ z
     <g id="ytick_4">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m192f75045f" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10c7cae95e" x="95.67625" y="173.163479" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -1042,7 +1042,7 @@ z
     <g id="ytick_5">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m192f75045f" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10c7cae95e" x="95.67625" y="208.51433" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -1105,7 +1105,7 @@ z
     <g id="ytick_6">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m192f75045f" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10c7cae95e" x="95.67625" y="243.865181" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -1172,7 +1172,7 @@ z
     <g id="ytick_7">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m192f75045f" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10c7cae95e" x="95.67625" y="279.216032" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -1212,7 +1212,7 @@ z
     <g id="ytick_8">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m192f75045f" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m10c7cae95e" x="95.67625" y="314.566884" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -2092,18 +2092,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagea9a2cec599" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
+iVBORw0KGgoAAAANSUhEUgAAAA8AAAEvCAYAAACaDZvIAAABiklEQVR4nO2aS47FIAwETcKd5kpz/31gjjAKJaXUguxbtvtj8h5p9fsza/G5VoFVVb1dbT9wWwcftr8Ex7INHHakOuB/H8j2fvbsF6Cs39qJcZOZSdv9tgjLZdurjHSWZo4NRmSqYtn21pA1M5WKgFkwQOXLqszYBh6hhGlnlTYzlSqUMPLW653PzNuoskSYZxIqVShhoScGYtsDr4+NKseyDToP1TlWKi8YFRqM7bxt7jBgklDCevPWENnbpG3GdmPHjVSZ7jBNqkiTwFujutfBqd62TEIv+BKXwVlDr8HLXw1V9ZojEMykYm2PRMJMtvcjrM/5LIMP29+CAWHmGookbM+lP9YPaFpZatvcYalS7cf2nCcYLysnzuy1TdlOnFlsez5eMMjMoO0+tcr1WMEQZyaViT1hJLVgmPb0UnWC8QoMg6EtfaCzKBWqjKQilZlUwyPMeqER2dba7iPS27lSJXobmSQ1GJneFn/RoU0CcqGCwUUuZfuAPwOnSoX+rj1sbwI+O+w78B+Qkis1u1lHkQAAAABJRU5ErkJggg==" id="imagebc355b83f4" transform="scale(1 -1) translate(0 -218.16)" x="521.28" y="-82.08" width="10.8" height="218.16"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_20">
       <defs>
-       <path id="m91fa0f4fc9" d="M 0 0 
+       <path id="mf0be9d2986" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf0be9d2986" x="531.876562" y="296.858375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_108">
@@ -2129,7 +2129,7 @@ z
     <g id="ytick_10">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf0be9d2986" x="531.876562" y="270.353507" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_109">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_11">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf0be9d2986" x="531.876562" y="243.84864" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_110">
@@ -2163,7 +2163,7 @@ z
     <g id="ytick_12">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf0be9d2986" x="531.876562" y="217.343772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_111">
@@ -2180,7 +2180,7 @@ z
     <g id="ytick_13">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf0be9d2986" x="531.876562" y="190.838905" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_112">
@@ -2196,7 +2196,7 @@ z
     <g id="ytick_14">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf0be9d2986" x="531.876562" y="164.334037" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_113">
@@ -2212,7 +2212,7 @@ z
     <g id="ytick_15">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf0be9d2986" x="531.876562" y="137.829169" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_114">
@@ -2228,7 +2228,7 @@ z
     <g id="ytick_16">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf0be9d2986" x="531.876562" y="111.324302" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_115">
@@ -2244,7 +2244,7 @@ z
     <g id="ytick_17">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m91fa0f4fc9" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mf0be9d2986" x="531.876562" y="84.819434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_116">
@@ -2882,8 +2882,8 @@ z
    </g>
   </g>
   <g id="text_119">
-   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(16.467344 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T06:43:08Z  ·  Linux chungus2 x86_64  ·  commit f2d5688e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(17.453359 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2953,13 +2953,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2999,109 +2999,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.195312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.982422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.769531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.34375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.130859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.095703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.435547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.617188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.320312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.433594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.710938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.089844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.712891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.404297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.583984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.207031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4747.994141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.617188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.240234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.027344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.734375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.201172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.988281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.5625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.349609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.136719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.587891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.769531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.148438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.003906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.480469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5842.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.068359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5913.855469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.644531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.84375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.626953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6340.90625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.285156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.171875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.306641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.785156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6852.966797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6925.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.654297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.767578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.046875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.007812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.791016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7299.890625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.410156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.185547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7721.96875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.347656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.130859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.230469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.439453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.222656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pda4891642b">
+  <clipPath id="p4ddd8574b3">
    <rect x="95.67625" y="49.4355" width="416.571298" height="282.806809"/>
   </clipPath>
  </defs>

--- a/bench/graphs/canterbury_summary.svg
+++ b/bench/graphs/canterbury_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.465312pt" height="386.202469pt" viewBox="0 0 575.465312 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.493281pt" height="386.202469pt" viewBox="0 0 573.493281 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.465312 386.202469 
-L 575.465312 0 
+L 573.493281 386.202469 
+L 573.493281 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.857656 104.1264 
-L 294.482656 104.1264 
-L 294.482656 74.7432 
-L 189.857656 74.7432 
+    <path d="M 188.871641 104.1264 
+L 293.496641 104.1264 
+L 293.496641 74.7432 
+L 188.871641 74.7432 
 z
-" clip-path="url(#pb46d830823)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #e5f49b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.482656 104.1264 
-L 399.107656 104.1264 
-L 399.107656 74.7432 
-L 294.482656 74.7432 
+    <path d="M 293.496641 104.1264 
+L 398.121641 104.1264 
+L 398.121641 74.7432 
+L 293.496641 74.7432 
 z
-" clip-path="url(#pb46d830823)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.107656 104.1264 
-L 503.732656 104.1264 
-L 503.732656 74.7432 
-L 399.107656 74.7432 
+    <path d="M 398.121641 104.1264 
+L 502.746641 104.1264 
+L 502.746641 74.7432 
+L 398.121641 74.7432 
 z
-" clip-path="url(#pb46d830823)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.857656 133.5096 
-L 294.482656 133.5096 
-L 294.482656 104.1264 
-L 189.857656 104.1264 
+    <path d="M 188.871641 133.5096 
+L 293.496641 133.5096 
+L 293.496641 104.1264 
+L 188.871641 104.1264 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.482656 133.5096 
-L 399.107656 133.5096 
-L 399.107656 104.1264 
-L 294.482656 104.1264 
+    <path d="M 293.496641 133.5096 
+L 398.121641 133.5096 
+L 398.121641 104.1264 
+L 293.496641 104.1264 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fff6b0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.107656 133.5096 
-L 503.732656 133.5096 
-L 503.732656 104.1264 
-L 399.107656 104.1264 
+    <path d="M 398.121641 133.5096 
+L 502.746641 133.5096 
+L 502.746641 104.1264 
+L 398.121641 104.1264 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fdb768; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.857656 162.8928 
-L 294.482656 162.8928 
-L 294.482656 133.5096 
-L 189.857656 133.5096 
+    <path d="M 188.871641 162.8928 
+L 293.496641 162.8928 
+L 293.496641 133.5096 
+L 188.871641 133.5096 
 z
-" clip-path="url(#pb46d830823)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #f8fcb6; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.482656 162.8928 
-L 399.107656 162.8928 
-L 399.107656 133.5096 
-L 294.482656 133.5096 
+    <path d="M 293.496641 162.8928 
+L 398.121641 162.8928 
+L 398.121641 133.5096 
+L 293.496641 133.5096 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.107656 162.8928 
-L 503.732656 162.8928 
-L 503.732656 133.5096 
-L 399.107656 133.5096 
+    <path d="M 398.121641 162.8928 
+L 502.746641 162.8928 
+L 502.746641 133.5096 
+L 398.121641 133.5096 
 z
-" clip-path="url(#pb46d830823)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #bbe278; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.857656 192.276 
-L 294.482656 192.276 
-L 294.482656 162.8928 
-L 189.857656 162.8928 
+    <path d="M 188.871641 192.276 
+L 293.496641 192.276 
+L 293.496641 162.8928 
+L 188.871641 162.8928 
 z
-" clip-path="url(#pb46d830823)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #f7fcb4; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.482656 192.276 
-L 399.107656 192.276 
-L 399.107656 162.8928 
-L 294.482656 162.8928 
+    <path d="M 293.496641 192.276 
+L 398.121641 192.276 
+L 398.121641 162.8928 
+L 293.496641 162.8928 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.107656 192.276 
-L 503.732656 192.276 
-L 503.732656 162.8928 
-L 399.107656 162.8928 
+    <path d="M 398.121641 192.276 
+L 502.746641 192.276 
+L 502.746641 162.8928 
+L 398.121641 162.8928 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fdc776; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.857656 221.6592 
-L 294.482656 221.6592 
-L 294.482656 192.276 
-L 189.857656 192.276 
+    <path d="M 188.871641 221.6592 
+L 293.496641 221.6592 
+L 293.496641 192.276 
+L 188.871641 192.276 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.482656 221.6592 
-L 399.107656 221.6592 
-L 399.107656 192.276 
-L 294.482656 192.276 
+    <path d="M 293.496641 221.6592 
+L 398.121641 221.6592 
+L 398.121641 192.276 
+L 293.496641 192.276 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fed481; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.107656 221.6592 
-L 503.732656 221.6592 
-L 503.732656 192.276 
-L 399.107656 192.276 
+    <path d="M 398.121641 221.6592 
+L 502.746641 221.6592 
+L 502.746641 192.276 
+L 398.121641 192.276 
 z
-" clip-path="url(#pb46d830823)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #addc6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.857656 251.0424 
-L 294.482656 251.0424 
-L 294.482656 221.6592 
-L 189.857656 221.6592 
+    <path d="M 188.871641 251.0424 
+L 293.496641 251.0424 
+L 293.496641 221.6592 
+L 188.871641 221.6592 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fed884; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.482656 251.0424 
-L 399.107656 251.0424 
-L 399.107656 221.6592 
-L 294.482656 221.6592 
+    <path d="M 293.496641 251.0424 
+L 398.121641 251.0424 
+L 398.121641 221.6592 
+L 293.496641 221.6592 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.107656 251.0424 
-L 503.732656 251.0424 
-L 503.732656 221.6592 
-L 399.107656 221.6592 
+    <path d="M 398.121641 251.0424 
+L 502.746641 251.0424 
+L 502.746641 221.6592 
+L 398.121641 221.6592 
 z
-" clip-path="url(#pb46d830823)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.857656 280.4256 
-L 294.482656 280.4256 
-L 294.482656 251.0424 
-L 189.857656 251.0424 
+    <path d="M 188.871641 280.4256 
+L 293.496641 280.4256 
+L 293.496641 251.0424 
+L 188.871641 251.0424 
 z
-" clip-path="url(#pb46d830823)" style="fill: #f4fab0; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #f4fab0; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.482656 280.4256 
-L 399.107656 280.4256 
-L 399.107656 251.0424 
-L 294.482656 251.0424 
+    <path d="M 293.496641 280.4256 
+L 398.121641 280.4256 
+L 398.121641 251.0424 
+L 293.496641 251.0424 
 z
-" clip-path="url(#pb46d830823)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.107656 280.4256 
-L 503.732656 280.4256 
-L 503.732656 251.0424 
-L 399.107656 251.0424 
+    <path d="M 398.121641 280.4256 
+L 502.746641 280.4256 
+L 502.746641 251.0424 
+L 398.121641 251.0424 
 z
-" clip-path="url(#pb46d830823)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #f36b42; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.857656 309.8088 
-L 294.482656 309.8088 
-L 294.482656 280.4256 
-L 189.857656 280.4256 
+    <path d="M 188.871641 309.8088 
+L 293.496641 309.8088 
+L 293.496641 280.4256 
+L 188.871641 280.4256 
 z
-" clip-path="url(#pb46d830823)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.482656 309.8088 
-L 399.107656 309.8088 
-L 399.107656 280.4256 
-L 294.482656 280.4256 
+    <path d="M 293.496641 309.8088 
+L 398.121641 309.8088 
+L 398.121641 280.4256 
+L 293.496641 280.4256 
 z
-" clip-path="url(#pb46d830823)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #f98e52; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.107656 309.8088 
-L 503.732656 309.8088 
-L 503.732656 280.4256 
-L 399.107656 280.4256 
+    <path d="M 398.121641 309.8088 
+L 502.746641 309.8088 
+L 502.746641 280.4256 
+L 398.121641 280.4256 
 z
-" clip-path="url(#pb46d830823)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #ee613e; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.857656 339.192 
-L 294.482656 339.192 
-L 294.482656 309.8088 
-L 189.857656 309.8088 
+    <path d="M 188.871641 339.192 
+L 293.496641 339.192 
+L 293.496641 309.8088 
+L 188.871641 309.8088 
 z
-" clip-path="url(#pb46d830823)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.482656 339.192 
-L 399.107656 339.192 
-L 399.107656 309.8088 
-L 294.482656 309.8088 
+    <path d="M 293.496641 339.192 
+L 398.121641 339.192 
+L 398.121641 309.8088 
+L 293.496641 309.8088 
 z
-" clip-path="url(#pb46d830823)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.107656 339.192 
-L 503.732656 339.192 
-L 503.732656 309.8088 
-L 399.107656 309.8088 
+    <path d="M 398.121641 339.192 
+L 502.746641 339.192 
+L 502.746641 309.8088 
+L 398.121641 309.8088 
 z
-" clip-path="url(#pb46d830823)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#p8632bfad4e)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.844922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.858906 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.129141 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.143125 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.70125 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.715234 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(407.052969 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.066953 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.782656 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.796641 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.296 -->
-    <g transform="translate(230.718906 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -946,7 +946,7 @@ z
    </g>
    <g id="text_7">
     <!-- 158 -->
-    <g transform="translate(339.160156 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.174141 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -1034,7 +1034,7 @@ z
    </g>
    <g id="text_8">
     <!-- 925 -->
-    <g transform="translate(443.785156 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 91.6423) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-39"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1042,7 +1042,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.420781 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.434766 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1141,7 +1141,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.299 -->
-    <g transform="translate(230.718906 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1151,7 +1151,7 @@ z
    </g>
    <g id="text_11">
     <!-- 73 -->
-    <g transform="translate(341.705156 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -1202,7 +1202,7 @@ z
    </g>
    <g id="text_12">
     <!-- 283 -->
-    <g transform="translate(443.785156 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1210,7 +1210,7 @@ z
    </g>
    <g id="text_13">
     <!-- zlib -->
-    <g transform="translate(130.683906 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(129.697891 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1234,7 +1234,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.299 -->
-    <g transform="translate(230.718906 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1244,14 +1244,14 @@ z
    </g>
    <g id="text_15">
     <!-- 55 -->
-    <g transform="translate(341.705156 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 692 -->
-    <g transform="translate(443.785156 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1259,7 +1259,7 @@ z
    </g>
    <g id="text_17">
     <!-- Go compress/flate -->
-    <g transform="translate(101.113906 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(100.127891 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1430,7 +1430,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.299 -->
-    <g transform="translate(230.718906 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1440,14 +1440,14 @@ z
    </g>
    <g id="text_19">
     <!-- 52 -->
-    <g transform="translate(341.705156 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 323 -->
-    <g transform="translate(443.785156 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(127.246094 0)"/>
@@ -1455,7 +1455,7 @@ z
    </g>
    <g id="text_21">
     <!-- miniz_oxide -->
-    <g transform="translate(113.990156 209.06385) scale(0.08 -0.08)">
+    <g transform="translate(113.004141 209.06385) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1514,7 +1514,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.299 -->
-    <g transform="translate(230.718906 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -1524,14 +1524,14 @@ z
    </g>
    <g id="text_23">
     <!-- 51 -->
-    <g transform="translate(341.705156 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 729 -->
-    <g transform="translate(443.785156 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-37"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(127.246094 0)"/>
@@ -1539,7 +1539,7 @@ z
    </g>
    <g id="text_25">
     <!-- JS fflate -->
-    <g transform="translate(122.146406 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(121.160391 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1599,7 +1599,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.307 -->
-    <g transform="translate(230.718906 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1609,7 +1609,7 @@ z
    </g>
    <g id="text_27">
     <!-- 41 -->
-    <g transform="translate(341.705156 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 238.5583) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1637,14 +1637,14 @@ z
    </g>
    <g id="text_28">
     <!-- 80 -->
-    <g transform="translate(446.330156 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(445.344141 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-38"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.492031 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.506016 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1753,7 +1753,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.298 -->
-    <g transform="translate(229.518281 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.532266 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1884,14 +1884,14 @@ z
    </g>
    <g id="text_31">
     <!-- 28 -->
-    <g transform="translate(341.228906 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(340.242891 267.9415) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-Bold-32"/>
      <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
     </g>
    </g>
    <g id="text_32">
-    <!-- 138 -->
-    <g transform="translate(443.070781 267.9415) scale(0.08 -0.08)">
+    <!-- 137 -->
+    <g transform="translate(442.084766 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1939,15 +1939,25 @@ Q 3834 3144 3618 2883
 Q 3403 2622 2981 2516 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666 
+L 3944 4666 
+L 3944 3988 
+L 2125 0 
+L 953 0 
+L 2675 3781 
+L 428 3781 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.607031 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.621016 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2012,7 +2022,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.321 -->
-    <g transform="translate(230.718906 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2022,14 +2032,14 @@ z
    </g>
    <g id="text_35">
     <!-- 23 -->
-    <g transform="translate(341.705156 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 117 -->
-    <g transform="translate(443.785156 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -2037,7 +2047,7 @@ z
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.828281 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.842266 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2048,7 +2058,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.279 -->
-    <g transform="translate(230.718906 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(95.410156 0)"/>
@@ -2058,13 +2068,13 @@ z
    </g>
    <g id="text_39">
     <!-- 0 -->
-    <g transform="translate(344.250156 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.264141 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.420156 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.434141 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2080,7 +2090,7 @@ z
   </g>
   <g id="text_41">
    <!-- canterbury — geomean over files, level 6 -->
-   <g transform="translate(137.241406 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(136.255391 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-62" d="M 2400 722 
 Q 2759 722 2948 984 
@@ -2293,7 +2303,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-06T06:43:08Z  ·  Linux chungus2 x86_64  ·  commit f2d5688e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2435,13 +2445,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2481,110 +2491,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.195312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.982422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.769531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.34375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.130859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.095703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.435547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.617188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.320312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.433594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.710938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.089844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.712891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.404297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.583984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.207031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4747.994141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.617188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.240234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.027344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.734375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.201172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.988281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.5625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.349609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.136719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.587891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.769531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.148438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.003906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.480469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5842.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.068359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5913.855469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.644531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.84375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.626953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6340.90625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.285156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.171875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.306641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.785156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6852.966797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6925.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.654297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.767578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.046875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.007812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.791016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7299.890625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.410156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.185547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7721.96875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.347656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.130859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.230469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.439453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.222656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb46d830823">
-   <rect x="85.232656" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="p8632bfad4e">
+   <rect x="84.246641" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/graphs/silesia_compress_heatmap.svg
+++ b/bench/graphs/silesia_compress_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p9b90173a96)">
+   <g clip-path="url(#p4c094ddc7f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9ElEQVR4nO3YPY5k1R2HYbqrpulp8JjPFoNI7MSyCCwsIcvb8DocOfUa2AAZoRfgwIkDB0iQEJJgJMCW0PBlo9G46K7u9iLQef/D1fOs4Fc6deq+dU9uv3nv7pktu3oyvWCtk9PpBWvdHqcXrLX18zteTS9Y6+KF6QVr/fB4egE/xu5sesFaW/9+3jufXrDUxp9+AAA8bQQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAACp/UfHz6c3LHV2bz89YanD8Wp6wlIPH7w+PWGpz77/YnrCUseTm+kJS/36/kvTE5Y6Pns+PWGpfz/+1/SEpS7vX05PWOpwdpyesNTJM0+mJyzlDSgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaX15cTm9Y6uFzv5yesNSjJ59PT1jqtcO2/yM9ePk30xOWOtudT09Y6ub2OD1hqa2f3+Y/3+m2P9/+9I3pCUudHw7TE5ba9tMdAICnjgAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACC1f3Z3Mb1hqW8PX05PWGrr53fz4kvTE5b64j8fTU9Y6vH1YXrCUm+/+Pb0hKWu7o7TE5b67PtPpycs9ebLv52esNQHX74/PWGpt17d9vl5AwoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQOrn5x5/upkcsdXs7vYAfY+vnd+o/IIzZ+v3z+/nTdjxOL1hq46cHAMDTRoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJDaX37w8fSGpXZnu+kJSz36+KvpCUu9+8e3pics9c6H2z6/37/xYHrCUn/5+6fTE5b68x9+NT1hqb/+87/TE5b6xQv3pycs9e3/rqcnLPW7hxfTE5byBhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEidXN/87W56xEq766vpCWvtzqYXrHU8TC9Ya38+vWCt3X56wVp3t9ML1rre+P072fg7mNNt37/rk23fv3vH4/SEpTZ++wAAeNoIUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUvvDzZPpDUs998NhesJaP7ucXrDWd19PL1jr569NL1jratu/LzfnF9MTlto93vr9e316wVq3x+kFS9179Mn0hLWef2V6wVLegAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACk/g8Sr3vdaRLPNQAAAABJRU5ErkJggg==" id="imageb3b16c29f8" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAqAAAAGaCAYAAADQNfGTAAAJ9UlEQVR4nO3Yv47cVx2H4ezOeLO2hRM7YhWjNNBEEUUUpAjlNrgOKlqugRugo+QCUqRJkQIpNCnTQKT8k0IAA5ZjJruzu1xEdN6v+el5ruAzOnt23jknN//8w+1LW3b5fHrBWien0wvWujlOL1hr6+d3vJxesNa9V6cXrPX9s+kF/BC7s+kFa2397/PO+fSCpTb+7QcAwItGgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkNp/cvxiesNSZ3f20xOWOhwvpycs9fjBT6YnLPX50y+nJyx1PLmenrDUW3cfTU9Y6vjy+fSEpb5+9tX0hKUu7l5MT1jqcHacnrDUyUvPpycs5QUUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7S/uXUxvWOrx/Z9NT1jq2+dfTE9Y6vXDtn8jPXjt7ekJS53tzqcnLHV9c5yesNTWz2/zn+90259vf/rG9ISlzg+H6QlLbfvbHQCAF44ABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgtX95d296w1JPDt9MT1hq6+d3/fDR9ISlvvz3J9MTlnp2dZiesNS7D9+dnrDU5e1xesJSnz/9bHrCUj9/7RfTE5b6+Js/TU9Y6p0fb/v8vIACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApE6uP/rN7fSIpW5uphfwQ2z9/E79BoQxW79//n/+fzsepxcstfHTAwDgRSNAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBI7S8+/nR6w1K7s930hKW+/fTv0xOW+v2v35mesNTv/rzt83vvjQfTE5b644efTU9Y6re/enN6wlLv//U/0xOW+umrd6cnLPXkv1fTE5b65eN70xOW8gIKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkTq6uP7idHrHS7upyesJau7PpBWsdD9ML1tqfTy9Ya7efXrDW7c30grWuNn7/Tjb+BnO67ft3dbLt+3fneJyesNTGbx8AAC8aAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQEqAAgCQEqAAAKQEKAAAKQEKAEBKgAIAkBKgAACkBCgAACkBCgBASoACAJASoAAApAQoAAApAQoAQGp/uH4+vWGp+98fpies9aOL6QVr/esf0wvWeuX16QVrHbd9/67PzqcnLLX77sn0hLUebPz+3d5ML1jqzt/+Mj1hrfuPphcs5QUUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAICVAAQBICVAAAFICFACAlAAFACAlQAEASAlQAABSAhQAgJQABQAgJUABAEgJUAAAUgIUAICUAAUAIPU/DwB73DYa88AAAAAASUVORK5CYII=" id="image079efa15b7" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="483.84" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="mbb9f7bc651" d="M 0 0 
+       <path id="mca0f78ac40" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mbb9f7bc651" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="115.814949" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="156.092348" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="196.369746" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="236.647145" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="276.924544" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="317.201942" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="357.479341" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="397.756739" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="438.034138" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="478.311536" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="518.588935" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mbb9f7bc651" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mca0f78ac40" x="558.866334" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m6269f7bbc3" d="M 0 0 
+       <path id="mfa13dfd189" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m6269f7bbc3" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa13dfd189" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m6269f7bbc3" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa13dfd189" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m6269f7bbc3" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa13dfd189" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m6269f7bbc3" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa13dfd189" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m6269f7bbc3" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa13dfd189" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m6269f7bbc3" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa13dfd189" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m6269f7bbc3" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa13dfd189" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m6269f7bbc3" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mfa13dfd189" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -1138,7 +1138,7 @@ L 579.005033 49.34175
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_21">
-    <!-- +17 -->
+    <!-- +19 -->
     <g transform="translate(108.955926 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-2b" d="M 2944 4013 
@@ -1170,24 +1170,44 @@ L 794 0
 L 794 531 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666 
-L 3525 4666 
-L 3525 4397 
-L 1831 0 
-L 1172 0 
-L 2766 4134 
-L 525 4134 
-L 525 4666 
+      <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(147.412109 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(147.412109 0)"/>
     </g>
    </g>
    <g id="text_22">
-    <!-- -26 -->
+    <!-- -27 -->
     <g transform="translate(150.784184 69.553235) scale(0.065 -0.065)">
      <defs>
       <path id="DejaVuSans-32" d="M 1228 531 
@@ -1214,6 +1234,83 @@ Q 2828 2175 2409 1742
 Q 1991 1309 1228 531 
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- +1 -->
+    <g transform="translate(191.578535 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2b"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(83.789062 0)"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- -39 -->
+    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- -11 -->
+    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
+     <use xlink:href="#DejaVuSans-2d"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- -16 -->
+    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
+     <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
 Q 1191 2003 1191 1497 
@@ -1246,81 +1343,8 @@ z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(36.083984 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_23">
-    <!-- -1 -->
-    <g transform="translate(193.129395 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-    </g>
-   </g>
-   <g id="text_24">
-    <!-- -40 -->
-    <g transform="translate(231.338981 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-34" d="M 2419 4116 
-L 825 1625 
-L 2419 1625 
-L 2419 4116 
-z
-M 2253 4666 
-L 3047 4666 
-L 3047 1625 
-L 3713 1625 
-L 3713 1100 
-L 3047 1100 
-L 3047 0 
-L 2419 0 
-L 2419 1100 
-L 313 1100 
-L 313 1709 
-L 2253 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-30" d="M 2034 4250 
-Q 1547 4250 1301 3770 
-Q 1056 3291 1056 2328 
-Q 1056 1369 1301 889 
-Q 1547 409 2034 409 
-Q 2525 409 2770 889 
-Q 3016 1369 3016 2328 
-Q 3016 3291 2770 3770 
-Q 2525 4250 2034 4250 
-z
-M 2034 4750 
-Q 2819 4750 3233 4129 
-Q 3647 3509 3647 2328 
-Q 3647 1150 3233 529 
-Q 2819 -91 2034 -91 
-Q 1250 -91 836 529 
-Q 422 1150 422 2328 
-Q 422 3509 836 4129 
-Q 1250 4750 2034 4750 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_25">
-    <!-- -12 -->
-    <g transform="translate(271.616379 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(99.707031 0)"/>
-    </g>
-   </g>
-   <g id="text_26">
-    <!-- -17 -->
-    <g transform="translate(311.893778 69.553235) scale(0.065 -0.065)">
-     <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_27">
@@ -1358,45 +1382,11 @@ z
     </g>
    </g>
    <g id="text_28">
-    <!-- -36 -->
+    <!-- -35 -->
     <g transform="translate(392.448575 69.553235) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-33" d="M 2597 2516 
-Q 3050 2419 3304 2112 
-Q 3559 1806 3559 1356 
-Q 3559 666 3084 287 
-Q 2609 -91 1734 -91 
-Q 1441 -91 1130 -33 
-Q 819 25 488 141 
-L 488 750 
-Q 750 597 1062 519 
-Q 1375 441 1716 441 
-Q 2309 441 2620 675 
-Q 2931 909 2931 1356 
-Q 2931 1769 2642 2001 
-Q 2353 2234 1838 2234 
-L 1294 2234 
-L 1294 2753 
-L 1863 2753 
-Q 2328 2753 2575 2939 
-Q 2822 3125 2822 3475 
-Q 2822 3834 2567 4026 
-Q 2313 4219 1838 4219 
-Q 1578 4219 1281 4162 
-Q 984 4106 628 3988 
-L 628 4550 
-Q 988 4650 1302 4700 
-Q 1616 4750 1894 4750 
-Q 2613 4750 3031 4423 
-Q 3450 4097 3450 3541 
-Q 3450 3153 3228 2886 
-Q 3006 2619 2597 2516 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-36" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_29">
@@ -1407,24 +1397,46 @@ z
     </g>
    </g>
    <g id="text_30">
-    <!-- -10 -->
-    <g transform="translate(473.003372 69.553235) scale(0.065 -0.065)">
+    <!-- -9 -->
+    <g transform="translate(475.071185 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-39" transform="translate(36.083984 0)"/>
     </g>
    </g>
    <g id="text_31">
-    <!-- -53 -->
+    <!-- -51 -->
     <g transform="translate(513.280771 69.553235) scale(0.065 -0.065)">
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(36.083984 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(99.707031 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(99.707031 0)"/>
     </g>
    </g>
    <g id="text_32">
     <!-- -30 -->
     <g transform="translate(553.558169 69.553235) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(36.083984 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(99.707031 0)"/>
@@ -1477,6 +1489,27 @@ z
    <g id="text_39">
     <!-- -4 -->
     <g transform="translate(354.238989 106.389018) scale(0.065 -0.065)">
+     <defs>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-2d"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(36.083984 0)"/>
     </g>
@@ -1507,38 +1540,6 @@ z
    <g id="text_43">
     <!-- +9 -->
     <g transform="translate(513.797724 106.389018) scale(0.065 -0.065)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97 
-L 703 672 
-Q 941 559 1184 500 
-Q 1428 441 1663 441 
-Q 2288 441 2617 861 
-Q 2947 1281 2994 2138 
-Q 2813 1869 2534 1725 
-Q 2256 1581 1919 1581 
-Q 1219 1581 811 2004 
-Q 403 2428 403 3163 
-Q 403 3881 828 4315 
-Q 1253 4750 1959 4750 
-Q 2769 4750 3195 4129 
-Q 3622 3509 3622 2328 
-Q 3622 1225 3098 567 
-Q 2575 -91 1691 -91 
-Q 1453 -91 1209 -44 
-Q 966 3 703 97 
-z
-M 1959 2075 
-Q 2384 2075 2632 2365 
-Q 2881 2656 2881 3163 
-Q 2881 3666 2632 3958 
-Q 2384 4250 1959 4250 
-Q 1534 4250 1286 3958 
-Q 1038 3666 1038 3163 
-Q 1038 2656 1286 2365 
-Q 1534 2075 1959 2075 
-z
-" transform="scale(0.015625)"/>
-     </defs>
      <use xlink:href="#DejaVuSans-2b"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(83.789062 0)"/>
     </g>
@@ -2189,18 +2190,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image72e9f67e74" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
+iVBORw0KGgoAAAANSUhEUgAAABIAAAFgCAYAAAC2UykpAAAB1ElEQVR4nO2b0a3DMAwD7cSzvM3fmI47gvpxCK6ENABhnkQ5aZH5P/7OAGpdFyEzBiQDnija2qSEghnZhIIZCa3NyWQkmZFOKJhRsDXsOopmJJwjaEPOmxHirE3MWjOqhSBr2EAGMyKtMVpc+ynYwe3viNQVbA0LrZDRFbxGbNbWyM3auG0RGbo1Qp0IZCSMiG2OgtNvbL+Oke6BvddIWaQ1qP3RjGSTLXypwdaIMP2ctWb0olAzKkr4LhLMCPvnOJiRbo6CrTWjF4WCGYHWJtU1TKgZvSZkfNAKZhRsDftFa96MkJCRrf29ausyWrOtWiMjmxDH6FAfDJzzIEKctQc60ToDEqJOBLbfZs04RxQjobWOSFXrjM0IdURqIaG1jkhVPmvGOUqOCPLJMdh+6kRk+zFGMtjKOdK13zbZ2EBGMxLOkSz90YygK9tozSbUa6Qu4RxtRifZ2np0jDY32YiOc44gIQo2aI1ZkB2Rb4SiIyJbtcr0Q0IPdCQyIpCQDnZHpC5uQ27uOtJFBBptH2zlHOnab+uaMSK29htXrW2NKK0hOtlrxLaPjIxys4a99x9dRKgTgUK69gsZ9RxVFWzNyIi6RZIZtbXfE+qI1BU8R5i1D2e5X2tFkZmlAAAAAElFTkSuQmCC" id="image3caa51e6b7" transform="scale(1 -1) translate(0 -253.44)" x="588.96" y="-69.84" width="12.96" height="253.44"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="md75de07880" d="M 0 0 
+       <path id="m2c7721cc70" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#md75de07880" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c7721cc70" x="601.779688" y="322.507463" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2223,7 +2224,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#md75de07880" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c7721cc70" x="601.779688" y="280.566603" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2237,7 +2238,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#md75de07880" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c7721cc70" x="601.779688" y="238.625742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2251,7 +2252,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md75de07880" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c7721cc70" x="601.779688" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2264,7 +2265,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#md75de07880" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c7721cc70" x="601.779688" y="154.74402" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2277,7 +2278,7 @@ z
     <g id="ytick_14">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md75de07880" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c7721cc70" x="601.779688" y="112.803159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_122">
@@ -2290,7 +2291,7 @@ z
     <g id="ytick_15">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#md75de07880" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2c7721cc70" x="601.779688" y="70.862298" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_123">
@@ -2906,8 +2907,8 @@ z
    </g>
   </g>
   <g id="text_126">
-   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.467344 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T06:43:08Z  ·  Linux chungus2 x86_64  ·  commit f2d5688e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.453359 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2999,13 +3000,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -3045,109 +3046,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.195312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.982422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.769531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.34375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.130859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.095703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.435547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.617188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.320312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.433594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.710938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.089844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.712891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.404297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.583984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.207031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4747.994141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.617188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.240234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.027344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.734375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.201172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.988281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.5625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.349609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.136719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.587891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.769531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.148438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.003906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.480469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5842.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.068359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5913.855469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.644531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.84375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.626953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6340.90625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.285156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.171875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.306641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.785156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6852.966797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6925.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.654297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.767578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.046875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.007812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.791016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7299.890625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.410156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.185547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7721.96875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.347656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.130859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.230469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.439453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.222656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9b90173a96">
+  <clipPath id="p4c094ddc7f">
    <rect x="95.67625" y="49.34175" width="483.328783" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_compress_pareto.svg
+++ b/bench/graphs/silesia_compress_pareto.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 61.085542 412.80375 
 L 61.085542 48.323125 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m8346af2443" d="M 0 0 
+       <path id="m6f228c0f5c" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8346af2443" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6f228c0f5c" x="61.085542" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -130,11 +130,11 @@ z
      <g id="line2d_3">
       <path d="M 145.270284 412.80375 
 L 145.270284 48.323125 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8346af2443" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6f228c0f5c" x="145.270284" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,11 +177,11 @@ z
      <g id="line2d_5">
       <path d="M 229.455026 412.80375 
 L 229.455026 48.323125 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8346af2443" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6f228c0f5c" x="229.455026" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -219,11 +219,11 @@ z
      <g id="line2d_7">
       <path d="M 313.639768 412.80375 
 L 313.639768 48.323125 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8346af2443" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6f228c0f5c" x="313.639768" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -272,11 +272,11 @@ z
      <g id="line2d_9">
       <path d="M 397.82451 412.80375 
 L 397.82451 48.323125 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8346af2443" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6f228c0f5c" x="397.82451" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -334,11 +334,11 @@ z
      <g id="line2d_11">
       <path d="M 482.009253 412.80375 
 L 482.009253 48.323125 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8346af2443" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6f228c0f5c" x="482.009253" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -355,11 +355,11 @@ L 482.009253 48.323125
      <g id="line2d_13">
       <path d="M 566.193995 412.80375 
 L 566.193995 48.323125 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8346af2443" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6f228c0f5c" x="566.193995" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -856,16 +856,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 368.08164 
 L 637.2 368.08164 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m28b740e96d" d="M 0 0 
+       <path id="m01762f53b6" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m28b740e96d" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01762f53b6" x="49.078125" y="368.08164" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -897,11 +897,11 @@ z
      <g id="line2d_17">
       <path d="M 49.078125 243.439835 
 L 637.2 243.439835 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m28b740e96d" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01762f53b6" x="49.078125" y="243.439835" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -917,11 +917,11 @@ L 637.2 243.439835
      <g id="line2d_19">
       <path d="M 49.078125 118.798029 
 L 637.2 118.798029 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m28b740e96d" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m01762f53b6" x="49.078125" y="118.798029" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -937,16 +937,16 @@ L 637.2 118.798029
      <g id="line2d_21">
       <path d="M 49.078125 405.602562 
 L 637.2 405.602562 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="mb624f864c8" d="M 0 0 
+       <path id="m4e7ee0f713" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="405.602562" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -954,11 +954,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 395.733268 
 L 637.2 395.733268 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="395.733268" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -966,11 +966,11 @@ L 637.2 395.733268
      <g id="line2d_25">
       <path d="M 49.078125 387.3889 
 L 637.2 387.3889 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="387.3889" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -978,11 +978,11 @@ L 637.2 387.3889
      <g id="line2d_27">
       <path d="M 49.078125 380.160679 
 L 637.2 380.160679 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="380.160679" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -990,11 +990,11 @@ L 637.2 380.160679
      <g id="line2d_29">
       <path d="M 49.078125 373.784936 
 L 637.2 373.784936 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="373.784936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1002,11 +1002,11 @@ L 637.2 373.784936
      <g id="line2d_31">
       <path d="M 49.078125 330.560718 
 L 637.2 330.560718 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="330.560718" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1014,11 +1014,11 @@ L 637.2 330.560718
      <g id="line2d_33">
       <path d="M 49.078125 308.612385 
 L 637.2 308.612385 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="308.612385" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1026,11 +1026,11 @@ L 637.2 308.612385
      <g id="line2d_35">
       <path d="M 49.078125 293.039796 
 L 637.2 293.039796 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="293.039796" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1038,11 +1038,11 @@ L 637.2 293.039796
      <g id="line2d_37">
       <path d="M 49.078125 280.960757 
 L 637.2 280.960757 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="280.960757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1050,11 +1050,11 @@ L 637.2 280.960757
      <g id="line2d_39">
       <path d="M 49.078125 271.091463 
 L 637.2 271.091463 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="271.091463" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1062,11 +1062,11 @@ L 637.2 271.091463
      <g id="line2d_41">
       <path d="M 49.078125 262.747094 
 L 637.2 262.747094 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="262.747094" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1074,11 +1074,11 @@ L 637.2 262.747094
      <g id="line2d_43">
       <path d="M 49.078125 255.518874 
 L 637.2 255.518874 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="255.518874" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1086,11 +1086,11 @@ L 637.2 255.518874
      <g id="line2d_45">
       <path d="M 49.078125 249.143131 
 L 637.2 249.143131 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="249.143131" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1098,11 +1098,11 @@ L 637.2 249.143131
      <g id="line2d_47">
       <path d="M 49.078125 205.918912 
 L 637.2 205.918912 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="205.918912" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1110,11 +1110,11 @@ L 637.2 205.918912
      <g id="line2d_49">
       <path d="M 49.078125 183.97058 
 L 637.2 183.97058 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="183.97058" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1122,11 +1122,11 @@ L 637.2 183.97058
      <g id="line2d_51">
       <path d="M 49.078125 168.39799 
 L 637.2 168.39799 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="168.39799" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1134,11 +1134,11 @@ L 637.2 168.39799
      <g id="line2d_53">
       <path d="M 49.078125 156.318951 
 L 637.2 156.318951 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="156.318951" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1146,11 +1146,11 @@ L 637.2 156.318951
      <g id="line2d_55">
       <path d="M 49.078125 146.449658 
 L 637.2 146.449658 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="146.449658" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1158,11 +1158,11 @@ L 637.2 146.449658
      <g id="line2d_57">
       <path d="M 49.078125 138.105289 
 L 637.2 138.105289 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="138.105289" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1170,11 +1170,11 @@ L 637.2 138.105289
      <g id="line2d_59">
       <path d="M 49.078125 130.877068 
 L 637.2 130.877068 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="130.877068" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1182,11 +1182,11 @@ L 637.2 130.877068
      <g id="line2d_61">
       <path d="M 49.078125 124.501326 
 L 637.2 124.501326 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="124.501326" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1194,11 +1194,11 @@ L 637.2 124.501326
      <g id="line2d_63">
       <path d="M 49.078125 81.277107 
 L 637.2 81.277107 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="81.277107" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1206,11 +1206,11 @@ L 637.2 81.277107
      <g id="line2d_65">
       <path d="M 49.078125 59.328775 
 L 637.2 59.328775 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mb624f864c8" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4e7ee0f713" x="49.078125" y="59.328775" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1332,7 +1332,7 @@ L 637.2 48.323125
    </g>
    <g id="text_13">
     <!-- L1 -->
-    <g style="fill: #d62728" transform="translate(324.643112 122.797254) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(324.643112 122.779858) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-4c" d="M 588 4666 
 L 1791 4666 
@@ -1364,7 +1364,7 @@ z
    </g>
    <g id="text_14">
     <!-- L10 -->
-    <g style="fill: #d62728" transform="translate(102.799363 311.815309) scale(0.07 -0.07)">
+    <g style="fill: #d62728" transform="translate(102.799363 312.295793) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1686,23 +1686,23 @@ z
    </g>
    <g id="line2d_67">
     <defs>
-     <path id="m901485b555" d="M -2.5 2.5 
+     <path id="m95802df9f0" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p931dae7db1)">
-     <use xlink:href="#m901485b555" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m901485b555" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m901485b555" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m901485b555" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m901485b555" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m901485b555" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m901485b555" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m901485b555" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m901485b555" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc909886f)">
+     <use xlink:href="#m95802df9f0" x="377.110281" y="104.685421" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95802df9f0" x="323.801439" y="110.409833" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95802df9f0" x="272.665744" y="126.308323" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95802df9f0" x="235.168828" y="128.026741" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95802df9f0" x="186.228265" y="149.377587" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95802df9f0" x="158.303164" y="171.457731" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95802df9f0" x="149.489547" y="182.192614" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95802df9f0" x="140.563162" y="202.482797" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m95802df9f0" x="138.984853" y="209.328911" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_68">
@@ -1755,7 +1755,7 @@ L 327.133241 110.069256
 L 326.02264 110.18302 
 L 324.91204 110.296545 
 L 323.801439 110.409833 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_69">
     <path d="M 323.801439 110.409833 
@@ -1807,7 +1807,7 @@ L 275.861725 125.44037
 L 274.796398 125.731236 
 L 273.731071 126.020548 
 L 272.665744 126.308323 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_70">
     <path d="M 272.665744 126.308323 
@@ -1859,7 +1859,7 @@ L 237.512385 127.920923
 L 236.7312 127.956219 
 L 235.950014 127.991491 
 L 235.168828 128.026741 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_71">
     <path d="M 235.168828 128.026741 
@@ -1911,7 +1911,7 @@ L 189.28705 148.263499
 L 188.267455 148.637415 
 L 187.24786 149.008766 
 L 186.228265 149.377587 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_72">
     <path d="M 186.228265 149.377587 
@@ -1963,7 +1963,7 @@ L 160.048483 170.312481
 L 159.46671 170.696929 
 L 158.884937 171.078667 
 L 158.303164 171.457731 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_73">
     <path d="M 158.303164 171.457731 
@@ -2015,7 +2015,7 @@ L 150.040398 181.580576
 L 149.856781 181.785359 
 L 149.673164 181.989369 
 L 149.489547 182.192614 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_74">
     <path d="M 149.489547 182.192614 
@@ -2067,7 +2067,7 @@ L 141.121061 201.414753
 L 140.935095 201.773114 
 L 140.749129 202.129119 
 L 140.563162 202.482797 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_75">
     <path d="M 140.563162 202.482797 
@@ -2119,26 +2119,26 @@ L 139.083497 208.925481
 L 139.050616 209.060292 
 L 139.017734 209.194768 
 L 138.984853 209.328911 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_76">
     <defs>
-     <path id="m87ae9942f9" d="M 0 -2.5 
+     <path id="mf665228f92" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p931dae7db1)">
-     <use xlink:href="#m87ae9942f9" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ae9942f9" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ae9942f9" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ae9942f9" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ae9942f9" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ae9942f9" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ae9942f9" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ae9942f9" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m87ae9942f9" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc909886f)">
+     <use xlink:href="#mf665228f92" x="610.467187" y="71.939349" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf665228f92" x="319.880958" y="101.884157" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf665228f92" x="210.281253" y="129.778154" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf665228f92" x="196.287076" y="133.586625" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf665228f92" x="176.054419" y="147.38645" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf665228f92" x="152.161413" y="174.753272" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf665228f92" x="146.720208" y="186.587648" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf665228f92" x="143.994022" y="196.356323" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf665228f92" x="142.666037" y="200.180971" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_77">
@@ -2191,7 +2191,7 @@ L 338.042598 100.427247
 L 331.988718 100.917253 
 L 325.934838 101.402864 
 L 319.880958 101.884157 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_78">
     <path d="M 319.880958 101.884157 
@@ -2243,7 +2243,7 @@ L 217.131235 128.398367
 L 214.847908 128.862215 
 L 212.564581 129.322122 
 L 210.281253 129.778154 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_79">
     <path d="M 210.281253 129.778154 
@@ -2295,7 +2295,7 @@ L 197.161712 133.356286
 L 196.870166 133.433175 
 L 196.578621 133.509954 
 L 196.287076 133.586625 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_80">
     <path d="M 196.287076 133.586625 
@@ -2347,7 +2347,7 @@ L 177.31896 146.619719
 L 176.897447 146.876504 
 L 176.475933 147.132078 
 L 176.054419 147.38645 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_81">
     <path d="M 176.054419 147.38645 
@@ -2399,7 +2399,7 @@ L 153.654726 173.393769
 L 153.156955 173.850741 
 L 152.659184 174.303887 
 L 152.161413 174.753272 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_82">
     <path d="M 152.161413 174.753272 
@@ -2451,7 +2451,7 @@ L 147.060283 185.919158
 L 146.946925 186.142906 
 L 146.833566 186.365734 
 L 146.720208 186.587648 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_83">
     <path d="M 146.720208 186.587648 
@@ -2503,7 +2503,7 @@ L 144.164409 195.794799
 L 144.107613 195.982622 
 L 144.050817 196.169795 
 L 143.994022 196.356323 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
     <path d="M 143.994022 196.356323 
@@ -2555,30 +2555,30 @@ L 142.749036 199.949687
 L 142.72137 200.026891 
 L 142.693704 200.103986 
 L 142.666037 200.180971 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
     <defs>
-     <path id="mf765730cdc" d="M -0 3.535534 
+     <path id="m15f8d0bf73" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p931dae7db1)">
-     <use xlink:href="#mf765730cdc" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf765730cdc" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc909886f)">
+     <use xlink:href="#m15f8d0bf73" x="292.033351" y="64.890426" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="242.839153" y="80.778898" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="218.251194" y="86.377096" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="197.814984" y="90.309617" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="166.378359" y="99.066934" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="145.830392" y="110.431955" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="134.598477" y="126.026287" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="124.077268" y="149.033155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="122.462976" y="157.476606" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="81.012077" y="220.06889" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="77.44276" y="239.652656" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m15f8d0bf73" x="76.953425" y="252.706566" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_86">
@@ -2631,7 +2631,7 @@ L 245.91379 79.91142
 L 244.888911 80.202126 
 L 243.864032 80.49128 
 L 242.839153 80.778898 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_87">
     <path d="M 242.839153 80.778898 
@@ -2683,7 +2683,7 @@ L 219.787941 86.043669
 L 219.275692 86.155039 
 L 218.763443 86.266182 
 L 218.251194 86.377096 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_88">
     <path d="M 218.251194 86.377096 
@@ -2735,7 +2735,7 @@ L 199.092247 90.072029
 L 198.666492 90.151341 
 L 198.240738 90.230537 
 L 197.814984 90.309617 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_89">
     <path d="M 197.814984 90.309617 
@@ -2787,7 +2787,7 @@ L 168.343148 98.559208
 L 167.688219 98.72898 
 L 167.033289 98.898221 
 L 166.378359 99.066934 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_90">
     <path d="M 166.378359 99.066934 
@@ -2839,7 +2839,7 @@ L 147.11464 109.78743
 L 146.686557 110.003126 
 L 146.258475 110.217965 
 L 145.830392 110.431955 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_91">
     <path d="M 145.830392 110.431955 
@@ -2891,7 +2891,7 @@ L 135.300472 125.172774
 L 135.066474 125.458776 
 L 134.832476 125.743276 
 L 134.598477 126.026287 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_92">
     <path d="M 134.598477 126.026287 
@@ -2943,7 +2943,7 @@ L 124.734843 147.848882
 L 124.515652 148.246526 
 L 124.29646 148.641269 
 L 124.077268 149.033155 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_93">
     <path d="M 124.077268 149.033155 
@@ -2995,7 +2995,7 @@ L 122.56387 156.985769
 L 122.530239 157.149876 
 L 122.496607 157.313488 
 L 122.462976 157.476606 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_94">
     <path d="M 122.462976 157.476606 
@@ -3047,7 +3047,7 @@ L 83.602758 217.699074
 L 82.739198 218.500595 
 L 81.875637 219.290422 
 L 81.012077 220.06889 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_95">
     <path d="M 81.012077 220.06889 
@@ -3099,7 +3099,7 @@ L 77.665842 238.615761
 L 77.591481 238.963605 
 L 77.517121 239.309227 
 L 77.44276 239.652656 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_96">
     <path d="M 77.44276 239.652656 
@@ -3151,23 +3151,23 @@ L 76.984008 251.97672
 L 76.973814 252.221097 
 L 76.96362 252.464376 
 L 76.953425 252.706566 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_97">
     <defs>
-     <path id="m92aced012f" d="M -0 2.5 
+     <path id="m0b19b779fc" d="M -0 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p931dae7db1)">
-     <use xlink:href="#m92aced012f" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc909886f)">
+     <use xlink:href="#m0b19b779fc" x="75.810937" y="396.236449" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_98">
     <defs>
-     <path id="mee0c7e31fb" d="M -0.833333 2.5 
+     <path id="m97be5afa44" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -3182,16 +3182,16 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p931dae7db1)">
-     <use xlink:href="#mee0c7e31fb" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee0c7e31fb" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee0c7e31fb" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee0c7e31fb" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee0c7e31fb" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee0c7e31fb" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee0c7e31fb" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee0c7e31fb" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mee0c7e31fb" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc909886f)">
+     <use xlink:href="#m97be5afa44" x="432.495268" y="96.067622" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m97be5afa44" x="300.62247" y="112.493412" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m97be5afa44" x="266.967623" y="120.8136" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m97be5afa44" x="226.040946" y="122.099593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m97be5afa44" x="180.985721" y="141.85872" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m97be5afa44" x="164.441833" y="156.106179" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m97be5afa44" x="157.761315" y="165.23787" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m97be5afa44" x="151.269082" y="178.700983" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m97be5afa44" x="150.327087" y="185.23695" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_99">
@@ -3244,7 +3244,7 @@ L 308.86452 111.600609
 L 306.11717 111.899849 
 L 303.36982 112.197444 
 L 300.62247 112.493412 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_100">
     <path d="M 300.62247 112.493412 
@@ -3296,7 +3296,7 @@ L 269.071051 120.329422
 L 268.369908 120.491297 
 L 267.668766 120.652688 
 L 266.967623 120.8136 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_101">
     <path d="M 266.967623 120.8136 
@@ -3348,7 +3348,7 @@ L 228.598863 122.020108
 L 227.746224 122.046616 
 L 226.893585 122.073111 
 L 226.040946 122.099593 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_102">
     <path d="M 226.040946 122.099593 
@@ -3400,7 +3400,7 @@ L 183.801673 140.814056
 L 182.863022 141.164522 
 L 181.924372 141.512734 
 L 180.985721 141.85872 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_103">
     <path d="M 180.985721 141.85872 
@@ -3452,7 +3452,7 @@ L 165.475826 155.317544
 L 165.131161 155.581701 
 L 164.786497 155.844575 
 L 164.441833 156.106179 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_104">
     <path d="M 164.441833 156.106179 
@@ -3504,7 +3504,7 @@ L 158.178848 164.710119
 L 158.03967 164.886608 
 L 157.900493 165.062524 
 L 157.761315 165.23787 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_105">
     <path d="M 157.761315 165.23787 
@@ -3556,7 +3556,7 @@ L 151.674847 177.950842
 L 151.539592 178.202046 
 L 151.404337 178.452089 
 L 151.269082 178.700983 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_106">
     <path d="M 151.269082 178.700983 
@@ -3608,11 +3608,11 @@ L 150.385962 184.850776
 L 150.366337 184.979807 
 L 150.346712 185.108531 
 L 150.327087 185.23695 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_107">
     <defs>
-     <path id="mbb46e5c2a2" d="M -1.25 2.5 
+     <path id="m67ed19be3f" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -3627,16 +3627,16 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p931dae7db1)">
-     <use xlink:href="#mbb46e5c2a2" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb46e5c2a2" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb46e5c2a2" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb46e5c2a2" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb46e5c2a2" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb46e5c2a2" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb46e5c2a2" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb46e5c2a2" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mbb46e5c2a2" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc909886f)">
+     <use xlink:href="#m67ed19be3f" x="345.030867" y="136.859359" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m67ed19be3f" x="273.364924" y="143.571257" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m67ed19be3f" x="240.719951" y="149.310846" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m67ed19be3f" x="221.353978" y="154.160538" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m67ed19be3f" x="207.129625" y="156.092215" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m67ed19be3f" x="181.064802" y="166.758473" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m67ed19be3f" x="179.282169" y="170.289343" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m67ed19be3f" x="177.719335" y="175.489948" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m67ed19be3f" x="177.643939" y="181.552088" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_108">
@@ -3689,7 +3689,7 @@ L 277.844045 143.175283
 L 276.351005 143.307597 
 L 274.857964 143.439587 
 L 273.364924 143.571257 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_109">
     <path d="M 273.364924 143.571257 
@@ -3741,7 +3741,7 @@ L 242.760262 148.96941
 L 242.080158 149.083462 
 L 241.400055 149.197273 
 L 240.719951 149.310846 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_110">
     <path d="M 240.719951 149.310846 
@@ -3793,7 +3793,7 @@ L 222.564351 153.869835
 L 222.160893 153.966909 
 L 221.757435 154.06381 
 L 221.353978 154.160538 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_111">
     <path d="M 221.353978 154.160538 
@@ -3845,7 +3845,7 @@ L 208.018647 155.973483
 L 207.722306 156.013089 
 L 207.425965 156.052666 
 L 207.129625 156.092215 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_112">
     <path d="M 207.129625 156.092215 
@@ -3897,7 +3897,7 @@ L 182.693853 166.149994
 L 182.150836 166.353581 
 L 181.607819 166.556405 
 L 181.064802 166.758473 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_113">
     <path d="M 181.064802 166.758473 
@@ -3949,7 +3949,7 @@ L 179.393584 170.075284
 L 179.356445 170.146731 
 L 179.319307 170.218084 
 L 179.282169 170.289343 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_114">
     <path d="M 179.282169 170.289343 
@@ -4001,7 +4001,7 @@ L 177.817012 175.179146
 L 177.784453 175.282945 
 L 177.751894 175.386546 
 L 177.719335 175.489948 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_115">
     <path d="M 177.719335 175.489948 
@@ -4053,11 +4053,11 @@ L 177.648651 181.192458
 L 177.64708 181.3126 
 L 177.645509 181.432477 
 L 177.643939 181.552088 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_116">
     <defs>
-     <path id="mc515657357" d="M 0 -2.5 
+     <path id="mad5df05ce9" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -4070,16 +4070,16 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p931dae7db1)">
-     <use xlink:href="#mc515657357" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc515657357" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc515657357" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc515657357" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc515657357" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc515657357" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc515657357" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc515657357" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#mc515657357" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p1bc909886f)">
+     <use xlink:href="#mad5df05ce9" x="226.871027" y="113.224491" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mad5df05ce9" x="226.871027" y="113.066324" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mad5df05ce9" x="226.871027" y="113.178221" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mad5df05ce9" x="226.871027" y="113.089884" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mad5df05ce9" x="177.768423" y="132.327899" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mad5df05ce9" x="160.37503" y="145.652356" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mad5df05ce9" x="153.995779" y="152.678629" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mad5df05ce9" x="147.106887" y="168.143801" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#mad5df05ce9" x="145.871703" y="175.118358" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_117">
@@ -4132,7 +4132,7 @@ L 226.871027 113.076223
 L 226.871027 113.072924 
 L 226.871027 113.069624 
 L 226.871027 113.066324 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_118">
     <path d="M 226.871027 113.066324 
@@ -4184,7 +4184,7 @@ L 226.871027 113.171234
 L 226.871027 113.173563 
 L 226.871027 113.175892 
 L 226.871027 113.178221 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_119">
     <path d="M 226.871027 113.178221 
@@ -4236,7 +4236,7 @@ L 226.871027 113.09541
 L 226.871027 113.093568 
 L 226.871027 113.091726 
 L 226.871027 113.089884 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_120">
     <path d="M 226.871027 113.089884 
@@ -4288,7 +4288,7 @@ L 180.837336 131.306392
 L 179.814365 131.649041 
 L 178.791394 131.989534 
 L 177.768423 132.327899 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_121">
     <path d="M 177.768423 132.327899 
@@ -4340,7 +4340,7 @@ L 161.462117 144.909076
 L 161.099755 145.157972 
 L 160.737393 145.405728 
 L 160.37503 145.652356 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_122">
     <path d="M 160.37503 145.652356 
@@ -4392,7 +4392,7 @@ L 154.394483 152.265218
 L 154.261581 152.403373 
 L 154.12868 152.541176 
 L 153.995779 152.678629 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_123">
     <path d="M 153.995779 152.678629 
@@ -4444,7 +4444,7 @@ L 147.537442 167.296442
 L 147.393924 167.580372 
 L 147.250405 167.862819 
 L 147.106887 168.143801 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_124">
     <path d="M 147.106887 168.143801 
@@ -4496,11 +4496,11 @@ L 145.948902 174.70781
 L 145.923169 174.845005 
 L 145.897436 174.981854 
 L 145.871703 175.118358 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_125">
     <defs>
-     <path id="mfbbf324ae2" d="M 0 -2.5 
+     <path id="mb8008d103c" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -4509,16 +4509,16 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p931dae7db1)">
-     <use xlink:href="#mfbbf324ae2" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfbbf324ae2" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfbbf324ae2" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfbbf324ae2" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfbbf324ae2" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfbbf324ae2" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfbbf324ae2" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfbbf324ae2" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mfbbf324ae2" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#p1bc909886f)">
+     <use xlink:href="#mb8008d103c" x="585.66883" y="173.051371" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8008d103c" x="527.144592" y="175.326465" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8008d103c" x="457.339427" y="183.688849" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8008d103c" x="292.124837" y="178.486631" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8008d103c" x="243.129344" y="190.369032" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8008d103c" x="213.541392" y="204.43395" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8008d103c" x="204.551957" y="212.140784" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8008d103c" x="195.860087" y="228.582256" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8008d103c" x="194.019853" y="234.294862" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_126">
@@ -4571,7 +4571,7 @@ L 530.802357 175.187039
 L 529.583102 175.233554 
 L 528.363847 175.28003 
 L 527.144592 175.326465 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_127">
     <path d="M 527.144592 175.326465 
@@ -4623,7 +4623,7 @@ L 461.70225 183.20239
 L 460.247976 183.36503 
 L 458.793701 183.527182 
 L 457.339427 183.688849 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_128">
     <path d="M 457.339427 183.688849 
@@ -4675,7 +4675,7 @@ L 302.450749 178.826834
 L 299.008779 178.713671 
 L 295.566808 178.60027 
 L 292.124837 178.486631 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_129">
     <path d="M 292.124837 178.486631 
@@ -4727,7 +4727,7 @@ L 246.191563 189.6981
 L 245.170823 189.922669 
 L 244.150084 190.146311 
 L 243.129344 190.369032 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_130">
     <path d="M 243.129344 190.369032 
@@ -4779,7 +4779,7 @@ L 215.390639 203.654226
 L 214.774224 203.915384 
 L 214.157808 204.175288 
 L 213.541392 204.43395 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_131">
     <path d="M 213.541392 204.43395 
@@ -4831,7 +4831,7 @@ L 205.113797 211.689953
 L 204.926517 211.840648 
 L 204.739237 211.990924 
 L 204.551957 212.140784 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_132">
     <path d="M 204.551957 212.140784 
@@ -4883,7 +4883,7 @@ L 196.403329 227.688717
 L 196.222248 227.988205 
 L 196.041168 228.286045 
 L 195.860087 228.582256 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="line2d_133">
     <path d="M 195.860087 228.582256 
@@ -4935,7 +4935,7 @@ L 194.134867 233.954953
 L 194.096529 234.068494 
 L 194.058191 234.181796 
 L 194.019853 234.294862 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linecap: square"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -4953,7 +4953,7 @@ z
     </g>
     <g id="line2d_134">
      <defs>
-      <path id="m5cac22a7ae" d="M 0 3.5 
+      <path id="mc7bce7586a" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -4966,7 +4966,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m5cac22a7ae" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#mc7bce7586a" x="434.04625" y="353.9475" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_16">
@@ -5025,7 +5025,7 @@ z
     </g>
     <g id="line2d_135">
      <g>
-      <use xlink:href="#m901485b555" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m95802df9f0" x="434.04625" y="365.69" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -5039,7 +5039,7 @@ z
     </g>
     <g id="line2d_136">
      <g>
-      <use xlink:href="#m87ae9942f9" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf665228f92" x="434.04625" y="377.4325" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -5084,7 +5084,7 @@ z
     </g>
     <g id="line2d_137">
      <g>
-      <use xlink:href="#mf765730cdc" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m15f8d0bf73" x="434.04625" y="389.3975" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -5127,7 +5127,7 @@ z
     </g>
     <g id="line2d_138">
      <g>
-      <use xlink:href="#m92aced012f" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m0b19b779fc" x="434.04625" y="401.14" style="fill-opacity: 0; stroke: #ff7f0e; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -5143,7 +5143,7 @@ z
     </g>
     <g id="line2d_139">
      <g>
-      <use xlink:href="#mee0c7e31fb" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m97be5afa44" x="537.72375" y="353.9475" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_21">
@@ -5197,7 +5197,7 @@ z
     </g>
     <g id="line2d_140">
      <g>
-      <use xlink:href="#mbb46e5c2a2" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m67ed19be3f" x="537.72375" y="365.69" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -5262,7 +5262,7 @@ z
     </g>
     <g id="line2d_141">
      <g>
-      <use xlink:href="#mc515657357" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#mad5df05ce9" x="537.72375" y="377.4325" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_23">
@@ -5300,7 +5300,7 @@ z
     </g>
     <g id="line2d_142">
      <g>
-      <use xlink:href="#mfbbf324ae2" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb8008d103c" x="537.72375" y="389.175" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_24">
@@ -5370,486 +5370,486 @@ z
     </g>
    </g>
    <g id="line2d_143">
-    <g clip-path="url(#p931dae7db1)">
-     <use xlink:href="#m5cac22a7ae" x="319.643112" y="127.797254" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5cac22a7ae" x="269.129958" y="143.505192" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5cac22a7ae" x="247.452898" y="148.47912" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5cac22a7ae" x="199.911377" y="162.26353" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5cac22a7ae" x="190.761816" y="173.189283" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5cac22a7ae" x="165.858468" y="183.360893" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5cac22a7ae" x="159.340043" y="192.900333" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5cac22a7ae" x="158.195355" y="196.946157" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5cac22a7ae" x="120.106777" y="289.153815" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m5cac22a7ae" x="97.799363" y="316.815309" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#p1bc909886f)">
+     <use xlink:href="#mc7bce7586a" x="319.643112" y="127.779858" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc7bce7586a" x="269.129958" y="143.348459" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc7bce7586a" x="247.452898" y="148.339458" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc7bce7586a" x="199.911377" y="162.046831" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc7bce7586a" x="190.761816" y="173.046251" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc7bce7586a" x="165.858468" y="182.910023" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc7bce7586a" x="159.340043" y="192.65277" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc7bce7586a" x="158.195355" y="196.717909" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc7bce7586a" x="120.106777" y="289.46825" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#mc7bce7586a" x="97.799363" y="317.295793" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
    <g id="line2d_144">
-    <path d="M 319.643112 127.797254 
-L 318.590755 128.175605 
-L 317.538397 128.551329 
-L 316.48604 128.924463 
-L 315.433682 129.295043 
-L 314.381325 129.663104 
-L 313.328968 130.028678 
-L 312.27661 130.3918 
-L 311.224253 130.752503 
-L 310.171896 131.110818 
-L 309.119538 131.466776 
-L 308.067181 131.82041 
-L 307.014823 132.171748 
-L 305.962466 132.52082 
-L 304.910109 132.867656 
-L 303.857751 133.212283 
-L 302.805394 133.55473 
-L 301.753037 133.895025 
-L 300.700679 134.233194 
-L 299.648322 134.569263 
-L 298.595965 134.903258 
-L 297.543607 135.235206 
-L 296.49125 135.56513 
-L 295.438892 135.893055 
-L 294.386535 136.219006 
-L 293.334178 136.543006 
-L 292.28182 136.865078 
-L 291.229463 137.185246 
-L 290.177106 137.50353 
-L 289.124748 137.819955 
-L 288.072391 138.13454 
-L 287.020033 138.447307 
-L 285.967676 138.758278 
-L 284.915319 139.067473 
-L 283.862961 139.374911 
-L 282.810604 139.680613 
-L 281.758247 139.984599 
-L 280.705889 140.286887 
-L 279.653532 140.587496 
-L 278.601175 140.886445 
-L 277.548817 141.183752 
-L 276.49646 141.479435 
-L 275.444102 141.773512 
-L 274.391745 142.066 
-L 273.339388 142.356916 
-L 272.28703 142.646277 
-L 271.234673 142.934099 
-L 270.182316 143.220399 
-L 269.129958 143.505192 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 319.643112 127.779858 
+L 318.590755 128.15436 
+L 317.538397 128.526289 
+L 316.48604 128.89568 
+L 315.433682 129.262568 
+L 314.381325 129.626985 
+L 313.328968 129.988966 
+L 312.27661 130.348541 
+L 311.224253 130.705745 
+L 310.171896 131.060606 
+L 309.119538 131.413156 
+L 308.067181 131.763425 
+L 307.014823 132.111443 
+L 305.962466 132.457236 
+L 304.910109 132.800835 
+L 303.857751 133.142267 
+L 302.805394 133.481559 
+L 301.753037 133.818737 
+L 300.700679 134.153828 
+L 299.648322 134.486857 
+L 298.595965 134.81785 
+L 297.543607 135.146832 
+L 296.49125 135.473826 
+L 295.438892 135.798857 
+L 294.386535 136.121947 
+L 293.334178 136.443121 
+L 292.28182 136.7624 
+L 291.229463 137.079808 
+L 290.177106 137.395365 
+L 289.124748 137.709093 
+L 288.072391 138.021013 
+L 287.020033 138.331146 
+L 285.967676 138.639512 
+L 284.915319 138.946132 
+L 283.862961 139.251025 
+L 282.810604 139.55421 
+L 281.758247 139.855706 
+L 280.705889 140.155532 
+L 279.653532 140.453707 
+L 278.601175 140.750248 
+L 277.548817 141.045174 
+L 276.49646 141.338501 
+L 275.444102 141.630248 
+L 274.391745 141.920431 
+L 273.339388 142.209066 
+L 272.28703 142.49617 
+L 271.234673 142.78176 
+L 270.182316 143.065851 
+L 269.129958 143.348459 
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_145">
-    <path d="M 269.129958 143.505192 
-L 268.678353 143.613617 
-L 268.226747 143.721825 
-L 267.775142 143.829818 
-L 267.323537 143.937595 
-L 266.871931 144.045158 
-L 266.420326 144.152508 
-L 265.96872 144.259645 
-L 265.517115 144.366571 
-L 265.065509 144.473285 
-L 264.613904 144.57979 
-L 264.162299 144.686086 
-L 263.710693 144.792174 
-L 263.259088 144.898054 
-L 262.807482 145.003727 
-L 262.355877 145.109194 
-L 261.904271 145.214456 
-L 261.452666 145.319514 
-L 261.001061 145.424369 
-L 260.549455 145.529021 
-L 260.09785 145.63347 
-L 259.646244 145.737719 
-L 259.194639 145.841767 
-L 258.743034 145.945616 
-L 258.291428 146.049266 
-L 257.839823 146.152718 
-L 257.388217 146.255972 
-L 256.936612 146.35903 
-L 256.485006 146.461892 
-L 256.033401 146.564559 
-L 255.581796 146.667031 
-L 255.13019 146.76931 
-L 254.678585 146.871396 
-L 254.226979 146.97329 
-L 253.775374 147.074993 
-L 253.323769 147.176504 
-L 252.872163 147.277826 
-L 252.420558 147.378958 
-L 251.968952 147.479902 
-L 251.517347 147.580658 
-L 251.065741 147.681227 
-L 250.614136 147.781609 
-L 250.162531 147.881806 
-L 249.710925 147.981817 
-L 249.25932 148.081644 
-L 248.807714 148.181287 
-L 248.356109 148.280747 
-L 247.904503 148.380025 
-L 247.452898 148.47912 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 269.129958 143.348459 
+L 268.678353 143.457273 
+L 268.226747 143.565868 
+L 267.775142 143.674247 
+L 267.323537 143.782408 
+L 266.871931 143.890355 
+L 266.420326 143.998086 
+L 265.96872 144.105603 
+L 265.517115 144.212907 
+L 265.065509 144.319999 
+L 264.613904 144.426879 
+L 264.162299 144.533549 
+L 263.710693 144.640009 
+L 263.259088 144.74626 
+L 262.807482 144.852303 
+L 262.355877 144.958139 
+L 261.904271 145.063768 
+L 261.452666 145.169191 
+L 261.001061 145.274409 
+L 260.549455 145.379424 
+L 260.09785 145.484234 
+L 259.646244 145.588843 
+L 259.194639 145.693249 
+L 258.743034 145.797455 
+L 258.291428 145.90146 
+L 257.839823 146.005266 
+L 257.388217 146.108874 
+L 256.936612 146.212283 
+L 256.485006 146.315495 
+L 256.033401 146.418511 
+L 255.581796 146.521331 
+L 255.13019 146.623956 
+L 254.678585 146.726387 
+L 254.226979 146.828625 
+L 253.775374 146.930669 
+L 253.323769 147.032522 
+L 252.872163 147.134184 
+L 252.420558 147.235655 
+L 251.968952 147.336936 
+L 251.517347 147.438028 
+L 251.065741 147.538931 
+L 250.614136 147.639647 
+L 250.162531 147.740175 
+L 249.710925 147.840518 
+L 249.25932 147.940674 
+L 248.807714 148.040646 
+L 248.356109 148.140434 
+L 247.904503 148.240037 
+L 247.452898 148.339458 
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_146">
-    <path d="M 247.452898 148.47912 
-L 246.46245 148.805188 
-L 245.472001 149.129302 
-L 244.481553 149.451488 
-L 243.491105 149.771768 
-L 242.500656 150.090163 
-L 241.510208 150.406697 
-L 240.51976 150.721391 
-L 239.529311 151.034265 
-L 238.538863 151.345342 
-L 237.548414 151.654641 
-L 236.557966 151.962183 
-L 235.567518 152.267988 
-L 234.577069 152.572074 
-L 233.586621 152.874462 
-L 232.596173 153.17517 
-L 231.605724 153.474217 
-L 230.615276 153.771621 
-L 229.624828 154.0674 
-L 228.634379 154.361571 
-L 227.643931 154.654153 
-L 226.653483 154.945161 
-L 225.663034 155.234614 
-L 224.672586 155.522527 
-L 223.682137 155.808916 
-L 222.691689 156.093799 
-L 221.701241 156.37719 
-L 220.710792 156.659105 
-L 219.720344 156.939559 
-L 218.729896 157.218568 
-L 217.739447 157.496146 
-L 216.748999 157.772308 
-L 215.758551 158.047069 
-L 214.768102 158.320441 
-L 213.777654 158.59244 
-L 212.787206 158.863079 
-L 211.796757 159.132372 
-L 210.806309 159.400332 
-L 209.81586 159.666972 
-L 208.825412 159.932305 
-L 207.834964 160.196343 
-L 206.844515 160.4591 
-L 205.854067 160.720588 
-L 204.863619 160.980818 
-L 203.87317 161.239804 
-L 202.882722 161.497556 
-L 201.892274 161.754087 
-L 200.901825 162.009408 
-L 199.911377 162.26353 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 247.452898 148.339458 
+L 246.46245 148.663469 
+L 245.472001 148.985552 
+L 244.481553 149.30573 
+L 243.491105 149.624025 
+L 242.500656 149.940459 
+L 241.510208 150.255054 
+L 240.51976 150.567832 
+L 239.529311 150.878813 
+L 238.538863 151.188017 
+L 237.548414 151.495465 
+L 236.557966 151.801177 
+L 235.567518 152.105172 
+L 234.577069 152.407469 
+L 233.586621 152.708088 
+L 232.596173 153.007046 
+L 231.605724 153.304362 
+L 230.615276 153.600054 
+L 229.624828 153.89414 
+L 228.634379 154.186636 
+L 227.643931 154.477561 
+L 226.653483 154.76693 
+L 225.663034 155.054761 
+L 224.672586 155.341069 
+L 223.682137 155.625871 
+L 222.691689 155.909182 
+L 221.701241 156.191019 
+L 220.710792 156.471395 
+L 219.720344 156.750327 
+L 218.729896 157.027829 
+L 217.739447 157.303915 
+L 216.748999 157.578601 
+L 215.758551 157.851899 
+L 214.768102 158.123825 
+L 213.777654 158.394391 
+L 212.787206 158.663612 
+L 211.796757 158.931501 
+L 210.806309 159.19807 
+L 209.81586 159.463333 
+L 208.825412 159.727302 
+L 207.834964 159.989991 
+L 206.844515 160.251411 
+L 205.854067 160.511574 
+L 204.863619 160.770493 
+L 203.87317 161.02818 
+L 202.882722 161.284645 
+L 201.892274 161.539901 
+L 200.901825 161.79396 
+L 199.911377 162.046831 
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_147">
-    <path d="M 199.911377 162.26353 
-L 199.720761 162.515162 
-L 199.530145 162.76563 
-L 199.339529 163.014944 
-L 199.148913 163.263115 
-L 198.958298 163.510153 
-L 198.767682 163.75607 
-L 198.577066 164.000874 
-L 198.38645 164.244576 
-L 198.195834 164.487185 
-L 198.005218 164.728713 
-L 197.814603 164.969167 
-L 197.623987 165.208558 
-L 197.433371 165.446895 
-L 197.242755 165.684187 
-L 197.052139 165.920443 
-L 196.861523 166.155673 
-L 196.670907 166.389885 
-L 196.480292 166.623088 
-L 196.289676 166.855291 
-L 196.09906 167.086502 
-L 195.908444 167.316729 
-L 195.717828 167.545982 
-L 195.527212 167.774267 
-L 195.336596 168.001594 
-L 195.145981 168.22797 
-L 194.955365 168.453404 
-L 194.764749 168.677902 
-L 194.574133 168.901474 
-L 194.383517 169.124125 
-L 194.192901 169.345865 
-L 194.002286 169.5667 
-L 193.81167 169.786638 
-L 193.621054 170.005686 
-L 193.430438 170.223851 
-L 193.239822 170.44114 
-L 193.049206 170.65756 
-L 192.85859 170.873119 
-L 192.667975 171.087823 
-L 192.477359 171.301678 
-L 192.286743 171.514692 
-L 192.096127 171.726871 
-L 191.905511 171.938221 
-L 191.714895 172.14875 
-L 191.524279 172.358463 
-L 191.333664 172.567366 
-L 191.143048 172.775467 
-L 190.952432 172.98277 
-L 190.761816 173.189283 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 199.911377 162.046831 
+L 199.720761 162.300333 
+L 199.530145 162.552654 
+L 199.339529 162.803805 
+L 199.148913 163.053795 
+L 198.958298 163.302636 
+L 198.767682 163.550338 
+L 198.577066 163.796912 
+L 198.38645 164.042368 
+L 198.195834 164.286717 
+L 198.005218 164.529967 
+L 197.814603 164.772128 
+L 197.623987 165.013212 
+L 197.433371 165.253226 
+L 197.242755 165.492181 
+L 197.052139 165.730085 
+L 196.861523 165.966949 
+L 196.670907 166.202781 
+L 196.480292 166.437589 
+L 196.289676 166.671384 
+L 196.09906 166.904173 
+L 195.908444 167.135965 
+L 195.717828 167.366769 
+L 195.527212 167.596593 
+L 195.336596 167.825446 
+L 195.145981 168.053335 
+L 194.955365 168.280268 
+L 194.764749 168.506255 
+L 194.574133 168.731301 
+L 194.383517 168.955416 
+L 194.192901 169.178607 
+L 194.002286 169.400882 
+L 193.81167 169.622247 
+L 193.621054 169.842711 
+L 193.430438 170.06228 
+L 193.239822 170.280963 
+L 193.049206 170.498766 
+L 192.85859 170.715696 
+L 192.667975 170.93176 
+L 192.477359 171.146965 
+L 192.286743 171.361317 
+L 192.096127 171.574825 
+L 191.905511 171.787493 
+L 191.714895 171.999329 
+L 191.524279 172.21034 
+L 191.333664 172.420531 
+L 191.143048 172.629909 
+L 190.952432 172.838481 
+L 190.761816 173.046251 
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_148">
-    <path d="M 190.761816 173.189283 
-L 190.242996 173.421908 
-L 189.724177 173.653538 
-L 189.205357 173.884181 
-L 188.686537 174.113846 
-L 188.167717 174.34254 
-L 187.648898 174.570272 
-L 187.130078 174.79705 
-L 186.611258 175.022882 
-L 186.092438 175.247775 
-L 185.573619 175.471739 
-L 185.054799 175.694779 
-L 184.535979 175.916904 
-L 184.017159 176.138121 
-L 183.498339 176.358438 
-L 182.97952 176.577862 
-L 182.4607 176.7964 
-L 181.94188 177.01406 
-L 181.42306 177.230847 
-L 180.904241 177.44677 
-L 180.385421 177.661835 
-L 179.866601 177.876049 
-L 179.347781 178.089419 
-L 178.828962 178.301951 
-L 178.310142 178.513651 
-L 177.791322 178.724527 
-L 177.272502 178.934585 
-L 176.753683 179.143831 
-L 176.234863 179.352271 
-L 175.716043 179.559911 
-L 175.197223 179.766758 
-L 174.678404 179.972817 
-L 174.159584 180.178096 
-L 173.640764 180.382598 
-L 173.121944 180.586331 
-L 172.603125 180.7893 
-L 172.084305 180.991511 
-L 171.565485 181.192969 
-L 171.046665 181.39368 
-L 170.527846 181.59365 
-L 170.009026 181.792884 
-L 169.490206 181.991387 
-L 168.971386 182.189165 
-L 168.452566 182.386223 
-L 167.933747 182.582566 
-L 167.414927 182.7782 
-L 166.896107 182.973129 
-L 166.377287 183.167358 
-L 165.858468 183.360893 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 190.761816 173.046251 
+L 190.242996 173.271192 
+L 189.724177 173.495202 
+L 189.205357 173.718289 
+L 188.686537 173.94046 
+L 188.167717 174.161723 
+L 187.648898 174.382085 
+L 187.130078 174.601554 
+L 186.611258 174.820137 
+L 186.092438 175.03784 
+L 185.573619 175.254672 
+L 185.054799 175.470638 
+L 184.535979 175.685746 
+L 184.017159 175.900003 
+L 183.498339 176.113415 
+L 182.97952 176.325989 
+L 182.4607 176.537731 
+L 181.94188 176.748649 
+L 181.42306 176.958748 
+L 180.904241 177.168034 
+L 180.385421 177.376514 
+L 179.866601 177.584195 
+L 179.347781 177.791082 
+L 178.828962 177.997181 
+L 178.310142 178.202498 
+L 177.791322 178.40704 
+L 177.272502 178.610812 
+L 176.753683 178.813819 
+L 176.234863 179.016068 
+L 175.716043 179.217564 
+L 175.197223 179.418313 
+L 174.678404 179.61832 
+L 174.159584 179.817591 
+L 173.640764 180.016131 
+L 173.121944 180.213945 
+L 172.603125 180.411039 
+L 172.084305 180.607418 
+L 171.565485 180.803087 
+L 171.046665 180.998052 
+L 170.527846 181.192317 
+L 170.009026 181.385887 
+L 169.490206 181.578767 
+L 168.971386 181.770963 
+L 168.452566 181.962479 
+L 167.933747 182.153319 
+L 167.414927 182.343489 
+L 166.896107 182.532993 
+L 166.377287 182.721836 
+L 165.858468 182.910023 
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_149">
-    <path d="M 165.858468 183.360893 
-L 165.722667 183.577784 
-L 165.586867 183.793809 
-L 165.451066 184.008975 
-L 165.315266 184.223289 
-L 165.179465 184.436759 
-L 165.043665 184.649389 
-L 164.907864 184.861188 
-L 164.772064 185.072161 
-L 164.636263 185.282316 
-L 164.500463 185.491657 
-L 164.364662 185.700192 
-L 164.228862 185.907927 
-L 164.093061 186.114867 
-L 163.957261 186.32102 
-L 163.82146 186.52639 
-L 163.685659 186.730984 
-L 163.549859 186.934808 
-L 163.414058 187.137867 
-L 163.278258 187.340167 
-L 163.142457 187.541714 
-L 163.006657 187.742514 
-L 162.870856 187.942571 
-L 162.735056 188.141892 
-L 162.599255 188.340481 
-L 162.463455 188.538345 
-L 162.327654 188.735488 
-L 162.191854 188.931915 
-L 162.056053 189.127632 
-L 161.920253 189.322645 
-L 161.784452 189.516957 
-L 161.648652 189.710574 
-L 161.512851 189.903501 
-L 161.377051 190.095743 
-L 161.24125 190.287305 
-L 161.10545 190.478191 
-L 160.969649 190.668406 
-L 160.833849 190.857955 
-L 160.698048 191.046843 
-L 160.562248 191.235074 
-L 160.426447 191.422653 
-L 160.290647 191.609584 
-L 160.154846 191.795872 
-L 160.019046 191.981521 
-L 159.883245 192.166535 
-L 159.747445 192.350919 
-L 159.611644 192.534677 
-L 159.475844 192.717814 
-L 159.340043 192.900333 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 165.858468 182.910023 
+L 165.722667 183.131954 
+L 165.586867 183.352979 
+L 165.451066 183.573106 
+L 165.315266 183.79234 
+L 165.179465 184.010691 
+L 165.043665 184.228164 
+L 164.907864 184.444767 
+L 164.772064 184.660507 
+L 164.636263 184.87539 
+L 164.500463 185.089424 
+L 164.364662 185.302615 
+L 164.228862 185.514969 
+L 164.093061 185.726494 
+L 163.957261 185.937195 
+L 163.82146 186.147079 
+L 163.685659 186.356153 
+L 163.549859 186.564422 
+L 163.414058 186.771893 
+L 163.278258 186.978572 
+L 163.142457 187.184465 
+L 163.006657 187.389578 
+L 162.870856 187.593916 
+L 162.735056 187.797486 
+L 162.599255 188.000293 
+L 162.463455 188.202343 
+L 162.327654 188.403642 
+L 162.191854 188.604195 
+L 162.056053 188.804008 
+L 161.920253 189.003086 
+L 161.784452 189.201434 
+L 161.648652 189.399058 
+L 161.512851 189.595964 
+L 161.377051 189.792155 
+L 161.24125 189.987639 
+L 161.10545 190.182418 
+L 160.969649 190.3765 
+L 160.833849 190.569888 
+L 160.698048 190.762588 
+L 160.562248 190.954604 
+L 160.426447 191.145941 
+L 160.290647 191.336604 
+L 160.154846 191.526599 
+L 160.019046 191.715928 
+L 159.883245 191.904598 
+L 159.747445 192.092613 
+L 159.611644 192.279976 
+L 159.475844 192.466694 
+L 159.340043 192.65277 
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_150">
-    <path d="M 159.340043 192.900333 
-L 159.316195 192.98778 
-L 159.292348 193.075086 
-L 159.2685 193.162251 
-L 159.244652 193.249277 
-L 159.220805 193.336163 
-L 159.196957 193.422909 
-L 159.173109 193.509517 
-L 159.149262 193.595986 
-L 159.125414 193.682318 
-L 159.101566 193.768512 
-L 159.077719 193.854569 
-L 159.053871 193.940489 
-L 159.030023 194.026273 
-L 159.006176 194.111922 
-L 158.982328 194.197435 
-L 158.95848 194.282813 
-L 158.934633 194.368057 
-L 158.910785 194.453167 
-L 158.886937 194.538143 
-L 158.86309 194.622986 
-L 158.839242 194.707696 
-L 158.815394 194.792274 
-L 158.791547 194.87672 
-L 158.767699 194.961035 
-L 158.743851 195.045218 
-L 158.720004 195.12927 
-L 158.696156 195.213193 
-L 158.672308 195.296985 
-L 158.648461 195.380648 
-L 158.624613 195.464182 
-L 158.600765 195.547587 
-L 158.576918 195.630863 
-L 158.55307 195.714012 
-L 158.529222 195.797034 
-L 158.505375 195.879928 
-L 158.481527 195.962695 
-L 158.457679 196.045336 
-L 158.433832 196.127851 
-L 158.409984 196.210241 
-L 158.386136 196.292505 
-L 158.362289 196.374644 
-L 158.338441 196.456659 
-L 158.314593 196.53855 
-L 158.290746 196.620318 
-L 158.266898 196.701961 
-L 158.24305 196.783482 
-L 158.219203 196.864881 
-L 158.195355 196.946157 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 159.340043 192.65277 
+L 159.316195 192.74065 
+L 159.292348 192.828388 
+L 159.2685 192.915983 
+L 159.244652 193.003438 
+L 159.220805 193.090751 
+L 159.196957 193.177923 
+L 159.173109 193.264956 
+L 159.149262 193.351848 
+L 159.125414 193.438602 
+L 159.101566 193.525217 
+L 159.077719 193.611693 
+L 159.053871 193.698031 
+L 159.030023 193.784232 
+L 159.006176 193.870296 
+L 158.982328 193.956223 
+L 158.95848 194.042014 
+L 158.934633 194.127669 
+L 158.910785 194.213189 
+L 158.886937 194.298574 
+L 158.86309 194.383825 
+L 158.839242 194.468941 
+L 158.815394 194.553924 
+L 158.791547 194.638774 
+L 158.767699 194.723491 
+L 158.743851 194.808075 
+L 158.720004 194.892528 
+L 158.696156 194.976849 
+L 158.672308 195.061039 
+L 158.648461 195.145098 
+L 158.624613 195.229027 
+L 158.600765 195.312825 
+L 158.576918 195.396495 
+L 158.55307 195.480035 
+L 158.529222 195.563446 
+L 158.505375 195.64673 
+L 158.481527 195.729885 
+L 158.457679 195.812912 
+L 158.433832 195.895813 
+L 158.409984 195.978587 
+L 158.386136 196.061234 
+L 158.362289 196.143755 
+L 158.338441 196.226151 
+L 158.314593 196.308422 
+L 158.290746 196.390567 
+L 158.266898 196.472589 
+L 158.24305 196.554486 
+L 158.219203 196.636259 
+L 158.195355 196.717909 
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_151">
-    <path d="M 158.195355 196.946157 
-L 157.401843 201.789386 
-L 156.608331 206.234645 
-L 155.814819 210.3424 
-L 155.021307 214.160304 
-L 154.227795 217.72658 
-L 153.434283 221.072354 
-L 152.640771 224.223313 
-L 151.847259 227.200902 
-L 151.053747 230.023208 
-L 150.260234 232.705627 
-L 149.466722 235.261374 
-L 148.67321 237.701875 
-L 147.879698 240.037077 
-L 147.086186 242.275691 
-L 146.292674 244.425392 
-L 145.499162 246.492973 
-L 144.70565 248.484478 
-L 143.912138 250.405307 
-L 143.118626 252.260306 
-L 142.325114 254.053837 
-L 141.531602 255.789844 
-L 140.73809 257.471903 
-L 139.944578 259.103265 
-L 139.151066 260.686897 
-L 138.357554 262.225513 
-L 137.564042 263.721602 
-L 136.77053 265.177452 
-L 135.977018 266.59517 
-L 135.183506 267.976703 
-L 134.389994 269.323852 
-L 133.596482 270.638288 
-L 132.80297 271.921561 
-L 132.009458 273.175116 
-L 131.215945 274.400296 
-L 130.422433 275.59836 
-L 129.628921 276.77048 
-L 128.835409 277.917757 
-L 128.041897 279.041221 
-L 127.248385 280.141843 
-L 126.454873 281.220531 
-L 125.661361 282.278143 
-L 124.867849 283.315487 
-L 124.074337 284.333325 
-L 123.280825 285.332377 
-L 122.487313 286.313325 
-L 121.693801 287.276811 
-L 120.900289 288.223448 
-L 120.106777 289.153815 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 158.195355 196.717909 
+L 157.401843 201.618178 
+L 156.608331 206.111437 
+L 155.814819 210.260142 
+L 155.021307 214.113394 
+L 154.227795 217.710491 
+L 153.434283 221.083378 
+L 152.640771 224.258372 
+L 151.847259 227.257414 
+L 151.053747 230.098986 
+L 150.260234 232.798802 
+L 149.466722 235.370337 
+L 148.67321 237.82523 
+L 147.879698 240.173605 
+L 147.086186 242.424322 
+L 146.292674 244.585181 
+L 145.499162 246.663082 
+L 144.70565 248.664159 
+L 143.912138 250.593892 
+L 143.118626 252.457193 
+L 142.325114 254.258485 
+L 141.531602 256.001761 
+L 140.73809 257.690643 
+L 139.944578 259.328422 
+L 139.151066 260.918101 
+L 138.357554 262.462425 
+L 137.564042 263.963909 
+L 136.77053 265.424868 
+L 135.977018 266.84743 
+L 135.183506 268.233562 
+L 134.389994 269.585085 
+L 133.596482 270.903684 
+L 132.80297 272.190925 
+L 132.009458 273.448265 
+L 131.215945 274.677062 
+L 130.422433 275.878582 
+L 129.628921 277.054012 
+L 128.835409 278.204459 
+L 128.041897 279.330963 
+L 127.248385 280.434502 
+L 126.454873 281.515992 
+L 125.661361 282.576298 
+L 124.867849 283.616233 
+L 124.074337 284.636565 
+L 123.280825 285.63802 
+L 122.487313 286.621284 
+L 121.693801 287.587006 
+L 120.900289 288.5358 
+L 120.106777 289.46825 
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_152">
-    <path d="M 120.106777 289.153815 
-L 119.642039 289.900803 
-L 119.177301 290.637622 
-L 118.712564 291.364547 
-L 118.247826 292.081839 
-L 117.783088 292.789751 
-L 117.31835 293.488524 
-L 116.853612 294.178392 
-L 116.388875 294.859578 
-L 115.924137 295.532298 
-L 115.459399 296.196761 
-L 114.994661 296.853166 
-L 114.529924 297.501707 
-L 114.065186 298.14257 
-L 113.600448 298.775934 
-L 113.13571 299.401973 
-L 112.670972 300.020855 
-L 112.206235 300.632741 
-L 111.741497 301.237787 
-L 111.276759 301.836145 
-L 110.812021 302.427962 
-L 110.347283 303.013377 
-L 109.882546 303.59253 
-L 109.417808 304.165552 
-L 108.95307 304.732571 
-L 108.488332 305.293712 
-L 108.023595 305.849096 
-L 107.558857 306.39884 
-L 107.094119 306.943056 
-L 106.629381 307.481856 
-L 106.164643 308.015345 
-L 105.699906 308.543628 
-L 105.235168 309.066805 
-L 104.77043 309.584974 
-L 104.305692 310.09823 
-L 103.840955 310.606665 
-L 103.376217 311.110369 
-L 102.911479 311.609429 
-L 102.446741 312.10393 
-L 101.982003 312.593954 
-L 101.517266 313.079582 
-L 101.052528 313.560892 
-L 100.58779 314.03796 
-L 100.123052 314.510861 
-L 99.658315 314.979666 
-L 99.193577 315.444445 
-L 98.728839 315.905268 
-L 98.264101 316.362201 
-L 97.799363 316.815309 
-" clip-path="url(#p931dae7db1)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 120.106777 289.46825 
+L 119.642039 290.220934 
+L 119.177301 290.963295 
+L 118.712564 291.695613 
+L 118.247826 292.418156 
+L 117.783088 293.131181 
+L 117.31835 293.834936 
+L 116.853612 294.529659 
+L 116.388875 295.215579 
+L 115.924137 295.892915 
+L 115.459399 296.561881 
+L 114.994661 297.222681 
+L 114.529924 297.875511 
+L 114.065186 298.520562 
+L 113.600448 299.158016 
+L 113.13571 299.788051 
+L 112.670972 300.410837 
+L 112.206235 301.02654 
+L 111.741497 301.635318 
+L 111.276759 302.237325 
+L 110.812021 302.832711 
+L 110.347283 303.42162 
+L 109.882546 304.004191 
+L 109.417808 304.580558 
+L 108.95307 305.150853 
+L 108.488332 305.715203 
+L 108.023595 306.273729 
+L 107.558857 306.826552 
+L 107.094119 307.373785 
+L 106.629381 307.915542 
+L 106.164643 308.451931 
+L 105.699906 308.983056 
+L 105.235168 309.509021 
+L 104.77043 310.029924 
+L 104.305692 310.545863 
+L 103.840955 311.05693 
+L 103.376217 311.563218 
+L 102.911479 312.064813 
+L 102.446741 312.561804 
+L 101.982003 313.054273 
+L 101.517266 313.542302 
+L 101.052528 314.025971 
+L 100.58779 314.505356 
+L 100.123052 314.980533 
+L 99.658315 315.451575 
+L 99.193577 315.918553 
+L 98.728839 316.381537 
+L 98.264101 316.840595 
+L 97.799363 317.295793 
+" clip-path="url(#p1bc909886f)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_25">
@@ -6166,8 +6166,8 @@ z
    </g>
   </g>
   <g id="text_26">
-   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.467344 465.66) scale(0.07 -0.07)">
+   <!-- 2026-07-06T06:43:08Z  ·  Linux chungus2 x86_64  ·  commit f2d5688e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.453359 465.66) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-37" d="M 525 4666 
 L 3525 4666 
@@ -6188,31 +6188,6 @@ L 1638 0
 L 1638 4134 
 L -19 4134 
 L -19 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-35" d="M 691 4666 
-L 3169 4666 
-L 3169 4134 
-L 1269 4134 
-L 1269 2991 
-Q 1406 3038 1543 3061 
-Q 1681 3084 1819 3084 
-Q 2600 3084 3056 2656 
-Q 3513 2228 3513 1497 
-Q 3513 744 3044 326 
-Q 2575 -91 1722 -91 
-Q 1428 -91 1123 -41 
-Q 819 9 494 109 
-L 494 744 
-Q 775 591 1075 516 
-Q 1375 441 1709 441 
-Q 2250 441 2565 725 
-Q 2881 1009 2881 1497 
-Q 2881 1984 2565 2268 
-Q 2250 2553 1709 2553 
-Q 1456 2553 1204 2497 
-Q 953 2441 691 2322 
-L 691 4666 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-3a" d="M 750 794 
@@ -6285,6 +6260,31 @@ Q 2894 3584 3203 3211
 Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3d" d="M 678 2906 
 L 4684 2906 
 L 4684 2381 
@@ -6326,13 +6326,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -6372,109 +6372,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.195312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.982422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.769531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.34375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.130859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.095703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.435547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.617188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.320312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.433594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.710938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.089844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.712891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.404297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.583984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.207031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4747.994141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.617188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.240234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.027344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.734375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.201172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.988281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.5625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.349609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.136719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.587891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.769531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.148438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.003906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.480469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5842.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.068359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5913.855469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.644531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.84375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.626953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6340.90625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.285156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.171875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.306641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.785156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6852.966797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6925.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.654297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.767578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.046875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.007812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.791016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7299.890625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.410156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.185547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7721.96875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.347656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.130859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.230469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.439453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.222656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p931dae7db1">
+  <clipPath id="p1bc909886f">
    <rect x="49.078125" y="48.323125" width="588.121875" height="364.480625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_density.svg
+++ b/bench/graphs/silesia_decode_density.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 82.373685 412.80375 
 L 82.373685 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="maa893f17ff" d="M 0 0 
+       <path id="m2242afd4dd" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#maa893f17ff" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242afd4dd" x="82.373685" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -111,11 +111,11 @@ z
      <g id="line2d_3">
       <path d="M 165.44644 412.80375 
 L 165.44644 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#maa893f17ff" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242afd4dd" x="165.44644" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -157,11 +157,11 @@ z
      <g id="line2d_5">
       <path d="M 248.519195 412.80375 
 L 248.519195 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#maa893f17ff" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242afd4dd" x="248.519195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -211,11 +211,11 @@ z
      <g id="line2d_7">
       <path d="M 331.59195 412.80375 
 L 331.59195 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#maa893f17ff" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242afd4dd" x="331.59195" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -252,11 +252,11 @@ z
      <g id="line2d_9">
       <path d="M 414.664704 412.80375 
 L 414.664704 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#maa893f17ff" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242afd4dd" x="414.664704" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -299,11 +299,11 @@ z
      <g id="line2d_11">
       <path d="M 497.737459 412.80375 
 L 497.737459 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#maa893f17ff" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242afd4dd" x="497.737459" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -351,11 +351,11 @@ z
      <g id="line2d_13">
       <path d="M 580.810214 412.80375 
 L 580.810214 47.3475 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#maa893f17ff" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2242afd4dd" x="580.810214" y="412.80375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -897,16 +897,16 @@ z
      <g id="line2d_15">
       <path d="M 49.078125 391.82245 
 L 637.2 391.82245 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <defs>
-       <path id="m3291c2fef2" d="M 0 0 
+       <path id="m3ffd01d8be" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3291c2fef2" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ffd01d8be" x="49.078125" y="391.82245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -922,11 +922,11 @@ L -3.5 0
      <g id="line2d_17">
       <path d="M 49.078125 265.911133 
 L 637.2 265.911133 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m3291c2fef2" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ffd01d8be" x="49.078125" y="265.911133" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -942,11 +942,11 @@ L 637.2 265.911133
      <g id="line2d_19">
       <path d="M 49.078125 139.999816 
 L 637.2 139.999816 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m3291c2fef2" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3ffd01d8be" x="49.078125" y="139.999816" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -962,16 +962,16 @@ L 637.2 139.999816
      <g id="line2d_21">
       <path d="M 49.078125 411.32636 
 L 637.2 411.32636 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <defs>
-       <path id="md4fa40ca18" d="M 0 0 
+       <path id="m990a9fa08b" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="411.32636" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -979,11 +979,11 @@ L -2 0
      <g id="line2d_23">
       <path d="M 49.078125 404.024518 
 L 637.2 404.024518 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="404.024518" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -991,11 +991,11 @@ L 637.2 404.024518
      <g id="line2d_25">
       <path d="M 49.078125 397.583836 
 L 637.2 397.583836 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="397.583836" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1003,11 +1003,11 @@ L 637.2 397.583836
      <g id="line2d_27">
       <path d="M 49.078125 353.919367 
 L 637.2 353.919367 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="353.919367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1015,11 +1015,11 @@ L 637.2 353.919367
      <g id="line2d_29">
       <path d="M 49.078125 331.747485 
 L 637.2 331.747485 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="331.747485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1027,11 +1027,11 @@ L 637.2 331.747485
      <g id="line2d_31">
       <path d="M 49.078125 316.016284 
 L 637.2 316.016284 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="316.016284" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1039,11 +1039,11 @@ L 637.2 316.016284
      <g id="line2d_33">
       <path d="M 49.078125 303.814216 
 L 637.2 303.814216 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="303.814216" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1051,11 +1051,11 @@ L 637.2 303.814216
      <g id="line2d_35">
       <path d="M 49.078125 293.844402 
 L 637.2 293.844402 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="293.844402" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1063,11 +1063,11 @@ L 637.2 293.844402
      <g id="line2d_37">
       <path d="M 49.078125 285.415043 
 L 637.2 285.415043 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="285.415043" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1075,11 +1075,11 @@ L 637.2 285.415043
      <g id="line2d_39">
       <path d="M 49.078125 278.113201 
 L 637.2 278.113201 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="278.113201" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1087,11 +1087,11 @@ L 637.2 278.113201
      <g id="line2d_41">
       <path d="M 49.078125 271.672519 
 L 637.2 271.672519 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="271.672519" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1099,11 +1099,11 @@ L 637.2 271.672519
      <g id="line2d_43">
       <path d="M 49.078125 228.00805 
 L 637.2 228.00805 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="228.00805" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1111,11 +1111,11 @@ L 637.2 228.00805
      <g id="line2d_45">
       <path d="M 49.078125 205.836168 
 L 637.2 205.836168 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="205.836168" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1123,11 +1123,11 @@ L 637.2 205.836168
      <g id="line2d_47">
       <path d="M 49.078125 190.104967 
 L 637.2 190.104967 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="190.104967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1135,11 +1135,11 @@ L 637.2 190.104967
      <g id="line2d_49">
       <path d="M 49.078125 177.9029 
 L 637.2 177.9029 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="177.9029" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1147,11 +1147,11 @@ L 637.2 177.9029
      <g id="line2d_51">
       <path d="M 49.078125 167.933085 
 L 637.2 167.933085 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="167.933085" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1159,11 +1159,11 @@ L 637.2 167.933085
      <g id="line2d_53">
       <path d="M 49.078125 159.503726 
 L 637.2 159.503726 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="159.503726" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1171,11 +1171,11 @@ L 637.2 159.503726
      <g id="line2d_55">
       <path d="M 49.078125 152.201884 
 L 637.2 152.201884 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="152.201884" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1183,11 +1183,11 @@ L 637.2 152.201884
      <g id="line2d_57">
       <path d="M 49.078125 145.761202 
 L 637.2 145.761202 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="145.761202" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1195,11 +1195,11 @@ L 637.2 145.761202
      <g id="line2d_59">
       <path d="M 49.078125 102.096733 
 L 637.2 102.096733 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="102.096733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1207,11 +1207,11 @@ L 637.2 102.096733
      <g id="line2d_61">
       <path d="M 49.078125 79.924851 
 L 637.2 79.924851 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="79.924851" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1219,11 +1219,11 @@ L 637.2 79.924851
      <g id="line2d_63">
       <path d="M 49.078125 64.19365 
 L 637.2 64.19365 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="64.19365" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1231,11 +1231,11 @@ L 637.2 64.19365
      <g id="line2d_65">
       <path d="M 49.078125 51.991583 
 L 637.2 51.991583 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.6; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#md4fa40ca18" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m990a9fa08b" x="49.078125" y="51.991583" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1398,7 +1398,7 @@ z
    <g id="line2d_67">
     <path d="M 49.078125 63.959148 
 L 637.2 63.959148 
-" clip-path="url(#p1426252be7)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#pe9c3f339a8)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 49.078125 412.80375 
@@ -1762,78 +1762,78 @@ z
    </g>
    <g id="line2d_68">
     <defs>
-     <path id="m7bee23be3f" d="M -2.5 2.5 
+     <path id="m9614af643f" d="M -2.5 2.5 
 L 2.5 2.5 
 L 2.5 -2.5 
 L -2.5 -2.5 
 z
 " style="stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#m7bee23be3f" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m7bee23be3f" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe9c3f339a8)">
+     <use xlink:href="#m9614af643f" x="75.810937" y="263.216607" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="105.634056" y="269.620798" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="204.490635" y="301.215031" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="234.479899" y="307.658059" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="242.537956" y="315.917944" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="300.771958" y="298.734802" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="303.26414" y="310.074879" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="304.261013" y="319.328576" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="313.897453" y="319.101018" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="414.166268" y="335.426532" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="587.289889" y="328.826648" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m9614af643f" x="610.467187" y="319.678275" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_69">
     <defs>
-     <path id="md04406f221" d="M 0 -2.5 
+     <path id="mcf5dc94bfa" d="M 0 -2.5 
 L -2.5 2.5 
 L 2.5 2.5 
 z
 " style="stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#md04406f221" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md04406f221" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe9c3f339a8)">
+     <use xlink:href="#mcf5dc94bfa" x="75.810937" y="262.505003" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="105.634056" y="256.516219" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="204.490635" y="300.455891" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="234.479899" y="298.72384" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="242.537956" y="307.046683" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="300.771958" y="287.726284" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="303.26414" y="300.256724" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="304.261013" y="315.235818" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="313.897453" y="307.4765" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="414.166268" y="326.223389" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="587.289889" y="329.609806" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mcf5dc94bfa" x="610.467187" y="318.379704" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_70">
     <defs>
-     <path id="m2e009cffac" d="M -0 3.535534 
+     <path id="m00878d6e55" d="M -0 3.535534 
 L 3.535534 0 
 L 0 -3.535534 
 L -3.535534 -0 
 z
 " style="stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#m2e009cffac" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m2e009cffac" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe9c3f339a8)">
+     <use xlink:href="#m00878d6e55" x="75.810937" y="231.044207" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="105.634056" y="233.464672" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="204.490635" y="259.725746" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="234.479899" y="262.023129" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="242.537956" y="273.368182" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="300.771958" y="259.408271" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="303.26414" y="270.926655" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="304.261013" y="281.595692" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="313.897453" y="277.309155" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="414.166268" y="296.377475" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="587.289889" y="301.735817" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#m00878d6e55" x="610.467187" y="297.040139" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_71">
     <defs>
-     <path id="md03f756d09" d="M -0.833333 2.5 
+     <path id="mf0d6cf8542" d="M -0.833333 2.5 
 L 0.833333 2.5 
 L 0.833333 0.833333 
 L 2.5 0.833333 
@@ -1848,24 +1848,24 @@ L -0.833333 0.833333
 z
 " style="stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#md03f756d09" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#md03f756d09" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe9c3f339a8)">
+     <use xlink:href="#mf0d6cf8542" x="75.810937" y="286.910165" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="105.634056" y="294.974253" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="204.490635" y="327.107019" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="234.479899" y="335.778593" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="242.537956" y="341.647351" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="300.771958" y="337.663009" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="303.26414" y="345.502509" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="304.261013" y="345.645685" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="313.897453" y="351.930007" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="414.166268" y="363.456717" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="587.289889" y="368.243436" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mf0d6cf8542" x="610.467187" y="356.848113" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_72">
     <defs>
-     <path id="m1ed9c5d6df" d="M -1.25 2.5 
+     <path id="mb6602992e8" d="M -1.25 2.5 
 L 0 1.25 
 L 1.25 2.5 
 L 2.5 1.25 
@@ -1880,24 +1880,24 @@ L -2.5 1.25
 z
 " style="stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#m1ed9c5d6df" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#m1ed9c5d6df" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe9c3f339a8)">
+     <use xlink:href="#mb6602992e8" x="75.810937" y="328.907922" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="105.634056" y="342.121252" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="204.490635" y="364.316276" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="234.479899" y="371.357513" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="242.537956" y="368.122771" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="300.771958" y="365.072092" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="303.26414" y="374.607784" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="304.261013" y="366.131688" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="313.897453" y="378.589014" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="414.166268" y="386.15027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="587.289889" y="392.30027" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#mb6602992e8" x="610.467187" y="391.11076" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_73">
     <defs>
-     <path id="m8bc952b190" d="M 0 -2.5 
+     <path id="m447b1f7ad9" d="M 0 -2.5 
 L -0.561285 -0.772542 
 L -2.377641 -0.772542 
 L -0.908178 0.295085 
@@ -1910,24 +1910,24 @@ L 0.561285 -0.772542
 z
 " style="stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#m8bc952b190" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
-     <use xlink:href="#m8bc952b190" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pe9c3f339a8)">
+     <use xlink:href="#m447b1f7ad9" x="75.810937" y="274.450514" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="105.634056" y="287.578172" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="204.490635" y="320.76932" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="234.479899" y="321.538199" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="242.537956" y="326.688339" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="300.771958" y="333.426229" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="303.26414" y="337.000867" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="304.261013" y="346.386297" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="313.897453" y="336.174424" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="414.166268" y="357.767316" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="587.289889" y="366.526213" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+     <use xlink:href="#m447b1f7ad9" x="610.467187" y="361.324423" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_74">
     <defs>
-     <path id="mf1e8dc5d01" d="M 0 -2.5 
+     <path id="macc5185166" d="M 0 -2.5 
 L -2.165064 -1.25 
 L -2.165064 1.25 
 L -0 2.5 
@@ -1936,19 +1936,19 @@ L 2.165064 -1.25
 z
 " style="stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#mf1e8dc5d01" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
-     <use xlink:href="#mf1e8dc5d01" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+    <g clip-path="url(#pe9c3f339a8)">
+     <use xlink:href="#macc5185166" x="75.810937" y="345.30596" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="105.634056" y="352.048776" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="204.490635" y="367.386827" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="234.479899" y="374.711659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="242.537956" y="380.187639" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="300.771958" y="368.991079" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="303.26414" y="375.43221" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="304.261013" y="381.227374" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="313.897453" y="385.221601" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="414.166268" y="390.900659" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="587.289889" y="396.192102" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+     <use xlink:href="#macc5185166" x="610.467187" y="386.05669" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="legend_1">
@@ -1967,7 +1967,7 @@ z
     </g>
     <g id="line2d_75">
      <defs>
-      <path id="m1487120ad8" d="M 0 3.5 
+      <path id="m6fab33a2c5" d="M 0 3.5 
 C 0.928211 3.5 1.81853 3.131218 2.474874 2.474874 
 C 3.131218 1.81853 3.5 0.928211 3.5 0 
 C 3.5 -0.928211 3.131218 -1.81853 2.474874 -2.474874 
@@ -1980,7 +1980,7 @@ z
 " style="stroke: #d62728; stroke-width: 1.3"/>
      </defs>
      <g>
-      <use xlink:href="#m1487120ad8" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+      <use xlink:href="#m6fab33a2c5" x="434.04625" y="211.758125" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
      </g>
     </g>
     <g id="text_15">
@@ -2039,7 +2039,7 @@ z
     </g>
     <g id="line2d_76">
      <g>
-      <use xlink:href="#m7bee23be3f" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m9614af643f" x="434.04625" y="223.500625" style="fill-opacity: 0; stroke: #1f77b4; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
@@ -2053,7 +2053,7 @@ z
     </g>
     <g id="line2d_77">
      <g>
-      <use xlink:href="#md04406f221" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mcf5dc94bfa" x="434.04625" y="235.243125" style="fill-opacity: 0; stroke: #2ca02c; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_17">
@@ -2098,7 +2098,7 @@ z
     </g>
     <g id="line2d_78">
      <g>
-      <use xlink:href="#m2e009cffac" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#m00878d6e55" x="434.04625" y="247.208125" style="fill-opacity: 0; stroke: #9467bd; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
@@ -2118,7 +2118,7 @@ z
     </g>
     <g id="line2d_79">
      <g>
-      <use xlink:href="#md03f756d09" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mf0d6cf8542" x="537.72375" y="211.758125" style="fill-opacity: 0; stroke: #8c564b; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
@@ -2145,7 +2145,7 @@ z
     </g>
     <g id="line2d_80">
      <g>
-      <use xlink:href="#m1ed9c5d6df" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#mb6602992e8" x="537.72375" y="223.500625" style="fill-opacity: 0; stroke: #e377c2; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_20">
@@ -2210,7 +2210,7 @@ z
     </g>
     <g id="line2d_81">
      <g>
-      <use xlink:href="#m8bc952b190" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
+      <use xlink:href="#m447b1f7ad9" x="537.72375" y="235.243125" style="fill-opacity: 0; stroke: #bcbd22; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: bevel"/>
      </g>
     </g>
     <g id="text_21">
@@ -2248,7 +2248,7 @@ z
     </g>
     <g id="line2d_82">
      <g>
-      <use xlink:href="#mf1e8dc5d01" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
+      <use xlink:href="#macc5185166" x="537.72375" y="246.985625" style="fill-opacity: 0; stroke: #17becf; stroke-opacity: 0.95; stroke-width: 1.3; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
@@ -2318,19 +2318,19 @@ z
     </g>
    </g>
    <g id="line2d_83">
-    <g clip-path="url(#p1426252be7)">
-     <use xlink:href="#m1487120ad8" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
-     <use xlink:href="#m1487120ad8" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+    <g clip-path="url(#pe9c3f339a8)">
+     <use xlink:href="#m6fab33a2c5" x="75.810937" y="298.510024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="105.634056" y="315.672864" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="204.490635" y="347.595466" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="234.479899" y="355.186159" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="242.537956" y="354.419257" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="300.771958" y="342.079401" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="303.26414" y="366.152202" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="304.261013" y="375.092892" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="313.897453" y="369.574066" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="414.166268" y="382.204646" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="587.289889" y="393.510593" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
+     <use xlink:href="#m6fab33a2c5" x="610.467187" y="371.196024" style="fill: #d62728; stroke: #d62728; stroke-width: 1.3"/>
     </g>
    </g>
   </g>
@@ -3184,7 +3184,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p1426252be7">
+  <clipPath id="pe9c3f339a8">
    <rect x="49.078125" y="47.3475" width="588.121875" height="365.45625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_decode_ranking.svg
+++ b/bench/graphs/silesia_decode_ranking.svg
@@ -42,16 +42,16 @@ z
      <g id="line2d_1">
       <path d="M 290.788615 308.04375 
 L 290.788615 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
-       <path id="m5c613c82e4" d="M 0 0 
+       <path id="m4cf5a54c58" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5c613c82e4" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cf5a54c58" x="290.788615" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -136,11 +136,11 @@ z
      <g id="line2d_3">
       <path d="M 447.590599 308.04375 
 L 447.590599 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m5c613c82e4" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4cf5a54c58" x="447.590599" y="308.04375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -177,16 +177,16 @@ z
      <g id="line2d_5">
       <path d="M 181.188732 308.04375 
 L 181.188732 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <defs>
-       <path id="m80769aa95f" d="M 0 0 
+       <path id="m4f0b128503" d="M 0 0 
 L 0 2 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m80769aa95f" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="181.188732" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -194,11 +194,11 @@ L 0 2
      <g id="line2d_7">
       <path d="M 208.800191 308.04375 
 L 208.800191 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m80769aa95f" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="208.800191" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -206,11 +206,11 @@ L 208.800191 56.7075
      <g id="line2d_9">
       <path d="M 228.390833 308.04375 
 L 228.390833 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m80769aa95f" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="228.390833" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -218,11 +218,11 @@ L 228.390833 56.7075
      <g id="line2d_11">
       <path d="M 243.586515 308.04375 
 L 243.586515 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m80769aa95f" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="243.586515" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -230,11 +230,11 @@ L 243.586515 56.7075
      <g id="line2d_13">
       <path d="M 256.002291 308.04375 
 L 256.002291 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m80769aa95f" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="256.002291" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -242,11 +242,11 @@ L 256.002291 56.7075
      <g id="line2d_15">
       <path d="M 266.499681 308.04375 
 L 266.499681 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m80769aa95f" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="266.499681" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -254,11 +254,11 @@ L 266.499681 56.7075
      <g id="line2d_17">
       <path d="M 275.592933 308.04375 
 L 275.592933 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m80769aa95f" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="275.592933" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -266,11 +266,11 @@ L 275.592933 56.7075
      <g id="line2d_19">
       <path d="M 283.61375 308.04375 
 L 283.61375 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m80769aa95f" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="283.61375" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -278,11 +278,11 @@ L 283.61375 56.7075
      <g id="line2d_21">
       <path d="M 337.990716 308.04375 
 L 337.990716 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m80769aa95f" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="337.990716" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -290,11 +290,11 @@ L 337.990716 56.7075
      <g id="line2d_23">
       <path d="M 365.602174 308.04375 
 L 365.602174 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m80769aa95f" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="365.602174" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -302,11 +302,11 @@ L 365.602174 56.7075
      <g id="line2d_25">
       <path d="M 385.192816 308.04375 
 L 385.192816 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m80769aa95f" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="385.192816" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -314,11 +314,11 @@ L 385.192816 56.7075
      <g id="line2d_27">
       <path d="M 400.388498 308.04375 
 L 400.388498 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m80769aa95f" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="400.388498" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -326,11 +326,11 @@ L 400.388498 56.7075
      <g id="line2d_29">
       <path d="M 412.804275 308.04375 
 L 412.804275 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m80769aa95f" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="412.804275" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -338,11 +338,11 @@ L 412.804275 56.7075
      <g id="line2d_31">
       <path d="M 423.301664 308.04375 
 L 423.301664 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m80769aa95f" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="423.301664" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -350,11 +350,11 @@ L 423.301664 56.7075
      <g id="line2d_33">
       <path d="M 432.394917 308.04375 
 L 432.394917 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m80769aa95f" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="432.394917" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -362,11 +362,11 @@ L 432.394917 56.7075
      <g id="line2d_35">
       <path d="M 440.415734 308.04375 
 L 440.415734 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m80769aa95f" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="440.415734" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -374,11 +374,11 @@ L 440.415734 56.7075
      <g id="line2d_37">
       <path d="M 494.792699 308.04375 
 L 494.792699 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m80769aa95f" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="494.792699" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -386,11 +386,11 @@ L 494.792699 56.7075
      <g id="line2d_39">
       <path d="M 522.404158 308.04375 
 L 522.404158 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m80769aa95f" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="522.404158" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -398,11 +398,11 @@ L 522.404158 56.7075
      <g id="line2d_41">
       <path d="M 541.9948 308.04375 
 L 541.9948 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m80769aa95f" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="541.9948" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -410,11 +410,11 @@ L 541.9948 56.7075
      <g id="line2d_43">
       <path d="M 557.190482 308.04375 
 L 557.190482 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.4; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m80769aa95f" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m4f0b128503" x="557.190482" y="308.04375" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -985,12 +985,12 @@ z
     <g id="ytick_1">
      <g id="line2d_45">
       <defs>
-       <path id="mdc77b50919" d="M 0 0 
+       <path id="m4e40e2bd15" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e40e2bd15" x="139.360469" y="296.619375" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -1062,7 +1062,7 @@ z
     <g id="ytick_2">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e40e2bd15" x="139.360469" y="263.978304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -1129,7 +1129,7 @@ z
     <g id="ytick_3">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e40e2bd15" x="139.360469" y="231.337232" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -1242,7 +1242,7 @@ z
     <g id="ytick_4">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e40e2bd15" x="139.360469" y="198.696161" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -1298,7 +1298,7 @@ z
     <g id="ytick_5">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e40e2bd15" x="139.360469" y="166.055089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -1345,7 +1345,7 @@ z
     <g id="ytick_6">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e40e2bd15" x="139.360469" y="133.414018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -1361,7 +1361,7 @@ z
     <g id="ytick_7">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e40e2bd15" x="139.360469" y="100.772946" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -1408,7 +1408,7 @@ z
     <g id="ytick_8">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mdc77b50919" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4e40e2bd15" x="139.360469" y="68.131875" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -1431,47 +1431,47 @@ z
    <g id="LineCollection_1">
     <path d="M 139.360469 296.619375 
 L 154.556151 296.619375 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #17becf; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_2">
     <path d="M 139.360469 263.978304 
 L 162.32653 263.978304 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #e377c2; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_3">
     <path d="M 139.360469 231.337232 
 L 178.681331 231.337232 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #d62728; stroke-opacity: 0.9; stroke-width: 2.4"/>
    </g>
    <g id="LineCollection_4">
     <path d="M 139.360469 198.696161 
 L 201.044126 198.696161 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #8c564b; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_5">
     <path d="M 139.360469 166.055089 
 L 209.976983 166.055089 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #bcbd22; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_6">
     <path d="M 139.360469 133.414018 
 L 239.121093 133.414018 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #1f77b4; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_7">
     <path d="M 139.360469 100.772946 
 L 247.282543 100.772946 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #2ca02c; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="LineCollection_8">
     <path d="M 139.360469 68.131875 
 L 285.279501 68.131875 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke: #9467bd; stroke-opacity: 0.9; stroke-width: 1.3"/>
    </g>
    <g id="line2d_53">
     <path d="M 542.286834 308.04375 
 L 542.286834 56.7075 
-" clip-path="url(#p226beb7eef)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
+" clip-path="url(#p93a5b1f9d9)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #777777; stroke-width: 1.4"/>
    </g>
    <g id="patch_3">
     <path d="M 139.360469 308.04375 
@@ -1875,7 +1875,7 @@ z
    </g>
    <g id="line2d_54">
     <defs>
-     <path id="ma411708496" d="M 0 3 
+     <path id="m7c3980ef5e" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1887,13 +1887,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #17becf"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#ma411708496" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
+    <g clip-path="url(#p93a5b1f9d9)">
+     <use xlink:href="#m7c3980ef5e" x="154.556151" y="296.619375" style="fill: #17becf; stroke: #17becf"/>
     </g>
    </g>
    <g id="line2d_55">
     <defs>
-     <path id="m1cf1554c37" d="M 0 3 
+     <path id="m7142242b58" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1905,13 +1905,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #e377c2"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#m1cf1554c37" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
+    <g clip-path="url(#p93a5b1f9d9)">
+     <use xlink:href="#m7142242b58" x="162.32653" y="263.978304" style="fill: #e377c2; stroke: #e377c2"/>
     </g>
    </g>
    <g id="line2d_56">
     <defs>
-     <path id="mfeefa3e48a" d="M 0 5 
+     <path id="mc9ba483131" d="M 0 5 
 C 1.326016 5 2.597899 4.473168 3.535534 3.535534 
 C 4.473168 2.597899 5 1.326016 5 0 
 C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534 
@@ -1923,13 +1923,13 @@ C -2.597899 4.473168 -1.326016 5 0 5
 z
 " style="stroke: #d62728"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#mfeefa3e48a" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
+    <g clip-path="url(#p93a5b1f9d9)">
+     <use xlink:href="#mc9ba483131" x="178.681331" y="231.337232" style="fill: #d62728; stroke: #d62728"/>
     </g>
    </g>
    <g id="line2d_57">
     <defs>
-     <path id="m998b032618" d="M 0 3 
+     <path id="mb24fe627dc" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1941,13 +1941,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #8c564b"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#m998b032618" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
+    <g clip-path="url(#p93a5b1f9d9)">
+     <use xlink:href="#mb24fe627dc" x="201.044126" y="198.696161" style="fill: #8c564b; stroke: #8c564b"/>
     </g>
    </g>
    <g id="line2d_58">
     <defs>
-     <path id="mc9c9953a71" d="M 0 3 
+     <path id="mbde29285ac" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1959,13 +1959,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #bcbd22"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#mc9c9953a71" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
+    <g clip-path="url(#p93a5b1f9d9)">
+     <use xlink:href="#mbde29285ac" x="209.976983" y="166.055089" style="fill: #bcbd22; stroke: #bcbd22"/>
     </g>
    </g>
    <g id="line2d_59">
     <defs>
-     <path id="mff19055156" d="M 0 3 
+     <path id="m5e5f1f9ba0" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1977,13 +1977,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #1f77b4"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#mff19055156" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
+    <g clip-path="url(#p93a5b1f9d9)">
+     <use xlink:href="#m5e5f1f9ba0" x="239.121093" y="133.414018" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_60">
     <defs>
-     <path id="m43c7729c95" d="M 0 3 
+     <path id="m9239699b67" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -1995,13 +1995,13 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #2ca02c"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#m43c7729c95" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
+    <g clip-path="url(#p93a5b1f9d9)">
+     <use xlink:href="#m9239699b67" x="247.282543" y="100.772946" style="fill: #2ca02c; stroke: #2ca02c"/>
     </g>
    </g>
    <g id="line2d_61">
     <defs>
-     <path id="m94dbf7a018" d="M 0 3 
+     <path id="mf1443ad1b1" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -2013,8 +2013,8 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #9467bd"/>
     </defs>
-    <g clip-path="url(#p226beb7eef)">
-     <use xlink:href="#m94dbf7a018" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
+    <g clip-path="url(#p93a5b1f9d9)">
+     <use xlink:href="#mf1443ad1b1" x="285.279501" y="68.131875" style="fill: #9467bd; stroke: #9467bd"/>
     </g>
    </g>
   </g>
@@ -2869,7 +2869,7 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p226beb7eef">
+  <clipPath id="p93a5b1f9d9">
    <rect x="139.360469" y="56.7075" width="425.839531" height="251.33625"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_ratio_heatmap.svg
+++ b/bench/graphs/silesia_ratio_heatmap.svg
@@ -37,20 +37,20 @@ L 95.67625 49.34175
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p748564b91f)">
+   <g clip-path="url(#p524e25c2f1)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ90lEQVR4nO3YvY5dVx2H4TOe8Yc8jse2khBhEBK2KAghJQoFNKkQFFwDV0BDRYW4AypugA5FlG5SIgUIHyEFRIQPYZAxMXZMZOzxeA5X8BYoWvqjo+e5gt/RPlr73Wvv9M4Pt5sddPyjW9MTljj7+ivTE5bZe/GT0xOW2P76N9MTltj74svTE5bYPno4PWGZu995Y3rCEi9+/+vTE5bYu/aJ6QlrHD+aXrDM6c9287w/Mz0AAID/X2IRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC09+/jN7bTI1Y4/Nfd6QlLfHD54vSEZf5z8tH0hCU+/eHx9IQlPnzhpekJS5xuT6cnLHP14Nr0hDXu/Xl6wRIPr+7m83ruT7+fnrDM9nNfmp6whJtFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSweG9O9Mb1rh4ZXrBEtvt8fSEZT715i+mJ6zx+temFyxx9MHfpyescXoyvWCdwx09P85fml6wxOV/7ub7+f5nbkxPWObqX9+ZnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T19dms7PWKF/bt/nJ6wxJ3nzk1PWOajpw+mJyxx4y8PpicscfKFL09PWOLRycPpCcsc7V+ZnrDE9v2fT09Y4vFnX5mesMSFd96anrDMk1dfm56whJtFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIO395P1vb6dHrHDtwuH0hCXee3BvesIy3/rBL6cnLPGr731jesISR+ePpics8d2fvj09YZmvXL8wPWGJb954bXrCEm/efmt6whKXzu7m/3Cz2Wx+/If70xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApL2nz25tp0escP/J3ekJSxweXJ6esMx7D347PWGJm1denp6wxHZ7Oj1hiUsnu/sN/bfT3TwXrx/enJ6wxONnj6YnLLGrZ8dms9nsnzmYnrDE7p6KAAB8bGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASAf7ewfTG5Z4fv/a9IQ19s9NL1jm6PzR9IQlDg8uT09Y4tn2ZHrCEqdnd/cb+qXtxekJ/A929f18vH08PWGZh0/uTk9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOthsT6c3rLGjv+sfj29PT1jm6Nzz0xPWuPO76QVL7L9wc3rCGtuT6QXLHJ/ZzXNx//a70xPWuP756QVLXHz37ekJyxy++tXpCUu4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSfwFIxJkM6WST9QAAAABJRU5ErkJggg==" id="image293be742a2" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
+iVBORw0KGgoAAAANSUhEUgAAAosAAAGaCAYAAABniAm0AAAJ90lEQVR4nO3YvY5dVx2H4TOe8Yc8jse2khBhEBK2KAghJQoFNKkQFFwDV0BDRYW4AypugA5FlG5SIgUIHyEFRIQPYZAxMXZMZOzxeA5X8BYoWvqjo+e5gt/RPlr73Wvv9M4Pt5sddPyjW9MTljj7+ivTE5bZe/GT0xOW2P76N9MTltj74svTE5bYPno4PWGZu995Y3rCEi9+/+vTE5bYu/aJ6QlrHD+aXrDM6c9287w/Mz0AAID/X2IRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIC09+/jN7bTI1Y4/Nfd6QlLfHD54vSEZf5z8tH0hCU+/eHx9IQlPnzhpekJS5xuT6cnLHP14Nr0hDXu/Xl6wRIPr+7m83ruT7+fnrDM9nNfmp6whJtFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSweG9O9Mb1rh4ZXrBEtvt8fSEZT715i+mJ6zx+temFyxx9MHfpyescXoyvWCdwx09P85fml6wxOV/7ub7+f5nbkxPWObqX9+ZnrCEm0UAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAgiUUAAJJYBAAg7T19dms7PWKF/bt/nJ6wxJ3nzk1PWOajpw+mJyxx4y8PpicscfKFL09PWOLRycPpCcsc7V+ZnrDE9v2fT09Y4vFnX5mesMSFd96anrDMk1dfm56whJtFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIO395P1vb6dHrHDtwuH0hCXee3BvesIy3/rBL6cnLPGr731jesISR+ePpics8d2fvj09YZmvXL8wPWGJb954bXrCEm/efmt6whKXzu7m/3Cz2Wx+/If70xOWcLMIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAAJLEIAEASiwAApL2nz25tp0escP/J3ekJSxweXJ6esMx7D347PWGJm1denp6wxHZ7Oj1hiUsnu/sN/bfT3TwXrx/enJ6wxONnj6YnLLGrZ8dms9nsnzmYnrDE7p6KAAB8bGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASGIRAIAkFgEASAf7ewfTG5Z4fv/a9IQ19s9NL1jm6PzR9IQlDg8uT09Y4tn2ZHrCEqdnd/cb+qXtxekJ/A929f18vH08PWGZh0/uTk9YYndPRQAAPjaxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAEosAACSxCABAOthsT6c3rLGjv+sfj29PT1jm6Nzz0xPWuPO76QVL7L9wc3rCGtuT6QXLHJ/ZzXNx//a70xPWuP756QVLXHz37ekJyxy++tXpCUu4WQQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAACSWAQAIIlFAADSfwFIxJkM6WST9QAAAABJRU5ErkJggg==" id="imageca0c79f9dc" transform="scale(1 -1) translate(0 -295.2)" x="95.67625" y="-48.828011" width="468.72" height="295.2"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m11853e6c73" d="M 0 0 
+       <path id="m4da52a0fe0" d="M 0 0 
 L 0 3.5 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m11853e6c73" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="115.182137" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -220,7 +220,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m11853e6c73" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="154.193912" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -345,7 +345,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m11853e6c73" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="193.205687" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -378,7 +378,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m11853e6c73" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="232.217462" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -393,7 +393,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m11853e6c73" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="271.229237" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -435,7 +435,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m11853e6c73" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="310.241012" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -479,7 +479,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m11853e6c73" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="349.252787" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -538,7 +538,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m11853e6c73" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="388.264562" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -555,7 +555,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m11853e6c73" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="427.276336" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -570,7 +570,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m11853e6c73" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="466.288111" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -607,7 +607,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m11853e6c73" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="505.299886" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -648,7 +648,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m11853e6c73" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m4da52a0fe0" x="544.311661" y="344.028011" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -665,12 +665,12 @@ z
     <g id="ytick_1">
      <g id="line2d_13">
       <defs>
-       <path id="m772a10c669" d="M 0 0 
+       <path id="m3758ca7a2e" d="M 0 0 
 L -3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m772a10c669" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3758ca7a2e" x="95.67625" y="67.759641" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -764,7 +764,7 @@ z
     <g id="ytick_2">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m772a10c669" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3758ca7a2e" x="95.67625" y="104.595424" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
@@ -796,7 +796,7 @@ z
     <g id="ytick_3">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m772a10c669" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3758ca7a2e" x="95.67625" y="141.431207" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -818,7 +818,7 @@ z
     <g id="ytick_4">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m772a10c669" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3758ca7a2e" x="95.67625" y="178.266989" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -836,7 +836,7 @@ z
     <g id="ytick_5">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m772a10c669" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3758ca7a2e" x="95.67625" y="215.102772" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -899,7 +899,7 @@ z
     <g id="ytick_6">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m772a10c669" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3758ca7a2e" x="95.67625" y="251.938555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -966,7 +966,7 @@ z
     <g id="ytick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m772a10c669" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3758ca7a2e" x="95.67625" y="288.774337" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -1047,7 +1047,7 @@ z
     <g id="ytick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m772a10c669" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3758ca7a2e" x="95.67625" y="325.61012" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -2060,18 +2060,18 @@ z
 " style="fill: #ffffff"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image9ec91250df" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFUCAYAAADCj9eRAAAB2ElEQVR4nO2aQY7EIAwEIeFP+6X9/33C3MPcKKSS1TygZRftNlLS2//fbJtn9KvvajAi17ZCM7Uzeg+TEyJhsh4TE8D25ZhYRMJkPSYmmZ0zIhfQEMPkJq74JpgQlUBMABkIrOV2KLMRItXMhrQjqcQUSszsbGuomFSbHULEAlblE0klor1zMaG0XwnDBDAsBVY0O4CIBizlE4ntEbCijK3mE8vKUPkEEIF8YslYje2RZFP5BJkdCxOonf1i6jEhRICOyjEBzFaPiWd2iChoYbKKhMkqgmSsh4kkHkU+6UyeACJEJaLZ6QQTzy7WtGPyicX2Kp/c+yKaATTliSWoTXsnPllEEtTLGX37f+7WRpuPQ4RhomlntCdMTohATIDbKceEaGfOD1BJZueIiImJZQBNTCxgw2Q91N7Zf7RBsxMmR0TqMdmvxPRmI0TmDJNVJExWkTBZRcJkFSnFZH6Q5aVhQrQzkYUOVEIxIXxSjAnRDjQ7mndsZud9VEwsPtFcsWjvaNZofHKoEpFPELCPJmORdqblMWxiYjEbw+QJk/dR+SQD+BbROFbEJAP4Q4RgQpiNCupKIhAT4gewakws7YTJIREoY4FPeNWYaNoJk18iQNqXY1LKJ1/07Ct/l+QCQgAAAABJRU5ErkJggg==" id="image62275eaeab" transform="scale(1 -1) translate(0 -244.8)" x="573.84" y="-74.16" width="12.24" height="244.8"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_9">
      <g id="line2d_21">
       <defs>
-       <path id="m4a8aad0b4e" d="M 0 0 
+       <path id="mbaaea22ab2" d="M 0 0 
 L 3.5 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4a8aad0b4e" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaea22ab2" x="585.876562" y="282.022672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_117">
@@ -2097,7 +2097,7 @@ z
     <g id="ytick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m4a8aad0b4e" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaea22ab2" x="585.876562" y="239.353777" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_118">
@@ -2114,7 +2114,7 @@ z
     <g id="ytick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m4a8aad0b4e" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaea22ab2" x="585.876562" y="196.684881" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_119">
@@ -2130,7 +2130,7 @@ z
     <g id="ytick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m4a8aad0b4e" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaea22ab2" x="585.876562" y="154.015985" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_120">
@@ -2146,7 +2146,7 @@ z
     <g id="ytick_13">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4a8aad0b4e" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mbaaea22ab2" x="585.876562" y="111.347089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_121">
@@ -2739,8 +2739,8 @@ z
    </g>
   </g>
   <g id="text_124">
-   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
-   <g style="fill: #555555" transform="translate(43.467344 401.184) scale(0.07 -0.07)">
+   <!-- 2026-07-06T06:43:08Z  ·  Linux chungus2 x86_64  ·  commit f2d5688e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <g style="fill: #555555" transform="translate(44.453359 401.184) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-54" d="M -19 4666 
 L 3928 4666 
@@ -2764,44 +2764,6 @@ L 1409 3309
 L 1409 2516 
 L 750 2516 
 L 750 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-b7" d="M 684 2619 
-L 1344 2619 
-L 1344 1825 
-L 684 1825 
-L 684 2619 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-4c" d="M 628 4666 
-L 1259 4666 
-L 1259 531 
-L 3531 531 
-L 3531 0 
-L 628 0 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-75" d="M 544 1381 
-L 544 3500 
-L 1119 3500 
-L 1119 1403 
-Q 1119 906 1312 657 
-Q 1506 409 1894 409 
-Q 2359 409 2629 706 
-Q 2900 1003 2900 1516 
-L 2900 3500 
-L 3475 3500 
-L 3475 0 
-L 2900 0 
-L 2900 538 
-Q 2691 219 2414 64 
-Q 2138 -91 1772 -91 
-Q 1169 -91 856 284 
-Q 544 659 544 1381 
-z
-M 1991 3584 
-L 1991 3584 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-38" d="M 2034 2216 
@@ -2843,6 +2805,44 @@ Q 1625 4250 1398 4047
 Q 1172 3844 1172 3481 
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-b7" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-3b" d="M 750 3309 
 L 1409 3309 
 L 1409 2516 
@@ -2871,13 +2871,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2917,109 +2917,109 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.195312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.982422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.769531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.34375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.130859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.095703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.435547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.617188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.320312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.433594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.710938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.089844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.712891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.404297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.583984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.207031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4747.994141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.617188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.240234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.027344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.734375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.201172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.988281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.5625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.349609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.136719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.587891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.769531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.148438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.003906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.480469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5842.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.068359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5913.855469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.644531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.84375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.626953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6340.90625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.285156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.171875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.306641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.785156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6852.966797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6925.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.654297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.767578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.046875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.007812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.791016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7299.890625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.410156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.185547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7721.96875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.347656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.130859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.230469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.439453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.222656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p748564b91f">
+  <clipPath id="p524e25c2f1">
    <rect x="95.67625" y="49.34175" width="468.141298" height="294.686261"/>
   </clipPath>
  </defs>

--- a/bench/graphs/silesia_summary.svg
+++ b/bench/graphs/silesia_summary.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="575.465312pt" height="386.202469pt" viewBox="0 0 575.465312 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="573.493281pt" height="386.202469pt" viewBox="0 0 573.493281 386.202469" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -22,232 +22,232 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 386.202469 
-L 575.465312 386.202469 
-L 575.465312 0 
+L 573.493281 386.202469 
+L 573.493281 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 189.857656 104.1264 
-L 294.482656 104.1264 
-L 294.482656 74.7432 
-L 189.857656 74.7432 
+    <path d="M 188.871641 104.1264 
+L 293.496641 104.1264 
+L 293.496641 74.7432 
+L 188.871641 74.7432 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fffdbc; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_3">
-    <path d="M 294.482656 104.1264 
-L 399.107656 104.1264 
-L 399.107656 74.7432 
-L 294.482656 74.7432 
+    <path d="M 293.496641 104.1264 
+L 398.121641 104.1264 
+L 398.121641 74.7432 
+L 293.496641 74.7432 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 399.107656 104.1264 
-L 503.732656 104.1264 
-L 503.732656 74.7432 
-L 399.107656 74.7432 
+    <path d="M 398.121641 104.1264 
+L 502.746641 104.1264 
+L 502.746641 74.7432 
+L 398.121641 74.7432 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 189.857656 133.5096 
-L 294.482656 133.5096 
-L 294.482656 104.1264 
-L 189.857656 104.1264 
+    <path d="M 188.871641 133.5096 
+L 293.496641 133.5096 
+L 293.496641 104.1264 
+L 188.871641 104.1264 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fee695; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 294.482656 133.5096 
-L 399.107656 133.5096 
-L 399.107656 104.1264 
-L 294.482656 104.1264 
+    <path d="M 293.496641 133.5096 
+L 398.121641 133.5096 
+L 398.121641 104.1264 
+L 293.496641 104.1264 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fafdb8; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 399.107656 133.5096 
-L 503.732656 133.5096 
-L 503.732656 104.1264 
-L 399.107656 104.1264 
+    <path d="M 398.121641 133.5096 
+L 502.746641 133.5096 
+L 502.746641 104.1264 
+L 398.121641 104.1264 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fece7c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 189.857656 162.8928 
-L 294.482656 162.8928 
-L 294.482656 133.5096 
-L 189.857656 133.5096 
+    <path d="M 188.871641 162.8928 
+L 293.496641 162.8928 
+L 293.496641 133.5096 
+L 188.871641 133.5096 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fee08b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 294.482656 162.8928 
-L 399.107656 162.8928 
-L 399.107656 133.5096 
-L 294.482656 133.5096 
+    <path d="M 293.496641 162.8928 
+L 398.121641 162.8928 
+L 398.121641 133.5096 
+L 293.496641 133.5096 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #feefa3; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 399.107656 162.8928 
-L 503.732656 162.8928 
-L 503.732656 133.5096 
-L 399.107656 133.5096 
+    <path d="M 398.121641 162.8928 
+L 502.746641 162.8928 
+L 502.746641 133.5096 
+L 398.121641 133.5096 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fdbf6f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 189.857656 192.276 
-L 294.482656 192.276 
-L 294.482656 162.8928 
-L 189.857656 162.8928 
+    <path d="M 188.871641 192.276 
+L 293.496641 192.276 
+L 293.496641 162.8928 
+L 188.871641 162.8928 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fdb567; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 294.482656 192.276 
-L 399.107656 192.276 
-L 399.107656 162.8928 
-L 294.482656 162.8928 
+    <path d="M 293.496641 192.276 
+L 398.121641 192.276 
+L 398.121641 162.8928 
+L 293.496641 162.8928 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fede89; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.107656 192.276 
-L 503.732656 192.276 
-L 503.732656 162.8928 
-L 399.107656 162.8928 
+    <path d="M 398.121641 192.276 
+L 502.746641 192.276 
+L 502.746641 162.8928 
+L 398.121641 162.8928 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #f7814c; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 189.857656 221.6592 
-L 294.482656 221.6592 
-L 294.482656 192.276 
-L 189.857656 192.276 
+    <path d="M 188.871641 221.6592 
+L 293.496641 221.6592 
+L 293.496641 192.276 
+L 188.871641 192.276 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #feea9b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 294.482656 221.6592 
-L 399.107656 221.6592 
-L 399.107656 192.276 
-L 294.482656 192.276 
+    <path d="M 293.496641 221.6592 
+L 398.121641 221.6592 
+L 398.121641 192.276 
+L 293.496641 192.276 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fed27f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 399.107656 221.6592 
-L 503.732656 221.6592 
-L 503.732656 192.276 
-L 399.107656 192.276 
+    <path d="M 398.121641 221.6592 
+L 502.746641 221.6592 
+L 502.746641 192.276 
+L 398.121641 192.276 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fffcba; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 189.857656 251.0424 
-L 294.482656 251.0424 
-L 294.482656 221.6592 
-L 189.857656 221.6592 
+    <path d="M 188.871641 251.0424 
+L 293.496641 251.0424 
+L 293.496641 221.6592 
+L 188.871641 221.6592 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fff3ac; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 294.482656 251.0424 
-L 399.107656 251.0424 
-L 399.107656 221.6592 
-L 294.482656 221.6592 
+    <path d="M 293.496641 251.0424 
+L 398.121641 251.0424 
+L 398.121641 221.6592 
+L 293.496641 221.6592 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fecc7b; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 399.107656 251.0424 
-L 503.732656 251.0424 
-L 503.732656 221.6592 
-L 399.107656 221.6592 
+    <path d="M 398.121641 251.0424 
+L 502.746641 251.0424 
+L 502.746641 221.6592 
+L 398.121641 221.6592 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #e8f59f; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 189.857656 280.4256 
-L 294.482656 280.4256 
-L 294.482656 251.0424 
-L 189.857656 251.0424 
+    <path d="M 188.871641 280.4256 
+L 293.496641 280.4256 
+L 293.496641 251.0424 
+L 188.871641 251.0424 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fedc88; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 294.482656 280.4256 
-L 399.107656 280.4256 
-L 399.107656 251.0424 
-L 294.482656 251.0424 
+    <path d="M 293.496641 280.4256 
+L 398.121641 280.4256 
+L 398.121641 251.0424 
+L 293.496641 251.0424 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fdbd6d; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 399.107656 280.4256 
-L 503.732656 280.4256 
-L 503.732656 251.0424 
-L 399.107656 251.0424 
+    <path d="M 398.121641 280.4256 
+L 502.746641 280.4256 
+L 502.746641 251.0424 
+L 398.121641 251.0424 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #f88c51; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_23">
-    <path d="M 189.857656 309.8088 
-L 294.482656 309.8088 
-L 294.482656 280.4256 
-L 189.857656 280.4256 
+    <path d="M 188.871641 309.8088 
+L 293.496641 309.8088 
+L 293.496641 280.4256 
+L 188.871641 280.4256 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_24">
-    <path d="M 294.482656 309.8088 
-L 399.107656 309.8088 
-L 399.107656 280.4256 
-L 294.482656 280.4256 
+    <path d="M 293.496641 309.8088 
+L 398.121641 309.8088 
+L 398.121641 280.4256 
+L 293.496641 280.4256 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #fa9b58; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_25">
-    <path d="M 399.107656 309.8088 
-L 503.732656 309.8088 
-L 503.732656 280.4256 
-L 399.107656 280.4256 
+    <path d="M 398.121641 309.8088 
+L 502.746641 309.8088 
+L 502.746641 280.4256 
+L 398.121641 280.4256 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_26">
-    <path d="M 189.857656 339.192 
-L 294.482656 339.192 
-L 294.482656 309.8088 
-L 189.857656 309.8088 
+    <path d="M 188.871641 339.192 
+L 293.496641 339.192 
+L 293.496641 309.8088 
+L 188.871641 309.8088 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #3faa59; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 294.482656 339.192 
-L 399.107656 339.192 
-L 399.107656 309.8088 
-L 294.482656 309.8088 
+    <path d="M 293.496641 339.192 
+L 398.121641 339.192 
+L 398.121641 309.8088 
+L 293.496641 309.8088 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #e54e35; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 399.107656 339.192 
-L 503.732656 339.192 
-L 503.732656 309.8088 
-L 399.107656 309.8088 
+    <path d="M 398.121641 339.192 
+L 502.746641 339.192 
+L 502.746641 309.8088 
+L 398.121641 309.8088 
 z
-" clip-path="url(#pb007eb364d)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
+" clip-path="url(#pa8ed153ee9)" style="fill: #f2f2f2; stroke: #ffffff; stroke-linejoin: miter"/>
    </g>
    <g id="text_1">
     <!-- codec -->
-    <g transform="translate(122.844922 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(121.858906 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391 
 L 3366 2478 
@@ -352,7 +352,7 @@ z
    </g>
    <g id="text_2">
     <!-- ratio -->
-    <g transform="translate(230.129141 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(229.143125 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-72" d="M 3138 2547 
 Q 2991 2616 2845 2648 
@@ -448,7 +448,7 @@ z
    </g>
    <g id="text_3">
     <!-- compress MB/s -->
-    <g transform="translate(308.70125 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(307.715234 62.535037) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
 Q 3994 3244 4286 3414 
@@ -613,7 +613,7 @@ z
    </g>
    <g id="text_4">
     <!-- decompress MB/s -->
-    <g transform="translate(407.052969 62.535037) scale(0.09 -0.09)">
+    <g transform="translate(406.066953 62.535037) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSans-Bold-64"/>
      <use xlink:href="#DejaVuSans-Bold-65" transform="translate(71.582031 0)"/>
      <use xlink:href="#DejaVuSans-Bold-63" transform="translate(139.404297 0)"/>
@@ -633,7 +633,7 @@ z
    </g>
    <g id="text_5">
     <!-- libdeflate -->
-    <g transform="translate(118.782656 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(117.796641 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6c" d="M 603 4863 
 L 1178 4863 
@@ -822,7 +822,7 @@ z
    </g>
    <g id="text_6">
     <!-- 0.320 -->
-    <g transform="translate(230.718906 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-30" d="M 2034 4250 
 Q 1547 4250 1301 3770 
@@ -918,7 +918,7 @@ z
    </g>
    <g id="text_7">
     <!-- 117 -->
-    <g transform="translate(339.160156 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(338.174141 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-31" d="M 794 531 
 L 1825 531 
@@ -952,7 +952,7 @@ z
    </g>
    <g id="text_8">
     <!-- 852 -->
-    <g transform="translate(443.785156 91.6423) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 91.6423) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-38" d="M 2034 2216 
 Q 1584 2216 1326 1975 
@@ -1026,7 +1026,7 @@ z
    </g>
    <g id="text_9">
     <!-- Zig std.flate -->
-    <g transform="translate(113.420781 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(112.434766 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-5a" d="M 359 4666 
 L 4025 4666 
@@ -1125,7 +1125,7 @@ z
    </g>
    <g id="text_10">
     <!-- 0.324 -->
-    <g transform="translate(230.718906 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-34" d="M 2419 4116 
 L 825 1625 
@@ -1156,7 +1156,7 @@ z
    </g>
    <g id="text_11">
     <!-- 61 -->
-    <g transform="translate(341.705156 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 121.0255) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-36" d="M 2113 2584 
 Q 1688 2584 1439 2293 
@@ -1195,7 +1195,7 @@ z
    </g>
    <g id="text_12">
     <!-- 312 -->
-    <g transform="translate(443.785156 121.0255) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 121.0255) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(127.246094 0)"/>
@@ -1203,7 +1203,7 @@ z
    </g>
    <g id="text_13">
     <!-- Go compress/flate -->
-    <g transform="translate(101.113906 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(100.127891 150.4087) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -1374,7 +1374,7 @@ z
    </g>
    <g id="text_14">
     <!-- 0.325 -->
-    <g transform="translate(230.718906 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1384,14 +1384,14 @@ z
    </g>
    <g id="text_15">
     <!-- 50 -->
-    <g transform="translate(341.705156 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_16">
     <!-- 275 -->
-    <g transform="translate(443.785156 150.4087) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 150.4087) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
@@ -1399,7 +1399,7 @@ z
    </g>
    <g id="text_17">
     <!-- JS fflate -->
-    <g transform="translate(122.146406 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(121.160391 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4a" d="M 628 4666 
 L 1259 4666 
@@ -1459,7 +1459,7 @@ z
    </g>
    <g id="text_18">
     <!-- 0.329 -->
-    <g transform="translate(230.718906 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 179.7919) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-39" d="M 703 97 
 L 703 672 
@@ -1501,14 +1501,14 @@ z
    </g>
    <g id="text_19">
     <!-- 41 -->
-    <g transform="translate(341.705156 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 160 -->
-    <g transform="translate(443.785156 179.7919) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 179.7919) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -1516,7 +1516,7 @@ z
    </g>
    <g id="text_21">
     <!-- zlib -->
-    <g transform="translate(130.683906 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(129.697891 209.1751) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-7a" d="M 353 3500 
 L 3084 3500 
@@ -1540,7 +1540,7 @@ z
    </g>
    <g id="text_22">
     <!-- 0.323 -->
-    <g transform="translate(230.718906 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1550,14 +1550,14 @@ z
    </g>
    <g id="text_23">
     <!-- 38 -->
-    <g transform="translate(341.705156 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_24">
     <!-- 448 -->
-    <g transform="translate(443.785156 209.1751) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 209.1751) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-34"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-38" transform="translate(127.246094 0)"/>
@@ -1565,7 +1565,7 @@ z
    </g>
    <g id="text_25">
     <!-- miniz_oxide -->
-    <g transform="translate(113.990156 238.44705) scale(0.08 -0.08)">
+    <g transform="translate(113.004141 238.44705) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113 
 L 3513 0 
@@ -1624,7 +1624,7 @@ z
    </g>
    <g id="text_26">
     <!-- 0.322 -->
-    <g transform="translate(230.718906 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -1634,14 +1634,14 @@ z
    </g>
    <g id="text_27">
     <!-- 36 -->
-    <g transform="translate(341.705156 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_28">
     <!-- 527 -->
-    <g transform="translate(443.785156 238.5583) scale(0.08 -0.08)">
+    <g transform="translate(442.799141 238.5583) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(127.246094 0)"/>
@@ -1649,7 +1649,7 @@ z
    </g>
    <g id="text_29">
     <!-- lean-zip (native) -->
-    <g transform="translate(100.492031 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(99.506016 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-6c" d="M 538 4863 
 L 1656 4863 
@@ -1758,7 +1758,7 @@ z
    </g>
    <g id="text_30">
     <!-- 0.325 -->
-    <g transform="translate(229.518281 267.9415) scale(0.08 -0.08)">
+    <g transform="translate(228.532266 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338 
 Q 2944 3213 2780 3570 
@@ -1876,15 +1876,8 @@ z
     </g>
    </g>
    <g id="text_31">
-    <!-- 30 -->
-    <g transform="translate(341.228906 267.9415) scale(0.08 -0.08)">
-     <use xlink:href="#DejaVuSans-Bold-33"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
-    </g>
-   </g>
-   <g id="text_32">
-    <!-- 179 -->
-    <g transform="translate(443.070781 267.9415) scale(0.08 -0.08)">
+    <!-- 31 -->
+    <g transform="translate(340.242891 267.9415) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-Bold-31" d="M 750 831 
 L 1813 831 
@@ -1900,6 +1893,15 @@ L 750 0
 L 750 831 
 z
 " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(69.580078 0)"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- 178 -->
+    <g transform="translate(442.084766 267.9415) scale(0.08 -0.08)">
+     <defs>
       <path id="DejaVuSans-Bold-37" d="M 428 4666 
 L 3944 4666 
 L 3944 3988 
@@ -1910,45 +1912,54 @@ L 428 3781
 L 428 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-39" d="M 641 103 
-L 641 966 
-Q 928 831 1190 764 
-Q 1453 697 1709 697 
-Q 2247 697 2547 995 
-Q 2847 1294 2900 1881 
-Q 2688 1725 2447 1647 
-Q 2206 1569 1925 1569 
-Q 1209 1569 770 1986 
-Q 331 2403 331 3084 
-Q 331 3838 820 4291 
-Q 1309 4744 2131 4744 
-Q 3044 4744 3544 4128 
-Q 4044 3513 4044 2388 
-Q 4044 1231 3459 570 
-Q 2875 -91 1856 -91 
-Q 1528 -91 1228 -42 
-Q 928 6 641 103 
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
 z
-M 2125 2350 
-Q 2441 2350 2600 2554 
-Q 2759 2759 2759 3169 
-Q 2759 3575 2600 3781 
-Q 2441 3988 2125 3988 
-Q 1809 3988 1650 3781 
-Q 1491 3575 1491 3169 
-Q 1491 2759 1650 2554 
-Q 1809 2350 2125 2350 
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
 z
 " transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-31"/>
      <use xlink:href="#DejaVuSans-Bold-37" transform="translate(69.580078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-39" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(139.160156 0)"/>
     </g>
    </g>
    <g id="text_33">
     <!-- OCaml decompress -->
-    <g transform="translate(98.607031 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(97.621016 297.3247) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-4f" d="M 2522 4238 
 Q 1834 4238 1429 3725 
@@ -2013,7 +2024,7 @@ z
    </g>
    <g id="text_34">
     <!-- 0.336 -->
-    <g transform="translate(230.718906 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2023,21 +2034,21 @@ z
    </g>
    <g id="text_35">
     <!-- 21 -->
-    <g transform="translate(341.705156 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(340.719141 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-32"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_36">
     <!-- 69 -->
-    <g transform="translate(446.330156 297.3247) scale(0.08 -0.08)">
+    <g transform="translate(445.344141 297.3247) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-36"/>
      <use xlink:href="#DejaVuSans-39" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_37">
     <!-- zopfli -->
-    <g transform="translate(126.828281 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(125.842266 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-7a"/>
      <use xlink:href="#DejaVuSans-6f" transform="translate(52.490234 0)"/>
      <use xlink:href="#DejaVuSans-70" transform="translate(113.671875 0)"/>
@@ -2048,7 +2059,7 @@ z
    </g>
    <g id="text_38">
     <!-- 0.303 -->
-    <g transform="translate(230.718906 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(229.732891 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-30"/>
      <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(95.410156 0)"/>
@@ -2058,13 +2069,13 @@ z
    </g>
    <g id="text_39">
     <!-- 1 -->
-    <g transform="translate(344.250156 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(343.264141 326.7079) scale(0.08 -0.08)">
      <use xlink:href="#DejaVuSans-31"/>
     </g>
    </g>
    <g id="text_40">
     <!-- — -->
-    <g transform="translate(447.420156 326.7079) scale(0.08 -0.08)">
+    <g transform="translate(446.434141 326.7079) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-2014" d="M 313 1978 
 L 6088 1978 
@@ -2080,7 +2091,7 @@ z
   </g>
   <g id="text_41">
    <!-- silesia — geomean over files, level 6 -->
-   <g transform="translate(154.334375 17.077969) scale(0.13 -0.13)">
+   <g transform="translate(153.348359 17.077969) scale(0.13 -0.13)">
     <defs>
      <path id="DejaVuSans-Bold-2014" d="M 344 2156 
 L 6056 2156 
@@ -2224,7 +2235,7 @@ z
    </g>
   </g>
   <g id="text_42">
-   <!-- 2026-07-06T05:11:12Z  ·  Linux chungus2 x86_64  ·  commit 05a43b60  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
+   <!-- 2026-07-06T06:43:08Z  ·  Linux chungus2 x86_64  ·  commit f2d5688e  ·  leanprover/lean4:v4.30.0-rc2  ·  throughput = median snapshot; ratio is deterministic -->
    <g style="fill: #555555" transform="translate(7.2 377.352) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-2d" d="M 313 2009 
@@ -2366,13 +2377,13 @@ z
     <use xlink:href="#DejaVuSans-36" transform="translate(517.529297 0)"/>
     <use xlink:href="#DejaVuSans-54" transform="translate(581.152344 0)"/>
     <use xlink:href="#DejaVuSans-30" transform="translate(642.236328 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(705.859375 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(705.859375 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(769.482422 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(803.173828 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(803.173828 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(866.796875 0)"/>
     <use xlink:href="#DejaVuSans-3a" transform="translate(930.419922 0)"/>
-    <use xlink:href="#DejaVuSans-31" transform="translate(964.111328 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(1027.734375 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(964.111328 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(1027.734375 0)"/>
     <use xlink:href="#DejaVuSans-5a" transform="translate(1091.357422 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1159.863281 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(1191.650391 0)"/>
@@ -2412,110 +2423,110 @@ z
     <use xlink:href="#DejaVuSans-69" transform="translate(2973.095703 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(3000.878906 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(3040.087891 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3071.875 0)"/>
-    <use xlink:href="#DejaVuSans-35" transform="translate(3135.498047 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3199.121094 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(3260.400391 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(3324.023438 0)"/>
-    <use xlink:href="#DejaVuSans-62" transform="translate(3387.646484 0)"/>
-    <use xlink:href="#DejaVuSans-36" transform="translate(3451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(3514.746094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3578.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3610.15625 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(3641.943359 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3673.730469 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3705.517578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3737.304688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3765.087891 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3826.611328 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3887.890625 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(3951.269531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4014.746094 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4053.609375 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4114.791016 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4173.970703 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4235.494141 0)"/>
-    <use xlink:href="#DejaVuSans-2f" transform="translate(4276.607422 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4310.298828 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4338.082031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(4399.605469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4460.884766 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4524.263672 0)"/>
-    <use xlink:href="#DejaVuSans-3a" transform="translate(4587.886719 0)"/>
-    <use xlink:href="#DejaVuSans-76" transform="translate(4621.578125 0)"/>
-    <use xlink:href="#DejaVuSans-34" transform="translate(4680.757812 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4744.380859 0)"/>
-    <use xlink:href="#DejaVuSans-33" transform="translate(4776.167969 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4839.791016 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4903.414062 0)"/>
-    <use xlink:href="#DejaVuSans-30" transform="translate(4935.201172 0)"/>
-    <use xlink:href="#DejaVuSans-2d" transform="translate(4998.824219 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5034.908203 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(5073.771484 0)"/>
-    <use xlink:href="#DejaVuSans-32" transform="translate(5128.751953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5192.375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5224.162109 0)"/>
-    <use xlink:href="#DejaVuSans-b7" transform="translate(5255.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5287.736328 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5319.523438 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5351.310547 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5390.519531 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(5453.898438 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(5492.761719 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5553.943359 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(5617.322266 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(5680.798828 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(5744.177734 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(5807.654297 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(5871.033203 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(5910.242188 0)"/>
-    <use xlink:href="#DejaVuSans-3d" transform="translate(5942.029297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6025.818359 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(6057.605469 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(6155.017578 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(6216.541016 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(6280.017578 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6307.800781 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6369.080078 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6432.458984 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6464.246094 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(6516.345703 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(6579.724609 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(6641.003906 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(6704.480469 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(6756.580078 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(6819.958984 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(6881.140625 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(6920.349609 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(6954.041016 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(6985.828125 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(7026.941406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7088.220703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7127.429688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(7155.212891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7216.394531 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7248.181641 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7275.964844 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(7328.064453 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(7359.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7423.328125 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7484.851562 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(7524.060547 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(7585.583984 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(7624.947266 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7722.359375 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(7750.142578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7813.521484 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(7841.304688 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(7893.404297 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(7932.613281 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(7960.396484 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(3071.875 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(3107.080078 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3170.703125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(3234.179688 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(3297.802734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3361.425781 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(3425.048828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3488.671875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3550.195312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3581.982422 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(3613.769531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3645.556641 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3677.34375 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3709.130859 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3736.914062 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3798.4375 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3859.716797 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3923.095703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3986.572266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(4025.435547 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4086.617188 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4145.796875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(4207.320312 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(4248.433594 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4282.125 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4309.908203 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4371.431641 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4432.710938 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4496.089844 0)"/>
+    <use xlink:href="#DejaVuSans-3a" transform="translate(4559.712891 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4593.404297 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4652.583984 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4716.207031 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(4747.994141 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4811.617188 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4875.240234 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4907.027344 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(4970.650391 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5006.734375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5045.597656 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(5100.578125 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5164.201172 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5195.988281 0)"/>
+    <use xlink:href="#DejaVuSans-b7" transform="translate(5227.775391 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5259.5625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5291.349609 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5323.136719 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5362.345703 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5425.724609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5464.587891 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5525.769531 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(5589.148438 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(5652.625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(5716.003906 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(5779.480469 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5842.859375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5882.068359 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(5913.855469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5997.644531 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(6029.431641 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6126.84375 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(6188.367188 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(6251.84375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6279.626953 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6340.90625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6404.285156 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6436.072266 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6488.171875 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6551.550781 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(6612.830078 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6676.306641 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(6728.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6791.785156 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6852.966797 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(6892.175781 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6925.867188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6957.654297 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6998.767578 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7060.046875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7099.255859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7127.039062 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7188.220703 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7220.007812 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7247.791016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7299.890625 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(7331.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7395.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7456.677734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7495.886719 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7557.410156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7596.773438 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7694.185547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(7721.96875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7785.347656 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7813.130859 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7865.230469 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7904.439453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7932.222656 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pb007eb364d">
-   <rect x="85.232656" y="45.36" width="418.5" height="293.832"/>
+  <clipPath id="pa8ed153ee9">
+   <rect x="84.246641" y="45.36" width="418.5" height="293.832"/>
   </clipPath>
  </defs>
 </svg>

--- a/bench/results/latest.json
+++ b/bench/results/latest.json
@@ -1,8 +1,8 @@
 {
  "meta": {
-  "date": "2026-07-06T05:11:12Z",
+  "date": "2026-07-06T06:43:08Z",
   "machine": "Linux chungus2 x86_64",
-  "git_commit": "05a43b60",
+  "git_commit": "f2d5688e",
   "toolchain": "leanprover/lean4:v4.30.0-rc2",
   "note": "compress_mbps/decompress_mbps are a median-of-5 snapshot on the machine above; ratio is deterministic"
  },
@@ -14,7 +14,7 @@
    "level": 1,
    "out_size": 60455,
    "ratio": 0.3975,
-   "compress_mbps": 68.25,
+   "compress_mbps": 67.6,
    "decompress_mbps": 112.5
   },
   {
@@ -24,8 +24,8 @@
    "level": 2,
    "out_size": 56316,
    "ratio": 0.3703,
-   "compress_mbps": 49.33,
-   "decompress_mbps": 124.7
+   "compress_mbps": 48.73,
+   "decompress_mbps": 124.91
   },
   {
    "compressor": "native",
@@ -34,8 +34,8 @@
    "level": 3,
    "out_size": 55646,
    "ratio": 0.3659,
-   "compress_mbps": 43.97,
-   "decompress_mbps": 135.81
+   "compress_mbps": 43.56,
+   "decompress_mbps": 135.99
   },
   {
    "compressor": "native",
@@ -44,8 +44,8 @@
    "level": 4,
    "out_size": 54690,
    "ratio": 0.3596,
-   "compress_mbps": 33.09,
-   "decompress_mbps": 139.45
+   "compress_mbps": 33.13,
+   "decompress_mbps": 139.09
   },
   {
    "compressor": "native",
@@ -54,8 +54,8 @@
    "level": 5,
    "out_size": 54441,
    "ratio": 0.358,
-   "compress_mbps": 26.57,
-   "decompress_mbps": 146.5
+   "compress_mbps": 26.56,
+   "decompress_mbps": 146.08
   },
   {
    "compressor": "native",
@@ -64,8 +64,8 @@
    "level": 6,
    "out_size": 54359,
    "ratio": 0.3574,
-   "compress_mbps": 25.54,
-   "decompress_mbps": 151.09
+   "compress_mbps": 25.58,
+   "decompress_mbps": 150.78
   },
   {
    "compressor": "native",
@@ -74,8 +74,8 @@
    "level": 7,
    "out_size": 54142,
    "ratio": 0.356,
-   "compress_mbps": 21.49,
-   "decompress_mbps": 151.72
+   "compress_mbps": 21.45,
+   "decompress_mbps": 151.62
   },
   {
    "compressor": "native",
@@ -84,8 +84,8 @@
    "level": 8,
    "out_size": 54127,
    "ratio": 0.3559,
-   "compress_mbps": 20.59,
-   "decompress_mbps": 152.11
+   "compress_mbps": 20.57,
+   "decompress_mbps": 151.89
   },
   {
    "compressor": "native",
@@ -94,8 +94,8 @@
    "level": 9,
    "out_size": 52732,
    "ratio": 0.3467,
-   "compress_mbps": 4.14,
-   "decompress_mbps": 152.22
+   "compress_mbps": 4.07,
+   "decompress_mbps": 152.07
   },
   {
    "compressor": "native",
@@ -104,7 +104,7 @@
    "level": 10,
    "out_size": 52078,
    "ratio": 0.3424,
-   "compress_mbps": 2.32,
+   "compress_mbps": 2.27,
    "decompress_mbps": null
   },
   {
@@ -114,8 +114,8 @@
    "level": 1,
    "out_size": 53135,
    "ratio": 0.4245,
-   "compress_mbps": 62.4,
-   "decompress_mbps": 105.88
+   "compress_mbps": 61.79,
+   "decompress_mbps": 105.78
   },
   {
    "compressor": "native",
@@ -124,8 +124,8 @@
    "level": 2,
    "out_size": 50187,
    "ratio": 0.4009,
-   "compress_mbps": 46.3,
-   "decompress_mbps": 113.65
+   "compress_mbps": 45.85,
+   "decompress_mbps": 113.54
   },
   {
    "compressor": "native",
@@ -134,8 +134,8 @@
    "level": 3,
    "out_size": 49810,
    "ratio": 0.3979,
-   "compress_mbps": 41.65,
-   "decompress_mbps": 123.05
+   "compress_mbps": 41.41,
+   "decompress_mbps": 122.85
   },
   {
    "compressor": "native",
@@ -144,8 +144,8 @@
    "level": 4,
    "out_size": 48996,
    "ratio": 0.3914,
-   "compress_mbps": 31.18,
-   "decompress_mbps": 127.73
+   "compress_mbps": 31.35,
+   "decompress_mbps": 127.79
   },
   {
    "compressor": "native",
@@ -154,8 +154,8 @@
    "level": 5,
    "out_size": 48894,
    "ratio": 0.3906,
-   "compress_mbps": 26.77,
-   "decompress_mbps": 133.61
+   "compress_mbps": 26.91,
+   "decompress_mbps": 133.8
   },
   {
    "compressor": "native",
@@ -164,7 +164,7 @@
    "level": 6,
    "out_size": 48719,
    "ratio": 0.3892,
-   "compress_mbps": 24.53,
+   "compress_mbps": 24.3,
    "decompress_mbps": 136.87
   },
   {
@@ -174,8 +174,8 @@
    "level": 7,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 22.27,
-   "decompress_mbps": 136.76
+   "compress_mbps": 22.1,
+   "decompress_mbps": 137.12
   },
   {
    "compressor": "native",
@@ -184,8 +184,8 @@
    "level": 8,
    "out_size": 48634,
    "ratio": 0.3885,
-   "compress_mbps": 22.06,
-   "decompress_mbps": 137.22
+   "compress_mbps": 21.85,
+   "decompress_mbps": 137.02
   },
   {
    "compressor": "native",
@@ -194,8 +194,8 @@
    "level": 9,
    "out_size": 47430,
    "ratio": 0.3789,
-   "compress_mbps": 4.53,
-   "decompress_mbps": 137.23
+   "compress_mbps": 4.42,
+   "decompress_mbps": 137.42
   },
   {
    "compressor": "native",
@@ -204,7 +204,7 @@
    "level": 10,
    "out_size": 46865,
    "ratio": 0.3744,
-   "compress_mbps": 2.72,
+   "compress_mbps": 2.65,
    "decompress_mbps": null
   },
   {
@@ -214,8 +214,8 @@
    "level": 1,
    "out_size": 8476,
    "ratio": 0.3445,
-   "compress_mbps": 61.76,
-   "decompress_mbps": 125.64
+   "compress_mbps": 61.89,
+   "decompress_mbps": 124.87
   },
   {
    "compressor": "native",
@@ -224,8 +224,8 @@
    "level": 2,
    "out_size": 8271,
    "ratio": 0.3362,
-   "compress_mbps": 51.47,
-   "decompress_mbps": 130.19
+   "compress_mbps": 51.32,
+   "decompress_mbps": 128.91
   },
   {
    "compressor": "native",
@@ -234,8 +234,8 @@
    "level": 3,
    "out_size": 8158,
    "ratio": 0.3316,
-   "compress_mbps": 49.59,
-   "decompress_mbps": 132.85
+   "compress_mbps": 49.1,
+   "decompress_mbps": 131.79
   },
   {
    "compressor": "native",
@@ -244,8 +244,8 @@
    "level": 4,
    "out_size": 7961,
    "ratio": 0.3236,
-   "compress_mbps": 43.27,
-   "decompress_mbps": 139.0
+   "compress_mbps": 43.3,
+   "decompress_mbps": 137.58
   },
   {
    "compressor": "native",
@@ -254,8 +254,8 @@
    "level": 5,
    "out_size": 7932,
    "ratio": 0.3224,
-   "compress_mbps": 36.03,
-   "decompress_mbps": 142.91
+   "compress_mbps": 36.55,
+   "decompress_mbps": 141.55
   },
   {
    "compressor": "native",
@@ -264,8 +264,8 @@
    "level": 6,
    "out_size": 7940,
    "ratio": 0.3227,
-   "compress_mbps": 35.87,
-   "decompress_mbps": 144.43
+   "compress_mbps": 36.13,
+   "decompress_mbps": 142.6
   },
   {
    "compressor": "native",
@@ -274,8 +274,8 @@
    "level": 7,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 32.55,
-   "decompress_mbps": 146.26
+   "compress_mbps": 32.83,
+   "decompress_mbps": 144.0
   },
   {
    "compressor": "native",
@@ -284,8 +284,8 @@
    "level": 8,
    "out_size": 7929,
    "ratio": 0.3223,
-   "compress_mbps": 32.53,
-   "decompress_mbps": 145.81
+   "compress_mbps": 32.75,
+   "decompress_mbps": 143.95
   },
   {
    "compressor": "native",
@@ -294,8 +294,8 @@
    "level": 9,
    "out_size": 7803,
    "ratio": 0.3172,
-   "compress_mbps": 4.81,
-   "decompress_mbps": 146.36
+   "compress_mbps": 4.64,
+   "decompress_mbps": 143.89
   },
   {
    "compressor": "native",
@@ -304,7 +304,7 @@
    "level": 10,
    "out_size": 7737,
    "ratio": 0.3145,
-   "compress_mbps": 2.83,
+   "compress_mbps": 2.77,
    "decompress_mbps": null
   },
   {
@@ -314,8 +314,8 @@
    "level": 1,
    "out_size": 3509,
    "ratio": 0.3147,
-   "compress_mbps": 47.21,
-   "decompress_mbps": 101.47
+   "compress_mbps": 46.66,
+   "decompress_mbps": 99.93
   },
   {
    "compressor": "native",
@@ -324,8 +324,8 @@
    "level": 2,
    "out_size": 3269,
    "ratio": 0.2932,
-   "compress_mbps": 41.04,
-   "decompress_mbps": 104.47
+   "compress_mbps": 40.72,
+   "decompress_mbps": 103.67
   },
   {
    "compressor": "native",
@@ -334,8 +334,8 @@
    "level": 3,
    "out_size": 3208,
    "ratio": 0.2877,
-   "compress_mbps": 39.65,
-   "decompress_mbps": 107.83
+   "compress_mbps": 39.58,
+   "decompress_mbps": 106.96
   },
   {
    "compressor": "native",
@@ -344,8 +344,8 @@
    "level": 4,
    "out_size": 3141,
    "ratio": 0.2817,
-   "compress_mbps": 35.95,
-   "decompress_mbps": 110.13
+   "compress_mbps": 36.24,
+   "decompress_mbps": 109.2
   },
   {
    "compressor": "native",
@@ -354,8 +354,8 @@
    "level": 5,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 31.97,
-   "decompress_mbps": 112.14
+   "compress_mbps": 32.13,
+   "decompress_mbps": 111.13
   },
   {
    "compressor": "native",
@@ -364,8 +364,8 @@
    "level": 6,
    "out_size": 3135,
    "ratio": 0.2812,
-   "compress_mbps": 32.41,
-   "decompress_mbps": 113.24
+   "compress_mbps": 32.38,
+   "decompress_mbps": 111.93
   },
   {
    "compressor": "native",
@@ -374,8 +374,8 @@
    "level": 7,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 30.34,
-   "decompress_mbps": 113.08
+   "compress_mbps": 30.35,
+   "decompress_mbps": 112.06
   },
   {
    "compressor": "native",
@@ -384,8 +384,8 @@
    "level": 8,
    "out_size": 3128,
    "ratio": 0.2805,
-   "compress_mbps": 30.16,
-   "decompress_mbps": 113.18
+   "compress_mbps": 30.22,
+   "decompress_mbps": 112.08
   },
   {
    "compressor": "native",
@@ -394,8 +394,8 @@
    "level": 9,
    "out_size": 3056,
    "ratio": 0.2741,
-   "compress_mbps": 5.28,
-   "decompress_mbps": 112.67
+   "compress_mbps": 5.18,
+   "decompress_mbps": 112.18
   },
   {
    "compressor": "native",
@@ -404,7 +404,7 @@
    "level": 10,
    "out_size": 3032,
    "ratio": 0.2719,
-   "compress_mbps": 2.96,
+   "compress_mbps": 2.91,
    "decompress_mbps": null
   },
   {
@@ -414,8 +414,8 @@
    "level": 1,
    "out_size": 1282,
    "ratio": 0.3445,
-   "compress_mbps": 24.84,
-   "decompress_mbps": 57.18
+   "compress_mbps": 24.58,
+   "decompress_mbps": 56.91
   },
   {
    "compressor": "native",
@@ -424,8 +424,8 @@
    "level": 2,
    "out_size": 1225,
    "ratio": 0.3292,
-   "compress_mbps": 23.32,
-   "decompress_mbps": 57.88
+   "compress_mbps": 22.94,
+   "decompress_mbps": 57.48
   },
   {
    "compressor": "native",
@@ -434,8 +434,8 @@
    "level": 3,
    "out_size": 1220,
    "ratio": 0.3279,
-   "compress_mbps": 23.05,
-   "decompress_mbps": 57.81
+   "compress_mbps": 22.78,
+   "decompress_mbps": 57.62
   },
   {
    "compressor": "native",
@@ -444,8 +444,8 @@
    "level": 4,
    "out_size": 1213,
    "ratio": 0.326,
-   "compress_mbps": 22.24,
-   "decompress_mbps": 58.94
+   "compress_mbps": 22.08,
+   "decompress_mbps": 58.49
   },
   {
    "compressor": "native",
@@ -454,8 +454,8 @@
    "level": 5,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.42,
-   "decompress_mbps": 59.33
+   "compress_mbps": 21.21,
+   "decompress_mbps": 59.0
   },
   {
    "compressor": "native",
@@ -464,8 +464,8 @@
    "level": 6,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 21.07,
-   "decompress_mbps": 59.64
+   "compress_mbps": 20.76,
+   "decompress_mbps": 58.79
   },
   {
    "compressor": "native",
@@ -474,8 +474,8 @@
    "level": 7,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.9,
-   "decompress_mbps": 59.46
+   "compress_mbps": 20.52,
+   "decompress_mbps": 58.82
   },
   {
    "compressor": "native",
@@ -484,8 +484,8 @@
    "level": 8,
    "out_size": 1209,
    "ratio": 0.3249,
-   "compress_mbps": 20.91,
-   "decompress_mbps": 59.55
+   "compress_mbps": 20.53,
+   "decompress_mbps": 59.0
   },
   {
    "compressor": "native",
@@ -494,8 +494,8 @@
    "level": 9,
    "out_size": 1205,
    "ratio": 0.3238,
-   "compress_mbps": 4.88,
-   "decompress_mbps": 59.55
+   "compress_mbps": 4.79,
+   "decompress_mbps": 59.12
   },
   {
    "compressor": "native",
@@ -504,7 +504,7 @@
    "level": 10,
    "out_size": 1191,
    "ratio": 0.3201,
-   "compress_mbps": 2.91,
+   "compress_mbps": 2.86,
    "decompress_mbps": null
   },
   {
@@ -514,8 +514,8 @@
    "level": 1,
    "out_size": 251793,
    "ratio": 0.2445,
-   "compress_mbps": 129.58,
-   "decompress_mbps": 208.05
+   "compress_mbps": 128.93,
+   "decompress_mbps": 207.26
   },
   {
    "compressor": "native",
@@ -524,8 +524,8 @@
    "level": 2,
    "out_size": 242565,
    "ratio": 0.2356,
-   "compress_mbps": 89.26,
-   "decompress_mbps": 223.46
+   "compress_mbps": 88.92,
+   "decompress_mbps": 223.0
   },
   {
    "compressor": "native",
@@ -534,8 +534,8 @@
    "level": 3,
    "out_size": 242532,
    "ratio": 0.2355,
-   "compress_mbps": 76.4,
-   "decompress_mbps": 233.04
+   "compress_mbps": 75.4,
+   "decompress_mbps": 231.89
   },
   {
    "compressor": "native",
@@ -544,8 +544,8 @@
    "level": 4,
    "out_size": 239996,
    "ratio": 0.2331,
-   "compress_mbps": 72.57,
-   "decompress_mbps": 240.1
+   "compress_mbps": 72.36,
+   "decompress_mbps": 238.8
   },
   {
    "compressor": "native",
@@ -554,8 +554,8 @@
    "level": 5,
    "out_size": 218163,
    "ratio": 0.2119,
-   "compress_mbps": 49.19,
-   "decompress_mbps": 236.59
+   "compress_mbps": 49.14,
+   "decompress_mbps": 235.6
   },
   {
    "compressor": "native",
@@ -564,8 +564,8 @@
    "level": 6,
    "out_size": 201839,
    "ratio": 0.196,
-   "compress_mbps": 36.15,
-   "decompress_mbps": 243.51
+   "compress_mbps": 35.33,
+   "decompress_mbps": 242.22
   },
   {
    "compressor": "native",
@@ -574,8 +574,8 @@
    "level": 7,
    "out_size": 201287,
    "ratio": 0.1955,
-   "compress_mbps": 27.85,
-   "decompress_mbps": 246.01
+   "compress_mbps": 27.7,
+   "decompress_mbps": 244.84
   },
   {
    "compressor": "native",
@@ -585,7 +585,7 @@
    "out_size": 200711,
    "ratio": 0.1949,
    "compress_mbps": 21.17,
-   "decompress_mbps": 249.18
+   "decompress_mbps": 247.79
   },
   {
    "compressor": "native",
@@ -594,8 +594,8 @@
    "level": 9,
    "out_size": 182508,
    "ratio": 0.1772,
-   "compress_mbps": 3.39,
-   "decompress_mbps": 249.28
+   "compress_mbps": 3.31,
+   "decompress_mbps": 249.82
   },
   {
    "compressor": "native",
@@ -604,7 +604,7 @@
    "level": 10,
    "out_size": 178067,
    "ratio": 0.1729,
-   "compress_mbps": 1.42,
+   "compress_mbps": 1.39,
    "decompress_mbps": null
   },
   {
@@ -614,8 +614,8 @@
    "level": 1,
    "out_size": 160674,
    "ratio": 0.3765,
-   "compress_mbps": 73.94,
-   "decompress_mbps": 120.0
+   "compress_mbps": 74.01,
+   "decompress_mbps": 120.45
   },
   {
    "compressor": "native",
@@ -624,8 +624,8 @@
    "level": 2,
    "out_size": 149787,
    "ratio": 0.351,
-   "compress_mbps": 52.75,
-   "decompress_mbps": 129.28
+   "compress_mbps": 52.67,
+   "decompress_mbps": 129.89
   },
   {
    "compressor": "native",
@@ -634,8 +634,8 @@
    "level": 3,
    "out_size": 148055,
    "ratio": 0.3469,
-   "compress_mbps": 46.66,
-   "decompress_mbps": 142.33
+   "compress_mbps": 46.32,
+   "decompress_mbps": 142.69
   },
   {
    "compressor": "native",
@@ -644,8 +644,8 @@
    "level": 4,
    "out_size": 145641,
    "ratio": 0.3413,
-   "compress_mbps": 35.6,
-   "decompress_mbps": 147.26
+   "compress_mbps": 35.56,
+   "decompress_mbps": 146.4
   },
   {
    "compressor": "native",
@@ -654,8 +654,8 @@
    "level": 5,
    "out_size": 145327,
    "ratio": 0.3405,
-   "compress_mbps": 28.91,
-   "decompress_mbps": 154.56
+   "compress_mbps": 28.92,
+   "decompress_mbps": 154.15
   },
   {
    "compressor": "native",
@@ -664,8 +664,8 @@
    "level": 6,
    "out_size": 145066,
    "ratio": 0.3399,
-   "compress_mbps": 27.11,
-   "decompress_mbps": 157.73
+   "compress_mbps": 26.93,
+   "decompress_mbps": 158.15
   },
   {
    "compressor": "native",
@@ -674,8 +674,8 @@
    "level": 7,
    "out_size": 144558,
    "ratio": 0.3387,
-   "compress_mbps": 23.34,
-   "decompress_mbps": 158.77
+   "compress_mbps": 23.37,
+   "decompress_mbps": 158.69
   },
   {
    "compressor": "native",
@@ -684,8 +684,8 @@
    "level": 8,
    "out_size": 144538,
    "ratio": 0.3387,
-   "compress_mbps": 22.6,
-   "decompress_mbps": 159.28
+   "compress_mbps": 22.62,
+   "decompress_mbps": 158.51
   },
   {
    "compressor": "native",
@@ -694,8 +694,8 @@
    "level": 9,
    "out_size": 140322,
    "ratio": 0.3288,
-   "compress_mbps": 4.11,
-   "decompress_mbps": 159.31
+   "compress_mbps": 4.07,
+   "decompress_mbps": 159.37
   },
   {
    "compressor": "native",
@@ -704,7 +704,7 @@
    "level": 10,
    "out_size": 138830,
    "ratio": 0.3253,
-   "compress_mbps": 2.42,
+   "compress_mbps": 2.39,
    "decompress_mbps": null
   },
   {
@@ -714,8 +714,8 @@
    "level": 1,
    "out_size": 212588,
    "ratio": 0.4412,
-   "compress_mbps": 62.7,
-   "decompress_mbps": 100.1
+   "compress_mbps": 62.62,
+   "decompress_mbps": 100.64
   },
   {
    "compressor": "native",
@@ -724,8 +724,8 @@
    "level": 2,
    "out_size": 199981,
    "ratio": 0.415,
-   "compress_mbps": 44.78,
-   "decompress_mbps": 109.1
+   "compress_mbps": 44.64,
+   "decompress_mbps": 109.63
   },
   {
    "compressor": "native",
@@ -734,8 +734,8 @@
    "level": 3,
    "out_size": 198551,
    "ratio": 0.4121,
-   "compress_mbps": 39.87,
-   "decompress_mbps": 118.48
+   "compress_mbps": 39.6,
+   "decompress_mbps": 119.81
   },
   {
    "compressor": "native",
@@ -744,8 +744,8 @@
    "level": 4,
    "out_size": 195465,
    "ratio": 0.4056,
-   "compress_mbps": 28.15,
-   "decompress_mbps": 123.38
+   "compress_mbps": 28.04,
+   "decompress_mbps": 123.08
   },
   {
    "compressor": "native",
@@ -754,8 +754,8 @@
    "level": 5,
    "out_size": 194911,
    "ratio": 0.4045,
-   "compress_mbps": 23.46,
-   "decompress_mbps": 129.76
+   "compress_mbps": 23.3,
+   "decompress_mbps": 130.0
   },
   {
    "compressor": "native",
@@ -764,8 +764,8 @@
    "level": 6,
    "out_size": 195183,
    "ratio": 0.4051,
-   "compress_mbps": 23.4,
-   "decompress_mbps": 133.07
+   "compress_mbps": 23.19,
+   "decompress_mbps": 133.6
   },
   {
    "compressor": "native",
@@ -774,8 +774,8 @@
    "level": 7,
    "out_size": 194387,
    "ratio": 0.4034,
-   "compress_mbps": 19.48,
-   "decompress_mbps": 133.35
+   "compress_mbps": 19.56,
+   "decompress_mbps": 133.54
   },
   {
    "compressor": "native",
@@ -785,7 +785,7 @@
    "out_size": 194379,
    "ratio": 0.4034,
    "compress_mbps": 18.96,
-   "decompress_mbps": 133.67
+   "decompress_mbps": 133.49
   },
   {
    "compressor": "native",
@@ -794,8 +794,8 @@
    "level": 9,
    "out_size": 189365,
    "ratio": 0.393,
-   "compress_mbps": 3.94,
-   "decompress_mbps": 133.73
+   "compress_mbps": 3.89,
+   "decompress_mbps": 133.47
   },
   {
    "compressor": "native",
@@ -814,8 +814,8 @@
    "level": 1,
    "out_size": 60161,
    "ratio": 0.1172,
-   "compress_mbps": 208.2,
-   "decompress_mbps": 343.45
+   "compress_mbps": 207.84,
+   "decompress_mbps": 343.96
   },
   {
    "compressor": "native",
@@ -824,8 +824,8 @@
    "level": 2,
    "out_size": 58873,
    "ratio": 0.1147,
-   "compress_mbps": 152.36,
-   "decompress_mbps": 359.39
+   "compress_mbps": 152.47,
+   "decompress_mbps": 357.21
   },
   {
    "compressor": "native",
@@ -834,8 +834,8 @@
    "level": 3,
    "out_size": 58327,
    "ratio": 0.1137,
-   "compress_mbps": 133.54,
-   "decompress_mbps": 382.59
+   "compress_mbps": 132.67,
+   "decompress_mbps": 379.7
   },
   {
    "compressor": "native",
@@ -844,8 +844,8 @@
    "level": 4,
    "out_size": 55688,
    "ratio": 0.1085,
-   "compress_mbps": 90.23,
-   "decompress_mbps": 355.87
+   "compress_mbps": 90.55,
+   "decompress_mbps": 355.57
   },
   {
    "compressor": "native",
@@ -854,8 +854,8 @@
    "level": 5,
    "out_size": 55213,
    "ratio": 0.1076,
-   "compress_mbps": 68.03,
-   "decompress_mbps": 378.74
+   "compress_mbps": 68.04,
+   "decompress_mbps": 370.53
   },
   {
    "compressor": "native",
@@ -864,8 +864,8 @@
    "level": 6,
    "out_size": 55321,
    "ratio": 0.1078,
-   "compress_mbps": 56.24,
-   "decompress_mbps": 404.83
+   "compress_mbps": 55.84,
+   "decompress_mbps": 404.18
   },
   {
    "compressor": "native",
@@ -874,8 +874,8 @@
    "level": 7,
    "out_size": 54414,
    "ratio": 0.106,
-   "compress_mbps": 40.94,
-   "decompress_mbps": 428.74
+   "compress_mbps": 40.8,
+   "decompress_mbps": 427.16
   },
   {
    "compressor": "native",
@@ -884,8 +884,8 @@
    "level": 8,
    "out_size": 53303,
    "ratio": 0.1039,
-   "compress_mbps": 35.33,
-   "decompress_mbps": 455.27
+   "compress_mbps": 35.18,
+   "decompress_mbps": 453.07
   },
   {
    "compressor": "native",
@@ -894,8 +894,8 @@
    "level": 9,
    "out_size": 52835,
    "ratio": 0.1029,
-   "compress_mbps": 5.44,
-   "decompress_mbps": 472.88
+   "compress_mbps": 5.38,
+   "decompress_mbps": 462.75
   },
   {
    "compressor": "native",
@@ -904,7 +904,7 @@
    "level": 10,
    "out_size": 52234,
    "ratio": 0.1018,
-   "compress_mbps": 3.55,
+   "compress_mbps": 3.5,
    "decompress_mbps": null
   },
   {
@@ -914,8 +914,8 @@
    "level": 1,
    "out_size": 14249,
    "ratio": 0.3726,
-   "compress_mbps": 52.42,
-   "decompress_mbps": 114.22
+   "compress_mbps": 52.17,
+   "decompress_mbps": 113.39
   },
   {
    "compressor": "native",
@@ -924,8 +924,8 @@
    "level": 2,
    "out_size": 13825,
    "ratio": 0.3615,
-   "compress_mbps": 45.53,
-   "decompress_mbps": 117.16
+   "compress_mbps": 45.39,
+   "decompress_mbps": 116.67
   },
   {
    "compressor": "native",
@@ -934,8 +934,8 @@
    "level": 3,
    "out_size": 13751,
    "ratio": 0.3596,
-   "compress_mbps": 43.86,
-   "decompress_mbps": 119.11
+   "compress_mbps": 43.5,
+   "decompress_mbps": 118.36
   },
   {
    "compressor": "native",
@@ -944,8 +944,8 @@
    "level": 4,
    "out_size": 13370,
    "ratio": 0.3496,
-   "compress_mbps": 38.46,
-   "decompress_mbps": 124.97
+   "compress_mbps": 38.33,
+   "decompress_mbps": 123.8
   },
   {
    "compressor": "native",
@@ -955,7 +955,7 @@
    "out_size": 13343,
    "ratio": 0.3489,
    "compress_mbps": 33.71,
-   "decompress_mbps": 130.88
+   "decompress_mbps": 130.1
   },
   {
    "compressor": "native",
@@ -964,8 +964,8 @@
    "level": 6,
    "out_size": 13047,
    "ratio": 0.3412,
-   "compress_mbps": 18.77,
-   "decompress_mbps": 133.51
+   "compress_mbps": 18.54,
+   "decompress_mbps": 132.55
   },
   {
    "compressor": "native",
@@ -974,8 +974,8 @@
    "level": 7,
    "out_size": 13040,
    "ratio": 0.341,
-   "compress_mbps": 17.19,
-   "decompress_mbps": 134.34
+   "compress_mbps": 17.02,
+   "decompress_mbps": 133.19
   },
   {
    "compressor": "native",
@@ -984,8 +984,8 @@
    "level": 8,
    "out_size": 13036,
    "ratio": 0.3409,
-   "compress_mbps": 15.8,
-   "decompress_mbps": 136.35
+   "compress_mbps": 15.65,
+   "decompress_mbps": 134.9
   },
   {
    "compressor": "native",
@@ -994,8 +994,8 @@
    "level": 9,
    "out_size": 12427,
    "ratio": 0.325,
-   "compress_mbps": 5.2,
-   "decompress_mbps": 137.48
+   "compress_mbps": 5.1,
+   "decompress_mbps": 136.77
   },
   {
    "compressor": "native",
@@ -1004,7 +1004,7 @@
    "level": 10,
    "out_size": 12274,
    "ratio": 0.321,
-   "compress_mbps": 2.97,
+   "compress_mbps": 2.91,
    "decompress_mbps": null
   },
   {
@@ -1014,8 +1014,8 @@
    "level": 1,
    "out_size": 1800,
    "ratio": 0.4258,
-   "compress_mbps": 25.91,
-   "decompress_mbps": 58.67
+   "compress_mbps": 25.86,
+   "decompress_mbps": 58.29
   },
   {
    "compressor": "native",
@@ -1024,8 +1024,8 @@
    "level": 2,
    "out_size": 1750,
    "ratio": 0.414,
-   "compress_mbps": 24.36,
-   "decompress_mbps": 59.21
+   "compress_mbps": 24.55,
+   "decompress_mbps": 58.86
   },
   {
    "compressor": "native",
@@ -1034,8 +1034,8 @@
    "level": 3,
    "out_size": 1742,
    "ratio": 0.4121,
-   "compress_mbps": 24.4,
-   "decompress_mbps": 59.32
+   "compress_mbps": 24.22,
+   "decompress_mbps": 59.08
   },
   {
    "compressor": "native",
@@ -1044,8 +1044,8 @@
    "level": 4,
    "out_size": 1732,
    "ratio": 0.4097,
-   "compress_mbps": 23.55,
-   "decompress_mbps": 60.52
+   "compress_mbps": 23.48,
+   "decompress_mbps": 60.35
   },
   {
    "compressor": "native",
@@ -1054,8 +1054,8 @@
    "level": 5,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 23.06,
-   "decompress_mbps": 60.97
+   "compress_mbps": 23.04,
+   "decompress_mbps": 60.58
   },
   {
    "compressor": "native",
@@ -1064,8 +1064,8 @@
    "level": 6,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 22.02,
-   "decompress_mbps": 60.95
+   "compress_mbps": 21.74,
+   "decompress_mbps": 60.69
   },
   {
    "compressor": "native",
@@ -1074,8 +1074,8 @@
    "level": 7,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 22.18,
-   "decompress_mbps": 60.8
+   "compress_mbps": 21.83,
+   "decompress_mbps": 60.42
   },
   {
    "compressor": "native",
@@ -1084,8 +1084,8 @@
    "level": 8,
    "out_size": 1729,
    "ratio": 0.409,
-   "compress_mbps": 22.14,
-   "decompress_mbps": 60.98
+   "compress_mbps": 21.86,
+   "decompress_mbps": 60.84
   },
   {
    "compressor": "native",
@@ -1094,8 +1094,8 @@
    "level": 9,
    "out_size": 1708,
    "ratio": 0.4041,
-   "compress_mbps": 5.34,
-   "decompress_mbps": 60.87
+   "compress_mbps": 5.27,
+   "decompress_mbps": 60.61
   },
   {
    "compressor": "native",
@@ -1104,7 +1104,7 @@
    "level": 10,
    "out_size": 1693,
    "ratio": 0.4005,
-   "compress_mbps": 3.22,
+   "compress_mbps": 3.17,
    "decompress_mbps": null
   },
   {
@@ -4414,8 +4414,8 @@
    "level": 1,
    "out_size": 4259644,
    "ratio": 0.4179,
-   "compress_mbps": 65.73,
-   "decompress_mbps": 105.06
+   "compress_mbps": 64.95,
+   "decompress_mbps": 105.63
   },
   {
    "compressor": "native",
@@ -4424,8 +4424,8 @@
    "level": 2,
    "out_size": 3977395,
    "ratio": 0.3902,
-   "compress_mbps": 46.74,
-   "decompress_mbps": 112.77
+   "compress_mbps": 46.5,
+   "decompress_mbps": 114.04
   },
   {
    "compressor": "native",
@@ -4434,8 +4434,8 @@
    "level": 3,
    "out_size": 3945296,
    "ratio": 0.3871,
-   "compress_mbps": 41.3,
-   "decompress_mbps": 123.64
+   "compress_mbps": 41.29,
+   "decompress_mbps": 125.12
   },
   {
    "compressor": "native",
@@ -4444,8 +4444,8 @@
    "level": 4,
    "out_size": 3882625,
    "ratio": 0.3809,
-   "compress_mbps": 30.18,
-   "decompress_mbps": 127.4
+   "compress_mbps": 30.19,
+   "decompress_mbps": 127.44
   },
   {
    "compressor": "native",
@@ -4454,8 +4454,8 @@
    "level": 5,
    "out_size": 3871163,
    "ratio": 0.3798,
-   "compress_mbps": 25.09,
-   "decompress_mbps": 132.67
+   "compress_mbps": 25.16,
+   "decompress_mbps": 134.12
   },
   {
    "compressor": "native",
@@ -4464,8 +4464,8 @@
    "level": 6,
    "out_size": 3878951,
    "ratio": 0.3806,
-   "compress_mbps": 24.79,
-   "decompress_mbps": 137.99
+   "compress_mbps": 25.09,
+   "decompress_mbps": 138.28
   },
   {
    "compressor": "native",
@@ -4474,8 +4474,8 @@
    "level": 7,
    "out_size": 3865304,
    "ratio": 0.3792,
-   "compress_mbps": 20.93,
-   "decompress_mbps": 138.74
+   "compress_mbps": 20.98,
+   "decompress_mbps": 139.36
   },
   {
    "compressor": "native",
@@ -4484,8 +4484,8 @@
    "level": 8,
    "out_size": 3864629,
    "ratio": 0.3792,
-   "compress_mbps": 20.21,
-   "decompress_mbps": 137.95
+   "compress_mbps": 20.23,
+   "decompress_mbps": 138.71
   },
   {
    "compressor": "native",
@@ -4494,8 +4494,8 @@
    "level": 9,
    "out_size": 3766584,
    "ratio": 0.3695,
-   "compress_mbps": 4.03,
-   "decompress_mbps": 141.57
+   "compress_mbps": 3.99,
+   "decompress_mbps": 142.36
   },
   {
    "compressor": "native",
@@ -4504,7 +4504,7 @@
    "level": 10,
    "out_size": 3711172,
    "ratio": 0.3641,
-   "compress_mbps": 2.38,
+   "compress_mbps": 2.33,
    "decompress_mbps": null
   },
   {
@@ -4514,8 +4514,8 @@
    "level": 1,
    "out_size": 21267086,
    "ratio": 0.4152,
-   "compress_mbps": 80.74,
-   "decompress_mbps": 132.8
+   "compress_mbps": 80.06,
+   "decompress_mbps": 132.36
   },
   {
    "compressor": "native",
@@ -4524,8 +4524,8 @@
    "level": 2,
    "out_size": 20802983,
    "ratio": 0.4061,
-   "compress_mbps": 63.14,
-   "decompress_mbps": 140.18
+   "compress_mbps": 63.68,
+   "decompress_mbps": 139.47
   },
   {
    "compressor": "native",
@@ -4534,8 +4534,8 @@
    "level": 3,
    "out_size": 20665485,
    "ratio": 0.4035,
-   "compress_mbps": 59.09,
-   "decompress_mbps": 144.73
+   "compress_mbps": 59.04,
+   "decompress_mbps": 144.62
   },
   {
    "compressor": "native",
@@ -4544,8 +4544,8 @@
    "level": 4,
    "out_size": 20395611,
    "ratio": 0.3982,
-   "compress_mbps": 47.03,
-   "decompress_mbps": 148.32
+   "compress_mbps": 47.35,
+   "decompress_mbps": 148.02
   },
   {
    "compressor": "native",
@@ -4554,8 +4554,8 @@
    "level": 5,
    "out_size": 20267480,
    "ratio": 0.3957,
-   "compress_mbps": 37.2,
-   "decompress_mbps": 161.18
+   "compress_mbps": 37.11,
+   "decompress_mbps": 159.04
   },
   {
    "compressor": "native",
@@ -4564,8 +4564,8 @@
    "level": 6,
    "out_size": 19212471,
    "ratio": 0.3751,
-   "compress_mbps": 25.33,
-   "decompress_mbps": 163.54
+   "compress_mbps": 25.13,
+   "decompress_mbps": 161.37
   },
   {
    "compressor": "native",
@@ -4574,8 +4574,8 @@
    "level": 7,
    "out_size": 19179977,
    "ratio": 0.3745,
-   "compress_mbps": 20.75,
-   "decompress_mbps": 164.75
+   "compress_mbps": 20.81,
+   "decompress_mbps": 162.86
   },
   {
    "compressor": "native",
@@ -4584,8 +4584,8 @@
    "level": 8,
    "out_size": 19171663,
    "ratio": 0.3743,
-   "compress_mbps": 18.07,
-   "decompress_mbps": 165.08
+   "compress_mbps": 18.02,
+   "decompress_mbps": 162.72
   },
   {
    "compressor": "native",
@@ -4594,8 +4594,8 @@
    "level": 9,
    "out_size": 18686872,
    "ratio": 0.3648,
-   "compress_mbps": 4.21,
-   "decompress_mbps": 160.87
+   "compress_mbps": 4.16,
+   "decompress_mbps": 162.01
   },
   {
    "compressor": "native",
@@ -4604,7 +4604,7 @@
    "level": 10,
    "out_size": 18539905,
    "ratio": 0.362,
-   "compress_mbps": 2.27,
+   "compress_mbps": 2.22,
    "decompress_mbps": null
   },
   {
@@ -4614,8 +4614,8 @@
    "level": 1,
    "out_size": 3864163,
    "ratio": 0.3876,
-   "compress_mbps": 79.15,
-   "decompress_mbps": 120.12
+   "compress_mbps": 79.76,
+   "decompress_mbps": 121.13
   },
   {
    "compressor": "native",
@@ -4624,8 +4624,8 @@
    "level": 2,
    "out_size": 3734957,
    "ratio": 0.3746,
-   "compress_mbps": 61.09,
-   "decompress_mbps": 129.57
+   "compress_mbps": 61.27,
+   "decompress_mbps": 129.55
   },
   {
    "compressor": "native",
@@ -4634,8 +4634,8 @@
    "level": 3,
    "out_size": 3708443,
    "ratio": 0.3719,
-   "compress_mbps": 52.38,
-   "decompress_mbps": 140.74
+   "compress_mbps": 52.44,
+   "decompress_mbps": 141.2
   },
   {
    "compressor": "native",
@@ -4644,8 +4644,8 @@
    "level": 4,
    "out_size": 3708985,
    "ratio": 0.372,
-   "compress_mbps": 35.94,
-   "decompress_mbps": 132.71
+   "compress_mbps": 35.93,
+   "decompress_mbps": 132.75
   },
   {
    "compressor": "native",
@@ -4654,8 +4654,8 @@
    "level": 5,
    "out_size": 3705516,
    "ratio": 0.3716,
-   "compress_mbps": 28.34,
-   "decompress_mbps": 138.49
+   "compress_mbps": 28.5,
+   "decompress_mbps": 138.64
   },
   {
    "compressor": "native",
@@ -4664,8 +4664,8 @@
    "level": 6,
    "out_size": 3613753,
    "ratio": 0.3624,
-   "compress_mbps": 25.9,
-   "decompress_mbps": 143.31
+   "compress_mbps": 26.41,
+   "decompress_mbps": 143.33
   },
   {
    "compressor": "native",
@@ -4674,8 +4674,8 @@
    "level": 7,
    "out_size": 3610087,
    "ratio": 0.3621,
-   "compress_mbps": 20.83,
-   "decompress_mbps": 144.93
+   "compress_mbps": 20.87,
+   "decompress_mbps": 145.3
   },
   {
    "compressor": "native",
@@ -4684,8 +4684,8 @@
    "level": 8,
    "out_size": 3609561,
    "ratio": 0.362,
-   "compress_mbps": 18.84,
-   "decompress_mbps": 148.39
+   "compress_mbps": 18.96,
+   "decompress_mbps": 148.74
   },
   {
    "compressor": "native",
@@ -4694,8 +4694,8 @@
    "level": 9,
    "out_size": 3581441,
    "ratio": 0.3592,
-   "compress_mbps": 4.45,
-   "decompress_mbps": 153.74
+   "compress_mbps": 4.43,
+   "decompress_mbps": 154.06
   },
   {
    "compressor": "native",
@@ -4704,7 +4704,7 @@
    "level": 10,
    "out_size": 3512886,
    "ratio": 0.3523,
-   "compress_mbps": 2.77,
+   "compress_mbps": 2.74,
    "decompress_mbps": null
   },
   {
@@ -4714,8 +4714,8 @@
    "level": 1,
    "out_size": 3785443,
    "ratio": 0.1128,
-   "compress_mbps": 234.97,
-   "decompress_mbps": 366.16
+   "compress_mbps": 233.13,
+   "decompress_mbps": 365.22
   },
   {
    "compressor": "native",
@@ -4724,8 +4724,8 @@
    "level": 2,
    "out_size": 3761560,
    "ratio": 0.1121,
-   "compress_mbps": 145.72,
-   "decompress_mbps": 411.99
+   "compress_mbps": 146.34,
+   "decompress_mbps": 410.86
   },
   {
    "compressor": "native",
@@ -4734,8 +4734,8 @@
    "level": 3,
    "out_size": 3606997,
    "ratio": 0.1075,
-   "compress_mbps": 124.5,
-   "decompress_mbps": 457.09
+   "compress_mbps": 125.04,
+   "decompress_mbps": 457.3
   },
   {
    "compressor": "native",
@@ -4744,8 +4744,8 @@
    "level": 4,
    "out_size": 3225558,
    "ratio": 0.0961,
-   "compress_mbps": 95.14,
-   "decompress_mbps": 469.25
+   "compress_mbps": 95.07,
+   "decompress_mbps": 467.87
   },
   {
    "compressor": "native",
@@ -4755,7 +4755,7 @@
    "out_size": 3147396,
    "ratio": 0.0938,
    "compress_mbps": 70.32,
-   "decompress_mbps": 533.46
+   "decompress_mbps": 532.43
   },
   {
    "compressor": "native",
@@ -4764,8 +4764,8 @@
    "level": 6,
    "out_size": 3161943,
    "ratio": 0.0942,
-   "compress_mbps": 68.66,
-   "decompress_mbps": 570.16
+   "compress_mbps": 69.33,
+   "decompress_mbps": 564.97
   },
   {
    "compressor": "native",
@@ -4774,8 +4774,8 @@
    "level": 7,
    "out_size": 3125514,
    "ratio": 0.0932,
-   "compress_mbps": 51.11,
-   "decompress_mbps": 584.63
+   "compress_mbps": 51.35,
+   "decompress_mbps": 580.49
   },
   {
    "compressor": "native",
@@ -4784,8 +4784,8 @@
    "level": 8,
    "out_size": 3113556,
    "ratio": 0.0928,
-   "compress_mbps": 42.67,
-   "decompress_mbps": 611.8
+   "compress_mbps": 42.52,
+   "decompress_mbps": 606.83
   },
   {
    "compressor": "native",
@@ -4794,8 +4794,8 @@
    "level": 9,
    "out_size": 3034875,
    "ratio": 0.0904,
-   "compress_mbps": 3.21,
-   "decompress_mbps": 613.33
+   "compress_mbps": 3.19,
+   "decompress_mbps": 608.34
   },
   {
    "compressor": "native",
@@ -4804,7 +4804,7 @@
    "level": 10,
    "out_size": 2902186,
    "ratio": 0.0865,
-   "compress_mbps": 1.86,
+   "compress_mbps": 1.84,
    "decompress_mbps": null
   },
   {
@@ -4814,8 +4814,8 @@
    "level": 1,
    "out_size": 3357083,
    "ratio": 0.5457,
-   "compress_mbps": 56.82,
-   "decompress_mbps": 92.92
+   "compress_mbps": 56.4,
+   "decompress_mbps": 92.53
   },
   {
    "compressor": "native",
@@ -4824,8 +4824,8 @@
    "level": 2,
    "out_size": 3285077,
    "ratio": 0.534,
-   "compress_mbps": 46.21,
-   "decompress_mbps": 94.56
+   "compress_mbps": 46.77,
+   "decompress_mbps": 93.58
   },
   {
    "compressor": "native",
@@ -4834,8 +4834,8 @@
    "level": 3,
    "out_size": 3272746,
    "ratio": 0.532,
-   "compress_mbps": 44.67,
-   "decompress_mbps": 97.03
+   "compress_mbps": 45.23,
+   "decompress_mbps": 96.33
   },
   {
    "compressor": "native",
@@ -4844,8 +4844,8 @@
    "level": 4,
    "out_size": 3237289,
    "ratio": 0.5262,
-   "compress_mbps": 36.87,
-   "decompress_mbps": 105.11
+   "compress_mbps": 37.08,
+   "decompress_mbps": 103.35
   },
   {
    "compressor": "native",
@@ -4854,8 +4854,8 @@
    "level": 5,
    "out_size": 3233957,
    "ratio": 0.5257,
-   "compress_mbps": 33.11,
-   "decompress_mbps": 108.95
+   "compress_mbps": 33.24,
+   "decompress_mbps": 108.14
   },
   {
    "compressor": "native",
@@ -4864,8 +4864,8 @@
    "level": 6,
    "out_size": 3168742,
    "ratio": 0.5151,
-   "compress_mbps": 23.36,
-   "decompress_mbps": 111.57
+   "compress_mbps": 23.38,
+   "decompress_mbps": 110.88
   },
   {
    "compressor": "native",
@@ -4874,8 +4874,8 @@
    "level": 7,
    "out_size": 3166089,
    "ratio": 0.5146,
-   "compress_mbps": 21.26,
-   "decompress_mbps": 111.75
+   "compress_mbps": 21.32,
+   "decompress_mbps": 110.34
   },
   {
    "compressor": "native",
@@ -4884,8 +4884,8 @@
    "level": 8,
    "out_size": 3165757,
    "ratio": 0.5146,
-   "compress_mbps": 20.55,
-   "decompress_mbps": 112.02
+   "compress_mbps": 20.76,
+   "decompress_mbps": 111.0
   },
   {
    "compressor": "native",
@@ -4895,7 +4895,7 @@
    "out_size": 3048772,
    "ratio": 0.4956,
    "compress_mbps": 4.9,
-   "decompress_mbps": 113.95
+   "decompress_mbps": 112.51
   },
   {
    "compressor": "native",
@@ -4904,7 +4904,7 @@
    "level": 10,
    "out_size": 3021986,
    "ratio": 0.4912,
-   "compress_mbps": 3.06,
+   "compress_mbps": 3.05,
    "decompress_mbps": null
   },
   {
@@ -4914,8 +4914,8 @@
    "level": 1,
    "out_size": 3838828,
    "ratio": 0.3806,
-   "compress_mbps": 89.77,
-   "decompress_mbps": 159.51
+   "compress_mbps": 90.15,
+   "decompress_mbps": 158.7
   },
   {
    "compressor": "native",
@@ -4924,8 +4924,8 @@
    "level": 2,
    "out_size": 3792520,
    "ratio": 0.376,
-   "compress_mbps": 65.94,
-   "decompress_mbps": 164.66
+   "compress_mbps": 66.91,
+   "decompress_mbps": 163.57
   },
   {
    "compressor": "native",
@@ -4934,8 +4934,8 @@
    "level": 3,
    "out_size": 3783171,
    "ratio": 0.3751,
-   "compress_mbps": 63.54,
-   "decompress_mbps": 167.69
+   "compress_mbps": 64.7,
+   "decompress_mbps": 168.35
   },
   {
    "compressor": "native",
@@ -4944,8 +4944,8 @@
    "level": 4,
    "out_size": 3706949,
    "ratio": 0.3675,
-   "compress_mbps": 55.61,
-   "decompress_mbps": 174.35
+   "compress_mbps": 56.34,
+   "decompress_mbps": 173.35
   },
   {
    "compressor": "native",
@@ -4954,8 +4954,8 @@
    "level": 5,
    "out_size": 3707010,
    "ratio": 0.3676,
-   "compress_mbps": 52.0,
-   "decompress_mbps": 178.32
+   "compress_mbps": 52.71,
+   "decompress_mbps": 177.92
   },
   {
    "compressor": "native",
@@ -4964,8 +4964,8 @@
    "level": 6,
    "out_size": 3707088,
    "ratio": 0.3676,
-   "compress_mbps": 41.39,
-   "decompress_mbps": 186.82
+   "compress_mbps": 41.43,
+   "decompress_mbps": 186.34
   },
   {
    "compressor": "native",
@@ -4974,8 +4974,8 @@
    "level": 7,
    "out_size": 3706770,
    "ratio": 0.3675,
-   "compress_mbps": 41.25,
-   "decompress_mbps": 189.88
+   "compress_mbps": 41.24,
+   "decompress_mbps": 188.71
   },
   {
    "compressor": "native",
@@ -4984,8 +4984,8 @@
    "level": 8,
    "out_size": 3706769,
    "ratio": 0.3675,
-   "compress_mbps": 41.45,
-   "decompress_mbps": 190.2
+   "compress_mbps": 41.35,
+   "decompress_mbps": 189.31
   },
   {
    "compressor": "native",
@@ -4994,8 +4994,8 @@
    "level": 9,
    "out_size": 3665069,
    "ratio": 0.3634,
-   "compress_mbps": 5.75,
-   "decompress_mbps": 194.95
+   "compress_mbps": 5.7,
+   "decompress_mbps": 194.34
   },
   {
    "compressor": "native",
@@ -5004,7 +5004,7 @@
    "level": 10,
    "out_size": 3647321,
    "ratio": 0.3616,
-   "compress_mbps": 3.27,
+   "compress_mbps": 3.24,
    "decompress_mbps": null
   },
   {
@@ -5014,8 +5014,8 @@
    "level": 1,
    "out_size": 2254442,
    "ratio": 0.3402,
-   "compress_mbps": 80.93,
-   "decompress_mbps": 130.88
+   "compress_mbps": 81.78,
+   "decompress_mbps": 132.09
   },
   {
    "compressor": "native",
@@ -5024,8 +5024,8 @@
    "level": 2,
    "out_size": 2044843,
    "ratio": 0.3086,
-   "compress_mbps": 56.12,
-   "decompress_mbps": 142.35
+   "compress_mbps": 55.97,
+   "decompress_mbps": 143.15
   },
   {
    "compressor": "native",
@@ -5034,8 +5034,8 @@
    "level": 3,
    "out_size": 1992105,
    "ratio": 0.3006,
-   "compress_mbps": 46.06,
-   "decompress_mbps": 158.55
+   "compress_mbps": 45.86,
+   "decompress_mbps": 158.18
   },
   {
    "compressor": "native",
@@ -5044,8 +5044,8 @@
    "level": 4,
    "out_size": 1900947,
    "ratio": 0.2868,
-   "compress_mbps": 31.05,
-   "decompress_mbps": 161.86
+   "compress_mbps": 30.93,
+   "decompress_mbps": 162.21
   },
   {
    "compressor": "native",
@@ -5054,8 +5054,8 @@
    "level": 5,
    "out_size": 1875392,
    "ratio": 0.283,
-   "compress_mbps": 19.96,
-   "decompress_mbps": 172.48
+   "compress_mbps": 19.98,
+   "decompress_mbps": 172.61
   },
   {
    "compressor": "native",
@@ -5064,8 +5064,8 @@
    "level": 6,
    "out_size": 1867552,
    "ratio": 0.2818,
-   "compress_mbps": 23.99,
-   "decompress_mbps": 183.96
+   "compress_mbps": 24.04,
+   "decompress_mbps": 183.95
   },
   {
    "compressor": "native",
@@ -5074,8 +5074,8 @@
    "level": 7,
    "out_size": 1843831,
    "ratio": 0.2782,
-   "compress_mbps": 15.27,
-   "decompress_mbps": 187.03
+   "compress_mbps": 15.21,
+   "decompress_mbps": 187.47
   },
   {
    "compressor": "native",
@@ -5084,8 +5084,8 @@
    "level": 8,
    "out_size": 1841549,
    "ratio": 0.2779,
-   "compress_mbps": 13.23,
-   "decompress_mbps": 189.37
+   "compress_mbps": 13.19,
+   "decompress_mbps": 189.87
   },
   {
    "compressor": "native",
@@ -5094,8 +5094,8 @@
    "level": 9,
    "out_size": 1773447,
    "ratio": 0.2676,
-   "compress_mbps": 2.81,
-   "decompress_mbps": 194.24
+   "compress_mbps": 2.75,
+   "decompress_mbps": 195.93
   },
   {
    "compressor": "native",
@@ -5114,8 +5114,8 @@
    "level": 1,
    "out_size": 6406301,
    "ratio": 0.2965,
-   "compress_mbps": 111.07,
-   "decompress_mbps": 198.0
+   "compress_mbps": 110.81,
+   "decompress_mbps": 198.44
   },
   {
    "compressor": "native",
@@ -5124,8 +5124,8 @@
    "level": 2,
    "out_size": 6102377,
    "ratio": 0.2824,
-   "compress_mbps": 81.42,
-   "decompress_mbps": 210.15
+   "compress_mbps": 81.37,
+   "decompress_mbps": 210.41
   },
   {
    "compressor": "native",
@@ -5134,8 +5134,8 @@
    "level": 3,
    "out_size": 6022184,
    "ratio": 0.2787,
-   "compress_mbps": 74.51,
-   "decompress_mbps": 219.25
+   "compress_mbps": 74.0,
+   "decompress_mbps": 219.72
   },
   {
    "compressor": "native",
@@ -5144,8 +5144,8 @@
    "level": 4,
    "out_size": 5881226,
    "ratio": 0.2722,
-   "compress_mbps": 56.19,
-   "decompress_mbps": 229.02
+   "compress_mbps": 56.35,
+   "decompress_mbps": 229.06
   },
   {
    "compressor": "native",
@@ -5154,8 +5154,8 @@
    "level": 5,
    "out_size": 5840132,
    "ratio": 0.2703,
-   "compress_mbps": 44.01,
-   "decompress_mbps": 242.11
+   "compress_mbps": 44.14,
+   "decompress_mbps": 240.09
   },
   {
    "compressor": "native",
@@ -5164,8 +5164,8 @@
    "level": 6,
    "out_size": 5425229,
    "ratio": 0.2511,
-   "compress_mbps": 36.34,
-   "decompress_mbps": 244.97
+   "compress_mbps": 36.75,
+   "decompress_mbps": 244.86
   },
   {
    "compressor": "native",
@@ -5174,8 +5174,8 @@
    "level": 7,
    "out_size": 5410113,
    "ratio": 0.2504,
-   "compress_mbps": 31.04,
-   "decompress_mbps": 247.84
+   "compress_mbps": 31.27,
+   "decompress_mbps": 246.22
   },
   {
    "compressor": "native",
@@ -5184,8 +5184,8 @@
    "level": 8,
    "out_size": 5407142,
    "ratio": 0.2503,
-   "compress_mbps": 28.85,
-   "decompress_mbps": 247.59
+   "compress_mbps": 28.87,
+   "decompress_mbps": 247.41
   },
   {
    "compressor": "native",
@@ -5194,8 +5194,8 @@
    "level": 9,
    "out_size": 5235865,
    "ratio": 0.2423,
-   "compress_mbps": 4.46,
-   "decompress_mbps": 250.82
+   "compress_mbps": 4.5,
+   "decompress_mbps": 250.6
   },
   {
    "compressor": "native",
@@ -5204,7 +5204,7 @@
    "level": 10,
    "out_size": 5177560,
    "ratio": 0.2396,
-   "compress_mbps": 2.48,
+   "compress_mbps": 2.45,
    "decompress_mbps": null
   },
   {
@@ -5214,8 +5214,8 @@
    "level": 1,
    "out_size": 5612204,
    "ratio": 0.7739,
-   "compress_mbps": 47.19,
-   "decompress_mbps": 93.21
+   "compress_mbps": 47.36,
+   "decompress_mbps": 92.06
   },
   {
    "compressor": "native",
@@ -5224,8 +5224,8 @@
    "level": 2,
    "out_size": 5533875,
    "ratio": 0.7631,
-   "compress_mbps": 39.43,
-   "decompress_mbps": 96.11
+   "compress_mbps": 39.89,
+   "decompress_mbps": 94.17
   },
   {
    "compressor": "native",
@@ -5234,8 +5234,8 @@
    "level": 3,
    "out_size": 5522436,
    "ratio": 0.7615,
-   "compress_mbps": 37.03,
-   "decompress_mbps": 98.37
+   "compress_mbps": 37.17,
+   "decompress_mbps": 97.03
   },
   {
    "compressor": "native",
@@ -5244,8 +5244,8 @@
    "level": 4,
    "out_size": 5500212,
    "ratio": 0.7584,
-   "compress_mbps": 30.63,
-   "decompress_mbps": 102.06
+   "compress_mbps": 31.25,
+   "decompress_mbps": 100.85
   },
   {
    "compressor": "native",
@@ -5254,8 +5254,8 @@
    "level": 5,
    "out_size": 5497345,
    "ratio": 0.7581,
-   "compress_mbps": 28.65,
-   "decompress_mbps": 104.6
+   "compress_mbps": 28.85,
+   "decompress_mbps": 102.7
   },
   {
    "compressor": "native",
@@ -5264,8 +5264,8 @@
    "level": 6,
    "out_size": 5477997,
    "ratio": 0.7554,
-   "compress_mbps": 21.7,
-   "decompress_mbps": 105.54
+   "compress_mbps": 21.65,
+   "decompress_mbps": 103.07
   },
   {
    "compressor": "native",
@@ -5274,8 +5274,8 @@
    "level": 7,
    "out_size": 5474894,
    "ratio": 0.755,
-   "compress_mbps": 20.43,
-   "decompress_mbps": 106.98
+   "compress_mbps": 20.33,
+   "decompress_mbps": 104.57
   },
   {
    "compressor": "native",
@@ -5285,7 +5285,7 @@
    "out_size": 5475351,
    "ratio": 0.755,
    "compress_mbps": 20.18,
-   "decompress_mbps": 106.5
+   "decompress_mbps": 103.78
   },
   {
    "compressor": "native",
@@ -5294,8 +5294,8 @@
    "level": 9,
    "out_size": 5284536,
    "ratio": 0.7287,
-   "compress_mbps": 4.91,
-   "decompress_mbps": 106.86
+   "compress_mbps": 4.95,
+   "decompress_mbps": 105.07
   },
   {
    "compressor": "native",
@@ -5304,7 +5304,7 @@
    "level": 10,
    "out_size": 5262319,
    "ratio": 0.7256,
-   "compress_mbps": 3.47,
+   "compress_mbps": 3.46,
    "decompress_mbps": null
   },
   {
@@ -5314,8 +5314,8 @@
    "level": 1,
    "out_size": 13727247,
    "ratio": 0.3311,
-   "compress_mbps": 83.25,
-   "decompress_mbps": 138.48
+   "compress_mbps": 83.28,
+   "decompress_mbps": 137.84
   },
   {
    "compressor": "native",
@@ -5324,8 +5324,8 @@
    "level": 2,
    "out_size": 12940398,
    "ratio": 0.3121,
-   "compress_mbps": 61.52,
-   "decompress_mbps": 149.85
+   "compress_mbps": 61.02,
+   "decompress_mbps": 149.46
   },
   {
    "compressor": "native",
@@ -5334,8 +5334,8 @@
    "level": 3,
    "out_size": 12703756,
    "ratio": 0.3064,
-   "compress_mbps": 55.96,
-   "decompress_mbps": 160.85
+   "compress_mbps": 56.19,
+   "decompress_mbps": 160.9
   },
   {
    "compressor": "native",
@@ -5344,8 +5344,8 @@
    "level": 4,
    "out_size": 12231168,
    "ratio": 0.295,
-   "compress_mbps": 42.16,
-   "decompress_mbps": 168.3
+   "compress_mbps": 42.1,
+   "decompress_mbps": 167.82
   },
   {
    "compressor": "native",
@@ -5354,8 +5354,8 @@
    "level": 5,
    "out_size": 12125487,
    "ratio": 0.2925,
-   "compress_mbps": 32.18,
-   "decompress_mbps": 177.09
+   "compress_mbps": 32.3,
+   "decompress_mbps": 176.86
   },
   {
    "compressor": "native",
@@ -5364,8 +5364,8 @@
    "level": 6,
    "out_size": 12172470,
    "ratio": 0.2936,
-   "compress_mbps": 32.89,
-   "decompress_mbps": 182.6
+   "compress_mbps": 32.99,
+   "decompress_mbps": 182.26
   },
   {
    "compressor": "native",
@@ -5374,8 +5374,8 @@
    "level": 7,
    "out_size": 12110320,
    "ratio": 0.2921,
-   "compress_mbps": 26.15,
-   "decompress_mbps": 184.08
+   "compress_mbps": 26.19,
+   "decompress_mbps": 183.04
   },
   {
    "compressor": "native",
@@ -5384,8 +5384,8 @@
    "level": 8,
    "out_size": 12106137,
    "ratio": 0.292,
-   "compress_mbps": 24.63,
-   "decompress_mbps": 185.05
+   "compress_mbps": 24.79,
+   "decompress_mbps": 185.31
   },
   {
    "compressor": "native",
@@ -5394,8 +5394,8 @@
    "level": 9,
    "out_size": 11806466,
    "ratio": 0.2848,
-   "compress_mbps": 3.77,
-   "decompress_mbps": 184.18
+   "compress_mbps": 3.71,
+   "decompress_mbps": 184.2
   },
   {
    "compressor": "native",
@@ -5404,7 +5404,7 @@
    "level": 10,
    "out_size": 11636727,
    "ratio": 0.2807,
-   "compress_mbps": 1.94,
+   "compress_mbps": 1.92,
    "decompress_mbps": null
   },
   {
@@ -5414,8 +5414,8 @@
    "level": 1,
    "out_size": 6438176,
    "ratio": 0.7597,
-   "compress_mbps": 43.11,
-   "decompress_mbps": 78.36
+   "compress_mbps": 43.94,
+   "decompress_mbps": 78.44
   },
   {
    "compressor": "native",
@@ -5424,8 +5424,8 @@
    "level": 2,
    "out_size": 6392101,
    "ratio": 0.7543,
-   "compress_mbps": 41.68,
-   "decompress_mbps": 79.2
+   "compress_mbps": 42.04,
+   "decompress_mbps": 79.35
   },
   {
    "compressor": "native",
@@ -5434,8 +5434,8 @@
    "level": 3,
    "out_size": 6392124,
    "ratio": 0.7543,
-   "compress_mbps": 42.03,
-   "decompress_mbps": 80.67
+   "compress_mbps": 42.18,
+   "decompress_mbps": 80.71
   },
   {
    "compressor": "native",
@@ -5444,8 +5444,8 @@
    "level": 4,
    "out_size": 6368719,
    "ratio": 0.7515,
-   "compress_mbps": 38.66,
-   "decompress_mbps": 81.03
+   "compress_mbps": 38.93,
+   "decompress_mbps": 80.61
   },
   {
    "compressor": "native",
@@ -5454,8 +5454,8 @@
    "level": 5,
    "out_size": 6368717,
    "ratio": 0.7515,
-   "compress_mbps": 38.69,
-   "decompress_mbps": 82.94
+   "compress_mbps": 38.53,
+   "decompress_mbps": 82.84
   },
   {
    "compressor": "native",
@@ -5464,8 +5464,8 @@
    "level": 6,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 16.37,
-   "decompress_mbps": 83.61
+   "compress_mbps": 17.09,
+   "decompress_mbps": 83.3
   },
   {
    "compressor": "native",
@@ -5474,8 +5474,8 @@
    "level": 7,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 16.36,
-   "decompress_mbps": 84.22
+   "compress_mbps": 17.12,
+   "decompress_mbps": 84.34
   },
   {
    "compressor": "native",
@@ -5484,8 +5484,8 @@
    "level": 8,
    "out_size": 6278507,
    "ratio": 0.7409,
-   "compress_mbps": 16.34,
-   "decompress_mbps": 83.29
+   "compress_mbps": 17.02,
+   "decompress_mbps": 83.7
   },
   {
    "compressor": "native",
@@ -5494,8 +5494,8 @@
    "level": 9,
    "out_size": 5952505,
    "ratio": 0.7024,
-   "compress_mbps": 5.87,
-   "decompress_mbps": 84.55
+   "compress_mbps": 5.88,
+   "decompress_mbps": 84.25
   },
   {
    "compressor": "native",
@@ -5504,7 +5504,7 @@
    "level": 10,
    "out_size": 5848663,
    "ratio": 0.6902,
-   "compress_mbps": 4.25,
+   "compress_mbps": 4.28,
    "decompress_mbps": null
   },
   {
@@ -5514,8 +5514,8 @@
    "level": 1,
    "out_size": 858525,
    "ratio": 0.1606,
-   "compress_mbps": 177.47,
-   "decompress_mbps": 269.64
+   "compress_mbps": 176.85,
+   "decompress_mbps": 271.65
   },
   {
    "compressor": "native",
@@ -5524,8 +5524,8 @@
    "level": 2,
    "out_size": 846807,
    "ratio": 0.1584,
-   "compress_mbps": 113.06,
-   "decompress_mbps": 305.41
+   "compress_mbps": 111.8,
+   "decompress_mbps": 301.83
   },
   {
    "compressor": "native",
@@ -5534,8 +5534,8 @@
    "level": 3,
    "out_size": 806798,
    "ratio": 0.1509,
-   "compress_mbps": 102.81,
-   "decompress_mbps": 339.98
+   "compress_mbps": 102.38,
+   "decompress_mbps": 337.51
   },
   {
    "compressor": "native",
@@ -5544,8 +5544,8 @@
    "level": 4,
    "out_size": 721777,
    "ratio": 0.135,
-   "compress_mbps": 75.41,
-   "decompress_mbps": 337.71
+   "compress_mbps": 75.31,
+   "decompress_mbps": 334.12
   },
   {
    "compressor": "native",
@@ -5554,8 +5554,8 @@
    "level": 5,
    "out_size": 711251,
    "ratio": 0.1331,
-   "compress_mbps": 57.8,
-   "decompress_mbps": 379.62
+   "compress_mbps": 57.67,
+   "decompress_mbps": 376.51
   },
   {
    "compressor": "native",
@@ -5564,8 +5564,8 @@
    "level": 6,
    "out_size": 689202,
    "ratio": 0.1289,
-   "compress_mbps": 55.32,
-   "decompress_mbps": 382.83
+   "compress_mbps": 55.75,
+   "decompress_mbps": 397.12
   },
   {
    "compressor": "native",
@@ -5574,8 +5574,8 @@
    "level": 7,
    "out_size": 676922,
    "ratio": 0.1266,
-   "compress_mbps": 43.7,
-   "decompress_mbps": 416.42
+   "compress_mbps": 43.48,
+   "decompress_mbps": 414.98
   },
   {
    "compressor": "native",
@@ -5584,8 +5584,8 @@
    "level": 8,
    "out_size": 674389,
    "ratio": 0.1262,
-   "compress_mbps": 38.62,
-   "decompress_mbps": 448.34
+   "compress_mbps": 38.5,
+   "decompress_mbps": 448.97
   },
   {
    "compressor": "native",
@@ -5594,8 +5594,8 @@
    "level": 9,
    "out_size": 659417,
    "ratio": 0.1234,
-   "compress_mbps": 4.27,
-   "decompress_mbps": 437.75
+   "compress_mbps": 4.23,
+   "decompress_mbps": 428.57
   },
   {
    "compressor": "native",
@@ -5604,7 +5604,7 @@
    "level": 10,
    "out_size": 643093,
    "ratio": 0.1203,
-   "compress_mbps": 2.89,
+   "compress_mbps": 2.86,
    "decompress_mbps": null
   },
   {


### PR DESCRIPTION
This PR adds `BitWriter.writeHuffCode2`, which merges two reversed Huffman codes into one 64-bit accumulator field with a single flush check — the way libdeflate writes its flush groups — and uses it in the packed emit walks to batch consecutive literal tokens. When the first field would not trigger an intermediate flush (`bitCount + len1 < flushThreshold`, the common case right after a flush leaves few pending bits), both codes are shift/OR-ed into the accumulator and flushed once; otherwise it falls back to the two sequential `writeHuffCode` calls. `writeHuffCode2_eq` proves it byte-identical to that sequential pair as a `BitWriter` value (not merely at the logical-bit level), so nothing downstream changes.

The packed emitters `emitTokensWithCodesP` and the fixed twin `emitTokensP` now peek ahead: when two consecutive tokens are literals, they emit them with one `writeHuffCode2` and advance by two. The packed-vs-boxed equalities (`emitTokensWithCodesP_eq` / `emitTokensP_eq`) still hold — the batched branch rewrites through `writeHuffCode2_eq` and unfolds the boxed emitter one extra step — so the block-size models and roundtrip stay byte-identical. Closes https://github.com/kim-em/lean-zip/issues/2764.

The full test suite (including byte-identical roundtrip conformance) passes; no `sorry`, no `native_decide`. A second opinion from Codex confirmed the guard arithmetic and that `writeHuffCode2_eq` proves genuine byte-level `BitWriter` equality.

🤖 Prepared with Claude Code